### PR TITLE
Fix up bugs in parsing special chracters in EditorConfig

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -93,6 +93,28 @@ build_metadata.Compile.ToRetrieve = ghi789
             );
         }
 
+        [Fact]
+        [WorkItem(52469, "https://github.com/dotnet/roslyn/issues/52469")]
+        public void CanGetSectionsWithSpecialCharacters()
+        {
+            var config = ParseConfigFile(@"is_global = true
+
+[/home/foo/src/\{releaseid\}.cs]
+build_metadata.Compile.ToRetrieve = abc123
+
+[/home/foo/src/Pages/\#foo/HomePage.cs]
+build_metadata.Compile.ToRetrieve = def456
+");
+
+            var set = AnalyzerConfigSet.Create(ImmutableArray.Create(config));
+
+            var sectionOptions = set.GetOptionsForSourcePath("/home/foo/src/{releaseid}.cs");
+            Assert.Equal("abc123", sectionOptions.AnalyzerOptions["build_metadata.compile.toretrieve"]);
+
+            sectionOptions = set.GetOptionsForSourcePath("/home/foo/src/Pages/#foo/HomePage.cs");
+            Assert.Equal("def456", sectionOptions.AnalyzerOptions["build_metadata.compile.toretrieve"]);
+        }
+
         [ConditionalFact(typeof(WindowsOnly))]
         public void WindowsPath()
         {

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return string.IsNullOrEmpty(FileName.ItemSpec) ? true : WriteMSBuildEditorConfig();
         }
 
-        private static bool WriteMSBuildEditorConfig()
+        internal bool WriteMSBuildEditorConfig()
         {
             try
             {

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
@@ -52,7 +52,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         [Required]
         public ITaskItem[] PropertyItems { get; set; }
 
-        [Required]
         public ITaskItem FileName { get; set; }
 
         public GenerateMSBuildEditorConfig()
@@ -107,26 +106,24 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
 
             ConfigFileContents = builder.ToString();
-            return WriteMSBuildEditorConfig();
+            return string.IsNullOrEmpty(FileName.ItemSpec) ? true : WriteMSBuildEditorConfig();
         }
 
         public bool WriteMSBuildEditorConfig()
         {
             try
             {
-                if (File.Exists(FileName.ItemSpec))
+                var targetFileName = FileName.ItemSpec;
+                if (File.Exists(targetFileName))
                 {
-                    string existingContents = File.ReadAllText(FileName.ItemSpec);
-                    if (existingContents.Length == ConfigFileContents.Length)
+                    string existingContents = File.ReadAllText(targetFileName);
+                    if (existingContents.Equals(ConfigFileContents))
                     {
-                        if (existingContents.Equals(ConfigFileContents))
-                        {
-                            return true;
-                        }
+                        return true;
                     }
                 }
                 var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
-                File.WriteAllText(FileName.ItemSpec, ConfigFileContents, encoding);
+                File.WriteAllText(targetFileName, ConfigFileContents, encoding);
                 return true;
             }
             catch (IOException ex)

--- a/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
+++ b/src/Compilers/Core/MSBuildTask/GenerateMSBuildEditorConfig.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return string.IsNullOrEmpty(FileName.ItemSpec) ? true : WriteMSBuildEditorConfig();
         }
 
-        public bool WriteMSBuildEditorConfig()
+        private static bool WriteMSBuildEditorConfig()
         {
             try
             {

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -186,14 +186,10 @@
     <!-- Transform the collected properties and items into an editor config file -->
     <GenerateMSBuildEditorConfig
       PropertyItems="@(_GeneratedEditorConfigProperty)"
-      MetadataItems="@(_GeneratedEditorConfigMetadata)">
-
-      <Output TaskParameter="ConfigFileContents"
-          PropertyName="_GeneratedEditorConfigFileContent" />
+      MetadataItems="@(_GeneratedEditorConfigMetadata)"
+      FileName="$(GeneratedMSBuildEditorConfigFile)">
     </GenerateMSBuildEditorConfig>
 
-    <!-- Write the output to the generated file, if it's changed -->
-    <WriteLinesToFile Lines="$(_GeneratedEditorConfigFileContent)" File="$(GeneratedMSBuildEditorConfigFile)" Overwrite="True" WriteOnlyWhenDifferent="True" />
   </Target>
 
   <!--

--- a/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
@@ -375,6 +375,7 @@ build_property.Property2 = def456
 ";
 
             Assert.True(File.Exists(fileName));
+            Assert.True(configTask.WriteMSBuildEditorConfig());
             Assert.Equal(expectedContents, File.ReadAllText(fileName));
         }
     }

--- a/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -22,10 +23,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         [Fact]
         public void GlobalPropertyIsGeneratedIfEmpty()
         {
-            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
-            {
-                FileName = GetTestFilePath()
-            };
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig();
             configTask.Execute();
 
             var result = configTask.ConfigFileContents;
@@ -41,8 +39,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                PropertyItems = new[] { property1, property2 },
-                FileName = GetTestFilePath()
+                PropertyItems = new[] { property1, property2 }
             };
             configTask.Execute();
 
@@ -61,8 +58,7 @@ build_property.Property2 = def456
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1 },
-                FileName = GetTestFilePath()
+                MetadataItems = new[] { item1 }
             };
             configTask.Execute();
 
@@ -84,8 +80,7 @@ build_metadata.Compile.ToRetrieve = abc123
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2, item3 },
-                FileName = GetTestFilePath()
+                MetadataItems = new[] { item1, item2, item3 }
             };
             configTask.Execute();
 
