### PR TITLE
Enable EnC diagnostics in LSP

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,7 +35,7 @@
     <VisualStudioEditorNewPackagesVersion>17.0.83-preview</VisualStudioEditorNewPackagesVersion>
     <ILAsmPackageVersion>5.0.0-alpha1.19409.1</ILAsmPackageVersion>
     <ILDAsmPackageVersion>5.0.0-preview.1.20112.8</ILDAsmPackageVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.0.20-g6553c6c46e</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.0.2062-g973d339867</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.0.0-previews-1-31318-291</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftBuildPackagesVersion>16.5.0</MicrosoftBuildPackagesVersion>
     <!-- The version of Roslyn we build Source Generators against that are built in this

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -67,7 +67,12 @@ namespace Microsoft.VisualStudio.LanguageServices
                 if (designTimeSolution.WorkspaceVersion == _correspondingDesignTimeSolutionVersion)
                 {
                     Contract.ThrowIfNull(_lazyCompileTimeSolution);
-                    return _lazyCompileTimeSolution;
+
+                    // Only re-use when the lazy solution is from the same branch as the requested solution.
+                    if (_lazyCompileTimeSolution.BranchId == designTimeSolution.BranchId)
+                    {
+                        return _lazyCompileTimeSolution;
+                    }
                 }
 
                 using var _1 = ArrayBuilder<DocumentId>.GetInstance(out var configIdsToRemove);

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices
         /// Cached compile time solution for a forked branch.  This is used primarily by LSP cases where
         /// we fork the workspace solution and request diagnostics for the forked solution.
         /// </summary>
-        private (int DesignTimeSolutionVersion, Solution CompileTimeSolution)? _forkedBranchCompileTimeCache;
+        private (int DesignTimeSolutionVersion, Solution CompileTimeSolution)? _forkedBranchCompileTimeSolutionCache;
 
         public CompileTimeSolutionProvider(Workspace workspace)
         {
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices
                     lock (_gate)
                     {
                         _primaryBranchCompileTimeSolutionCache = null;
-                        _forkedBranchCompileTimeCache = null;
+                        _forkedBranchCompileTimeSolutionCache = null;
                     }
                 }
             };
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.LanguageServices
         {
             // If the design time solution is for the primary branch, retrieve the last cached solution for it.
             // Otherwise this is a forked solution, so retrieve the last forked compile time solution we calculated.
-            var cachedCompileTimeSolution = designTimeSolution.BranchId == _workspace.PrimaryBranchId ? _primaryBranchCompileTimeSolutionCache : _forkedBranchCompileTimeCache;
+            var cachedCompileTimeSolution = designTimeSolution.BranchId == _workspace.PrimaryBranchId ? _primaryBranchCompileTimeSolutionCache : _forkedBranchCompileTimeSolutionCache;
 
             // Verify that the design time solution has not changed since the last calculated compile time solution and that
             // the design time solution branch matches the cached instance.
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             }
             else
             {
-                _forkedBranchCompileTimeCache = (designTimeSolution.WorkspaceVersion, compileTimeSolution);
+                _forkedBranchCompileTimeSolutionCache = (designTimeSolution.WorkspaceVersion, compileTimeSolution);
             }
         }
     }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -354,6 +354,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             if (diagnosticData.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary))
                 result.Add(DiagnosticTag.Unnecessary);
 
+            if (diagnosticData.CustomTags.Contains(WellKnownDiagnosticTags.EditAndContinue))
+                result.Add(VSDiagnosticTags.EditAndContinueError);
+
             return result.ToArray();
         }
     }


### PR DESCRIPTION
Adds support for EnC diagnostics via LSP

![enc_diagnostics_lsp](https://user-images.githubusercontent.com/5749229/124024911-ae799680-d9a4-11eb-908d-424d384db227.png)

Note that there seems to still be an issue on the Razor side with squiggle color (I verified we are returning the appropriate EnC tag for Razor diagnostics) cc @NTaylorMullen 
![razor_enc_diagnostics_lsp](https://user-images.githubusercontent.com/5749229/124025023-cfda8280-d9a4-11eb-8a3a-9622251467f0.png)
