### PR TITLE
Completion: Conditional access on nullable parameter suggests Nullable members

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8070,6 +8070,23 @@ class A
             await VerifyItemIsAbsentAsync(markup, "value");
         }
 
+        [WorkItem(54361, "https://github.com/dotnet/roslyn/issues/54361")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task ConditionalAccessNullableIsUnwrappedOnParameter()
+        {
+            var markup = @"
+class A
+{
+    void M(System.DateTime? dt)
+    {
+        dt?.$$
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "Day");
+            await VerifyItemIsAbsentAsync(markup, "value");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CompletionAfterConditionalIndexing()
         {

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Recommendations
         {
             var symbols = TryGetMemberSymbolsForLambdaParameter(parameter, position);
             return symbols.IsDefault
-                ? GetMemberSymbols(parameter.Type, position, excludeInstance: false, useBaseReferenceAccessibility)
+                ? GetMemberSymbols(parameter.Type.RemoveNullableIfPresent(), position, excludeInstance: false, useBaseReferenceAccessibility)
                 : symbols;
         }
 


### PR DESCRIPTION
Fix #54361

Root cause is here:
https://github.com/dotnet/roslyn/blob/1b9f72faef56200bfa59254e1ffcfb4e05d0b305/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs#L463-L468

The `containerSymbol` is fixed with `RemoveNullableIfPresent`, but the parameter symbols type is not. This is fixed later in `GetMemberSymbolsForParameter`.