@@ -114,8 +109,7 @@ build_metadata.AdditionalFiles.ToRetrieve = ghi789
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2, item3 },
-                FileName = GetTestFilePath()
+                MetadataItems = new[] { item1, item2, item3 }
             };
             configTask.Execute();
 
@@ -142,8 +136,7 @@ build_metadata.Compile.ToRetrieve = ghi789
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2 },
-                FileName = GetTestFilePath()
+                MetadataItems = new[] { item1, item2 }
             };
             configTask.Execute();
 
@@ -164,8 +157,7 @@ build_metadata.AdditionalFile.ToRetrieve = def456
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1 },
-                FileName = GetTestFilePath()
+                MetadataItems = new[] { item1 }
             };
             configTask.Execute();
 
@@ -187,8 +179,7 @@ build_metadata.Compile.ToRetrieve =
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2, item3 },
-                FileName = GetTestFilePath()
+                MetadataItems = new[] { item1, item2, item3 }
             };
             configTask.Execute();
 
@@ -214,8 +205,7 @@ build_metadata.Compile.ToRetrieve =
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1, item2, item3, item4 },
-                PropertyItems = new[] { property1, property2 },
-                FileName = GetTestFilePath()
+                PropertyItems = new[] { property1, property2 }
             };
             configTask.Execute();
 
@@ -246,8 +236,7 @@ build_metadata.AdditionalFiles.ToRetrieve = ghi789
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2, item3 },
-                FileName = GetTestFilePath()
+                MetadataItems = new[] { item1, item2, item3 }
             };
             configTask.Execute();
             var result = configTask.ConfigFileContents;
@@ -281,8 +270,7 @@ build_metadata.Compile.ToRetrieve = abc123
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2 },
-                FileName = GetTestFilePath()
+                MetadataItems = new[] { item1, item2 }
             };
             configTask.Execute();
 
@@ -325,8 +313,7 @@ values
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                PropertyItems = new[] { property1, property2 },
-                FileName = GetTestFilePath()
+                PropertyItems = new[] { property1, property2 }
             };
             configTask.Execute();
 
