### PR TITLE
Enhanced #line directives

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6640,8 +6640,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_LineSpanDirectiveInvalidValue" xml:space="preserve">
     <value>The #line directive value is missing or out of range</value>
   </data>
-  <data name="ERR_LineSpanDirectiveInvalidSpan" xml:space="preserve">
-    <value>The #line directive span is invalid</value>
+  <data name="ERR_LineSpanDirectiveEndLessThanStart" xml:space="preserve">
+    <value>The #line directive end position must be greater than or equal to the start position</value>
   </data>
   <data name="WRN_DoNotCompareFunctionPointers" xml:space="preserve">
     <value>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6637,6 +6637,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureLineSpanDirective" xml:space="preserve">
     <value>line span directive</value>
   </data>
+  <data name="ERR_LineSpanDirectiveInvalidValue" xml:space="preserve">
+    <value>The #line directive value is missing or out of range</value>
+  </data>
+  <data name="ERR_LineSpanDirectiveInvalidSpan" xml:space="preserve">
+    <value>The #line directive span is invalid</value>
+  </data>
   <data name="WRN_DoNotCompareFunctionPointers" xml:space="preserve">
     <value>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6634,6 +6634,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureInferredDelegateType" xml:space="preserve">
     <value>inferred delegate type</value>
   </data>
+  <data name="IDS_FeatureLineSpanDirective" xml:space="preserve">
+    <value>line span directive</value>
+  </data>
   <data name="WRN_DoNotCompareFunctionPointers" xml:space="preserve">
     <value>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1960,6 +1960,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BuilderAttributeDisallowed = 8935,
         ERR_FeatureNotAvailableInVersion10 = 8936,
         ERR_SimpleProgramIsEmpty = 8937,
+        ERR_LineSpanDirectiveInvalidValue = 8938,
+        ERR_LineSpanDirectiveInvalidSpan = 8939,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1961,7 +1961,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_FeatureNotAvailableInVersion10 = 8936,
         ERR_SimpleProgramIsEmpty = 8937,
         ERR_LineSpanDirectiveInvalidValue = 8938,
-        ERR_LineSpanDirectiveInvalidSpan = 8939,
+        ERR_LineSpanDirectiveEndLessThanStart = 8939,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -229,6 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureLambdaReturnType = MessageBase + 12804,
         IDS_AsyncMethodBuilderOverride = MessageBase + 12805,
         IDS_FeatureImplicitImplementationOfNonPublicMemebers = MessageBase + 12806,
+        IDS_FeatureLineSpanDirective = MessageBase + 12807,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -354,6 +355,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_AsyncMethodBuilderOverride: // semantic check
                 case MessageID.IDS_FeatureConstantInterpolatedStrings: // semantic check
                 case MessageID.IDS_FeatureImplicitImplementationOfNonPublicMemebers: // semantic check
+                case MessageID.IDS_FeatureLineSpanDirective:
                     return LanguageVersion.CSharp10;
 
                 // C# 9.0 features.

--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -1180,7 +1180,7 @@ directive_trivia
   | end_if_directive_trivia
   | end_region_directive_trivia
   | error_directive_trivia
-  | line_directive_trivia
+  | line_or_span_directive_trivia
   | load_directive_trivia
   | nullable_directive_trivia
   | pragma_checksum_directive_trivia
@@ -1234,8 +1234,21 @@ error_directive_trivia
   : '#' 'error'
   ;
 
+line_or_span_directive_trivia
+  : line_directive_trivia
+  | line_span_directive_trivia
+  ;
+
 line_directive_trivia
   : '#' 'line' (numeric_literal_token | 'default' | 'hidden') string_literal_token?
+  ;
+
+line_span_directive_trivia
+  : '#' 'line' line_directive_position '-' line_directive_position numeric_literal_token? string_literal_token
+  ;
+
+line_directive_position
+  : '(' numeric_literal_token ',' numeric_literal_token ')'
   ;
 
 load_directive_trivia

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
@@ -32227,7 +32227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         public abstract SyntaxToken LineKeyword { get; }
 
-        public abstract SyntaxToken File { get; }
+        public abstract SyntaxToken? File { get; }
     }
 
     internal sealed partial class LineDirectiveTriviaSyntax : LineOrSpanDirectiveTriviaSyntax

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
@@ -32208,7 +32208,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
     }
 
