### PR TITLE
Inline Hints Alignment Bug

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
@@ -157,10 +157,11 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                 Background = format.BackgroundBrush,
                 Child = block,
                 MaxHeight = lineHeight,
+                VerticalAlignment = VerticalAlignment.Center,
                 CornerRadius = new CornerRadius(2),
 
                 // Highlighting lines are 2px buffer.  So shift us up by one from the bottom so we feel centered between them.
-                Margin = new Thickness(left, top: 0, right, bottom: 1),
+                Margin = new Thickness(left, top: 0, right, bottom: 2),
             };
 
             border.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
@@ -150,25 +150,35 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             // left or right side.
             var left = leftPadding * 5;
             var right = rightPadding * 5;
+            var lineHeight = Math.Floor(format.Typeface.FontFamily.LineSpacing * format.FontRenderingEmSize * 0.75);
 
             var border = new Border
             {
                 Background = format.BackgroundBrush,
                 Child = block,
+                MaxHeight = lineHeight,
                 CornerRadius = new CornerRadius(2),
 
                 // Highlighting lines are 2px buffer.  So shift us up by one from the bottom so we feel centered between them.
                 Margin = new Thickness(left, top: 0, right, bottom: 1),
             };
 
+            border.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+
+            var stackPanel = new StackPanel
+            {
+                Height = lineHeight * (4 / 3),
+                Orientation = Orientation.Horizontal
+            };
+
             // Need to set these properties to avoid unnecessary reformatting because some dependancy properties
             // affect layout
-            TextOptions.SetTextFormattingMode(border, TextOptions.GetTextFormattingMode(textView.VisualElement));
-            TextOptions.SetTextHintingMode(border, TextOptions.GetTextHintingMode(textView.VisualElement));
-            TextOptions.SetTextRenderingMode(border, TextOptions.GetTextRenderingMode(textView.VisualElement));
+            TextOptions.SetTextFormattingMode(stackPanel, TextOptions.GetTextFormattingMode(textView.VisualElement));
+            TextOptions.SetTextHintingMode(stackPanel, TextOptions.GetTextHintingMode(textView.VisualElement));
+            TextOptions.SetTextRenderingMode(stackPanel, TextOptions.GetTextRenderingMode(textView.VisualElement));
 
-            border.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
-            return border;
+            stackPanel.Children.Add(border);
+            return stackPanel;
         }
 
         private static (ImmutableArray<TaggedText> texts, int leftPadding, int rightPadding) Trim(ImmutableArray<TaggedText> taggedTexts)

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
@@ -124,8 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
 
                 // Adds a little bit of padding to the left of the text relative to the border to make the text seem
                 // more balanced in the border
-                Padding = new Thickness(left: 2, top: 0, right: 2, bottom: 0),
-                VerticalAlignment = VerticalAlignment.Center,
+                Padding = new Thickness(left: 2, top: 0, right: 2, bottom: 0)
             };
 
             var (trimmedTexts, leftPadding, rightPadding) = Trim(taggedTexts);
@@ -150,35 +149,45 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             // left or right side.
             var left = leftPadding * 5;
             var right = rightPadding * 5;
-            var lineHeight = Math.Floor(format.Typeface.FontFamily.LineSpacing * format.FontRenderingEmSize * 0.75);
 
             var border = new Border
             {
                 Background = format.BackgroundBrush,
                 Child = block,
-                MaxHeight = lineHeight,
-                VerticalAlignment = VerticalAlignment.Center,
                 CornerRadius = new CornerRadius(2),
-
-                // Highlighting lines are 2px buffer.  So shift us up by one from the bottom so we feel centered between them.
-                Margin = new Thickness(left, top: 0, right, bottom: 2),
+                VerticalAlignment = VerticalAlignment.Bottom,
+                Margin = new Thickness(left, top: 0, right, bottom: 0),
             };
 
             border.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            // gets pixel distance of baseline to top of the font height
+            var dockPanelHeight = format.Typeface.FontFamily.Baseline * format.FontRenderingEmSize;
+
+            var dockPanel = new DockPanel
+            {
+                Height = dockPanelHeight,
+                LastChildFill = false,
+                // VerticalAlignment is set to Top because it will rest to the top relative to the stackpanel
+                VerticalAlignment = VerticalAlignment.Top
+            };
+
+            dockPanel.Children.Add(border);
+            DockPanel.SetDock(border, Dock.Bottom);
 
             var stackPanel = new StackPanel
             {
-                Height = lineHeight * (4 / 3),
-                Orientation = Orientation.Horizontal
+                // Height set to align the baseline of the text within the TextBlock with the baseline of text in the editor
+                Height = dockPanelHeight + (block.DesiredSize.Height - (block.FontFamily.Baseline * block.FontSize)),
+                Orientation = Orientation.Vertical
             };
 
+            stackPanel.Children.Add(dockPanel);
             // Need to set these properties to avoid unnecessary reformatting because some dependancy properties
             // affect layout
             TextOptions.SetTextFormattingMode(stackPanel, TextOptions.GetTextFormattingMode(textView.VisualElement));
             TextOptions.SetTextHintingMode(stackPanel, TextOptions.GetTextHintingMode(textView.VisualElement));
             TextOptions.SetTextRenderingMode(stackPanel, TextOptions.GetTextRenderingMode(textView.VisualElement));
 
-            stackPanel.Children.Add(border);
             return stackPanel;
         }
 


### PR DESCRIPTION
Hello!

This is a fix for an inline hints issue that came to light in dev17. The hints did not look centered anymore with the switch from default font of Consolas to Cascadia Code.

Before:
![image](https://user-images.githubusercontent.com/40616383/124205568-5c18a280-da96-11eb-89fb-4ff65de724ee.png)

After:
![image](https://user-images.githubusercontent.com/40616383/124205311-ddbc0080-da95-11eb-9abc-952f969b0f24.png)


This fix constructs containers that are positioned relative to the baseline of the font. This way we can align the text within the textblock with the text in the editor. This removes the need for a margin at the bottom of the Border in order to lift it and make it feel more balanced in the line. That margin would vary from font to font because of the different size spaces between text and the bottom of the line.