@@ -354,8 +341,7 @@ build_property.Property2 = def456
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1 },
-                FileName = GetTestFilePath()
+                MetadataItems = new[] { item1 }
             };
             configTask.Execute();
 
@@ -368,11 +354,28 @@ build_metadata.Compile.ToRetrieve = abc123
 ", result);
         }
 
-        private static ITaskItem GetTestFilePath([CallerMemberName] string callerName = "")
+        [Fact]
+        public void ConfigFileCanBeWrittenToDisk()
         {
-            string executingLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)?.Replace('\\', '/') ?? string.Empty;
-            string path = $"{executingLocation}/{callerName}.GenerateMSBuildEditorConfig.editorconfig";
-            return new TaskItem(path);
+            ITaskItem property1 = MSBuildUtil.CreateTaskItem("Property1", new Dictionary<string, string> { { "Value", "abc123" } });
+            ITaskItem property2 = MSBuildUtil.CreateTaskItem("Property2", new Dictionary<string, string> { { "Value", "def456" } });
+
+            var fileName = Path.Combine(TempRoot.Root, "ConfigFileCanBeWrittenToDisk.GenerateMSBuildEditorConfig.editorconfig");
+
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
+            {
+                PropertyItems = new[] { property1, property2 },
+                FileName = new TaskItem(fileName)
+            };
+            configTask.Execute();
+
+            var expectedContents = @"is_global = true
+build_property.Property1 = abc123
+build_property.Property2 = def456
+";
+
+            Assert.True(File.Exists(fileName));
+            Assert.Equal(expectedContents, File.ReadAllText(fileName));
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/GenerateMSBuildEditorConfigTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
@@ -21,7 +22,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         [Fact]
         public void GlobalPropertyIsGeneratedIfEmpty()
         {
-            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig();
+            GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
+            {
+                FileName = GetTestFilePath()
+            };
             configTask.Execute();
 
             var result = configTask.ConfigFileContents;
@@ -37,7 +41,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                PropertyItems = new[] { property1, property2 }
+                PropertyItems = new[] { property1, property2 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -56,7 +61,8 @@ build_property.Property2 = def456
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1 }
+                MetadataItems = new[] { item1 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -78,7 +84,8 @@ build_metadata.Compile.ToRetrieve = abc123
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2, item3 }
+                MetadataItems = new[] { item1, item2, item3 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -107,7 +114,8 @@ build_metadata.AdditionalFiles.ToRetrieve = ghi789
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2, item3 }
+                MetadataItems = new[] { item1, item2, item3 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -134,7 +142,8 @@ build_metadata.Compile.ToRetrieve = ghi789
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2 }
+                MetadataItems = new[] { item1, item2 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -155,7 +164,8 @@ build_metadata.AdditionalFile.ToRetrieve = def456
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1 }
+                MetadataItems = new[] { item1 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -177,7 +187,8 @@ build_metadata.Compile.ToRetrieve =
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2, item3 }
+                MetadataItems = new[] { item1, item2, item3 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -203,7 +214,8 @@ build_metadata.Compile.ToRetrieve =
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
                 MetadataItems = new[] { item1, item2, item3, item4 },
-                PropertyItems = new[] { property1, property2 }
+                PropertyItems = new[] { property1, property2 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -234,7 +246,8 @@ build_metadata.AdditionalFiles.ToRetrieve = ghi789
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2, item3 }
+                MetadataItems = new[] { item1, item2, item3 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
             var result = configTask.ConfigFileContents;
@@ -268,7 +281,8 @@ build_metadata.Compile.ToRetrieve = abc123
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1, item2 }
+                MetadataItems = new[] { item1, item2 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -311,7 +325,8 @@ values
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                PropertyItems = new[] { property1, property2 }
+                PropertyItems = new[] { property1, property2 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -339,7 +354,8 @@ build_property.Property2 = def456
 
             GenerateMSBuildEditorConfig configTask = new GenerateMSBuildEditorConfig()
             {
-                MetadataItems = new[] { item1 }
+                MetadataItems = new[] { item1 },
+                FileName = GetTestFilePath()
             };
             configTask.Execute();
 
@@ -350,6 +366,13 @@ build_property.Property2 = def456
 [c:/file1.cs]
 build_metadata.Compile.ToRetrieve = abc123
 ", result);
+        }
+
+        private static ITaskItem GetTestFilePath([CallerMemberName] string callerName = "")
+        {
+            string executingLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)?.Replace('\\', '/') ?? string.Empty;
+            string path = $"{executingLocation}/{callerName}.GenerateMSBuildEditorConfig.editorconfig";
+            return new TaskItem(path);
         }
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -125,10 +125,6 @@ namespace Microsoft.CodeAnalysis
                 {
                     sb.Append(lexer.EatCurrentCharacter());
                 }
-                else
-                {
-                    sb.Append(lexer.CurrentCharacter);
-                }
             }
             escapedSectionName = sb.ToString();
             return true;

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -114,6 +114,26 @@ namespace Microsoft.CodeAnalysis
                 numberRangePairs.ToImmutableAndFree());
         }
 