-    internal sealed partial class LineDirectiveTriviaSyntax : DirectiveTriviaSyntax
+    internal abstract partial class LineOrSpanDirectiveTriviaSyntax : DirectiveTriviaSyntax
+    {
+        internal LineOrSpanDirectiveTriviaSyntax(SyntaxKind kind, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+          : base(kind, diagnostics, annotations)
+        {
+        }
+
+        internal LineOrSpanDirectiveTriviaSyntax(SyntaxKind kind)
+          : base(kind)
+        {
+        }
+
+        protected LineOrSpanDirectiveTriviaSyntax(ObjectReader reader)
+          : base(reader)
+        {
+        }
+
+        public abstract SyntaxToken LineKeyword { get; }
+
+        public abstract SyntaxToken File { get; }
+    }
+
+    internal sealed partial class LineDirectiveTriviaSyntax : LineOrSpanDirectiveTriviaSyntax
     {
         internal readonly SyntaxToken hashToken;
         internal readonly SyntaxToken lineKeyword;
@@ -32279,9 +32301,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         public override SyntaxToken HashToken => this.hashToken;
-        public SyntaxToken LineKeyword => this.lineKeyword;
+        public override SyntaxToken LineKeyword => this.lineKeyword;
         public SyntaxToken Line => this.line;
-        public SyntaxToken? File => this.file;
+        public override SyntaxToken? File => this.file;
         public override SyntaxToken EndOfDirectiveToken => this.endOfDirectiveToken;
         public override bool IsActive => this.isActive;
 
@@ -32363,6 +32385,342 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         static LineDirectiveTriviaSyntax()
         {
             ObjectBinder.RegisterTypeReader(typeof(LineDirectiveTriviaSyntax), r => new LineDirectiveTriviaSyntax(r));
+        }
+    }
+
+    internal sealed partial class LineDirectivePositionSyntax : CSharpSyntaxNode
+    {
+        internal readonly SyntaxToken openParenToken;
+        internal readonly SyntaxToken line;
+        internal readonly SyntaxToken commaToken;
+        internal readonly SyntaxToken character;
+        internal readonly SyntaxToken closeParenToken;
+
+        internal LineDirectivePositionSyntax(SyntaxKind kind, SyntaxToken openParenToken, SyntaxToken line, SyntaxToken commaToken, SyntaxToken character, SyntaxToken closeParenToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+          : base(kind, diagnostics, annotations)
+        {
+            this.SlotCount = 5;
+            this.AdjustFlagsAndWidth(openParenToken);
+            this.openParenToken = openParenToken;
+            this.AdjustFlagsAndWidth(line);
+            this.line = line;
+            this.AdjustFlagsAndWidth(commaToken);
+            this.commaToken = commaToken;
+            this.AdjustFlagsAndWidth(character);
+            this.character = character;
+            this.AdjustFlagsAndWidth(closeParenToken);
+            this.closeParenToken = closeParenToken;
+        }
+
+        internal LineDirectivePositionSyntax(SyntaxKind kind, SyntaxToken openParenToken, SyntaxToken line, SyntaxToken commaToken, SyntaxToken character, SyntaxToken closeParenToken, SyntaxFactoryContext context)
+          : base(kind)
+        {
+            this.SetFactoryContext(context);
+            this.SlotCount = 5;
+            this.AdjustFlagsAndWidth(openParenToken);
+            this.openParenToken = openParenToken;
+            this.AdjustFlagsAndWidth(line);
+            this.line = line;
+            this.AdjustFlagsAndWidth(commaToken);
+            this.commaToken = commaToken;
+            this.AdjustFlagsAndWidth(character);
+            this.character = character;
+            this.AdjustFlagsAndWidth(closeParenToken);
+            this.closeParenToken = closeParenToken;
+        }
+
+        internal LineDirectivePositionSyntax(SyntaxKind kind, SyntaxToken openParenToken, SyntaxToken line, SyntaxToken commaToken, SyntaxToken character, SyntaxToken closeParenToken)
+          : base(kind)
+        {
+            this.SlotCount = 5;
+            this.AdjustFlagsAndWidth(openParenToken);
+            this.openParenToken = openParenToken;
+            this.AdjustFlagsAndWidth(line);
+            this.line = line;
+            this.AdjustFlagsAndWidth(commaToken);
+            this.commaToken = commaToken;
+            this.AdjustFlagsAndWidth(character);
+            this.character = character;
+            this.AdjustFlagsAndWidth(closeParenToken);
+            this.closeParenToken = closeParenToken;
+        }
+
+        public SyntaxToken OpenParenToken => this.openParenToken;
+        public SyntaxToken Line => this.line;
+        public SyntaxToken CommaToken => this.commaToken;
+        public SyntaxToken Character => this.character;
+        public SyntaxToken CloseParenToken => this.closeParenToken;
+
+        internal override GreenNode? GetSlot(int index)
+            => index switch
+            {
+                0 => this.openParenToken,
+                1 => this.line,
+                2 => this.commaToken,
+                3 => this.character,
+                4 => this.closeParenToken,
+                _ => null,
+            };
+
+        internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new CSharp.Syntax.LineDirectivePositionSyntax(this, parent, position);
+
+        public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitLineDirectivePosition(this);
+        public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitLineDirectivePosition(this);
+
+        public LineDirectivePositionSyntax Update(SyntaxToken openParenToken, SyntaxToken line, SyntaxToken commaToken, SyntaxToken character, SyntaxToken closeParenToken)
+        {
+            if (openParenToken != this.OpenParenToken || line != this.Line || commaToken != this.CommaToken || character != this.Character || closeParenToken != this.CloseParenToken)
+            {
+                var newNode = SyntaxFactory.LineDirectivePosition(openParenToken, line, commaToken, character, closeParenToken);
+                var diags = GetDiagnostics();
+                if (diags?.Length > 0)
+                    newNode = newNode.WithDiagnosticsGreen(diags);
+                var annotations = GetAnnotations();
+                if (annotations?.Length > 0)
+                    newNode = newNode.WithAnnotationsGreen(annotations);
+                return newNode;
+            }
+
+            return this;
+        }
+
+        internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
+            => new LineDirectivePositionSyntax(this.Kind, this.openParenToken, this.line, this.commaToken, this.character, this.closeParenToken, diagnostics, GetAnnotations());
+
+        internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
+            => new LineDirectivePositionSyntax(this.Kind, this.openParenToken, this.line, this.commaToken, this.character, this.closeParenToken, GetDiagnostics(), annotations);
+
+        internal LineDirectivePositionSyntax(ObjectReader reader)
+          : base(reader)
+        {
+            this.SlotCount = 5;
+            var openParenToken = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(openParenToken);
+            this.openParenToken = openParenToken;
+            var line = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(line);
+            this.line = line;
+            var commaToken = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(commaToken);
+            this.commaToken = commaToken;
+            var character = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(character);
+            this.character = character;
+            var closeParenToken = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(closeParenToken);
+            this.closeParenToken = closeParenToken;
+        }
+
+        internal override void WriteTo(ObjectWriter writer)
+        {
+            base.WriteTo(writer);
+            writer.WriteValue(this.openParenToken);
+            writer.WriteValue(this.line);
+            writer.WriteValue(this.commaToken);
+            writer.WriteValue(this.character);
+            writer.WriteValue(this.closeParenToken);
+        }
+
+        static LineDirectivePositionSyntax()
+        {
+            ObjectBinder.RegisterTypeReader(typeof(LineDirectivePositionSyntax), r => new LineDirectivePositionSyntax(r));
+        }
+    }
+
+    internal sealed partial class LineSpanDirectiveTriviaSyntax : LineOrSpanDirectiveTriviaSyntax
+    {
+        internal readonly SyntaxToken hashToken;
+        internal readonly SyntaxToken lineKeyword;
+        internal readonly LineDirectivePositionSyntax start;
+        internal readonly SyntaxToken minusToken;
+        internal readonly LineDirectivePositionSyntax end;
+        internal readonly SyntaxToken? characterOffset;
+        internal readonly SyntaxToken file;
+        internal readonly SyntaxToken endOfDirectiveToken;
+        internal readonly bool isActive;
+
+        internal LineSpanDirectiveTriviaSyntax(SyntaxKind kind, SyntaxToken hashToken, SyntaxToken lineKeyword, LineDirectivePositionSyntax start, SyntaxToken minusToken, LineDirectivePositionSyntax end, SyntaxToken? characterOffset, SyntaxToken file, SyntaxToken endOfDirectiveToken, bool isActive, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+          : base(kind, diagnostics, annotations)
+        {
+            this.SlotCount = 8;
+            this.AdjustFlagsAndWidth(hashToken);
+            this.hashToken = hashToken;
+            this.AdjustFlagsAndWidth(lineKeyword);
+            this.lineKeyword = lineKeyword;
+            this.AdjustFlagsAndWidth(start);
+            this.start = start;
+            this.AdjustFlagsAndWidth(minusToken);
+            this.minusToken = minusToken;
+            this.AdjustFlagsAndWidth(end);
+            this.end = end;
+            if (characterOffset != null)
+            {
+                this.AdjustFlagsAndWidth(characterOffset);
+                this.characterOffset = characterOffset;
+            }
+            this.AdjustFlagsAndWidth(file);
+            this.file = file;
+            this.AdjustFlagsAndWidth(endOfDirectiveToken);
+            this.endOfDirectiveToken = endOfDirectiveToken;
+            this.isActive = isActive;
+        }
+
+        internal LineSpanDirectiveTriviaSyntax(SyntaxKind kind, SyntaxToken hashToken, SyntaxToken lineKeyword, LineDirectivePositionSyntax start, SyntaxToken minusToken, LineDirectivePositionSyntax end, SyntaxToken? characterOffset, SyntaxToken file, SyntaxToken endOfDirectiveToken, bool isActive, SyntaxFactoryContext context)
+          : base(kind)
+        {
+            this.SetFactoryContext(context);
+            this.SlotCount = 8;
+            this.AdjustFlagsAndWidth(hashToken);
+            this.hashToken = hashToken;
+            this.AdjustFlagsAndWidth(lineKeyword);
+            this.lineKeyword = lineKeyword;
+            this.AdjustFlagsAndWidth(start);
+            this.start = start;
+            this.AdjustFlagsAndWidth(minusToken);
+            this.minusToken = minusToken;
+            this.AdjustFlagsAndWidth(end);
+            this.end = end;
+            if (characterOffset != null)
+            {
+                this.AdjustFlagsAndWidth(characterOffset);
+                this.characterOffset = characterOffset;
+            }
+            this.AdjustFlagsAndWidth(file);
+            this.file = file;
+            this.AdjustFlagsAndWidth(endOfDirectiveToken);
+            this.endOfDirectiveToken = endOfDirectiveToken;
+            this.isActive = isActive;
+        }
+
+        internal LineSpanDirectiveTriviaSyntax(SyntaxKind kind, SyntaxToken hashToken, SyntaxToken lineKeyword, LineDirectivePositionSyntax start, SyntaxToken minusToken, LineDirectivePositionSyntax end, SyntaxToken? characterOffset, SyntaxToken file, SyntaxToken endOfDirectiveToken, bool isActive)
+          : base(kind)
+        {
+            this.SlotCount = 8;
+            this.AdjustFlagsAndWidth(hashToken);
+            this.hashToken = hashToken;
+            this.AdjustFlagsAndWidth(lineKeyword);
+            this.lineKeyword = lineKeyword;
+            this.AdjustFlagsAndWidth(start);
+            this.start = start;
+            this.AdjustFlagsAndWidth(minusToken);
+            this.minusToken = minusToken;
+            this.AdjustFlagsAndWidth(end);
+            this.end = end;
+            if (characterOffset != null)
+            {
+                this.AdjustFlagsAndWidth(characterOffset);
+                this.characterOffset = characterOffset;
+            }
+            this.AdjustFlagsAndWidth(file);
+            this.file = file;
+            this.AdjustFlagsAndWidth(endOfDirectiveToken);
+            this.endOfDirectiveToken = endOfDirectiveToken;
+            this.isActive = isActive;
+        }
+
+        public override SyntaxToken HashToken => this.hashToken;
+        public override SyntaxToken LineKeyword => this.lineKeyword;
+        public LineDirectivePositionSyntax Start => this.start;
+        public SyntaxToken MinusToken => this.minusToken;
+        public LineDirectivePositionSyntax End => this.end;
+        public SyntaxToken? CharacterOffset => this.characterOffset;
+        public override SyntaxToken File => this.file;
+        public override SyntaxToken EndOfDirectiveToken => this.endOfDirectiveToken;
+        public override bool IsActive => this.isActive;
+
+        internal override GreenNode? GetSlot(int index)
+            => index switch
+            {
+                0 => this.hashToken,
+                1 => this.lineKeyword,
+                2 => this.start,
+                3 => this.minusToken,
+                4 => this.end,
+                5 => this.characterOffset,
+                6 => this.file,
+                7 => this.endOfDirectiveToken,
+                _ => null,
+            };
+
+        internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new CSharp.Syntax.LineSpanDirectiveTriviaSyntax(this, parent, position);
+
+        public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitLineSpanDirectiveTrivia(this);
+        public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitLineSpanDirectiveTrivia(this);
+
+        public LineSpanDirectiveTriviaSyntax Update(SyntaxToken hashToken, SyntaxToken lineKeyword, LineDirectivePositionSyntax start, SyntaxToken minusToken, LineDirectivePositionSyntax end, SyntaxToken characterOffset, SyntaxToken file, SyntaxToken endOfDirectiveToken, bool isActive)
+        {
+            if (hashToken != this.HashToken || lineKeyword != this.LineKeyword || start != this.Start || minusToken != this.MinusToken || end != this.End || characterOffset != this.CharacterOffset || file != this.File || endOfDirectiveToken != this.EndOfDirectiveToken)
+            {
+                var newNode = SyntaxFactory.LineSpanDirectiveTrivia(hashToken, lineKeyword, start, minusToken, end, characterOffset, file, endOfDirectiveToken, isActive);
+                var diags = GetDiagnostics();
+                if (diags?.Length > 0)
+                    newNode = newNode.WithDiagnosticsGreen(diags);
+                var annotations = GetAnnotations();
+                if (annotations?.Length > 0)
+                    newNode = newNode.WithAnnotationsGreen(annotations);
+                return newNode;
+            }
+
+            return this;
+        }
+
+        internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
+            => new LineSpanDirectiveTriviaSyntax(this.Kind, this.hashToken, this.lineKeyword, this.start, this.minusToken, this.end, this.characterOffset, this.file, this.endOfDirectiveToken, this.isActive, diagnostics, GetAnnotations());
+
+        internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
+            => new LineSpanDirectiveTriviaSyntax(this.Kind, this.hashToken, this.lineKeyword, this.start, this.minusToken, this.end, this.characterOffset, this.file, this.endOfDirectiveToken, this.isActive, GetDiagnostics(), annotations);
+
+        internal LineSpanDirectiveTriviaSyntax(ObjectReader reader)
+          : base(reader)
+        {
+            this.SlotCount = 8;
+            var hashToken = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(hashToken);
+            this.hashToken = hashToken;
+            var lineKeyword = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(lineKeyword);
+            this.lineKeyword = lineKeyword;
+            var start = (LineDirectivePositionSyntax)reader.ReadValue();
+            AdjustFlagsAndWidth(start);
+            this.start = start;
+            var minusToken = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(minusToken);
+            this.minusToken = minusToken;
+            var end = (LineDirectivePositionSyntax)reader.ReadValue();
+            AdjustFlagsAndWidth(end);
+            this.end = end;
+            var characterOffset = (SyntaxToken?)reader.ReadValue();
+            if (characterOffset != null)
+            {
+                AdjustFlagsAndWidth(characterOffset);
+                this.characterOffset = characterOffset;
+            }
+            var file = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(file);
+            this.file = file;
+            var endOfDirectiveToken = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(endOfDirectiveToken);
+            this.endOfDirectiveToken = endOfDirectiveToken;
+            this.isActive = (bool)reader.ReadBoolean();
+        }
+
+        internal override void WriteTo(ObjectWriter writer)
+        {
+            base.WriteTo(writer);
+            writer.WriteValue(this.hashToken);
+            writer.WriteValue(this.lineKeyword);
+            writer.WriteValue(this.start);
+            writer.WriteValue(this.minusToken);
+            writer.WriteValue(this.end);
+            writer.WriteValue(this.characterOffset);
+            writer.WriteValue(this.file);
+            writer.WriteValue(this.endOfDirectiveToken);
+            writer.WriteBoolean(this.isActive);
+        }
+
+        static LineSpanDirectiveTriviaSyntax()
+        {
+            ObjectBinder.RegisterTypeReader(typeof(LineSpanDirectiveTriviaSyntax), r => new LineSpanDirectiveTriviaSyntax(r));
         }
     }
 
@@ -33481,6 +33839,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public virtual TResult VisitDefineDirectiveTrivia(DefineDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitUndefDirectiveTrivia(UndefDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitLineDirectiveTrivia(LineDirectiveTriviaSyntax node) => this.DefaultVisit(node);
+        public virtual TResult VisitLineDirectivePosition(LineDirectivePositionSyntax node) => this.DefaultVisit(node);
+        public virtual TResult VisitLineSpanDirectiveTrivia(LineSpanDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitPragmaWarningDirectiveTrivia(PragmaWarningDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitPragmaChecksumDirectiveTrivia(PragmaChecksumDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitReferenceDirectiveTrivia(ReferenceDirectiveTriviaSyntax node) => this.DefaultVisit(node);
@@ -33717,6 +34077,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public virtual void VisitDefineDirectiveTrivia(DefineDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual void VisitUndefDirectiveTrivia(UndefDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual void VisitLineDirectiveTrivia(LineDirectiveTriviaSyntax node) => this.DefaultVisit(node);
+        public virtual void VisitLineDirectivePosition(LineDirectivePositionSyntax node) => this.DefaultVisit(node);
+        public virtual void VisitLineSpanDirectiveTrivia(LineSpanDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual void VisitPragmaWarningDirectiveTrivia(PragmaWarningDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual void VisitPragmaChecksumDirectiveTrivia(PragmaChecksumDirectiveTriviaSyntax node) => this.DefaultVisit(node);
         public virtual void VisitReferenceDirectiveTrivia(ReferenceDirectiveTriviaSyntax node) => this.DefaultVisit(node);
@@ -34404,6 +34766,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         public override CSharpSyntaxNode VisitLineDirectiveTrivia(LineDirectiveTriviaSyntax node)
             => node.Update((SyntaxToken)Visit(node.HashToken), (SyntaxToken)Visit(node.LineKeyword), (SyntaxToken)Visit(node.Line), (SyntaxToken)Visit(node.File), (SyntaxToken)Visit(node.EndOfDirectiveToken), node.IsActive);
+
+        public override CSharpSyntaxNode VisitLineDirectivePosition(LineDirectivePositionSyntax node)
+            => node.Update((SyntaxToken)Visit(node.OpenParenToken), (SyntaxToken)Visit(node.Line), (SyntaxToken)Visit(node.CommaToken), (SyntaxToken)Visit(node.Character), (SyntaxToken)Visit(node.CloseParenToken));
+
+        public override CSharpSyntaxNode VisitLineSpanDirectiveTrivia(LineSpanDirectiveTriviaSyntax node)
+            => node.Update((SyntaxToken)Visit(node.HashToken), (SyntaxToken)Visit(node.LineKeyword), (LineDirectivePositionSyntax)Visit(node.Start), (SyntaxToken)Visit(node.MinusToken), (LineDirectivePositionSyntax)Visit(node.End), (SyntaxToken)Visit(node.CharacterOffset), (SyntaxToken)Visit(node.File), (SyntaxToken)Visit(node.EndOfDirectiveToken), node.IsActive);
 
         public override CSharpSyntaxNode VisitPragmaWarningDirectiveTrivia(PragmaWarningDirectiveTriviaSyntax node)
             => node.Update((SyntaxToken)Visit(node.HashToken), (SyntaxToken)Visit(node.PragmaKeyword), (SyntaxToken)Visit(node.WarningKeyword), (SyntaxToken)Visit(node.DisableOrRestoreKeyword), VisitList(node.ErrorCodes), (SyntaxToken)Visit(node.EndOfDirectiveToken), node.IsActive);
@@ -39216,6 +39584,53 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 #endif
 
             return new LineDirectiveTriviaSyntax(SyntaxKind.LineDirectiveTrivia, hashToken, lineKeyword, line, file, endOfDirectiveToken, isActive, this.context);
+        }
+
+        public LineDirectivePositionSyntax LineDirectivePosition(SyntaxToken openParenToken, SyntaxToken line, SyntaxToken commaToken, SyntaxToken character, SyntaxToken closeParenToken)
+        {
+#if DEBUG
+            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
+            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (line == null) throw new ArgumentNullException(nameof(line));
+            if (line.Kind != SyntaxKind.NumericLiteralToken) throw new ArgumentException(nameof(line));
+            if (commaToken == null) throw new ArgumentNullException(nameof(commaToken));
+            if (commaToken.Kind != SyntaxKind.CommaToken) throw new ArgumentException(nameof(commaToken));
+            if (character == null) throw new ArgumentNullException(nameof(character));
+            if (character.Kind != SyntaxKind.NumericLiteralToken) throw new ArgumentException(nameof(character));
+            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
+            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+#endif
+
+            return new LineDirectivePositionSyntax(SyntaxKind.LineDirectivePosition, openParenToken, line, commaToken, character, closeParenToken, this.context);
+        }
+
+        public LineSpanDirectiveTriviaSyntax LineSpanDirectiveTrivia(SyntaxToken hashToken, SyntaxToken lineKeyword, LineDirectivePositionSyntax start, SyntaxToken minusToken, LineDirectivePositionSyntax end, SyntaxToken? characterOffset, SyntaxToken file, SyntaxToken endOfDirectiveToken, bool isActive)
+        {
+#if DEBUG
+            if (hashToken == null) throw new ArgumentNullException(nameof(hashToken));
+            if (hashToken.Kind != SyntaxKind.HashToken) throw new ArgumentException(nameof(hashToken));
+            if (lineKeyword == null) throw new ArgumentNullException(nameof(lineKeyword));
+            if (lineKeyword.Kind != SyntaxKind.LineKeyword) throw new ArgumentException(nameof(lineKeyword));
+            if (start == null) throw new ArgumentNullException(nameof(start));
+            if (minusToken == null) throw new ArgumentNullException(nameof(minusToken));
+            if (minusToken.Kind != SyntaxKind.MinusToken) throw new ArgumentException(nameof(minusToken));
+            if (end == null) throw new ArgumentNullException(nameof(end));
+            if (characterOffset != null)
+            {
+                switch (characterOffset.Kind)
+                {
+                    case SyntaxKind.NumericLiteralToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(characterOffset));
+                }
+            }
+            if (file == null) throw new ArgumentNullException(nameof(file));
+            if (file.Kind != SyntaxKind.StringLiteralToken) throw new ArgumentException(nameof(file));
+            if (endOfDirectiveToken == null) throw new ArgumentNullException(nameof(endOfDirectiveToken));
+            if (endOfDirectiveToken.Kind != SyntaxKind.EndOfDirectiveToken) throw new ArgumentException(nameof(endOfDirectiveToken));
+#endif
+
+            return new LineSpanDirectiveTriviaSyntax(SyntaxKind.LineSpanDirectiveTrivia, hashToken, lineKeyword, start, minusToken, end, characterOffset, file, endOfDirectiveToken, isActive, this.context);
         }
 
         public PragmaWarningDirectiveTriviaSyntax PragmaWarningDirectiveTrivia(SyntaxToken hashToken, SyntaxToken pragmaKeyword, SyntaxToken warningKeyword, SyntaxToken disableOrRestoreKeyword, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ExpressionSyntax> errorCodes, SyntaxToken endOfDirectiveToken, bool isActive)
@@ -44131,6 +44546,53 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new LineDirectiveTriviaSyntax(SyntaxKind.LineDirectiveTrivia, hashToken, lineKeyword, line, file, endOfDirectiveToken, isActive);
         }
 
+        public static LineDirectivePositionSyntax LineDirectivePosition(SyntaxToken openParenToken, SyntaxToken line, SyntaxToken commaToken, SyntaxToken character, SyntaxToken closeParenToken)
+        {
+#if DEBUG
+            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
+            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (line == null) throw new ArgumentNullException(nameof(line));
+            if (line.Kind != SyntaxKind.NumericLiteralToken) throw new ArgumentException(nameof(line));
+            if (commaToken == null) throw new ArgumentNullException(nameof(commaToken));
+            if (commaToken.Kind != SyntaxKind.CommaToken) throw new ArgumentException(nameof(commaToken));
+            if (character == null) throw new ArgumentNullException(nameof(character));
+            if (character.Kind != SyntaxKind.NumericLiteralToken) throw new ArgumentException(nameof(character));
+            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
+            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+#endif
+
+            return new LineDirectivePositionSyntax(SyntaxKind.LineDirectivePosition, openParenToken, line, commaToken, character, closeParenToken);
+        }
+
+        public static LineSpanDirectiveTriviaSyntax LineSpanDirectiveTrivia(SyntaxToken hashToken, SyntaxToken lineKeyword, LineDirectivePositionSyntax start, SyntaxToken minusToken, LineDirectivePositionSyntax end, SyntaxToken? characterOffset, SyntaxToken file, SyntaxToken endOfDirectiveToken, bool isActive)
+        {
+#if DEBUG
+            if (hashToken == null) throw new ArgumentNullException(nameof(hashToken));
+            if (hashToken.Kind != SyntaxKind.HashToken) throw new ArgumentException(nameof(hashToken));
+            if (lineKeyword == null) throw new ArgumentNullException(nameof(lineKeyword));
+            if (lineKeyword.Kind != SyntaxKind.LineKeyword) throw new ArgumentException(nameof(lineKeyword));
+            if (start == null) throw new ArgumentNullException(nameof(start));
+            if (minusToken == null) throw new ArgumentNullException(nameof(minusToken));
+            if (minusToken.Kind != SyntaxKind.MinusToken) throw new ArgumentException(nameof(minusToken));
+            if (end == null) throw new ArgumentNullException(nameof(end));
+            if (characterOffset != null)
+            {
+                switch (characterOffset.Kind)
+                {
+                    case SyntaxKind.NumericLiteralToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(characterOffset));
+                }
+            }
+            if (file == null) throw new ArgumentNullException(nameof(file));
+            if (file.Kind != SyntaxKind.StringLiteralToken) throw new ArgumentException(nameof(file));
+            if (endOfDirectiveToken == null) throw new ArgumentNullException(nameof(endOfDirectiveToken));
+            if (endOfDirectiveToken.Kind != SyntaxKind.EndOfDirectiveToken) throw new ArgumentException(nameof(endOfDirectiveToken));
+#endif
+
+            return new LineSpanDirectiveTriviaSyntax(SyntaxKind.LineSpanDirectiveTrivia, hashToken, lineKeyword, start, minusToken, end, characterOffset, file, endOfDirectiveToken, isActive);
+        }
+
         public static PragmaWarningDirectiveTriviaSyntax PragmaWarningDirectiveTrivia(SyntaxToken hashToken, SyntaxToken pragmaKeyword, SyntaxToken warningKeyword, SyntaxToken disableOrRestoreKeyword, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ExpressionSyntax> errorCodes, SyntaxToken endOfDirectiveToken, bool isActive)
         {
 #if DEBUG
@@ -44483,6 +44945,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 typeof(DefineDirectiveTriviaSyntax),
                 typeof(UndefDirectiveTriviaSyntax),
                 typeof(LineDirectiveTriviaSyntax),
+                typeof(LineDirectivePositionSyntax),
+                typeof(LineSpanDirectiveTriviaSyntax),
                 typeof(PragmaWarningDirectiveTriviaSyntax),
                 typeof(PragmaChecksumDirectiveTriviaSyntax),
                 typeof(ReferenceDirectiveTriviaSyntax),

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -693,6 +693,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Called when the visitor visits a LineDirectiveTriviaSyntax node.</summary>
         public virtual TResult? VisitLineDirectiveTrivia(LineDirectiveTriviaSyntax node) => this.DefaultVisit(node);
 
+        /// <summary>Called when the visitor visits a LineDirectivePositionSyntax node.</summary>
+        public virtual TResult? VisitLineDirectivePosition(LineDirectivePositionSyntax node) => this.DefaultVisit(node);
+
+        /// <summary>Called when the visitor visits a LineSpanDirectiveTriviaSyntax node.</summary>
+        public virtual TResult? VisitLineSpanDirectiveTrivia(LineSpanDirectiveTriviaSyntax node) => this.DefaultVisit(node);
+
         /// <summary>Called when the visitor visits a PragmaWarningDirectiveTriviaSyntax node.</summary>
         public virtual TResult? VisitPragmaWarningDirectiveTrivia(PragmaWarningDirectiveTriviaSyntax node) => this.DefaultVisit(node);
 
@@ -1392,6 +1398,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Called when the visitor visits a LineDirectiveTriviaSyntax node.</summary>
         public virtual void VisitLineDirectiveTrivia(LineDirectiveTriviaSyntax node) => this.DefaultVisit(node);
 
+        /// <summary>Called when the visitor visits a LineDirectivePositionSyntax node.</summary>
+        public virtual void VisitLineDirectivePosition(LineDirectivePositionSyntax node) => this.DefaultVisit(node);
+
+        /// <summary>Called when the visitor visits a LineSpanDirectiveTriviaSyntax node.</summary>
+        public virtual void VisitLineSpanDirectiveTrivia(LineSpanDirectiveTriviaSyntax node) => this.DefaultVisit(node);
+
         /// <summary>Called when the visitor visits a PragmaWarningDirectiveTriviaSyntax node.</summary>
         public virtual void VisitPragmaWarningDirectiveTrivia(PragmaWarningDirectiveTriviaSyntax node) => this.DefaultVisit(node);
 
@@ -2090,6 +2102,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override SyntaxNode? VisitLineDirectiveTrivia(LineDirectiveTriviaSyntax node)
             => node.Update(VisitToken(node.HashToken), VisitToken(node.LineKeyword), VisitToken(node.Line), VisitToken(node.File), VisitToken(node.EndOfDirectiveToken), node.IsActive);
+
+        public override SyntaxNode? VisitLineDirectivePosition(LineDirectivePositionSyntax node)
+            => node.Update(VisitToken(node.OpenParenToken), VisitToken(node.Line), VisitToken(node.CommaToken), VisitToken(node.Character), VisitToken(node.CloseParenToken));
+
+        public override SyntaxNode? VisitLineSpanDirectiveTrivia(LineSpanDirectiveTriviaSyntax node)
+            => node.Update(VisitToken(node.HashToken), VisitToken(node.LineKeyword), (LineDirectivePositionSyntax?)Visit(node.Start) ?? throw new ArgumentNullException("start"), VisitToken(node.MinusToken), (LineDirectivePositionSyntax?)Visit(node.End) ?? throw new ArgumentNullException("end"), VisitToken(node.CharacterOffset), VisitToken(node.File), VisitToken(node.EndOfDirectiveToken), node.IsActive);
 
         public override SyntaxNode? VisitPragmaWarningDirectiveTrivia(PragmaWarningDirectiveTriviaSyntax node)
             => node.Update(VisitToken(node.HashToken), VisitToken(node.PragmaKeyword), VisitToken(node.WarningKeyword), VisitToken(node.DisableOrRestoreKeyword), VisitList(node.ErrorCodes), VisitToken(node.EndOfDirectiveToken), node.IsActive);
@@ -6089,6 +6107,48 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Creates a new LineDirectiveTriviaSyntax instance.</summary>
         public static LineDirectiveTriviaSyntax LineDirectiveTrivia(SyntaxToken line, bool isActive)
             => SyntaxFactory.LineDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.HashToken), SyntaxFactory.Token(SyntaxKind.LineKeyword), line, default, SyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken), isActive);
+
+        /// <summary>Creates a new LineDirectivePositionSyntax instance.</summary>
+        public static LineDirectivePositionSyntax LineDirectivePosition(SyntaxToken openParenToken, SyntaxToken line, SyntaxToken commaToken, SyntaxToken character, SyntaxToken closeParenToken)
+        {
+            if (openParenToken.Kind() != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (line.Kind() != SyntaxKind.NumericLiteralToken) throw new ArgumentException(nameof(line));
+            if (commaToken.Kind() != SyntaxKind.CommaToken) throw new ArgumentException(nameof(commaToken));
+            if (character.Kind() != SyntaxKind.NumericLiteralToken) throw new ArgumentException(nameof(character));
+            if (closeParenToken.Kind() != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+            return (LineDirectivePositionSyntax)Syntax.InternalSyntax.SyntaxFactory.LineDirectivePosition((Syntax.InternalSyntax.SyntaxToken)openParenToken.Node!, (Syntax.InternalSyntax.SyntaxToken)line.Node!, (Syntax.InternalSyntax.SyntaxToken)commaToken.Node!, (Syntax.InternalSyntax.SyntaxToken)character.Node!, (Syntax.InternalSyntax.SyntaxToken)closeParenToken.Node!).CreateRed();
+        }
+
+        /// <summary>Creates a new LineDirectivePositionSyntax instance.</summary>
+        public static LineDirectivePositionSyntax LineDirectivePosition(SyntaxToken line, SyntaxToken character)
+            => SyntaxFactory.LineDirectivePosition(SyntaxFactory.Token(SyntaxKind.OpenParenToken), line, SyntaxFactory.Token(SyntaxKind.CommaToken), character, SyntaxFactory.Token(SyntaxKind.CloseParenToken));
+
+        /// <summary>Creates a new LineSpanDirectiveTriviaSyntax instance.</summary>
+        public static LineSpanDirectiveTriviaSyntax LineSpanDirectiveTrivia(SyntaxToken hashToken, SyntaxToken lineKeyword, LineDirectivePositionSyntax start, SyntaxToken minusToken, LineDirectivePositionSyntax end, SyntaxToken characterOffset, SyntaxToken file, SyntaxToken endOfDirectiveToken, bool isActive)
+        {
+            if (hashToken.Kind() != SyntaxKind.HashToken) throw new ArgumentException(nameof(hashToken));
+            if (lineKeyword.Kind() != SyntaxKind.LineKeyword) throw new ArgumentException(nameof(lineKeyword));
+            if (start == null) throw new ArgumentNullException(nameof(start));
+            if (minusToken.Kind() != SyntaxKind.MinusToken) throw new ArgumentException(nameof(minusToken));
+            if (end == null) throw new ArgumentNullException(nameof(end));
+            switch (characterOffset.Kind())
+            {
+                case SyntaxKind.NumericLiteralToken:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(characterOffset));
+            }
+            if (file.Kind() != SyntaxKind.StringLiteralToken) throw new ArgumentException(nameof(file));
+            if (endOfDirectiveToken.Kind() != SyntaxKind.EndOfDirectiveToken) throw new ArgumentException(nameof(endOfDirectiveToken));
+            return (LineSpanDirectiveTriviaSyntax)Syntax.InternalSyntax.SyntaxFactory.LineSpanDirectiveTrivia((Syntax.InternalSyntax.SyntaxToken)hashToken.Node!, (Syntax.InternalSyntax.SyntaxToken)lineKeyword.Node!, (Syntax.InternalSyntax.LineDirectivePositionSyntax)start.Green, (Syntax.InternalSyntax.SyntaxToken)minusToken.Node!, (Syntax.InternalSyntax.LineDirectivePositionSyntax)end.Green, (Syntax.InternalSyntax.SyntaxToken?)characterOffset.Node, (Syntax.InternalSyntax.SyntaxToken)file.Node!, (Syntax.InternalSyntax.SyntaxToken)endOfDirectiveToken.Node!, isActive).CreateRed();
+        }
+
+        /// <summary>Creates a new LineSpanDirectiveTriviaSyntax instance.</summary>
+        public static LineSpanDirectiveTriviaSyntax LineSpanDirectiveTrivia(LineDirectivePositionSyntax start, LineDirectivePositionSyntax end, SyntaxToken characterOffset, SyntaxToken file, bool isActive)
+            => SyntaxFactory.LineSpanDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.HashToken), SyntaxFactory.Token(SyntaxKind.LineKeyword), start, SyntaxFactory.Token(SyntaxKind.MinusToken), end, characterOffset, file, SyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken), isActive);
+
+        /// <summary>Creates a new LineSpanDirectiveTriviaSyntax instance.</summary>
+        public static LineSpanDirectiveTriviaSyntax LineSpanDirectiveTrivia(LineDirectivePositionSyntax start, LineDirectivePositionSyntax end, SyntaxToken file, bool isActive)
+            => SyntaxFactory.LineSpanDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.HashToken), SyntaxFactory.Token(SyntaxKind.LineKeyword), start, SyntaxFactory.Token(SyntaxKind.MinusToken), end, default, file, SyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken), isActive);
 
         /// <summary>Creates a new PragmaWarningDirectiveTriviaSyntax instance.</summary>
         public static PragmaWarningDirectiveTriviaSyntax PragmaWarningDirectiveTrivia(SyntaxToken hashToken, SyntaxToken pragmaKeyword, SyntaxToken warningKeyword, SyntaxToken disableOrRestoreKeyword, SeparatedSyntaxList<ExpressionSyntax> errorCodes, SyntaxToken endOfDirectiveToken, bool isActive)

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
@@ -15138,13 +15138,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public UndefDirectiveTriviaSyntax WithIsActive(bool isActive) => Update(this.HashToken, this.UndefKeyword, this.Name, this.EndOfDirectiveToken, isActive);
     }
 
