### PR TITLE
Fix OptProf drop path in 16.10

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -211,7 +211,7 @@ stages:
         ARTIFACTSERVICES_DROP_PAT: $(_DevDivDropAccessToken)
       inputs:
         dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
-        buildNumber: 'ProfilingInputs/DevDiv/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)'
+        buildNumber: 'ProfilingInputs/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)'
         sourcePath: '$(Build.SourcesDirectory)\artifacts\OptProf\$(BuildConfiguration)\Data'
         toLowerCase: false
         usePat: false


### PR DESCRIPTION
We fixed the drop path a while ago in other branches (#53722) but forgot about 16.10, and it's causing OptProf test to break after we inserted a new build from dnceng pipeline recently. Fixed it in this branch too just in case

PR in VS that's fixing the drop issue:
https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/335189