### PR TITLE
Prototype for supporting help link for compilation end analyzers

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -96,10 +96,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     }
                 }
 
+                var errorId = GetErrorId(error);
+                var helpLink = DiagnosticProvider.GetHelpLinkForDiagnosticId(_projectId, errorId);
                 projectErrors.Add(GetDiagnosticData(
                     documentId: null,
                     _projectId,
-                    GetErrorId(error),
+                    errorId,
                     error.bstrText,
                     GetDiagnosticSeverity(error),
                     _language,
@@ -112,7 +114,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     originalStartLine: 0,
                     originalStartColumn: 0,
                     originalEndLine: 0,
-                    originalEndColumn: 0));
+                    originalEndColumn: 0,
+                    helpLink: helpLink));
             }
 
             DiagnosticProvider.AddNewErrors(_projectId, projectErrors, documentErrorsMap);
@@ -177,6 +180,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 column = spans[0].iStartIndex;
             }
 
+            var errorId = GetErrorId(error);
+            var helpLink = DiagnosticProvider.GetHelpLinkForDiagnosticId(_projectId, errorId);
+
             // save error line/column (surface buffer location) as mapped line/column so that we can display
             // right location on closed Venus file.
             return GetDiagnosticData(
@@ -195,7 +201,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 originalStartLine: line,
                 originalStartColumn: column,
                 originalEndLine: line,
-                originalEndColumn: column);
+                originalEndColumn: column,
+                helpLink: helpLink);
         }
 
         public int ReportError(string bstrErrorMessage, string bstrErrorId, [ComAliasName("VsShell.VSTASKPRIORITY")] VSTASKPRIORITY nPriority, int iLine, int iColumn, string bstrFileName)
@@ -240,6 +247,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 documentId = TryGetDocumentId(bstrFileName);
             }
 
+            var helpLink = DiagnosticProvider.GetHelpLinkForDiagnosticId(_projectId, bstrErrorId);
+
             var diagnostic = GetDiagnosticData(
                 documentId,
                 _projectId,
@@ -250,7 +259,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 mappedFilePath: null,
                 iStartLine, iStartColumn, iEndLine, iEndColumn,
                 bstrFileName,
-                iStartLine, iStartColumn, iEndLine, iEndColumn);
+                iStartLine, iStartColumn, iEndLine, iEndColumn,
+                helpLink);
 
             if (documentId == null)
             {
@@ -284,7 +294,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             int originalStartLine,
             int originalStartColumn,
             int originalEndLine,
-            int originalEndColumn)
+            int originalEndColumn,
+            string helpLink)
         {
             return new DiagnosticData(
                 id: errorId,
@@ -312,7 +323,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     mappedStartColumn: mappedStartColumn,
                     mappedEndLine: mappedEndLine,
                     mappedEndColumn: mappedEndColumn),
-                language: language);
+                language: language,
+                helpLink: helpLink);
         }
 
         private static bool IsCompilerDiagnostic(string errorId)

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             return GetDiagnosticData(
                 documentId,
                 _projectId,
-                GetErrorId(error),
+                errorId,
                 message: error.bstrText,
                 GetDiagnosticSeverity(error),
                 _language,


### PR DESCRIPTION
Confirmed that this change fixes the issue:

![image](https://user-images.githubusercontent.com/31348972/124035043-45be0880-d9fc-11eb-8c7a-a18c07a749ea.png)

The approach might not be the best.
I suggested a much better approach in https://github.com/dotnet/roslyn/issues/47345 comments, but that requires changes in project-system and another team as well (not sure which team it's)

Fixes https://github.com/dotnet/roslyn/issues/47345