+    public abstract partial class LineOrSpanDirectiveTriviaSyntax : DirectiveTriviaSyntax
+    {
+        internal LineOrSpanDirectiveTriviaSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
+          : base(green, parent, position)
+        {
+        }
+
+        public abstract SyntaxToken LineKeyword { get; }
+        public LineOrSpanDirectiveTriviaSyntax WithLineKeyword(SyntaxToken lineKeyword) => WithLineKeywordCore(lineKeyword);
+        internal abstract LineOrSpanDirectiveTriviaSyntax WithLineKeywordCore(SyntaxToken lineKeyword);
+
+        public abstract SyntaxToken File { get; }
+        public LineOrSpanDirectiveTriviaSyntax WithFile(SyntaxToken file) => WithFileCore(file);
+        internal abstract LineOrSpanDirectiveTriviaSyntax WithFileCore(SyntaxToken file);
+
+        public new LineOrSpanDirectiveTriviaSyntax WithHashToken(SyntaxToken hashToken) => (LineOrSpanDirectiveTriviaSyntax)WithHashTokenCore(hashToken);
+        public new LineOrSpanDirectiveTriviaSyntax WithEndOfDirectiveToken(SyntaxToken endOfDirectiveToken) => (LineOrSpanDirectiveTriviaSyntax)WithEndOfDirectiveTokenCore(endOfDirectiveToken);
+    }
+
     /// <remarks>
     /// <para>This node is associated with the following syntax kinds:</para>
     /// <list type="bullet">
     /// <item><description><see cref="SyntaxKind.LineDirectiveTrivia"/></description></item>
     /// </list>
     /// </remarks>
-    public sealed partial class LineDirectiveTriviaSyntax : DirectiveTriviaSyntax
+    public sealed partial class LineDirectiveTriviaSyntax : LineOrSpanDirectiveTriviaSyntax
     {
 
         internal LineDirectiveTriviaSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
@@ -15154,11 +15173,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         public override SyntaxToken HashToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LineDirectiveTriviaSyntax)this.Green).hashToken, Position, 0);
 
-        public SyntaxToken LineKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.LineDirectiveTriviaSyntax)this.Green).lineKeyword, GetChildPosition(1), GetChildIndex(1));
+        public override SyntaxToken LineKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.LineDirectiveTriviaSyntax)this.Green).lineKeyword, GetChildPosition(1), GetChildIndex(1));
 
         public SyntaxToken Line => new SyntaxToken(this, ((Syntax.InternalSyntax.LineDirectiveTriviaSyntax)this.Green).line, GetChildPosition(2), GetChildIndex(2));
 
-        public SyntaxToken File
+        public override SyntaxToken File
         {
             get
             {
@@ -15192,12 +15211,151 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         internal override DirectiveTriviaSyntax WithHashTokenCore(SyntaxToken hashToken) => WithHashToken(hashToken);
         public new LineDirectiveTriviaSyntax WithHashToken(SyntaxToken hashToken) => Update(hashToken, this.LineKeyword, this.Line, this.File, this.EndOfDirectiveToken, this.IsActive);
-        public LineDirectiveTriviaSyntax WithLineKeyword(SyntaxToken lineKeyword) => Update(this.HashToken, lineKeyword, this.Line, this.File, this.EndOfDirectiveToken, this.IsActive);
+        internal override LineOrSpanDirectiveTriviaSyntax WithLineKeywordCore(SyntaxToken lineKeyword) => WithLineKeyword(lineKeyword);
+        public new LineDirectiveTriviaSyntax WithLineKeyword(SyntaxToken lineKeyword) => Update(this.HashToken, lineKeyword, this.Line, this.File, this.EndOfDirectiveToken, this.IsActive);
         public LineDirectiveTriviaSyntax WithLine(SyntaxToken line) => Update(this.HashToken, this.LineKeyword, line, this.File, this.EndOfDirectiveToken, this.IsActive);
-        public LineDirectiveTriviaSyntax WithFile(SyntaxToken file) => Update(this.HashToken, this.LineKeyword, this.Line, file, this.EndOfDirectiveToken, this.IsActive);
+        internal override LineOrSpanDirectiveTriviaSyntax WithFileCore(SyntaxToken file) => WithFile(file);
+        public new LineDirectiveTriviaSyntax WithFile(SyntaxToken file) => Update(this.HashToken, this.LineKeyword, this.Line, file, this.EndOfDirectiveToken, this.IsActive);
         internal override DirectiveTriviaSyntax WithEndOfDirectiveTokenCore(SyntaxToken endOfDirectiveToken) => WithEndOfDirectiveToken(endOfDirectiveToken);
         public new LineDirectiveTriviaSyntax WithEndOfDirectiveToken(SyntaxToken endOfDirectiveToken) => Update(this.HashToken, this.LineKeyword, this.Line, this.File, endOfDirectiveToken, this.IsActive);
         public LineDirectiveTriviaSyntax WithIsActive(bool isActive) => Update(this.HashToken, this.LineKeyword, this.Line, this.File, this.EndOfDirectiveToken, isActive);
+    }
+
+    /// <remarks>
+    /// <para>This node is associated with the following syntax kinds:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="SyntaxKind.LineDirectivePosition"/></description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class LineDirectivePositionSyntax : CSharpSyntaxNode
+    {
+
+        internal LineDirectivePositionSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
+          : base(green, parent, position)
+        {
+        }
+
+        public SyntaxToken OpenParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LineDirectivePositionSyntax)this.Green).openParenToken, Position, 0);
+
+        public SyntaxToken Line => new SyntaxToken(this, ((Syntax.InternalSyntax.LineDirectivePositionSyntax)this.Green).line, GetChildPosition(1), GetChildIndex(1));
+
+        public SyntaxToken CommaToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LineDirectivePositionSyntax)this.Green).commaToken, GetChildPosition(2), GetChildIndex(2));
+
+        public SyntaxToken Character => new SyntaxToken(this, ((Syntax.InternalSyntax.LineDirectivePositionSyntax)this.Green).character, GetChildPosition(3), GetChildIndex(3));
+
+        public SyntaxToken CloseParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LineDirectivePositionSyntax)this.Green).closeParenToken, GetChildPosition(4), GetChildIndex(4));
+
+        internal override SyntaxNode? GetNodeSlot(int index) => null;
+
+        internal override SyntaxNode? GetCachedSlot(int index) => null;
+
+        public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitLineDirectivePosition(this);
+        public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitLineDirectivePosition(this);
+
+        public LineDirectivePositionSyntax Update(SyntaxToken openParenToken, SyntaxToken line, SyntaxToken commaToken, SyntaxToken character, SyntaxToken closeParenToken)
+        {
+            if (openParenToken != this.OpenParenToken || line != this.Line || commaToken != this.CommaToken || character != this.Character || closeParenToken != this.CloseParenToken)
+            {
+                var newNode = SyntaxFactory.LineDirectivePosition(openParenToken, line, commaToken, character, closeParenToken);
+                var annotations = GetAnnotations();
+                return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
+            }
+
+            return this;
+        }
+
+        public LineDirectivePositionSyntax WithOpenParenToken(SyntaxToken openParenToken) => Update(openParenToken, this.Line, this.CommaToken, this.Character, this.CloseParenToken);
+        public LineDirectivePositionSyntax WithLine(SyntaxToken line) => Update(this.OpenParenToken, line, this.CommaToken, this.Character, this.CloseParenToken);
+        public LineDirectivePositionSyntax WithCommaToken(SyntaxToken commaToken) => Update(this.OpenParenToken, this.Line, commaToken, this.Character, this.CloseParenToken);
+        public LineDirectivePositionSyntax WithCharacter(SyntaxToken character) => Update(this.OpenParenToken, this.Line, this.CommaToken, character, this.CloseParenToken);
+        public LineDirectivePositionSyntax WithCloseParenToken(SyntaxToken closeParenToken) => Update(this.OpenParenToken, this.Line, this.CommaToken, this.Character, closeParenToken);
+    }
+
+    /// <remarks>
+    /// <para>This node is associated with the following syntax kinds:</para>
+    /// <list type="bullet">
+    /// <item><description><see cref="SyntaxKind.LineSpanDirectiveTrivia"/></description></item>
+    /// </list>
+    /// </remarks>
+    public sealed partial class LineSpanDirectiveTriviaSyntax : LineOrSpanDirectiveTriviaSyntax
+    {
+        private LineDirectivePositionSyntax? start;
+        private LineDirectivePositionSyntax? end;
+
+        internal LineSpanDirectiveTriviaSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
+          : base(green, parent, position)
+        {
+        }
+
+        public override SyntaxToken HashToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LineSpanDirectiveTriviaSyntax)this.Green).hashToken, Position, 0);
+
+        public override SyntaxToken LineKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.LineSpanDirectiveTriviaSyntax)this.Green).lineKeyword, GetChildPosition(1), GetChildIndex(1));
+
+        public LineDirectivePositionSyntax Start => GetRed(ref this.start, 2)!;
+
+        public SyntaxToken MinusToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LineSpanDirectiveTriviaSyntax)this.Green).minusToken, GetChildPosition(3), GetChildIndex(3));
+
+        public LineDirectivePositionSyntax End => GetRed(ref this.end, 4)!;
+
+        public SyntaxToken CharacterOffset
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.LineSpanDirectiveTriviaSyntax)this.Green).characterOffset;
+                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(5), GetChildIndex(5)) : default;
+            }
+        }
+
+        public override SyntaxToken File => new SyntaxToken(this, ((Syntax.InternalSyntax.LineSpanDirectiveTriviaSyntax)this.Green).file, GetChildPosition(6), GetChildIndex(6));
+
+        public override SyntaxToken EndOfDirectiveToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LineSpanDirectiveTriviaSyntax)this.Green).endOfDirectiveToken, GetChildPosition(7), GetChildIndex(7));
+
+        public override bool IsActive => ((Syntax.InternalSyntax.LineSpanDirectiveTriviaSyntax)this.Green).IsActive;
+
+        internal override SyntaxNode? GetNodeSlot(int index)
+            => index switch
+            {
+                2 => GetRed(ref this.start, 2)!,
+                4 => GetRed(ref this.end, 4)!,
+                _ => null,
+            };
+
+        internal override SyntaxNode? GetCachedSlot(int index)
+            => index switch
+            {
+                2 => this.start,
+                4 => this.end,
+                _ => null,
+            };
+
+        public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitLineSpanDirectiveTrivia(this);
+        public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitLineSpanDirectiveTrivia(this);
+
+        public LineSpanDirectiveTriviaSyntax Update(SyntaxToken hashToken, SyntaxToken lineKeyword, LineDirectivePositionSyntax start, SyntaxToken minusToken, LineDirectivePositionSyntax end, SyntaxToken characterOffset, SyntaxToken file, SyntaxToken endOfDirectiveToken, bool isActive)
+        {
+            if (hashToken != this.HashToken || lineKeyword != this.LineKeyword || start != this.Start || minusToken != this.MinusToken || end != this.End || characterOffset != this.CharacterOffset || file != this.File || endOfDirectiveToken != this.EndOfDirectiveToken)
+            {
+                var newNode = SyntaxFactory.LineSpanDirectiveTrivia(hashToken, lineKeyword, start, minusToken, end, characterOffset, file, endOfDirectiveToken, isActive);
+                var annotations = GetAnnotations();
+                return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
+            }
+
+            return this;
+        }
+
+        internal override DirectiveTriviaSyntax WithHashTokenCore(SyntaxToken hashToken) => WithHashToken(hashToken);
+        public new LineSpanDirectiveTriviaSyntax WithHashToken(SyntaxToken hashToken) => Update(hashToken, this.LineKeyword, this.Start, this.MinusToken, this.End, this.CharacterOffset, this.File, this.EndOfDirectiveToken, this.IsActive);
+        internal override LineOrSpanDirectiveTriviaSyntax WithLineKeywordCore(SyntaxToken lineKeyword) => WithLineKeyword(lineKeyword);
+        public new LineSpanDirectiveTriviaSyntax WithLineKeyword(SyntaxToken lineKeyword) => Update(this.HashToken, lineKeyword, this.Start, this.MinusToken, this.End, this.CharacterOffset, this.File, this.EndOfDirectiveToken, this.IsActive);
+        public LineSpanDirectiveTriviaSyntax WithStart(LineDirectivePositionSyntax start) => Update(this.HashToken, this.LineKeyword, start, this.MinusToken, this.End, this.CharacterOffset, this.File, this.EndOfDirectiveToken, this.IsActive);
+        public LineSpanDirectiveTriviaSyntax WithMinusToken(SyntaxToken minusToken) => Update(this.HashToken, this.LineKeyword, this.Start, minusToken, this.End, this.CharacterOffset, this.File, this.EndOfDirectiveToken, this.IsActive);
+        public LineSpanDirectiveTriviaSyntax WithEnd(LineDirectivePositionSyntax end) => Update(this.HashToken, this.LineKeyword, this.Start, this.MinusToken, end, this.CharacterOffset, this.File, this.EndOfDirectiveToken, this.IsActive);
+        public LineSpanDirectiveTriviaSyntax WithCharacterOffset(SyntaxToken characterOffset) => Update(this.HashToken, this.LineKeyword, this.Start, this.MinusToken, this.End, characterOffset, this.File, this.EndOfDirectiveToken, this.IsActive);
+        internal override LineOrSpanDirectiveTriviaSyntax WithFileCore(SyntaxToken file) => WithFile(file);
+        public new LineSpanDirectiveTriviaSyntax WithFile(SyntaxToken file) => Update(this.HashToken, this.LineKeyword, this.Start, this.MinusToken, this.End, this.CharacterOffset, file, this.EndOfDirectiveToken, this.IsActive);
+        internal override DirectiveTriviaSyntax WithEndOfDirectiveTokenCore(SyntaxToken endOfDirectiveToken) => WithEndOfDirectiveToken(endOfDirectiveToken);
+        public new LineSpanDirectiveTriviaSyntax WithEndOfDirectiveToken(SyntaxToken endOfDirectiveToken) => Update(this.HashToken, this.LineKeyword, this.Start, this.MinusToken, this.End, this.CharacterOffset, this.File, endOfDirectiveToken, this.IsActive);
+        public LineSpanDirectiveTriviaSyntax WithIsActive(bool isActive) => Update(this.HashToken, this.LineKeyword, this.Start, this.MinusToken, this.End, this.CharacterOffset, this.File, this.EndOfDirectiveToken, isActive);
     }
 
     /// <remarks>

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2836,6 +2836,11 @@ top:
                     info.Kind = SyntaxKind.CommaToken;
                     break;
 
