### PR TITLE
Reduce overheads of NullOperationListener.Delay

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListenerProvider+NullOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListenerProvider+NullOperationListener.cs
@@ -40,9 +40,9 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
                 var t = Task.Delay(delay, cancellationToken);
                 if (t.IsCompleted)
                 {
-                    return t.Status == TaskStatus.RanToCompletion ?
-                        SpecializedTasks.True :
-                        Task.FromCanceled<bool>(cancellationToken);
+                    return t.Status == TaskStatus.RanToCompletion
+                        ? SpecializedTasks.True
+                        : Task.FromCanceled<bool>(cancellationToken);
                 }
 
                 return t.ContinueWith(

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListenerProvider+NullOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListenerProvider+NullOperationListener.cs
@@ -6,6 +6,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.TestHooks
 {
@@ -19,10 +20,42 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
                 [CallerFilePath] string filePath = "",
                 [CallerLineNumber] int lineNumber = 0) => EmptyAsyncToken.Instance;
 
-            public async Task<bool> Delay(TimeSpan delay, CancellationToken cancellationToken)
+            public Task<bool> Delay(TimeSpan delay, CancellationToken cancellationToken)
             {
-                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                return true;
+                // This could be as simple as:
+                //     await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                //     return true;
+                // However, whereas in general cancellation is expected to be rare and thus throwing
+                // an exception in response isn't very impactful, here it's expected to be the case
+                // more often than not as the operation is being used to delay an operation because
+                // it's expected something else is going to happen to obviate the need for that
+                // operation.  Thus, we can spend a little more code avoiding the additional throw
+                // for the common case of an exception occurring.
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return Task.FromCanceled<bool>(cancellationToken);
+                }
+
+                var t = Task.Delay(delay, cancellationToken);
+                if (t.IsCompleted)
+                {
+                    return t.Status == TaskStatus.RanToCompletion ?
+                        SpecializedTasks.True :
+                        Task.FromCanceled<bool>(cancellationToken);
+                }
+
+                return t.ContinueWith(
+                    _ => true,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.NotOnCanceled,
+                    TaskScheduler.Default);
+
+                // Note the above passes CancellationToken.None and TaskContinuationOptions.NotOnCanceled.
+                // That's cheaper than passing cancellationToken and with the same semantics except
+                // that if the returned task does end up being canceled, any operation canceled exception
+                // thrown won't contain the cancellationToken.  If that ends up being impactful, it can
+                // be switched to use `cancellationToken, TaskContinuationOptions.ExecuteSynchronously`.
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListenerProvider+NullOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListenerProvider+NullOperationListener.cs
@@ -40,6 +40,8 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
                 var t = Task.Delay(delay, cancellationToken);
                 if (t.IsCompleted)
                 {
+                    // Avoid ContinueWith overheads for a 0 delay or if race conditions resulted
+                    // in the delay task being complete by the time we checked.
                     return t.Status == TaskStatus.RanToCompletion
                         ? SpecializedTasks.True
                         : Task.FromCanceled<bool>(cancellationToken);


### PR DESCRIPTION
This is showing up as a primary source of first-chance cancellation exceptions while creating projects in VS.

On .NET Framework 4.8:

|                   Method |              Mean | Allocated |
|------------------------- |------------------:|----------:|
|        CanceledWithAsync |     13,006.369 ns |   2,327 B |
| CanceledWithContinueWith |      1,028.581 ns |   1,051 B |
|   |   |  |
|          Delay0WithAsync |         62.790 ns |       0 B |
|       Delay0ContinueWith |          6.936 ns |       0 B |
|   |   |  |
|          Delay1WithAsync | 15,848,603.711 ns |     640 B |
|       Delay1ContinueWith | 15,668,003.846 ns |     512 B |

On .NET 6.0:

|                   Method |              Mean | Allocated |
|------------------------- |------------------:|----------:|
|        CanceledWithAsync |      8,368.800 ns |   1,664 B |
| CanceledWithContinueWith |        397.767 ns |     696 B |
|   |   |  |
|          Delay0WithAsync |         17.956 ns |       0 B |
|       Delay0ContinueWith |          6.066 ns |       0 B |
|   |   |  |
|          Delay1WithAsync | 15,839,737.292 ns |     404 B |
|       Delay1ContinueWith | 15,718,382.169 ns |     406 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Running;
using System.Threading;
using System.Threading.Tasks;
using BenchmarkDotNet.Diagnosers;
using Perfolizer.Horology;
using BenchmarkDotNet.Columns;
using System.Globalization;
using BenchmarkDotNet.Reports;

[MemoryDiagnoser]
public class Program
{
    public static void Main(string[] args) =>
        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args,
            DefaultConfig.Instance.WithSummaryStyle(new SummaryStyle(CultureInfo.InvariantCulture,
                printUnitsInHeader: false,
                sizeUnit: SizeUnit.B,
                timeUnit: TimeUnit.Nanosecond,
                printZeroValuesInContent: true)));

    [Benchmark]
    public Task CanceledWithAsync()
    {
        var cts = new CancellationTokenSource();
        Task<bool> t = DelayWithAsync(1_000_000, cts.Token);
        cts.Cancel();
        return t.ContinueWith(_ => _, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
    }

    [Benchmark]
    public Task CanceledWithContinueWith()
    {
        var cts = new CancellationTokenSource();
        Task<bool> t = DelayWithContinueWith(1_000_000, cts.Token);
        cts.Cancel();
        return t.ContinueWith(_ => _, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
    }

    [Benchmark]
    public Task<bool> Delay0WithAsync() => DelayWithAsync(0, default);

    [Benchmark]
    public Task<bool> Delay0ContinueWith() => DelayWithContinueWith(0, default);

    [Benchmark]
    public Task<bool> Delay1WithAsync() => DelayWithAsync(1, default);

    [Benchmark]
    public Task<bool> Delay1ContinueWith() => DelayWithContinueWith(1, default);

    private static async Task<bool> DelayWithAsync(int delay, CancellationToken cancellationToken)
    {
        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
        return true;
    }

    private static Task<bool> DelayWithContinueWith(int delay, CancellationToken cancellationToken)
    {
        if (cancellationToken.IsCancellationRequested)
        {
            return Task.FromCanceled<bool>(cancellationToken);
        }

        var t = Task.Delay(delay, cancellationToken);
        if (t.IsCompleted)
        {
            return t.Status == TaskStatus.RanToCompletion ?
                SpecializedTasks.True :
                Task.FromCanceled<bool>(cancellationToken);
        }

        return t.ContinueWith(
            _ => true,
            CancellationToken.None,
            TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.NotOnCanceled,
            TaskScheduler.Default);
    }

    class SpecializedTasks
    {
        public static readonly Task<bool> True = Task.FromResult(true);
    }
}
```