### PR TITLE
Initial fix for issue "VB Formatting of LineContinuation Wrong after _ ' Comment"

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineTemporary/InlineTemporaryTests.vb
@@ -2916,7 +2916,7 @@ End Module
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)>
-        Public Async Function TestEscapeKeywordsIfNeeded5CommentsAfterLineContinuation() As Task
+        Public Async Function TestEscapeKeywordsIfNeeded5CommentsAfterLineContinuation_PC() As Task
             Dim code =
 <File>
 Imports System.Linq
@@ -2939,7 +2939,7 @@ Imports System.Linq
 Module Program
     Sub Main()
         Dim y = From x In ""
- _ ' Test
+                            _ ' Test
         [Take]()
         Dim t = 1
     End Sub

--- a/src/Workspaces/CoreTest/CodeCleanup/NormalizeModifiersOrOperatorsTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/NormalizeModifiersOrOperatorsTests.cs
@@ -671,7 +671,7 @@ End Class";
         [Fact]
         [WorkItem(544520, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544520")]
         [Trait(Traits.Feature, Traits.Features.NormalizeModifiersOrOperators)]
-        public async Task RemoveByVal_LineContinuation()
+        public async Task RemoveByVal_LineContinuation_PC()
         {
             var code = @"[|Class A
     Sub Method( _
@@ -684,7 +684,7 @@ End Class|]";
             var expected = @"Class A
     Sub Method( _
         ByVal _
- _
+              _
             t As String, ByRef t1 As String)
     End Sub
 End Class";
@@ -721,7 +721,7 @@ End Class|]";
             var expected = @"Class A
     Private _
         Shared _
- _
+               _
             a As Integer = 1
 End Class";
 

--- a/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.RemoveUnnecessaryLineContinuation)]
-        public async Task ColonTrivia_LineContinuation_Comment()
+        public async Task ColonTrivia_LineContinuation_Comment_PC()
         {
             var code = @"[|
         ::: 
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
 
             var expected = @"
 
- _
+                       _
         ' test
         Console.WriteLine("")";
 
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.RemoveUnnecessaryLineContinuation)]
-        public async Task ColonToken_LineContinuation_AfterColonToken_Colon_Comment()
+        public async Task ColonToken_LineContinuation_AfterColonToken_Colon_Comment_PC()
         {
             var code = @"[|
          Console.WriteLine() : _
@@ -398,9 +398,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
 
             var expected = @"
         Console.WriteLine() _
- _
+                            _
         ' test
- _
+        _
         Console.WriteLine()";
 
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
@@ -461,7 +461,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.RemoveUnnecessaryLineContinuation)]
-        public async Task ImplicitLineContinuation_Multiple()
+        public async Task ImplicitLineContinuation_Multiple_PC()
         {
             var code = @"[|
         Dim i = _
@@ -471,7 +471,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
 
             var expected = @"
         Dim i = _
- _
+                _
                 1 +
                 2";
 
@@ -799,7 +799,7 @@ End Module";
         [Fact]
         [WorkItem(544520, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544520")]
         [Trait(Traits.Feature, Traits.Features.RemoveUnnecessaryLineContinuation)]
-        public async Task LineContinuation_MixedWithImplicitLineContinuation()
+        public async Task LineContinuation_MixedWithImplicitLineContinuation_PC()
         {
             var code = @"[|Module Program
     Sub Main(
@@ -811,7 +811,7 @@ End Module|]";
 
             var expected = @"Module Program
     Sub Main(
- _
+             _
         args _
         As String)
     End Sub

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/TriviaEngine/LineColumnRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/TriviaEngine/LineColumnRule.cs
@@ -124,9 +124,9 @@ namespace Microsoft.CodeAnalysis.Formatting
             => new(
                 SpaceOperations.Force,
                 LineOperations.Preserve,
-                IndentationOperations.Absolute,
+                IndentationOperations.Follow,
                 lines: 0,
-                spacesOrIndentation,
+                1,
                 spacesOrIndentation);
 
         public enum SpaceOperations

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.Analyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.Analyzer.vb
@@ -35,12 +35,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                 If list.Count = 0 Then
                     Return
                 End If
-
+                Dim previousTrivia As SyntaxTrivia = New SyntaxTrivia
                 For Each trivia In list
                     If trivia.Kind = SyntaxKind.WhitespaceTrivia Then
                         AnalyzeWhitespacesInTrivia(trivia, result)
                     ElseIf trivia.Kind = SyntaxKind.EndOfLineTrivia Then
-                        AnalyzeLineBreak(trivia, result)
+                        AnalyzeLineBreak(previousTrivia, trivia, result)
                     ElseIf trivia.Kind = SyntaxKind.CommentTrivia OrElse trivia.Kind = SyntaxKind.DocumentationCommentTrivia Then
                         result.HasComments = True
                     ElseIf trivia.Kind = SyntaxKind.DisabledTextTrivia OrElse trivia.Kind = SyntaxKind.SkippedTokensTrivia Then
@@ -56,6 +56,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
                         result.HasPreprocessor = True
                     End If
+                    previousTrivia = trivia
                 Next
             End Sub
 
@@ -71,19 +72,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                 result.Tab = 0
             End Sub
 
-            Private Shared Sub AnalyzeLineBreak(trivia As SyntaxTrivia, ByRef result As AnalysisResult)
-                ' if there was any space before line break, then we have trailing spaces
-                If result.Space > 0 OrElse result.Tab > 0 Then
-                    result.HasTrailingSpace = True
+            Private Shared Sub AnalyzeLineBreak(previousTrivia As SyntaxTrivia, trivia As SyntaxTrivia, ByRef result As AnalysisResult)
+                ' if there was any space immediately before line break, then we have trailing spaces
+                Dim text = previousTrivia.ToString()
+                If previousTrivia.Kind = SyntaxKind.WhitespaceTrivia Then
+                    For i As Integer = 0 To previousTrivia.Width - 1
+                        If text(i) = " "c OrElse text(i) = vbTab Then
+                            result.HasTrailingSpace = True
+                            result.HasTabAfterSpace = False
+                            result.Space = 0
+                            result.Tab = 0
+                            result.TreatAsElastic = result.TreatAsElastic Or trivia.IsElastic()
+                            Exit For
+                        End If
+                    Next i
                 End If
 
                 ' reset space and tab information
                 result.LineBreaks += 1
 
-                result.HasTabAfterSpace = False
-                result.Space = 0
-                result.Tab = 0
-                result.TreatAsElastic = result.TreatAsElastic Or trivia.IsElastic()
             End Sub
 
             Private Shared Sub AnalyzeWhitespacesInTrivia(trivia As SyntaxTrivia, ByRef result As AnalysisResult)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
             ' line continuation
             If trivia2.Kind = SyntaxKind.LineContinuationTrivia Then
-                Return LineColumnRule.ForceSpacesOrUseAbsoluteIndentation(spacesOrIndentation:=1)
+                Return LineColumnRule.ForceSpacesOrUseAbsoluteIndentation(spacesOrIndentation:=0)
             End If
 
             If IsStartOrEndOfFile(trivia1, trivia2) Then

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -852,7 +852,7 @@ End Class"
         <Theory, Trait(Traits.Feature, Traits.Features.Formatting)>
         <InlineData("_")>
         <InlineData("_ ' Comment")>
-        Public Async Function LineContinuation4(continuation As String) As Task
+        Public Async Function LineContinuation4_PC(continuation As String) As Task
             Dim code = $"Class C
     Sub Method(Optional ByVal i As Integer = 1)
                     Dim aa = 1 + {continuation}
@@ -869,11 +869,11 @@ End Class"
             Dim expected = $"Class C
     Sub Method(Optional ByVal i As Integer = 1)
         Dim aa = 1 + {continuation}
- {continuation}
- {continuation}
- {continuation}
- {continuation}
- {continuation}
+                     {continuation}
+                     {continuation}
+                     {continuation}
+                     {continuation}
+                     {continuation}
 2 + {continuation}
 3
     End Sub
@@ -885,7 +885,7 @@ End Class"
         <Theory, Trait(Traits.Feature, Traits.Features.Formatting)>
         <InlineData("_")>
         <InlineData("_ ' Comment")>
-        Public Async Function LineContinuation5(continuation As String) As Task
+        Public Async Function LineContinuation5_PC(continuation As String) As Task
             Dim code = $"Class C
     Sub Method(Optional ByVal i As Integer = 1)
         Dim aa = 1 + {continuation}
@@ -902,11 +902,11 @@ End Class"
             Dim expected = $"Class C
     Sub Method(Optional ByVal i As Integer = 1)
         Dim aa = 1 + {continuation}
- {continuation}
- {continuation}
- {continuation}
- {continuation}
- {continuation}
+                     {continuation}
+                     {continuation}
+                     {continuation}
+                     {continuation}
+                     {continuation}
     2 + {continuation}
     3
     End Sub


### PR DESCRIPTION
Issue #36891 There are some VB constants in C# Abstract function that needs to be addressed and C# code needs to be cleaned up and not look like it was written by VB programmer. All "Line Continuation" Tests pass. I await all tests to run.