+                case '-':
+                    TextWindow.AdvanceChar();
+                    info.Kind = SyntaxKind.MinusToken;
+                    break;
+
                 case '!':
                     TextWindow.AdvanceChar();
                     if (TextWindow.PeekChar() == '=')

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 abstract Microsoft.CodeAnalysis.CSharp.Syntax.BaseExpressionColonSyntax.ColonToken.get -> Microsoft.CodeAnalysis.SyntaxToken
 abstract Microsoft.CodeAnalysis.CSharp.Syntax.BaseExpressionColonSyntax.Expression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax
+abstract Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax.File.get -> Microsoft.CodeAnalysis.SyntaxToken
+abstract Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax.LineKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp10 = 1000 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion
 Microsoft.CodeAnalysis.CSharp.Syntax.BaseExpressionColonSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.BaseExpressionColonSyntax.WithColonToken(Microsoft.CodeAnalysis.SyntaxToken colonToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.BaseExpressionColonSyntax
@@ -8,17 +10,66 @@ Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression, Microsoft.CodeAnalysis.SyntaxToken colonToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax.WithColonToken(Microsoft.CodeAnalysis.SyntaxToken colonToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax.WithExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression) -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.Character.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.CloseParenToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.CommaToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.Line.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.OpenParenToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken openParenToken, Microsoft.CodeAnalysis.SyntaxToken line, Microsoft.CodeAnalysis.SyntaxToken commaToken, Microsoft.CodeAnalysis.SyntaxToken character, Microsoft.CodeAnalysis.SyntaxToken closeParenToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.WithCharacter(Microsoft.CodeAnalysis.SyntaxToken character) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.WithCloseParenToken(Microsoft.CodeAnalysis.SyntaxToken closeParenToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.WithCommaToken(Microsoft.CodeAnalysis.SyntaxToken commaToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.WithLine(Microsoft.CodeAnalysis.SyntaxToken line) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.WithOpenParenToken(Microsoft.CodeAnalysis.SyntaxToken openParenToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+*REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectiveTriviaSyntax.File.get -> Microsoft.CodeAnalysis.SyntaxToken
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectiveTriviaSyntax.File.get -> Microsoft.CodeAnalysis.SyntaxToken
+*REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectiveTriviaSyntax.LineKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectiveTriviaSyntax.LineKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax.WithEndOfDirectiveToken(Microsoft.CodeAnalysis.SyntaxToken endOfDirectiveToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax.WithFile(Microsoft.CodeAnalysis.SyntaxToken file) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax.WithHashToken(Microsoft.CodeAnalysis.SyntaxToken hashToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax.WithLineKeyword(Microsoft.CodeAnalysis.SyntaxToken lineKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineOrSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.CharacterOffset.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.End.get -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.MinusToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.Start.get -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken hashToken, Microsoft.CodeAnalysis.SyntaxToken lineKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax start, Microsoft.CodeAnalysis.SyntaxToken minusToken, Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax end, Microsoft.CodeAnalysis.SyntaxToken characterOffset, Microsoft.CodeAnalysis.SyntaxToken file, Microsoft.CodeAnalysis.SyntaxToken endOfDirectiveToken, bool isActive) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.WithCharacterOffset(Microsoft.CodeAnalysis.SyntaxToken characterOffset) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.WithEnd(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax end) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.WithEndOfDirectiveToken(Microsoft.CodeAnalysis.SyntaxToken endOfDirectiveToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.WithFile(Microsoft.CodeAnalysis.SyntaxToken file) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.WithHashToken(Microsoft.CodeAnalysis.SyntaxToken hashToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.WithIsActive(bool isActive) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.WithLineKeyword(Microsoft.CodeAnalysis.SyntaxToken lineKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.WithMinusToken(Microsoft.CodeAnalysis.SyntaxToken minusToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.WithStart(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax start) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternSyntax.ExpressionColon.get -> Microsoft.CodeAnalysis.CSharp.Syntax.BaseExpressionColonSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternSyntax.Update(Microsoft.CodeAnalysis.CSharp.Syntax.BaseExpressionColonSyntax expressionColon, Microsoft.CodeAnalysis.CSharp.Syntax.PatternSyntax pattern) -> Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternSyntax.WithExpressionColon(Microsoft.CodeAnalysis.CSharp.Syntax.BaseExpressionColonSyntax expressionColon) -> Microsoft.CodeAnalysis.CSharp.Syntax.SubpatternSyntax
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.ExpressionColon = 9069 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.LineDirectivePosition = 9070 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.LineSpanDirectiveTrivia = 9071 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.RecordStructDeclaration = 9068 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 override Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetUsedAssemblyReferences(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.MetadataReference>
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitExpressionColon(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
+override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitLineDirectivePosition(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
+override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitLineSpanDirectiveTrivia(Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void
 override Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult> visitor) -> TResult
 override Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax.ColonToken.get -> Microsoft.CodeAnalysis.SyntaxToken
 override Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax.Expression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult> visitor) -> TResult
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult> visitor) -> TResult
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.EndOfDirectiveToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.File.get -> Microsoft.CodeAnalysis.SyntaxToken
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.HashToken.get -> Microsoft.CodeAnalysis.SyntaxToken
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.IsActive.get -> bool
+override Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax.LineKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken
 override Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax.Expression.get -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax
 *REMOVED*Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax.ColonToken.get -> Microsoft.CodeAnalysis.SyntaxToken
 override Microsoft.CodeAnalysis.CSharp.Syntax.NameColonSyntax.ColonToken.get -> Microsoft.CodeAnalysis.SyntaxToken
@@ -32,6 +83,11 @@ Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax.Update(
 Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax.Update(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.SyntaxTokenList modifiers, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax returnType, Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax parameterList, Microsoft.CodeAnalysis.SyntaxToken arrowToken, Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax block, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expressionBody) -> Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax.WithAttributeLists(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax> attributeLists) -> Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ExpressionColon(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expression, Microsoft.CodeAnalysis.SyntaxToken colonToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LineDirectivePosition(Microsoft.CodeAnalysis.SyntaxToken line, Microsoft.CodeAnalysis.SyntaxToken character) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LineDirectivePosition(Microsoft.CodeAnalysis.SyntaxToken openParenToken, Microsoft.CodeAnalysis.SyntaxToken line, Microsoft.CodeAnalysis.SyntaxToken commaToken, Microsoft.CodeAnalysis.SyntaxToken character, Microsoft.CodeAnalysis.SyntaxToken closeParenToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LineSpanDirectiveTrivia(Microsoft.CodeAnalysis.SyntaxToken hashToken, Microsoft.CodeAnalysis.SyntaxToken lineKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax start, Microsoft.CodeAnalysis.SyntaxToken minusToken, Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax end, Microsoft.CodeAnalysis.SyntaxToken characterOffset, Microsoft.CodeAnalysis.SyntaxToken file, Microsoft.CodeAnalysis.SyntaxToken endOfDirectiveToken, bool isActive) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LineSpanDirectiveTrivia(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax start, Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax end, Microsoft.CodeAnalysis.SyntaxToken characterOffset, Microsoft.CodeAnalysis.SyntaxToken file, bool isActive) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.LineSpanDirectiveTrivia(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax start, Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax end, Microsoft.CodeAnalysis.SyntaxToken file, bool isActive) -> Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax.WithReturnType(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax returnType) -> Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParenthesizedLambdaExpression(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.SyntaxTokenList modifiers, Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax parameterList, Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax block, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expressionBody) -> Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParenthesizedLambdaExpression(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.SyntaxTokenList modifiers, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax returnType, Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax parameterList, Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax block, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expressionBody) -> Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax
@@ -55,7 +111,11 @@ Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax.GlobalKeyword.get -> M
 Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken globalKeyword, Microsoft.CodeAnalysis.SyntaxToken usingKeyword, Microsoft.CodeAnalysis.SyntaxToken staticKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.NameEqualsSyntax alias, Microsoft.CodeAnalysis.CSharp.Syntax.NameSyntax name, Microsoft.CodeAnalysis.SyntaxToken semicolonToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax.WithGlobalKeyword(Microsoft.CodeAnalysis.SyntaxToken globalKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.UsingDirectiveSyntax
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitExpressionColon(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax node) -> void
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitLineDirectivePosition(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax node) -> void
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitLineSpanDirectiveTrivia(Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax node) -> void
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitExpressionColon(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionColonSyntax node) -> TResult
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitLineDirectivePosition(Microsoft.CodeAnalysis.CSharp.Syntax.LineDirectivePositionSyntax node) -> TResult
+virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitLineSpanDirectiveTrivia(Microsoft.CodeAnalysis.CSharp.Syntax.LineSpanDirectiveTriviaSyntax node) -> TResult
 *REMOVED*Microsoft.CodeAnalysis.CSharp.SyntaxKind.DataKeyword = 8441 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.GetLineMappings(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.LineMapping>
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.OperatorDeclaration(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.SyntaxTokenList modifiers, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax returnType, Microsoft.CodeAnalysis.CSharp.Syntax.ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier, Microsoft.CodeAnalysis.SyntaxToken operatorKeyword, Microsoft.CodeAnalysis.SyntaxToken operatorToken, Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax parameterList, Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax body, Microsoft.CodeAnalysis.CSharp.Syntax.ArrowExpressionClauseSyntax expressionBody, Microsoft.CodeAnalysis.SyntaxToken semicolonToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.OperatorDeclarationSyntax

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpLineDirectiveMap.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpLineDirectiveMap.cs
@@ -81,6 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     }
 
                 case LineSpanDirectiveTriviaSyntax spanDirective:
+                    if (!spanDirective.HasErrors)
                     {
                         LinePosition mappedStart = default;
                         LinePosition mappedEnd = default;
@@ -94,9 +95,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                         {
                             return new LineMappingEntry(unmappedLine, new LinePositionSpan(mappedStart, mappedEnd), characterOffset, mappedPathOpt);
                         }
-
-                        return new LineMappingEntry(unmappedLine, unmappedLine, mappedPathOpt: null, PositionState.Unmapped);
                     }
+
+                    return new LineMappingEntry(unmappedLine, unmappedLine, mappedPathOpt: null, PositionState.Unmapped);
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(directive);

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpLineDirectiveMap.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpLineDirectiveMap.cs
@@ -204,6 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     }
 
                 case PositionState.Remapped:
+                case PositionState.RemappedSpan:
                     return LineVisibility.Visible;
 
                 case PositionState.Hidden:

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpLineDirectiveMap.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpLineDirectiveMap.cs
@@ -77,11 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                             }
                         }
 
-                        return new LineMappingEntry(
-                            unmappedLine,
-                            mappedLine,
-                            mappedPathOpt,
-                            state);
+                        return new LineMappingEntry(unmappedLine, mappedLine, mappedPathOpt, state);
                     }
 
                 case LineSpanDirectiveTriviaSyntax spanDirective:

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -4735,12 +4735,16 @@
     </Field>
     <Field Name="IsActive" Type="bool" Override="true"/>
   </Node>
-  <Node Name="LineDirectiveTriviaSyntax" Base="DirectiveTriviaSyntax">
+  <AbstractNode Name="LineOrSpanDirectiveTriviaSyntax" Base="DirectiveTriviaSyntax">
+    <Field Name="LineKeyword" Type="SyntaxToken" />
+    <Field Name="File" Type="SyntaxToken" />
+  </AbstractNode>
+  <Node Name="LineDirectiveTriviaSyntax" Base="LineOrSpanDirectiveTriviaSyntax">
     <Kind Name="LineDirectiveTrivia"/>
     <Field Name="HashToken" Type="SyntaxToken" Override="true">
       <Kind Name="HashToken"/>
     </Field>
-    <Field Name="LineKeyword" Type="SyntaxToken">
+    <Field Name="LineKeyword" Type="SyntaxToken" Override="true">
       <Kind Name="LineKeyword"/>
     </Field>
     <Field Name="Line" Type="SyntaxToken">
@@ -4748,7 +4752,49 @@
       <Kind Name="DefaultKeyword"/>
       <Kind Name="HiddenKeyword"/>
     </Field>
-    <Field Name="File" Type="SyntaxToken" Optional="true">
+    <Field Name="File" Type="SyntaxToken" Optional="true" Override="true">
+      <Kind Name="StringLiteralToken"/>
+    </Field>
+    <Field Name="EndOfDirectiveToken" Type="SyntaxToken" Override="true">
+      <Kind Name="EndOfDirectiveToken"/>
+    </Field>
+    <Field Name="IsActive" Type="bool" Override="true"/>
+  </Node>
+  <Node Name="LineDirectivePositionSyntax" Base="CSharpSyntaxNode">
+    <Kind Name="LineDirectivePosition"/>
+    <Field Name="OpenParenToken" Type="SyntaxToken">
+      <Kind Name="OpenParenToken"/>
+    </Field>
+    <Field Name="Line" Type="SyntaxToken">
+      <Kind Name="NumericLiteralToken"/>
+    </Field>
+    <Field Name="CommaToken" Type="SyntaxToken">
+      <Kind Name="CommaToken"/>
+    </Field>
+    <Field Name="Character" Type="SyntaxToken">
+      <Kind Name="NumericLiteralToken"/>
+    </Field>
+    <Field Name="CloseParenToken" Type="SyntaxToken">
+      <Kind Name="CloseParenToken"/>
+    </Field>
+  </Node>
+  <Node Name="LineSpanDirectiveTriviaSyntax" Base="LineOrSpanDirectiveTriviaSyntax">
+    <Kind Name="LineSpanDirectiveTrivia"/>
+    <Field Name="HashToken" Type="SyntaxToken" Override="true">
+      <Kind Name="HashToken"/>
+    </Field>
+    <Field Name="LineKeyword" Type="SyntaxToken" Override="true">
+      <Kind Name="LineKeyword"/>
+    </Field>
+     <Field Name="Start" Type="LineDirectivePositionSyntax" />
+     <Field Name="MinusToken" Type="SyntaxToken">
+      <Kind Name="MinusToken"/>
+    </Field>
+    <Field Name="End" Type="LineDirectivePositionSyntax" />
+    <Field Name="CharacterOffset" Type="SyntaxToken"  Optional="true">
+      <Kind Name="NumericLiteralToken"/>
+    </Field>
+    <Field Name="File" Type="SyntaxToken" Override="true">
       <Kind Name="StringLiteralToken"/>
     </Field>
     <Field Name="EndOfDirectiveToken" Type="SyntaxToken" Override="true">

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -4737,7 +4737,7 @@
   </Node>
   <AbstractNode Name="LineOrSpanDirectiveTriviaSyntax" Base="DirectiveTriviaSyntax">
     <Field Name="LineKeyword" Type="SyntaxToken" />
-    <Field Name="File" Type="SyntaxToken" />
+    <Field Name="File" Type="SyntaxToken" Optional="true" />
   </AbstractNode>
   <Node Name="LineDirectiveTriviaSyntax" Base="LineOrSpanDirectiveTriviaSyntax">
     <Kind Name="LineDirectiveTrivia"/>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -859,5 +859,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         RecordStructDeclaration = 9068,
 
         ExpressionColon = 9069,
+        LineDirectivePosition = 9070,
+        LineSpanDirectiveTrivia = 9071,
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -247,6 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.ErrorDirectiveTrivia:
                 case SyntaxKind.WarningDirectiveTrivia:
                 case SyntaxKind.LineDirectiveTrivia:
+                case SyntaxKind.LineSpanDirectiveTrivia:
                 case SyntaxKind.PragmaWarningDirectiveTrivia:
                 case SyntaxKind.PragmaChecksumDirectiveTrivia:
                 case SyntaxKind.ReferenceDirectiveTrivia:

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Metoda {0} s blokem iterátoru musí být asynchronní, aby vrátila {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -677,6 +677,16 @@
         <target state="translated">Metoda {0} s blokem iterátoru musí být asynchronní, aby vrátila {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">Žádná přetížená metoda {0} neodpovídá ukazateli na funkci {1}.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Die Methode "{0}" mit einem Iteratorblock muss "async" lauten, um "{1}" zurückzugeben.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -677,6 +677,16 @@
         <target state="translated">Die Methode "{0}" mit einem Iteratorblock muss "async" lauten, um "{1}" zurückzugeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">Keine Überladung für "{0}" stimmt mit dem Funktionszeiger "{1}" überein.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -677,6 +677,16 @@
         <target state="translated">El método "{0}" con un bloqueo de iterador debe ser "asincrónico" para devolver "{1}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">Ninguna sobrecarga correspondiente a "{0}" coincide con el puntero de función "{1}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -677,9 +677,9 @@
         <target state="translated">El método "{0}" con un bloqueo de iterador debe ser "asincrónico" para devolver "{1}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -677,6 +677,16 @@
         <target state="translated">La méthode '{0}' avec un bloc itérateur doit être 'async' pour retourner '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">Aucune surcharge pour '{0}' ne correspond au pointeur de fonction '{1}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -677,9 +677,9 @@
         <target state="translated">La méthode '{0}' avec un bloc itérateur doit être 'async' pour retourner '{1}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Il metodo '{0}' con un blocco iteratore deve essere 'async' per restituire '{1}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -677,6 +677,16 @@
         <target state="translated">Il metodo '{0}' con un blocco iteratore deve essere 'async' per restituire '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">Nessun overload per '{0}' corrisponde al puntatore a funzione '{1}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -677,9 +677,9 @@
         <target state="translated">反復子ブロックを伴うメソッド '{0}' が '{1}' を返すには 'async' でなければなりません</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -677,6 +677,16 @@
         <target state="translated">反復子ブロックを伴うメソッド '{0}' が '{1}' を返すには 'async' でなければなりません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">関数ポインター '{1}' に一致する '{0}' のオーバーロードはありません</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -677,6 +677,16 @@
         <target state="translated">'{1}'을(를) 반환하려면 반복기 블록이 있는 '{0}' 메서드가 '비동기'여야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">함수 포인터 '{1}'과(와) 일치하는 '{0}'에 대한 오버로드가 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -677,9 +677,9 @@
         <target state="translated">'{1}'을(를) 반환하려면 반복기 블록이 있는 '{0}' 메서드가 '비동기'여야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Metoda „{0}” z blokiem iteratora musi być oznaczona jako „async”, aby zwrócić „{1}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -677,6 +677,16 @@
         <target state="translated">Metoda „{0}” z blokiem iteratora musi być oznaczona jako „async”, aby zwrócić „{1}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">Żadne z przeciążeń dla elementu „{0}” nie pasuje do wskaźnika funkcji „{1}”</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -677,6 +677,16 @@
         <target state="translated">O método '{0}' com um bloco do iterador deve ser 'async' para retornar '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">Nenhuma sobrecarga de '{0}' corresponde ao ponteiro de função '{1}'</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -677,9 +677,9 @@
         <target state="translated">O método '{0}' com um bloco do iterador deve ser 'async' para retornar '{1}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -677,6 +677,16 @@
         <target state="translated">Чтобы возвращать "{1}", метод "{0}" с блоком итератора должен быть асинхронным ("async").</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">Нет перегруженного метода для "{0}", который соответствует указателю на функцию "{1}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Чтобы возвращать "{1}", метод "{0}" с блоком итератора должен быть асинхронным ("async").</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -677,6 +677,16 @@
         <target state="translated">Yineleyici bloku olan '{0}' yönteminin '{1}' döndürmek için 'zaman uyumsuz' olması gerekir</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">'{0}' için aşırı yüklemelerin hiçbiri '{1}' işlev işaretçisiyle eşleşmiyor</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Yineleyici bloku olan '{0}' yönteminin '{1}' döndürmek için 'zaman uyumsuz' olması gerekir</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -677,9 +677,9 @@
         <target state="translated">具有迭代器块的方法“{0}”必须是“异步的”，这样才能返回“{1}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -677,6 +677,16 @@
         <target state="translated">具有迭代器块的方法“{0}”必须是“异步的”，这样才能返回“{1}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">“{0}”没有与函数指针“{1}”匹配的重载</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1137,6 +1137,11 @@
         <target state="new">lambda return type</target>
         <note />
       </trans-unit>
+      <trans-unit id="IDS_FeatureLineSpanDirective">
+        <source>line span directive</source>
+        <target state="new">line span directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IDS_FeaturePositionalFieldsInRecords">
         <source>positional fields in records</source>
         <target state="new">positional fields in records</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -677,9 +677,9 @@
         <target state="translated">具有迭代區塊的方法 '{0}' 必須為「非同步」才能傳回 '{1}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
-        <source>The #line directive span is invalid</source>
-        <target state="new">The #line directive span is invalid</target>
+      <trans-unit id="ERR_LineSpanDirectiveEndLessThanStart">
+        <source>The #line directive end position must be greater than or equal to the start position</source>
+        <target state="new">The #line directive end position must be greater than or equal to the start position</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveInvalidValue">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -677,6 +677,16 @@
         <target state="translated">具有迭代區塊的方法 '{0}' 必須為「非同步」才能傳回 '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidSpan">
+        <source>The #line directive span is invalid</source>
+        <target state="new">The #line directive span is invalid</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveInvalidValue">
+        <source>The #line directive value is missing or out of range</source>
+        <target state="new">The #line directive value is missing or out of range</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MethFuncPtrMismatch">
         <source>No overload for '{0}' matches function pointer '{1}'</source>
         <target state="translated">'{0}' 沒有任何多載符合函式指標 '{1}'</target>

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         F();
     }
     static void F() { }
-}";
+}".NormalizeLineEndings();
 
             var tree = SyntaxFactory.ParseSyntaxTree(source);
             var comp = CreateCompilation(tree);
@@ -244,6 +244,25 @@ void Render()
                 "(10,0)-(11,1) -> : (0,0)-(0,0)",
             };
             AssertEx.Equal(expectedLineMappings, actualLineMappings);
+
+            var textB = SourceText.From(sourceB);
+            var actualVisibility = textB.Lines.Select(line => treeB.GetLineVisibility(line.Start)).ToImmutableArray();
+            var expectedVisibility = new[]
+            {
+                LineVisibility.BeforeFirstLineDirective,
+                LineVisibility.Hidden,
+                LineVisibility.Hidden,
+                LineVisibility.Hidden,
+                LineVisibility.Hidden,
+                LineVisibility.Hidden,
+                LineVisibility.Visible,
+                LineVisibility.Visible,
+                LineVisibility.Visible,
+                LineVisibility.Visible,
+                LineVisibility.Hidden,
+                LineVisibility.Hidden,
+            };
+            AssertEx.Equal(expectedVisibility, actualVisibility);
 
             var statements = GetStatementsAndExpressionBodies(treeB);
             var actualTextSpans = statements.SelectAsArray(s => GetTextMapping(textA, treeB, s));

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
@@ -1,0 +1,306 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class LineSpanDirectiveTests : CSharpTestBase
+    {
+        [Fact]
+        public void LineSpanDirective_SingleLine()
+        {
+            string sourceA =
+@"         A1(); A2(); A3(); //123
+//4567890
+".NormalizeLineEndings();
+            var textA = SourceText.From(sourceA);
+
+            string sourceB =
+@"class Program
+{
+    static void Main()
+    {
+#line (1, 16) - (1, 26) 15 ""a.cs""
+        B1(); A2(); A3(); B4();
+        B5();
+    }
+}
+".NormalizeLineEndings();
+
+            var treeB = SyntaxFactory.ParseSyntaxTree(sourceB, path: "b.cs");
+            treeB.GetDiagnostics().Verify();
+
+            var actualLineMappings = GetLineMappings(treeB);
+            var expectedLineMappings = new[]
+            {
+                "(0,0)-(3,7) -> : (0,0)-(3,7)",
+                "(5,0)-(9,0),14 -> a.cs: (0,15)-(0,26)",
+            };
+            AssertEx.Equal(expectedLineMappings, actualLineMappings);
+
+            var statements = treeB.GetRoot().DescendantNodes().OfType<ExpressionStatementSyntax>().ToImmutableArray();
+            var actualTextSpans = statements.SelectAsArray(s => GetTextMapping(textA, treeB, s));
+            var expectedTextSpans = new[]
+            {
+                (@"B1();", @"[|A2(); A3();|]"),
+                (@"A2();", @"[|A2(); A3();|]"),
+                (@"A3();", @"[|A3();|]"),
+                (@"B4();", @"[|//123|]"),
+                (@"B5();", @"[|0|]"),
+            };
+            AssertEx.Equal(expectedTextSpans, actualTextSpans);
+        }
+
+        // 1. First and subsequent spans
+        [WorkItem(4747, "https://github.com/dotnet/csharplang/issues/4747")]
+        [Fact]
+        public void LineSpanDirective_Example1()
+        {
+            string sourceA =
+@"         A();B(
+);C();
+    D();
+".NormalizeLineEndings();
+            var textA = SourceText.From(sourceA);
+
+            string sourceB =
+@"class Program
+{
+ static void Main() {
+#line (1,10)-(1,15) 3 ""a"" // 3
+  A();B(              // 4
+);C();                // 5
+    D();              // 6
+ }
+ static void A() { }
+ static void B() { }
+ static void C() { }
+ static void D() { }
+}".NormalizeLineEndings();
+
+            var treeB = SyntaxFactory.ParseSyntaxTree(sourceB, path: "b.cs");
+            treeB.GetDiagnostics().Verify();
+
+            var actualLineMappings = GetLineMappings(treeB);
+            var expectedLineMappings = new[]
+            {
+                "(0,0)-(2,23) -> : (0,0)-(2,23)",
+                "(4,0)-(12,1),2 -> a: (0,9)-(0,15)",
+            };
+            AssertEx.Equal(expectedLineMappings, actualLineMappings);
+
+            var statements = treeB.GetRoot().DescendantNodes().OfType<ExpressionStatementSyntax>().ToImmutableArray();
+            var actualTextSpans = statements.SelectAsArray(s => GetTextMapping(textA, treeB, s));
+            var expectedTextSpans = new[]
+            {
+                (@"A();", @"[|A();B(|]"),
+                (@"B(              // 4...", @"[|B(
+);|]"),
+                (@"C();", @"[|C();|]"),
+                (@"D();", @"[|D();|]"),
+            };
+            AssertEx.Equal(expectedTextSpans, actualTextSpans);
+        }
+
+        // 5. Razor: block constructs
+        [WorkItem(4747, "https://github.com/dotnet/csharplang/issues/4747")]
+        [Fact]
+        public void LineSpanDirective_Example5()
+        {
+            string sourceA =
+@"@Html.Helper(() =>
+{
+    <p>Hello World</p>
+    @DateTime.Now
+})".NormalizeLineEndings();
+            var textA = SourceText.From(sourceA);
+
+            string sourceB =
+@"using System;
+class Page
+{
+    Builder _builder;
+    void Execute()
+    {
+#line (1, 2) - (5, 2) 22 ""a.razor"" // spanof('HtmlHelper(() => { ... })')
+        _builder.Add(Html.Helper(() =>
+#line 2 ""a.razor"" // lineof('{')
+        {
+#line (4, 6) - (4, 17) 26 ""a.razor"" // spanof('DateTime.Now')
+            _builder.Add(DateTime.Now);
+#line 5 ""a.razor"" // lineof('})')
+        })
+#line hidden
+        );
+    }
+}".NormalizeLineEndings();
+
+            var treeB = SyntaxFactory.ParseSyntaxTree(sourceB, path: "a.razor.g.cs");
+            treeB.GetDiagnostics().Verify();
+
+            var actualLineMappings = GetLineMappings(treeB);
+            var expectedLineMappings = new[]
+            {
+                "(0,0)-(5,7) -> : (0,0)-(5,7)",
+                "(7,0)-(7,40),21 -> a.razor: (0,1)-(4,2)",
+                "(9,0)-(9,11) -> a.razor: (1,0)-(1,11)",
+                "(11,0)-(11,41),25 -> a.razor: (3,5)-(3,17)",
+                "(13,0)-(13,12) -> a.razor: (4,0)-(4,12)",
+                "(15,0)-(17,1) -> : (0,0)-(0,0)",
+            };
+            AssertEx.Equal(expectedLineMappings, actualLineMappings);
+
+            var statements = treeB.GetRoot().DescendantNodes().OfType<ExpressionStatementSyntax>().ToImmutableArray();
+            var actualTextSpans = statements.SelectAsArray(s => GetTextMapping(textA, treeB, s));
+            var expectedTextSpans = new[]
+            {
+                (@"_builder.Add(Html.Helper(() =>...", @"[|Html.Helper(() =>
+{
+    <p>Hello World</p>
+    @DateTime.Now
+})|]"),
+                (@"_builder.Add(DateTime.Now);", @"[|DateTime.Now|]"),
+            };
+            AssertEx.Equal(expectedTextSpans, actualTextSpans);
+        }
+
+        private static ImmutableArray<string> GetLineMappings(SyntaxTree tree)
+        {
+            return tree.GetLineMappings().Select(mapping => mapping.ToString()!).ToImmutableArray();
+        }
+
+        private static (string, string) GetTextMapping(SourceText mappedText, SyntaxTree unmappedText, SyntaxNode syntax)
+        {
+            return (getDescription(syntax), getMapping(mappedText, unmappedText, syntax));
+
+            static string getDescription(SyntaxNode syntax)
+            {
+                var description = syntax.ToString();
+                int index = description.IndexOfAny(new[] { '\r', '\n' });
+                return index < 0 ?
+                    description :
+                    description.Substring(0, index) + "...";
+            }
+
+            static string getMapping(SourceText mappedText, SyntaxTree unmappedText, SyntaxNode syntax)
+            {
+                var mappedLineAndPositionSpan = unmappedText.GetMappedLineSpanAndVisibility(syntax.Span, out _);
+                var span = getTextSpan(mappedText.Lines, mappedLineAndPositionSpan.Span);
+                return $"[|{mappedText.GetSubText(span)}|]";
+            }
+
+            static TextSpan getTextSpan(TextLineCollection lines, LinePositionSpan span)
+            {
+                return TextSpan.FromBounds(getTextPosition(lines, span.Start), getTextPosition(lines, span.End));
+            }
+
+            static int getTextPosition(TextLineCollection lines, LinePosition position)
+            {
+                if (position.Line < lines.Count)
+                {
+                    var line = lines[position.Line];
+                    return Math.Min(line.Start + position.Character, line.End);
+                }
+                return (lines.Count == 0) ? 0 : lines[^1].End;
+            }
+        }
+
+        [Fact]
+        public void Diagnostics()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+#line (3, 3) - (6, 6) 8 ""a.txt""
+        A();
+#line default
+        B();
+#line (1, 1) - (1, 100) ""b.txt""
+        C();
+    }
+}".NormalizeLineEndings();
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // b.txt(1,9): error CS0103: The name 'C' does not exist in the current context
+                //         C();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(1, 9),
+                // a.txt(3,4): error CS0103: The name 'A' does not exist in the current context
+                //         A();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "A").WithArguments("A").WithLocation(3, 4),
+                // (8,9): error CS0103: The name 'B' does not exist in the current context
+                //         B();
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "B").WithArguments("B").WithLocation(8, 9));
+        }
+
+        [Fact]
+        public void SequencePoints()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+#line (3, 3) - (6, 6) 8 ""a.txt""
+        A();
+#line default
+        B();
+#line (1, 1) - (1, 100) ""b.txt""
+        C();
+    }
+    static void A() { }
+    static void B() { }
+    static void C() { }
+}".NormalizeLineEndings();
+            var verifier = CompileAndVerify(source, options: TestOptions.DebugDll);
+            verifier.VerifyIL("Program.Main", sequencePoints: "Program.Main", expectedIL:
+@"{
+  // Code size       20 (0x14)
+  .maxstack  0
+ -IL_0000:  nop
+ -IL_0001:  call       ""void Program.A()""
+  IL_0006:  nop
+ -IL_0007:  call       ""void Program.B()""
+  IL_000c:  nop
+ -IL_000d:  call       ""void Program.C()""
+  IL_0012:  nop
+ -IL_0013:  ret
+}");
+            verifier.VerifyPdb("Program.Main", expectedPdb:
+@"<symbols>
+  <files>
+    <file id=""1"" name="""" language=""C#"" />
+    <file id=""2"" name=""a.txt"" language=""C#"" />
+    <file id=""3"" name=""b.txt"" language=""C#"" />
+  </files>
+  <methods>
+    <method containingType=""Program"" name=""Main"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""3"" startColumn=""4"" endLine=""3"" endColumn=""8"" document=""2"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""13"" document=""1"" />
+        <entry offset=""0xd"" startLine=""1"" startColumn=""9"" endLine=""1"" endColumn=""13"" document=""3"" />
+        <entry offset=""0x13"" startLine=""2"" startColumn=""5"" endLine=""2"" endColumn=""6"" document=""3"" />
+      </sequencePoints>
+    </method>
+  </methods>
+</symbols>");
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             {
                 (@"A();", @"[|A();B(|]"),
                 (@"B(              // 4...", @"[|B(
-);|]"),
+);|]".NormalizeLineEndings()),
                 (@"C();", @"[|C();|]"),
                 (@"D();", @"[|D();|]"),
             };
@@ -168,7 +168,7 @@ class Page
 {
     <p>Hello World</p>
     @DateTime.Now
-})|]"),
+})|]".NormalizeLineEndings()),
                 (@"_builder.Add(DateTime.Now);", @"[|DateTime.Now|]"),
             };
             AssertEx.Equal(expectedTextSpans, actualTextSpans);

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/LineSpanDirectiveTests.cs
@@ -135,16 +135,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 }";
 
             var tree = SyntaxFactory.ParseSyntaxTree(source);
-            tree.GetDiagnostics().Verify();
-
             var comp = CreateCompilation(tree);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (9,18): error CS8939: The #line directive end position must be greater than or equal to the start position
+                // #line (10, 20) - (9, 20) "C"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveEndLessThanStart, "(9, 20)").WithLocation(9, 18),
+                // A(11,18): error CS8939: The #line directive end position must be greater than or equal to the start position
+                // #line (10, 20) - (10, 19) "B"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveEndLessThanStart, "(10, 19)").WithLocation(11, 18));
 
             var actualLineMappings = GetLineMappings(tree);
             var expectedLineMappings = new[]
             {
                 "(0,0)-(3,7) -> : (0,0)-(3,7)",
-                "(5,0)-(9,0),14 -> a.cs: (0,15)-(4,26)",
+                "(5,0)-(5,14) -> A: (9,19)-(9,20)",
+                "(7,0)-(7,14) -> : (7,0)-(7,14)",
+                "(9,0)-(9,14) -> : (9,0)-(9,14)",
+                "(11,0)-(14,1) -> D: (9,19)-(10,19)",
             };
             AssertEx.Equal(expectedLineMappings, actualLineMappings);
         }

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -688,6 +688,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private static Syntax.InternalSyntax.LineDirectiveTriviaSyntax GenerateLineDirectiveTrivia()
             => InternalSyntaxFactory.LineDirectiveTrivia(InternalSyntaxFactory.Token(SyntaxKind.HashToken), InternalSyntaxFactory.Token(SyntaxKind.LineKeyword), InternalSyntaxFactory.Literal(null, "1", 1, null), null, InternalSyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken), new bool());
 
+        private static Syntax.InternalSyntax.LineDirectivePositionSyntax GenerateLineDirectivePosition()
+            => InternalSyntaxFactory.LineDirectivePosition(InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), InternalSyntaxFactory.Literal(null, "1", 1, null), InternalSyntaxFactory.Token(SyntaxKind.CommaToken), InternalSyntaxFactory.Literal(null, "1", 1, null), InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken));
+
+        private static Syntax.InternalSyntax.LineSpanDirectiveTriviaSyntax GenerateLineSpanDirectiveTrivia()
+            => InternalSyntaxFactory.LineSpanDirectiveTrivia(InternalSyntaxFactory.Token(SyntaxKind.HashToken), InternalSyntaxFactory.Token(SyntaxKind.LineKeyword), GenerateLineDirectivePosition(), InternalSyntaxFactory.Token(SyntaxKind.MinusToken), GenerateLineDirectivePosition(), null, InternalSyntaxFactory.Literal(null, "string", "string", null), InternalSyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken), new bool());
+
         private static Syntax.InternalSyntax.PragmaWarningDirectiveTriviaSyntax GeneratePragmaWarningDirectiveTrivia()
             => InternalSyntaxFactory.PragmaWarningDirectiveTrivia(InternalSyntaxFactory.Token(SyntaxKind.HashToken), InternalSyntaxFactory.Token(SyntaxKind.PragmaKeyword), InternalSyntaxFactory.Token(SyntaxKind.WarningKeyword), InternalSyntaxFactory.Token(SyntaxKind.DisableKeyword), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ExpressionSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken), new bool());
 
@@ -3586,6 +3592,38 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.LineKeyword, node.LineKeyword.Kind);
             Assert.Equal(SyntaxKind.NumericLiteralToken, node.Line.Kind);
             Assert.Null(node.File);
+            Assert.Equal(SyntaxKind.EndOfDirectiveToken, node.EndOfDirectiveToken.Kind);
+            Assert.Equal(new bool(), node.IsActive);
+
+            AttachAndCheckDiagnostics(node);
+        }
+
+        [Fact]
+        public void TestLineDirectivePositionFactoryAndProperties()
+        {
+            var node = GenerateLineDirectivePosition();
+
+            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, node.Line.Kind);
+            Assert.Equal(SyntaxKind.CommaToken, node.CommaToken.Kind);
+            Assert.Equal(SyntaxKind.NumericLiteralToken, node.Character.Kind);
+            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
+
+            AttachAndCheckDiagnostics(node);
+        }
+
+        [Fact]
+        public void TestLineSpanDirectiveTriviaFactoryAndProperties()
+        {
+            var node = GenerateLineSpanDirectiveTrivia();
+
+            Assert.Equal(SyntaxKind.HashToken, node.HashToken.Kind);
+            Assert.Equal(SyntaxKind.LineKeyword, node.LineKeyword.Kind);
+            Assert.NotNull(node.Start);
+            Assert.Equal(SyntaxKind.MinusToken, node.MinusToken.Kind);
+            Assert.NotNull(node.End);
+            Assert.Null(node.CharacterOffset);
+            Assert.Equal(SyntaxKind.StringLiteralToken, node.File.Kind);
             Assert.Equal(SyntaxKind.EndOfDirectiveToken, node.EndOfDirectiveToken.Kind);
             Assert.Equal(new bool(), node.IsActive);
 
@@ -9560,6 +9598,58 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void TestLineDirectivePositionTokenDeleteRewriter()
+        {
+            var oldNode = GenerateLineDirectivePosition();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestLineDirectivePositionIdentityRewriter()
+        {
+            var oldNode = GenerateLineDirectivePosition();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
+        public void TestLineSpanDirectiveTriviaTokenDeleteRewriter()
+        {
+            var oldNode = GenerateLineSpanDirectiveTrivia();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestLineSpanDirectiveTriviaIdentityRewriter()
+        {
+            var oldNode = GenerateLineSpanDirectiveTrivia();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
         public void TestPragmaWarningDirectiveTriviaTokenDeleteRewriter()
         {
             var oldNode = GeneratePragmaWarningDirectiveTrivia();
@@ -10397,6 +10487,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         private static LineDirectiveTriviaSyntax GenerateLineDirectiveTrivia()
             => SyntaxFactory.LineDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.HashToken), SyntaxFactory.Token(SyntaxKind.LineKeyword), SyntaxFactory.Literal("1", 1), default(SyntaxToken), SyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken), new bool());
+
+        private static LineDirectivePositionSyntax GenerateLineDirectivePosition()
+            => SyntaxFactory.LineDirectivePosition(SyntaxFactory.Token(SyntaxKind.OpenParenToken), SyntaxFactory.Literal("1", 1), SyntaxFactory.Token(SyntaxKind.CommaToken), SyntaxFactory.Literal("1", 1), SyntaxFactory.Token(SyntaxKind.CloseParenToken));
+
+        private static LineSpanDirectiveTriviaSyntax GenerateLineSpanDirectiveTrivia()
+            => SyntaxFactory.LineSpanDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.HashToken), SyntaxFactory.Token(SyntaxKind.LineKeyword), GenerateLineDirectivePosition(), SyntaxFactory.Token(SyntaxKind.MinusToken), GenerateLineDirectivePosition(), default(SyntaxToken), SyntaxFactory.Literal("string", "string"), SyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken), new bool());
 
         private static PragmaWarningDirectiveTriviaSyntax GeneratePragmaWarningDirectiveTrivia()
             => SyntaxFactory.PragmaWarningDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.HashToken), SyntaxFactory.Token(SyntaxKind.PragmaKeyword), SyntaxFactory.Token(SyntaxKind.WarningKeyword), SyntaxFactory.Token(SyntaxKind.DisableKeyword), new SeparatedSyntaxList<ExpressionSyntax>(), SyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken), new bool());
@@ -13299,6 +13395,38 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.EndOfDirectiveToken, node.EndOfDirectiveToken.Kind());
             Assert.Equal(new bool(), node.IsActive);
             var newNode = node.WithHashToken(node.HashToken).WithLineKeyword(node.LineKeyword).WithLine(node.Line).WithFile(node.File).WithEndOfDirectiveToken(node.EndOfDirectiveToken).WithIsActive(node.IsActive);
+            Assert.Equal(node, newNode);
+        }
+
+        [Fact]
+        public void TestLineDirectivePositionFactoryAndProperties()
+        {
+            var node = GenerateLineDirectivePosition();
+
+            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
+            Assert.Equal(SyntaxKind.NumericLiteralToken, node.Line.Kind());
+            Assert.Equal(SyntaxKind.CommaToken, node.CommaToken.Kind());
+            Assert.Equal(SyntaxKind.NumericLiteralToken, node.Character.Kind());
+            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
+            var newNode = node.WithOpenParenToken(node.OpenParenToken).WithLine(node.Line).WithCommaToken(node.CommaToken).WithCharacter(node.Character).WithCloseParenToken(node.CloseParenToken);
+            Assert.Equal(node, newNode);
+        }
+
+        [Fact]
+        public void TestLineSpanDirectiveTriviaFactoryAndProperties()
+        {
+            var node = GenerateLineSpanDirectiveTrivia();
+
+            Assert.Equal(SyntaxKind.HashToken, node.HashToken.Kind());
+            Assert.Equal(SyntaxKind.LineKeyword, node.LineKeyword.Kind());
+            Assert.NotNull(node.Start);
+            Assert.Equal(SyntaxKind.MinusToken, node.MinusToken.Kind());
+            Assert.NotNull(node.End);
+            Assert.Equal(SyntaxKind.None, node.CharacterOffset.Kind());
+            Assert.Equal(SyntaxKind.StringLiteralToken, node.File.Kind());
+            Assert.Equal(SyntaxKind.EndOfDirectiveToken, node.EndOfDirectiveToken.Kind());
+            Assert.Equal(new bool(), node.IsActive);
+            var newNode = node.WithHashToken(node.HashToken).WithLineKeyword(node.LineKeyword).WithStart(node.Start).WithMinusToken(node.MinusToken).WithEnd(node.End).WithCharacterOffset(node.CharacterOffset).WithFile(node.File).WithEndOfDirectiveToken(node.EndOfDirectiveToken).WithIsActive(node.IsActive);
             Assert.Equal(node, newNode);
         }
 
@@ -19263,6 +19391,58 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestLineDirectiveTriviaIdentityRewriter()
         {
             var oldNode = GenerateLineDirectiveTrivia();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
+        public void TestLineDirectivePositionTokenDeleteRewriter()
+        {
+            var oldNode = GenerateLineDirectivePosition();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestLineDirectivePositionIdentityRewriter()
+        {
+            var oldNode = GenerateLineDirectivePosition();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
+        public void TestLineSpanDirectiveTriviaTokenDeleteRewriter()
+        {
+            var oldNode = GenerateLineSpanDirectiveTrivia();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestLineSpanDirectiveTriviaIdentityRewriter()
+        {
+            var oldNode = GenerateLineSpanDirectiveTrivia();
             var rewriter = new IdentityRewriter();
             var newNode = rewriter.Visit(oldNode);
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
@@ -1,0 +1,1585 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class LineSpanDirectiveParsingTests : ParsingTests
+    {
+        public LineSpanDirectiveParsingTests(ITestOutputHelper output) : base(output) { }
+
+        protected override SyntaxTree ParseTree(string text, CSharpParseOptions? options)
+        {
+            return SyntaxFactory.ParseSyntaxTree(text, options: options);
+        }
+
+        protected override CSharpSyntaxNode ParseNode(string text, CSharpParseOptions? options)
+        {
+            return SyntaxFactory.ParseExpression(text, options: options);
+        }
+
+        private void UsingLineDirective(string text, CSharpParseOptions? options, params DiagnosticDescription[] expectedErrors)
+        {
+            var node = ParseTree(text, options).GetCompilationUnitRoot();
+            Validate(text, node, expectedErrors);
+            UsingNode(node.GetDirectives().Single(d => d.Kind() is SyntaxKind.LineDirectiveTrivia or SyntaxKind.LineSpanDirectiveTrivia));
+        }
+
+        [Fact]
+        public void IsActive()
+        {
+            string source =
+@"#if IsActive
+#line (1, 2) - (3, 4) ""file.cs""
+#endif";
+
+            UsingLineDirective(source, TestOptions.Regular9);
+            verify();
+
+            UsingLineDirective(source, TestOptions.Regular9.WithPreprocessorSymbols("IsActive"),
+                // (2,2): error CS8773: Feature 'line span directive' is not available in C# 9.0. Please use language version 10.0 or greater.
+                // #line (1, 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion9, "line").WithArguments("line span directive", "10.0").WithLocation(2, 2));
+            verify();
+
+            void verify()
+            {
+                N(SyntaxKind.LineSpanDirectiveTrivia);
+                {
+                    N(SyntaxKind.HashToken);
+                    N(SyntaxKind.LineKeyword);
+                    N(SyntaxKind.LineDirectivePosition);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.NumericLiteralToken, "2");
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.MinusToken);
+                    N(SyntaxKind.LineDirectivePosition);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.NumericLiteralToken, "3");
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.NumericLiteralToken, "4");
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                    N(SyntaxKind.EndOfDirectiveToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void LineDirective_01()
+        {
+            string source = @"#line (1, 2) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, TestOptions.Regular9,
+                // (1,2): error CS8773: Feature 'line span directive' is not available in C# 9.0. Please use language version 10.0 or greater.
+                // #line (1, 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion9, "line").WithArguments("line span directive", "10.0").WithLocation(1, 2));
+            verify();
+
+            UsingLineDirective(source, TestOptions.Regular10);
+            verify();
+
+            void verify()
+            {
+                N(SyntaxKind.LineSpanDirectiveTrivia);
+                {
+                    N(SyntaxKind.HashToken);
+                    N(SyntaxKind.LineKeyword);
+                    N(SyntaxKind.LineDirectivePosition);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.NumericLiteralToken, "2");
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.MinusToken);
+                    N(SyntaxKind.LineDirectivePosition);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.NumericLiteralToken, "3");
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.NumericLiteralToken, "4");
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                    N(SyntaxKind.EndOfDirectiveToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void LineDirective_02()
+        {
+            string source = @"#line (1, 2) - (3, 4) 5 ""file.cs""";
+
+            UsingLineDirective(source, TestOptions.Regular9,
+                // (1,2): error CS8773: Feature 'line span directive' is not available in C# 9.0. Please use language version 10.0 or greater.
+                // #line (1, 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion9, "line").WithArguments("line span directive", "10.0").WithLocation(1, 2));
+            verify();
+
+            UsingLineDirective(source, TestOptions.Regular10);
+            verify();
+
+            void verify()
+            {
+                N(SyntaxKind.LineSpanDirectiveTrivia);
+                {
+                    N(SyntaxKind.HashToken);
+                    N(SyntaxKind.LineKeyword);
+                    N(SyntaxKind.LineDirectivePosition);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.NumericLiteralToken, "1");
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.NumericLiteralToken, "2");
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.MinusToken);
+                    N(SyntaxKind.LineDirectivePosition);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.NumericLiteralToken, "3");
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.NumericLiteralToken, "4");
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.NumericLiteralToken, "5");
+                    N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                    N(SyntaxKind.EndOfDirectiveToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void LineDirective_03()
+        {
+            string source = @"#line (1, 2) - (3, 4) """"";
+
+            UsingLineDirective(source, options: null);
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LineDirective_04()
+        {
+            string source = @"   #   line   (   1   ,   2   )   -   (   3   ,   4   )   5   ""   """;
+
+            UsingLineDirective(source, options: null);
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "5");
+                N(SyntaxKind.StringLiteralToken, "\"   \"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LineDirective_05()
+        {
+            string source = @"#line(1,2)-(3,4)""file.cs""";
+
+            UsingLineDirective(source, options: null);
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LineDirective_06()
+        {
+            string source = @"#line(1,2)-(3,4)5""file.cs""";
+
+            UsingLineDirective(source, options: null);
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "5");
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_01()
+        {
+            string source = @"#line (";
+
+            UsingLineDirective(source, options: null,
+                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "").WithLocation(1, 8));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_02()
+        {
+            string source = @"#line (1";
+
+            UsingLineDirective(source, options: null,
+                // (1,9): error CS1003: Syntax error, ',' expected
+                // #line (1
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments(",", "").WithLocation(1, 9));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_03()
+        {
+            string source = @"#line (1,";
+
+            UsingLineDirective(source, options: null,
+                // (1,10): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (1,
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "").WithLocation(1, 10));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_04()
+        {
+            string source = @"#line (1, 2";
+
+            UsingLineDirective(source, options: null,
+                // (1,12): error CS1026: ) expected
+                // #line (1, 2
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(1, 12));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_05()
+        {
+            string source = @"#line (1, 2)";
+
+            UsingLineDirective(source, options: null,
+                // (1,13): error CS1003: Syntax error, '-' expected
+                // #line (1, 2)
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("-", "").WithLocation(1, 13));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_06()
+        {
+            string source = @"#line (1, 2) -";
+
+            UsingLineDirective(source, options: null,
+                // (1,15): error CS1003: Syntax error, '(' expected
+                // #line (1, 2) -
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("(", "").WithLocation(1, 15));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_07()
+        {
+            string source = @"#line (1, 2) - (";
+
+            UsingLineDirective(source, options: null,
+                // (1,17): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (1, 2) - (
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "").WithLocation(1, 17));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_08()
+        {
+            string source = @"#line (1, 2) - (3";
+
+            UsingLineDirective(source, options: null,
+                // (1,18): error CS1003: Syntax error, ',' expected
+                // #line (1, 2) - (3
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments(",", "").WithLocation(1, 18));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_09()
+        {
+            string source = @"#line (1, 2) - (3,";
+
+            UsingLineDirective(source, options: null,
+                // (1,19): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (1, 2) - (3,
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "").WithLocation(1, 19));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_10()
+        {
+            string source = @"#line (1, 2) - (3, 4";
+
+            UsingLineDirective(source, options: null,
+                // (1,21): error CS1026: ) expected
+                // #line (1, 2) - (3, 4
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(1, 21));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_11()
+        {
+            string source = @"#line (1, 2) - (3, 4)";
+
+            UsingLineDirective(source, options: null,
+                // (1,22): error CS1578: Quoted file name, single-line comment or end-of-line expected
+                // #line (1, 2) - (3, 4)
+                Diagnostic(ErrorCode.ERR_MissingPPFile, "").WithLocation(1, 22));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Incomplete_12()
+        {
+            string source = @"#line (1, 2) - (3, 4) 5";
+
+            UsingLineDirective(source, options: null,
+                // (1,24): error CS1578: Quoted file name, single-line comment or end-of-line expected
+                // #line (1, 2) - (3, 4) 5
+                Diagnostic(ErrorCode.ERR_MissingPPFile, "").WithLocation(1, 24));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "5");
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_01()
+        {
+            string source = @"#line 1, 2) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,8): error CS1578: Quoted file name, single-line comment or end-of-line expected
+                // #line 1, 2) - 3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_MissingPPFile, ",").WithLocation(1, 8));
+
+            N(SyntaxKind.LineDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.NumericLiteralToken, "1");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_02()
+        {
+            string source = @"#line (, 2) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (, 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, ",").WithLocation(1, 8));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_03()
+        {
+            string source = @"#line (1 2) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,10): error CS1003: Syntax error, ',' expected
+                // #line (1 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_SyntaxError, "2").WithArguments(",", "").WithLocation(1, 10));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    M(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_04()
+        {
+            string source = @"#line (1, ) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,11): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (1, ) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, ")").WithLocation(1, 11));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_05()
+        {
+            string source = @"#line (1, 2 - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,13): error CS1026: ) expected
+                // #line (1, 2 - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "-").WithLocation(1, 13));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    M(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_06()
+        {
+            string source = @"#line (1, 2) (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,14): error CS1003: Syntax error, '-' expected
+                // #line (1, 2) (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments("-", "(").WithLocation(1, 14));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_07()
+        {
+            string source = @"#line (1, 2) - 3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,16): error CS1003: Syntax error, '(' expected
+                // #line (1, 2) - 3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_SyntaxError, "3").WithArguments("(", "").WithLocation(1, 16));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_08()
+        {
+            string source = @"#line (1, 2) - (, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,17): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (1, 2) - (, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, ",").WithLocation(1, 17));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_09()
+        {
+            string source = @"#line (1, 2) - (3 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,19): error CS1003: Syntax error, ',' expected
+                // #line (1, 2) - (3 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_SyntaxError, "4").WithArguments(",", "").WithLocation(1, 19));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    M(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_10()
+        {
+            string source = @"#line (1, 2) - (3, ) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,20): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (1, 2) - (3, ) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, ")").WithLocation(1, 20));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void Missing_11()
+        {
+            string source = @"#line (1, 2) - (3, 4 ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,22): error CS1026: ) expected
+                // #line (1, 2) - (3, 4 "file.cs"
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, @"""file.cs""").WithLocation(1, 22));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    M(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_01()
+        {
+            string source = @"#line ('1', 2) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line ('1', 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "'").WithLocation(1, 8));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_02()
+        {
+            string source = @"#line (1, ""2"") - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,11): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (1, "2") - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, @"""2""").WithLocation(1, 11));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"2\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_03()
+        {
+            string source = @"#line (1, 2) - (0b11, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,18): error CS1003: Syntax error, ',' expected
+                // #line (1, 2) - (0b11, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_SyntaxError, "b11").WithArguments(",", "").WithLocation(1, 18));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_04()
+        {
+            string source = @"#line (1, 2) - (3, 0x04) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,21): error CS1026: ) expected
+                // #line (1, 2) - (3, 0x04) "file.cs"
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "x04").WithLocation(1, 21));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_05()
+        {
+            string source = @"#line (null, 2) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (null, 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "null").WithLocation(1, 8));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_06()
+        {
+            string source = @"#line (1, true) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,11): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (1, true) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "true").WithLocation(1, 11));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_07()
+        {
+            string source = @"#line (1, 2) - (int, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,17): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (1, 2) - (int, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "int").WithLocation(1, 17));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_08()
+        {
+            string source = @"#line (1u, 2) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,9): error CS1003: Syntax error, ',' expected
+                // #line (1u, 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_SyntaxError, "u").WithArguments(",", "").WithLocation(1, 9));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_09()
+        {
+            string source = @"#line (1, 2f) - (3, 4) ""  """;
+
+            UsingLineDirective(source, options: null,
+                // (1,12): error CS1026: ) expected
+                // #line (1, 2f) - (3, 4) "  "
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "f").WithLocation(1, 12));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.MinusToken);
+                M(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void UnexpectedToken_11()
+        {
+            string source = @"#line (1, 2) - (3, 4) file.cs";
+
+            UsingLineDirective(source, options: null,
+                // (1,23): error CS1578: Quoted file name, single-line comment or end-of-line expected
+                // #line (1, 2) - (3, 4) file.cs
+                Diagnostic(ErrorCode.ERR_MissingPPFile, "file").WithLocation(1, 23));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void InvalidValue_01()
+        {
+            string source = @"#line (-1, 2) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // #line (-1, 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "-").WithLocation(1, 8));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.NumericLiteralToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    M(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void InvalidValue_02()
+        {
+            string source = @"#line (0, 0) - (0, 0) 0 ""file.cs""";
+
+            UsingLineDirective(source, options: null);
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "0");
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
@@ -751,6 +751,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        public void Incomplete_13()
+        {
+            ParseIncompleteSyntax(@"#line (1, 2) - (3, 4) 5 ""file.cs""");
+        }
+
+        [Fact]
         public void Missing_01()
         {
             string source = @"#line 1, 2) - (3, 4) ""file.cs""";
@@ -1511,7 +1517,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        public void InvalidValue_01()
+        public void VerifyValue_01()
         {
             string source = @"#line (-1, 2) - (3, 4) ""file.cs""";
 
@@ -1548,7 +1554,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        public void InvalidValue_02()
+        public void VerifyValue_02()
         {
             string source = @"#line (0, 0) - (0, 0) 0 ""file.cs""";
 
@@ -1598,7 +1604,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        public void InvalidValue_03()
+        public void VerifyValue_03()
         {
             string source = @"#line (16707565, 65536) - (16707565, 65536) 65536 ""file.cs""";
 
@@ -1633,7 +1639,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        public void InvalidValue_04()
+        public void VerifyValue_04()
         {
             string source = @"#line (16707566, 65537) - (16707566, 65537) 65537 ""file.cs""";
 
@@ -1676,6 +1682,148 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     N(SyntaxKind.CloseParenToken);
                 }
                 N(SyntaxKind.NumericLiteralToken, "65537");
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void VerifySpan_01()
+        {
+            string source = @"#line (10, 20) - (10, 20) ""file.cs""";
+
+            UsingLineDirective(source, options: null);
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "10");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "20");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "10");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "20");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void VerifySpan_02()
+        {
+            string source = @"#line (10, 20) - (10, 19) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,18): error CS8939: The #line directive end position must be greater than or equal to the start position
+                // #line (10, 20) - (10, 19) "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveEndLessThanStart, "(10, 19)").WithLocation(1, 18));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "10");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "20");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "10");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "19");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void VerifySpan_03()
+        {
+            string source = @"#line (10, 20) - (9, 20) ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,18): error CS8939: The #line directive end position must be greater than or equal to the start position
+                // #line (10, 20) - (9, 20) "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveEndLessThanStart, "(9, 20)").WithLocation(1, 18));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "10");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "20");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "9");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "20");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void VerifySpan_04()
+        {
+            string source = @"#line (10, 20) - (11, 1) ""file.cs""";
+
+            UsingLineDirective(source, options: null);
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "10");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "20");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "11");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CloseParenToken);
+                }
                 N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
                 N(SyntaxKind.EndOfDirectiveToken);
             }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
@@ -311,9 +311,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (";
 
             UsingLineDirective(source, options: null,
-                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,8): error CS8938: The #line directive value is missing or out of range
                 // #line (
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "").WithLocation(1, 8));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "").WithLocation(1, 8));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -385,9 +385,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1,";
 
             UsingLineDirective(source, options: null,
-                // (1,10): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,10): error CS8938: The #line directive value is missing or out of range
                 // #line (1,
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "").WithLocation(1, 10));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "").WithLocation(1, 10));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -533,9 +533,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, 2) - (";
 
             UsingLineDirective(source, options: null,
-                // (1,17): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,17): error CS8938: The #line directive value is missing or out of range
                 // #line (1, 2) - (
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "").WithLocation(1, 17));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "").WithLocation(1, 17));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -607,9 +607,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, 2) - (3,";
 
             UsingLineDirective(source, options: null,
-                // (1,19): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,19): error CS8938: The #line directive value is missing or out of range
                 // #line (1, 2) - (3,
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "").WithLocation(1, 19));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "").WithLocation(1, 19));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -776,9 +776,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (, 2) - (3, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,8): error CS8938: The #line directive value is missing or out of range
                 // #line (, 2) - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, ",").WithLocation(1, 8));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, ",").WithLocation(1, 8));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -850,9 +850,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, ) - (3, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,11): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,11): error CS8938: The #line directive value is missing or out of range
                 // #line (1, ) - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, ")").WithLocation(1, 11));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, ")").WithLocation(1, 11));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -998,9 +998,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, 2) - (, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,17): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,17): error CS8938: The #line directive value is missing or out of range
                 // #line (1, 2) - (, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, ",").WithLocation(1, 17));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, ",").WithLocation(1, 17));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1072,9 +1072,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, 2) - (3, ) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,20): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,20): error CS8938: The #line directive value is missing or out of range
                 // #line (1, 2) - (3, ) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, ")").WithLocation(1, 20));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, ")").WithLocation(1, 20));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1146,9 +1146,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line ('1', 2) - (3, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,8): error CS8938: The #line directive value is missing or out of range
                 // #line ('1', 2) - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "'").WithLocation(1, 8));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "'").WithLocation(1, 8));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1183,9 +1183,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, ""2"") - (3, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,11): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,11): error CS8938: The #line directive value is missing or out of range
                 // #line (1, "2") - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, @"""2""").WithLocation(1, 11));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, @"""2""").WithLocation(1, 11));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1220,9 +1220,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, 2) - (0b11, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,18): error CS1003: Syntax error, ',' expected
+                // (1,17): error CS8938: The #line directive value is missing or out of range
                 // #line (1, 2) - (0b11, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_SyntaxError, "b11").WithArguments(",", "").WithLocation(1, 18));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "0").WithLocation(1, 17));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1257,9 +1257,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, 2) - (3, 0x04) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,21): error CS1026: ) expected
+                // (1,20): error CS8938: The #line directive value is missing or out of range
                 // #line (1, 2) - (3, 0x04) "file.cs"
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, "x04").WithLocation(1, 21));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "0").WithLocation(1, 20));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1294,9 +1294,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (null, 2) - (3, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,8): error CS8938: The #line directive value is missing or out of range
                 // #line (null, 2) - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "null").WithLocation(1, 8));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "null").WithLocation(1, 8));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1331,9 +1331,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, true) - (3, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,11): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,11): error CS8938: The #line directive value is missing or out of range
                 // #line (1, true) - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "true").WithLocation(1, 11));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "true").WithLocation(1, 11));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1368,9 +1368,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (1, 2) - (int, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,17): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,17): error CS8938: The #line directive value is missing or out of range
                 // #line (1, 2) - (int, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "int").WithLocation(1, 17));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "int").WithLocation(1, 17));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1516,9 +1516,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line (-1, 2) - (3, 4) ""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,8): error CS1576: The line number specified for #line directive is missing or invalid
+                // (1,8): error CS8938: The #line directive value is missing or out of range
                 // #line (-1, 2) - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_InvalidLineNumber, "-").WithLocation(1, 8));
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "-").WithLocation(1, 8));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1552,7 +1552,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             string source = @"#line (0, 0) - (0, 0) 0 ""file.cs""";
 
-            UsingLineDirective(source, options: null);
+            UsingLineDirective(source, options: null,
+                // (1,8): error CS8938: The #line directive value is missing or out of range
+                // #line (0, 0) - (0, 0) 0 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "0").WithLocation(1, 8),
+                // (1,11): error CS8938: The #line directive value is missing or out of range
+                // #line (0, 0) - (0, 0) 0 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "0").WithLocation(1, 11),
+                // (1,17): error CS8938: The #line directive value is missing or out of range
+                // #line (0, 0) - (0, 0) 0 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "0").WithLocation(1, 17),
+                // (1,20): error CS8938: The #line directive value is missing or out of range
+                // #line (0, 0) - (0, 0) 0 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "0").WithLocation(1, 20),
+                // (1,23): error CS8938: The #line directive value is missing or out of range
+                // #line (0, 0) - (0, 0) 0 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "0").WithLocation(1, 23));
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
             {
@@ -1576,6 +1591,91 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     N(SyntaxKind.CloseParenToken);
                 }
                 N(SyntaxKind.NumericLiteralToken, "0");
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void InvalidValue_03()
+        {
+            string source = @"#line (16707565, 65536) - (16707565, 65536) 65536 ""file.cs""";
+
+            UsingLineDirective(source, options: null);
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "16707565");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "65536");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "16707565");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "65536");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "65536");
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void InvalidValue_04()
+        {
+            string source = @"#line (16707566, 65537) - (16707566, 65537) 65537 ""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,8): error CS8938: The #line directive value is missing or out of range
+                // #line (16707566, 65537) - (16707566, 65537) 65537 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "16707566").WithLocation(1, 8),
+                // (1,18): error CS8938: The #line directive value is missing or out of range
+                // #line (16707566, 65537) - (16707566, 65537) 65537 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "65537").WithLocation(1, 18),
+                // (1,28): error CS8938: The #line directive value is missing or out of range
+                // #line (16707566, 65537) - (16707566, 65537) 65537 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "16707566").WithLocation(1, 28),
+                // (1,38): error CS8938: The #line directive value is missing or out of range
+                // #line (16707566, 65537) - (16707566, 65537) 65537 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "65537").WithLocation(1, 38),
+                // (1,45): error CS8938: The #line directive value is missing or out of range
+                // #line (16707566, 65537) - (16707566, 65537) 65537 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveInvalidValue, "65537").WithLocation(1, 45));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "16707566");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "65537");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "16707566");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "65537");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "65537");
                 N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
                 N(SyntaxKind.EndOfDirectiveToken);
             }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -93,10 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal void UsingStatement(string text, ParseOptions? options, params DiagnosticDescription[] expectedErrors)
         {
             var node = SyntaxFactory.ParseStatement(text, options: options);
-            // we validate the text roundtrips
-            Assert.Equal(text, node.ToFullString());
-            var actualErrors = node.GetDiagnostics();
-            actualErrors.Verify(expectedErrors);
+            Validate(text, node, expectedErrors);
             UsingNode(node);
         }
 