+        internal static bool TryUnescapeSectionName(string sectionName, out string? escapedSectionName)
+        {
+            var sb = new StringBuilder();
+            SectionNameLexer lexer = new SectionNameLexer(sectionName);
+            while (!lexer.IsDone)
+            {
+                var tokenKind = lexer.Lex();
+                if (tokenKind == TokenKind.SimpleCharacter)
+                {
+                    sb.Append(lexer.EatCurrentCharacter());
+                }
+                else
+                {
+                    sb.Append(lexer.CurrentCharacter);
+                }
+            }
+            escapedSectionName = sb.ToString();
+            return true;
+        }
+
         /// <summary>
         /// Test if a section name is an absolute path with no special chars
         /// </summary>

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -199,7 +199,8 @@ namespace Microsoft.CodeAnalysis
             // If we have a global config, add any sections that match the full path 
             foreach (var section in _globalConfig.NamedSections)
             {
-                if (normalizedPath.Equals(section.Name, Section.NameComparer))
+                var escapedSectionName = TryUnescapeSectionName(section.Name, out var sectionName);
+                if (escapedSectionName && normalizedPath.Equals(sectionName, Section.NameComparer))
                 {
                     sectionKey.Add(section);
                 }


### PR DESCRIPTION
Resolves issues like https://github.com/dotnet/aspnetcore/issues/33832 and https://github.com/dotnet/roslyn/issues/51692.

Follow-up to https://github.com/dotnet/roslyn/pull/52515.

**Changes in this PR**

1. Avoid using the `WriteLinesToFile` task to write the editor config to disk and write to disk inside `GenerateMSBuildConfigEditor` task.

Moving from C# to MSBuild to EditorConfig causes a lot of weird issues when writing editorconfigs with special characters mostly due to MSBuild's behavior in certain scenarios.

* The editorconfig format uses backslashes to escape characters but MSBuild automatically converts backslashes to forward slashes which breaks writing special characters to disk.
* Semicolons aren't interpretted correctly when processed in MSBuild since they are treated as item separators.
* Probably some other weirdness that I'm not accounting for here.

Given all this, I think it makes sense to move the file writes to inside the `GenerateMSBuildConfigEditor` task to avoid issues that come up because of the interop between C# strings, MSBuild strings, and editorconfig's requirements.

2. Escape section names before comparing source paths with the associated section names in `GetSectionFromSource`.

**Validations**
- Local unit tests
- Ran the changeset against the https://github.com/dotnet/website project which contains an AdditionalText that falls victim to this bug ([ref](https://github.com/dotnet/website/blob/main/src/netlandingpage/Pages/thanks/%7Breleaseid%7D.cshtml))
- Ran the changeset against the Razor source generator integration tests