@@ -127,11 +124,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         protected void UsingNode(string text, CSharpSyntaxNode node, DiagnosticDescription[] expectedErrors)
         {
+            Validate(text, node, expectedErrors);
+            UsingNode(node);
+        }
+
+        protected void Validate(string text, CSharpSyntaxNode node, params DiagnosticDescription[] expectedErrors)
+        {
             // we validate the text roundtrips
             Assert.Equal(text, node.ToFullString());
             var actualErrors = node.GetDiagnostics();
             actualErrors.Verify(expectedErrors);
-            UsingNode(node);
         }
 
         internal void UsingExpression(string text, params DiagnosticDescription[] expectedErrors)
@@ -190,15 +192,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             try
             {
                 Assert.True(_treeEnumerator!.MoveNext());
-                Assert.Equal(kind, _treeEnumerator.Current.Kind());
-                Assert.False(_treeEnumerator.Current.IsMissing);
+                var current = _treeEnumerator.Current;
+
+                Assert.Equal(kind, current.Kind());
+                Assert.False(current.IsMissing);
 
                 if (value != null)
                 {
-                    Assert.Equal(_treeEnumerator.Current.ToString(), value);
+                    Assert.Equal(current.ToString(), value);
                 }
 
-                return _treeEnumerator.Current;
+                return current;
             }
             catch when (DumpAndCleanup())
             {
@@ -286,11 +290,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     case SyntaxKind.IdentifierToken:
                     case SyntaxKind.NumericLiteralToken:
+                    case SyntaxKind.StringLiteralToken:
                         if (node.IsMissing)
                         {
                             goto default;
                         }
-                        _output.WriteLine(@"N(SyntaxKind.{0}, ""{1}"");", node.Kind(), node.ToString());
+                        var value = node.ToString().Replace("\"", "\\\"");
+                        _output.WriteLine(@"N(SyntaxKind.{0}, ""{1}"");", node.Kind(), value);
                         break;
                     default:
                         _output.WriteLine("{0}(SyntaxKind.{1});", node.IsMissing ? "M" : "N", node.Kind());

--- a/src/Compilers/Core/CodeAnalysisTest/LineMappingTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/LineMappingTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class LineMappingTests
+    {
+        [Fact]
+        public void Equality()
+        {
+            var lineMappings = new LineMapping[]
+            {
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), hasMappedPath: true)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 2)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(2, 2)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 1), new LinePosition(1, 1)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(1, 0), new LinePosition(1, 1)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), null, new FileLinePositionSpan("file.cs", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), 0, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 2)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 0), new LinePosition(2, 2)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(0, 1), new LinePosition(1, 1)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), hasMappedPath: false)),
+                new LineMapping(new LinePositionSpan(new LinePosition(1, 0), new LinePosition(1, 1)), null, new FileLinePositionSpan("", new LinePositionSpan(new LinePosition(0, 0), new LinePosition(1, 1)), hasMappedPath: false)),
+            };
+            var equalityUnits = lineMappings.SelectMany((left, leftIndex) => lineMappings.Select((right, rightIndex) => CreateEqualityUnit(left, leftIndex, right, rightIndex))).ToArray();
+            EqualityUtil.RunAll(
+                (left, right) => left == right,
+                (left, right) => left != right,
+                equalityUnits);
+
+            static EqualityUnit<LineMapping> CreateEqualityUnit(LineMapping left, int leftIndex, LineMapping right, int rightIndex)
+            {
+                var leftUnit = EqualityUnit.Create(left);
+                return (leftIndex == rightIndex) ? leftUnit.WithEqualValues(right) : leftUnit.WithNotEqualValues(right);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -50,18 +50,18 @@ Microsoft.CodeAnalysis.GeneratorPostInitializationContext.CancellationToken.get 
 Microsoft.CodeAnalysis.GeneratorPostInitializationContext.GeneratorPostInitializationContext() -> void
 Microsoft.CodeAnalysis.IMethodSymbol.MethodImplementationFlags.get -> System.Reflection.MethodImplAttributes
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool
-Microsoft.CodeAnalysis.Operations.ISwitchExpressionOperation.IsExhaustive.get -> bool
 Microsoft.CodeAnalysis.LineMapping
-Microsoft.CodeAnalysis.LineMapping.Deconstruct(out Microsoft.CodeAnalysis.Text.LinePositionSpan span, out Microsoft.CodeAnalysis.FileLinePositionSpan mappedSpan) -> void
+Microsoft.CodeAnalysis.LineMapping.CharacterOffset.get -> int?
 Microsoft.CodeAnalysis.LineMapping.Equals(Microsoft.CodeAnalysis.LineMapping other) -> bool
 Microsoft.CodeAnalysis.LineMapping.IsHidden.get -> bool
 Microsoft.CodeAnalysis.LineMapping.LineMapping() -> void
-Microsoft.CodeAnalysis.LineMapping.LineMapping(Microsoft.CodeAnalysis.Text.LinePositionSpan span, Microsoft.CodeAnalysis.FileLinePositionSpan mappedSpan) -> void
+Microsoft.CodeAnalysis.LineMapping.LineMapping(Microsoft.CodeAnalysis.Text.LinePositionSpan span, int? characterOffset, Microsoft.CodeAnalysis.FileLinePositionSpan mappedSpan) -> void
 Microsoft.CodeAnalysis.LineMapping.MappedSpan.get -> Microsoft.CodeAnalysis.FileLinePositionSpan
 Microsoft.CodeAnalysis.LineMapping.Span.get -> Microsoft.CodeAnalysis.Text.LinePositionSpan
 override Microsoft.CodeAnalysis.LineMapping.Equals(object? obj) -> bool
 override Microsoft.CodeAnalysis.LineMapping.GetHashCode() -> int
-override Microsoft.CodeAnalysis.LineMapping.ToString() -> string?
+override Microsoft.CodeAnalysis.LineMapping.ToString() -> string!
+Microsoft.CodeAnalysis.Operations.ISwitchExpressionOperation.IsExhaustive.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void
 Microsoft.CodeAnalysis.SourceProductionContext

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -60,7 +60,7 @@ Microsoft.CodeAnalysis.LineMapping.MappedSpan.get -> Microsoft.CodeAnalysis.File
 Microsoft.CodeAnalysis.LineMapping.Span.get -> Microsoft.CodeAnalysis.Text.LinePositionSpan
 override Microsoft.CodeAnalysis.LineMapping.Equals(object? obj) -> bool
 override Microsoft.CodeAnalysis.LineMapping.GetHashCode() -> int
-override Microsoft.CodeAnalysis.LineMapping.ToString() -> string!
+override Microsoft.CodeAnalysis.LineMapping.ToString() -> string?
 Microsoft.CodeAnalysis.Operations.ISwitchExpressionOperation.IsExhaustive.get -> bool
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>
 Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.OperationWalker() -> void

--- a/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.LineMappingEntry.cs
+++ b/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.LineMappingEntry.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -28,6 +29,11 @@ namespace Microsoft.CodeAnalysis
             /// Used in C# for spans inside of <c>#line linenumber</c> directive
             /// </summary>
             Remapped,
+
+            /// <summary>
+            /// Used in C# for spans inside of <c>#line (startLine, startChar) - (endLine, endChar) charOffset</c> directive
+            /// </summary>
+            RemappedSpan,
 
             /// <summary>
             /// Used in VB for spans inside of a <c>#ExternalSource</c> directive that followed an unknown span
@@ -56,6 +62,12 @@ namespace Microsoft.CodeAnalysis
             // 0-based line it maps to.
             public readonly int MappedLine;
 
+            // 0-based mapped span from enhanced #line directive.
+            public readonly LinePositionSpan MappedSpan;
+
+            // optional 0-based character offset from enhanced #line directive.
+            public readonly int? UnmappedCharacterOffset;
+
             // raw value from #line or #ExternalDirective, may be null
             public readonly string? MappedPathOpt;
 
@@ -66,6 +78,8 @@ namespace Microsoft.CodeAnalysis
             {
                 this.UnmappedLine = unmappedLine;
                 this.MappedLine = unmappedLine;
+                this.MappedSpan = default;
+                this.UnmappedCharacterOffset = null;
                 this.MappedPathOpt = null;
                 this.State = PositionState.Unmapped;
             }
@@ -78,8 +92,24 @@ namespace Microsoft.CodeAnalysis
             {
                 this.UnmappedLine = unmappedLine;
                 this.MappedLine = mappedLine;
+                this.MappedSpan = default;
+                this.UnmappedCharacterOffset = null;
                 this.MappedPathOpt = mappedPathOpt;
                 this.State = state;
+            }
+
+            public LineMappingEntry(
+                int unmappedLine,
+                LinePositionSpan mappedSpan,
+                int? unmappedCharacterOffset,
+                string? mappedPathOpt)
+            {
+                this.UnmappedLine = unmappedLine;
+                this.MappedLine = -1;
+                this.MappedSpan = mappedSpan;
+                this.UnmappedCharacterOffset = unmappedCharacterOffset;
+                this.MappedPathOpt = mappedPathOpt;
+                this.State = PositionState.RemappedSpan;
             }
 
             public int CompareTo(LineMappingEntry other)

--- a/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.LineMappingEntry.cs
+++ b/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.LineMappingEntry.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
@@ -90,6 +91,8 @@ namespace Microsoft.CodeAnalysis
                 string? mappedPathOpt,
                 PositionState state)
             {
+                Debug.Assert(state != PositionState.RemappedSpan);
+
                 this.UnmappedLine = unmappedLine;
                 this.MappedLine = mappedLine;
                 this.MappedSpan = default;

--- a/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
+++ b/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
@@ -55,18 +55,44 @@ namespace Microsoft.CodeAnalysis
             return TranslateSpan(entry, treeFilePath, unmappedStartPos, unmappedEndPos);
         }
 
-        protected FileLinePositionSpan TranslateSpan(LineMappingEntry entry, string treeFilePath, LinePosition unmappedStartPos, LinePosition unmappedEndPos)
+        protected FileLinePositionSpan TranslateSpan(in LineMappingEntry entry, string treeFilePath, LinePosition unmappedStartPos, LinePosition unmappedEndPos)
         {
             string path = entry.MappedPathOpt ?? treeFilePath;
-            int mappedStartLine = unmappedStartPos.Line - entry.UnmappedLine + entry.MappedLine;
-            int mappedEndLine = unmappedEndPos.Line - entry.UnmappedLine + entry.MappedLine;
+            var span = entry.State == PositionState.RemappedSpan ?
+                TranslateEnhancedLineDirectiveSpan(entry, unmappedStartPos, unmappedEndPos) :
+                TranslateLineDirectiveSpan(entry, unmappedStartPos, unmappedEndPos);
+            return new FileLinePositionSpan(path, span, hasMappedPath: entry.MappedPathOpt != null);
+        }
 
-            return new FileLinePositionSpan(
-                path,
-                new LinePositionSpan(
-                    (mappedStartLine == -1) ? new LinePosition(unmappedStartPos.Character) : new LinePosition(mappedStartLine, unmappedStartPos.Character),
-                    (mappedEndLine == -1) ? new LinePosition(unmappedEndPos.Character) : new LinePosition(mappedEndLine, unmappedEndPos.Character)),
-                hasMappedPath: entry.MappedPathOpt != null);
+        private static LinePositionSpan TranslateLineDirectiveSpan(in LineMappingEntry entry, LinePosition unmappedStartPos, LinePosition unmappedEndPos)
+        {
+            return new LinePositionSpan(translatePosition(entry, unmappedStartPos), translatePosition(entry, unmappedEndPos));
+
+            static LinePosition translatePosition(in LineMappingEntry entry, LinePosition unmapped)
+            {
+                int mappedLine = unmapped.Line - entry.UnmappedLine + entry.MappedLine;
+                return (mappedLine == -1) ? new LinePosition(unmapped.Character) : new LinePosition(mappedLine, unmapped.Character);
+            }
+        }
+
+        private static LinePositionSpan TranslateEnhancedLineDirectiveSpan(in LineMappingEntry entry, LinePosition unmappedStartPos, LinePosition unmappedEndPos)
+        {
+            if (unmappedStartPos.Line == entry.UnmappedLine &&
+                unmappedStartPos.Character <= entry.UnmappedCharacterOffset.GetValueOrDefault())
+            {
+                return entry.MappedSpan;
+            }
+
+            return new LinePositionSpan(translatePosition(entry, unmappedStartPos), translatePosition(entry, unmappedEndPos));
+
+            static LinePosition translatePosition(in LineMappingEntry entry, LinePosition unmapped)
+            {
+                return new LinePosition(
+                    unmapped.Line - entry.UnmappedLine + entry.MappedSpan.Start.Line,
+                    unmapped.Line == entry.UnmappedLine ?
+                        entry.MappedSpan.Start.Character + Math.Max(unmapped.Character - entry.UnmappedCharacterOffset.GetValueOrDefault(), 0) :
+                        unmapped.Character);
+            }
         }
 
         /// <summary>
@@ -151,26 +177,6 @@ namespace Microsoft.CodeAnalysis
                 current.MappedLine == 0 &&
                 current.MappedPathOpt == null);
 
-            LineMapping CreateCurrentEntryMapping(in LineMappingEntry entry, int unmappedEndLine, int lineLength, int currentIndex)
-            {
-                var unmapped = new LinePositionSpan(
-                    new LinePosition(entry.UnmappedLine, character: 0),
-                    new LinePosition(unmappedEndLine, lineLength));
-
-                var isHidden =
-                    entry.State == PositionState.Hidden ||
-                    entry.State == PositionState.Unknown && GetUnknownStateVisibility(currentIndex) == LineVisibility.Hidden;
-
-                var mapped = isHidden ? default : new FileLinePositionSpan(
-                    entry.MappedPathOpt ?? string.Empty,
-                    new LinePositionSpan(
-                        new LinePosition(entry.MappedLine, character: 0),
-                        new LinePosition(entry.MappedLine + unmappedEndLine - entry.UnmappedLine, lineLength)),
-                    hasMappedPath: entry.MappedPathOpt != null);
-
-                return new LineMapping(unmapped, mapped);
-            }
-
             for (int i = 1; i < Entries.Length; i++)
             {
                 var next = Entries[i];
@@ -197,7 +203,7 @@ namespace Microsoft.CodeAnalysis
                     var endLine = lines[unmappedEndLine];
                     int lineLength = endLine.EndIncludingLineBreak - endLine.Start;
 
-                    yield return CreateCurrentEntryMapping(current, unmappedEndLine, lineLength, currentIndex: i - 1);
+                    yield return CreateLineMapping(current, unmappedEndLine, lineLength, currentIndex: i - 1);
                 }
 
                 current = next;
@@ -218,8 +224,38 @@ namespace Microsoft.CodeAnalysis
                 int lineLength = lastLine.EndIncludingLineBreak - lastLine.Start;
                 int unmappedEndLine = lastLine.LineNumber;
 
-                yield return CreateCurrentEntryMapping(current, unmappedEndLine, lineLength, currentIndex: Entries.Length - 1);
+                yield return CreateLineMapping(current, unmappedEndLine, lineLength, currentIndex: Entries.Length - 1);
             }
+        }
+
+        private LineMapping CreateLineMapping(in LineMappingEntry entry, int unmappedEndLine, int lineLength, int currentIndex)
+        {
+            var unmapped = new LinePositionSpan(
+                new LinePosition(entry.UnmappedLine, character: 0),
+                new LinePosition(unmappedEndLine, lineLength));
+
+            if (entry.State == PositionState.Hidden ||
+                entry.State == PositionState.Unknown && GetUnknownStateVisibility(currentIndex) == LineVisibility.Hidden)
+            {
+                return new LineMapping(unmapped, null, default);
+            }
+
+            string path = entry.MappedPathOpt ?? string.Empty;
+            bool hasMappedPath = entry.MappedPathOpt != null;
+
+            if (entry.State == PositionState.RemappedSpan)
+            {
+                return new LineMapping(
+                    unmapped,
+                    characterOffset: entry.UnmappedCharacterOffset,
+                    new FileLinePositionSpan(path, entry.MappedSpan, hasMappedPath));
+            }
+
+            var mappedSpan = new LinePositionSpan(
+                new LinePosition(entry.MappedLine, character: 0),
+                new LinePosition(entry.MappedLine + unmappedEndLine - entry.UnmappedLine, lineLength));
+            var mapped = new FileLinePositionSpan(path, mappedSpan, hasMappedPath);
+            return new LineMapping(unmapped, characterOffset: null, mapped);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
+++ b/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis
             if (entry.State == PositionState.Hidden ||
                 entry.State == PositionState.Unknown && GetUnknownStateVisibility(currentIndex) == LineVisibility.Hidden)
             {
-                return new LineMapping(unmapped, null, default);
+                return new LineMapping(unmapped, characterOffset: null, mappedSpan: default);
             }
 
             string path = entry.MappedPathOpt ?? string.Empty;

--- a/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
+++ b/src/Compilers/Core/Portable/Syntax/LineDirectiveMap.cs
@@ -77,12 +77,17 @@ namespace Microsoft.CodeAnalysis
 
         private static LinePositionSpan TranslateEnhancedLineDirectiveSpan(in LineMappingEntry entry, LinePosition unmappedStartPos, LinePosition unmappedEndPos)
         {
+            // A span starting on the first line, at or before 'UnmappedCharacterOffset' is
+            // mapped to the entire 'MappedSpan', regardless of the size of the unmapped span,
+            // even if the unmapped span ends before 'UnmappedCharacterOffset'.
             if (unmappedStartPos.Line == entry.UnmappedLine &&
                 unmappedStartPos.Character <= entry.UnmappedCharacterOffset.GetValueOrDefault())
             {
                 return entry.MappedSpan;
             }
 
+            // A span starting on the first line after 'UnmappedCharacterOffset', or starting on
+            // a subseqent line, is mapped to a span of corresponding size.
             return new LinePositionSpan(translatePosition(entry, unmappedStartPos), translatePosition(entry, unmappedEndPos));
 
             static LinePosition translatePosition(in LineMappingEntry entry, LinePosition unmapped)
@@ -90,7 +95,7 @@ namespace Microsoft.CodeAnalysis
                 return new LinePosition(
                     unmapped.Line - entry.UnmappedLine + entry.MappedSpan.Start.Line,
                     unmapped.Line == entry.UnmappedLine ?
-                        entry.MappedSpan.Start.Character + Math.Max(unmapped.Character - entry.UnmappedCharacterOffset.GetValueOrDefault(), 0) :
+                        entry.MappedSpan.Start.Character + unmapped.Character - entry.UnmappedCharacterOffset.GetValueOrDefault() :
                         unmapped.Character);
             }
         }

--- a/src/Compilers/Test/Core/TestResource.resx
+++ b/src/Compilers/Test/Core/TestResource.resx
@@ -867,7 +867,9 @@ namespace Comments.XmlComments.UndocumentedKeywords
 #line 6
 #line 2 "test.cs"
 #line default
-#line hidden</value>
+#line hidden
+#line (1, 1) - (2, 2) 3 "test.cs"
+</value>
   </data>
   <data name="AllInOneVisualBasicBaseline" xml:space="preserve">
     <value>Option Infer On

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
@@ -180,8 +180,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             var hasAnyLineDirectives = false;
-            foreach (var (unmappedSection, mappedSection) in oldTree.GetLineMappings(cancellationToken))
+            foreach (var lineMapping in oldTree.GetLineMappings(cancellationToken))
             {
+                var unmappedSection = lineMapping.Span;
+                var mappedSection = lineMapping.MappedSpan;
+
                 hasAnyLineDirectives = true;
 
                 var targetPath = mappedSection.HasMappedPath ? mappedSection.Path : oldTree.FilePath;


### PR DESCRIPTION
`#line (startLine, startChar) - (endLine, endChar) charOffset "fileName"`

Map lines after the `#line` directive to the span `(startLine, startChar) - (endLine, endChar)` in `"fileName"` where the origin of the unmapped span is the first line after the directive at character `charOffset`.

Proposal: https://github.com/dotnet/csharplang/issues/4747
Test plan: https://github.com/dotnet/roslyn/issues/54509