### PR TITLE
✨ Implement SegmentedHashSet<T>

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/ISet_Generic_Tests`1.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/ISet_Generic_Tests`1.cs
@@ -1,0 +1,617 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    /// <summary>
+    /// Contains tests that ensure the correctness of any class that implements the generic
+    /// ISet interface.
+    ///
+    /// Tests for an ISet follow a rather different structure because of the consistency in
+    /// function signatures. Instead of having a test for every data scenario within a class for
+    /// every set function, there is instead a test for every configuration of enumerable parameter.
+    /// Each of those tests calls a Validation function that calculates the expected result and then
+    /// compares it to the actual result of the set operation.
+    /// </summary>
+    public abstract class ISet_Generic_Tests<T> : ICollection_Generic_Tests<T>
+    {
+        #region ISet<T> Helper methods
+
+        /// <summary>
+        /// Creates an instance of an ISet{T} that can be used for testing.
+        /// </summary>
+        /// <returns>An instance of an ISet{T} that can be used for testing.</returns>
+        protected abstract ISet<T> GenericISetFactory();
+
+        /// <summary>
+        /// Creates an instance of an ISet{T} that can be used for testing.
+        /// </summary>
+        /// <param name="count">The number of unique items that the returned ISet{T} contains.</param>
+        /// <returns>An instance of an ISet{T} that can be used for testing.</returns>
+        protected virtual ISet<T> GenericISetFactory(int count)
+        {
+            ISet<T> collection = GenericISetFactory();
+            AddToCollection(collection, count);
+            return collection;
+        }
+
+        protected override void AddToCollection(ICollection<T> collection, int numberOfItemsToAdd)
+        {
+            int seed = 9600;
+            ISet<T> set = (ISet<T>)collection;
+            while (set.Count < numberOfItemsToAdd)
+            {
+                T toAdd = CreateT(seed++);
+                while (set.Contains(toAdd) || (InvalidValues != Array.Empty<T>() && InvalidValues.Contains(toAdd, GetIEqualityComparer())))
+                    toAdd = CreateT(seed++);
+                set.Add(toAdd);
+            }
+        }
+
+        protected virtual int ISet_Large_Capacity => 1000;
+
+        #endregion
+
+        #region ICollection<T> Helper Methods
+
+        protected override ICollection<T> GenericICollectionFactory() => GenericISetFactory();
+
+        protected override ICollection<T> GenericICollectionFactory(int count) => GenericISetFactory(count);
+
+        protected override bool DuplicateValuesAllowed => false;
+        protected override bool DefaultValueWhenNotAllowed_Throws => false;
+
+        #endregion
+
+        #region ICollection_Generic
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ICollection_Generic_Add_ReturnValue(int count)
+        {
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(count);
+                int seed = 92834;
+                T newValue = CreateT(seed++);
+                while (set.Contains(newValue))
+                    newValue = CreateT(seed++);
+                Assert.True(set.Add(newValue));
+                if (!DuplicateValuesAllowed)
+                    Assert.False(set.Add(newValue));
+                Assert.Equal(count + 1, set.Count);
+                Assert.True(set.Contains(newValue));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ICollection_Generic_Add_DuplicateValue_DoesNothing(int count)
+        {
+            if (!IsReadOnly)
+            {
+                if (!DuplicateValuesAllowed)
+                {
+                    ICollection<T> collection = GenericICollectionFactory(count);
+                    int seed = 800;
+                    T duplicateValue = CreateT(seed++);
+                    while (collection.Contains(duplicateValue))
+                        duplicateValue = CreateT(seed++);
+                    collection.Add(duplicateValue);
+                    collection.Add(duplicateValue);
+                    Assert.Equal(count + 1, collection.Count);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Set Function Validation
+
+        private void Validate_ExceptWith(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            if (set.Count == 0 || enumerable == set)
+            {
+                set.ExceptWith(enumerable);
+                Assert.Equal(0, set.Count);
+            }
+            else
+            {
+                HashSet<T> expected = new HashSet<T>(set, GetIEqualityComparer());
+                foreach (T element in enumerable)
+                    expected.Remove(element);
+                set.ExceptWith(enumerable);
+                Assert.Equal(expected.Count, set.Count);
+                Assert.True(expected.SetEquals(set));
+            }
+        }
+
+        private void Validate_IntersectWith(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            if (set.Count == 0 || Enumerable.Count(enumerable) == 0)
+            {
+                set.IntersectWith(enumerable);
+                Assert.Equal(0, set.Count);
+            }
+            else if (set == enumerable)
+            {
+                HashSet<T> beforeOperation = new HashSet<T>(set, GetIEqualityComparer());
+                set.IntersectWith(enumerable);
+                Assert.True(beforeOperation.SetEquals(set));
+            }
+            else
+            {
+                IEqualityComparer<T> comparer = GetIEqualityComparer();
+                HashSet<T> expected = new HashSet<T>(comparer);
+                foreach (T value in set)
+                    if (enumerable.Contains(value, comparer))
+                        expected.Add(value);
+                set.IntersectWith(enumerable);
+                Assert.Equal(expected.Count, set.Count);
+                Assert.True(expected.SetEquals(set));
+            }
+        }
+
+        private void Validate_IsProperSubsetOf(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            bool setContainsValueNotInEnumerable = false;
+            bool enumerableContainsValueNotInSet = false;
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            foreach (T value in set) // Every value in Set must be in Enumerable
+            {
+                if (!enumerable.Contains(value, comparer))
+                {
+                    setContainsValueNotInEnumerable = true;
+                    break;
+                }
+            }
+            foreach (T value in enumerable) // Enumerable must contain at least one value not in Set
+            {
+                if (!set.Contains(value, comparer))
+                {
+                    enumerableContainsValueNotInSet = true;
+                    break;
+                }
+            }
+            Assert.Equal(!setContainsValueNotInEnumerable && enumerableContainsValueNotInSet, set.IsProperSubsetOf(enumerable));
+        }
+
+        private void Validate_IsProperSupersetOf(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            bool isProperSuperset = true;
+            bool setContainsElementsNotInEnumerable = false;
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            foreach (T value in enumerable)
+            {
+                if (!set.Contains(value, comparer))
+                {
+                    isProperSuperset = false;
+                    break;
+                }
+            }
+            foreach (T value in set)
+            {
+                if (!enumerable.Contains(value, comparer))
+                {
+                    setContainsElementsNotInEnumerable = true;
+                    break;
+                }
+            }
+            isProperSuperset = isProperSuperset && setContainsElementsNotInEnumerable;
+            Assert.Equal(isProperSuperset, set.IsProperSupersetOf(enumerable));
+        }
+
+        private void Validate_IsSubsetOf(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            foreach (T value in set)
+                if (!enumerable.Contains(value, comparer))
+                {
+                    Assert.False(set.IsSubsetOf(enumerable));
+                    return;
+                }
+            Assert.True(set.IsSubsetOf(enumerable));
+        }
+
+        private void Validate_IsSupersetOf(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            foreach (T value in enumerable)
+                if (!set.Contains(value, comparer))
+                {
+                    Assert.False(set.IsSupersetOf(enumerable));
+                    return;
+                }
+            Assert.True(set.IsSupersetOf(enumerable));
+        }
+
+        private void Validate_Overlaps(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            foreach (T value in enumerable)
+            {
+                if (set.Contains(value, comparer))
+                {
+                    Assert.True(set.Overlaps(enumerable));
+                    return;
+                }
+            }
+            Assert.False(set.Overlaps(enumerable));
+        }
+
+        private void Validate_SetEquals(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            foreach (T value in set)
+            {
+                if (!enumerable.Contains(value, comparer))
+                {
+                    Assert.False(set.SetEquals(enumerable));
+                    return;
+                }
+            }
+            foreach (T value in enumerable)
+            {
+                if (!set.Contains(value, comparer))
+                {
+                    Assert.False(set.SetEquals(enumerable));
+                    return;
+                }
+            }
+            Assert.True(set.SetEquals(enumerable));
+        }
+
+        private void Validate_SymmetricExceptWith(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            HashSet<T> expected = new HashSet<T>(comparer);
+            foreach (T element in enumerable)
+                if (!set.Contains(element, comparer))
+                    expected.Add(element);
+            foreach (T element in set)
+                if (!enumerable.Contains(element, comparer))
+                    expected.Add(element);
+            set.SymmetricExceptWith(enumerable);
+            Assert.Equal(expected.Count, set.Count);
+            Assert.True(expected.SetEquals(set));
+        }
+
+        private void Validate_UnionWith(ISet<T> set, IEnumerable<T> enumerable)
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            HashSet<T> expected = new HashSet<T>(set, comparer);
+            foreach (T element in enumerable)
+                if (!set.Contains(element, comparer))
+                    expected.Add(element);
+            set.UnionWith(enumerable);
+            Assert.Equal(expected.Count, set.Count);
+            Assert.True(expected.SetEquals(set));
+        }
+
+        #endregion
+
+        #region Set Function tests
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_NullEnumerableArgument(int count)
+        {
+            ISet<T> set = GenericISetFactory(count);
+            Assert.Throws<ArgumentNullException>(() => set.ExceptWith(null));
+            Assert.Throws<ArgumentNullException>(() => set.IntersectWith(null));
+            Assert.Throws<ArgumentNullException>(() => set.IsProperSubsetOf(null));
+            Assert.Throws<ArgumentNullException>(() => set.IsProperSupersetOf(null));
+            Assert.Throws<ArgumentNullException>(() => set.IsSubsetOf(null));
+            Assert.Throws<ArgumentNullException>(() => set.IsSupersetOf(null));
+            Assert.Throws<ArgumentNullException>(() => set.Overlaps(null));
+            Assert.Throws<ArgumentNullException>(() => set.SetEquals(null));
+            Assert.Throws<ArgumentNullException>(() => set.SymmetricExceptWith(null));
+            Assert.Throws<ArgumentNullException>(() => set.UnionWith(null));
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_ExceptWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_ExceptWith(set, enumerable);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_IntersectWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_IntersectWith(set, enumerable);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_IsProperSubsetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_IsProperSubsetOf(set, enumerable);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_IsProperSupersetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_IsProperSupersetOf(set, enumerable);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_IsSubsetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_IsSubsetOf(set, enumerable);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_IsSupersetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_IsSupersetOf(set, enumerable);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_Overlaps(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_Overlaps(set, enumerable);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_SetEquals(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_SetEquals(set, enumerable);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_SymmetricExceptWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_SymmetricExceptWith(set, enumerable);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_UnionWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Validate_UnionWith(set, enumerable);
+        }
+
+        #endregion
+
+        #region Set Function tests on itself
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_ExceptWith_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Validate_ExceptWith(set, set);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws InvalidOperationException")]
+        public void ISet_Generic_IntersectWith_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Validate_IntersectWith(set, set);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_IsProperSubsetOf_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Validate_IsProperSubsetOf(set, set);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_IsProperSupersetOf_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Validate_IsProperSupersetOf(set, set);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_IsSubsetOf_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Validate_IsSubsetOf(set, set);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_IsSupersetOf_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Validate_IsSupersetOf(set, set);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_Overlaps_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Validate_Overlaps(set, set);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_SetEquals_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Assert.True(set.SetEquals(set));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_SymmetricExceptWith_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Validate_SymmetricExceptWith(set, set);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void ISet_Generic_UnionWith_Itself(int setLength)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            Validate_UnionWith(set, set);
+        }
+
+        #endregion
+
+        #region Set Function tests on a large Set
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_ExceptWith_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_ExceptWith(set, enumerable);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_IntersectWith_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_IntersectWith(set, enumerable);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_IsProperSubsetOf_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_IsProperSubsetOf(set, enumerable);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_IsProperSupersetOf_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_IsProperSupersetOf(set, enumerable);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_IsSubsetOf_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_IsSubsetOf(set, enumerable);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_IsSupersetOf_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_IsSupersetOf(set, enumerable);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_Overlaps_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_Overlaps(set, enumerable);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_SetEquals_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_SetEquals(set, enumerable);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_SymmetricExceptWith_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_SymmetricExceptWith(set, enumerable);
+        }
+
+        [Fact]
+        [OuterLoop]
+        public void ISet_Generic_UnionWith_LargeSet()
+        {
+            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+            Validate_UnionWith(set, enumerable);
+        }
+
+        #endregion
+
+        #region Other misc ISet test Scenarios
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void ISet_Generic_SymmetricExceptWith_AfterRemovingElements(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            ISet<T> set = GenericISetFactory(setLength);
+            T value = CreateT(532);
+            if (!set.Contains(value))
+                set.Add(value);
+            set.Remove(value);
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+            Debug.Assert(enumerable != null);
+
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            HashSet<T> expected = new HashSet<T>(comparer);
+            foreach (T element in enumerable)
+                if (!set.Contains(element, comparer))
+                    expected.Add(element);
+            foreach (T element in set)
+                if (!enumerable.Contains(element, comparer))
+                    expected.Add(element);
+            set.SymmetricExceptWith(enumerable);
+            Assert.Equal(expected.Count, set.Count);
+            Assert.True(expected.SetEquals(set));
+        }
+
+        #endregion
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/ISet_Generic_Tests`1.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/ISet_Generic_Tests`1.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/Common/tests/System/Collections/ISet.Generic.Tests.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/ISet_Generic_Tests`1.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/ISet_Generic_Tests`1.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/Common/tests/System/Collections/ISet.Generic.Tests.cs
@@ -7,12 +8,14 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace System.Collections.Tests
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
 {
     /// <summary>
     /// Contains tests that ensure the correctness of any class that implements the generic
@@ -25,6 +28,7 @@ namespace System.Collections.Tests
     /// compares it to the actual result of the set operation.
     /// </summary>
     public abstract class ISet_Generic_Tests<T> : ICollection_Generic_Tests<T>
+        where T : notnull
     {
         #region ISet<T> Helper methods
 
@@ -139,7 +143,7 @@ namespace System.Collections.Tests
 
         private void Validate_IntersectWith(ISet<T> set, IEnumerable<T> enumerable)
         {
-            if (set.Count == 0 || Enumerable.Count(enumerable) == 0)
+            if (set.Count == 0 || !Enumerable.Any(enumerable))
             {
                 set.IntersectWith(enumerable);
                 Assert.Equal(0, set.Count);
@@ -308,16 +312,16 @@ namespace System.Collections.Tests
         public void ISet_Generic_NullEnumerableArgument(int count)
         {
             ISet<T> set = GenericISetFactory(count);
-            Assert.Throws<ArgumentNullException>(() => set.ExceptWith(null));
-            Assert.Throws<ArgumentNullException>(() => set.IntersectWith(null));
-            Assert.Throws<ArgumentNullException>(() => set.IsProperSubsetOf(null));
-            Assert.Throws<ArgumentNullException>(() => set.IsProperSupersetOf(null));
-            Assert.Throws<ArgumentNullException>(() => set.IsSubsetOf(null));
-            Assert.Throws<ArgumentNullException>(() => set.IsSupersetOf(null));
-            Assert.Throws<ArgumentNullException>(() => set.Overlaps(null));
-            Assert.Throws<ArgumentNullException>(() => set.SetEquals(null));
-            Assert.Throws<ArgumentNullException>(() => set.SymmetricExceptWith(null));
-            Assert.Throws<ArgumentNullException>(() => set.UnionWith(null));
+            Assert.Throws<ArgumentNullException>(() => set.ExceptWith(null!));
+            Assert.Throws<ArgumentNullException>(() => set.IntersectWith(null!));
+            Assert.Throws<ArgumentNullException>(() => set.IsProperSubsetOf(null!));
+            Assert.Throws<ArgumentNullException>(() => set.IsProperSupersetOf(null!));
+            Assert.Throws<ArgumentNullException>(() => set.IsSubsetOf(null!));
+            Assert.Throws<ArgumentNullException>(() => set.IsSupersetOf(null!));
+            Assert.Throws<ArgumentNullException>(() => set.Overlaps(null!));
+            Assert.Throws<ArgumentNullException>(() => set.SetEquals(null!));
+            Assert.Throws<ArgumentNullException>(() => set.SymmetricExceptWith(null!));
+            Assert.Throws<ArgumentNullException>(() => set.UnionWith(null!));
         }
 
         [Theory]
@@ -422,9 +426,8 @@ namespace System.Collections.Tests
             Validate_ExceptWith(set, set);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(CoreClrOnly))]
         [MemberData(nameof(ValidCollectionSizes))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws InvalidOperationException")]
         public void ISet_Generic_IntersectWith_Itself(int setLength)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -500,7 +503,6 @@ namespace System.Collections.Tests
         #region Set Function tests on a large Set
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_ExceptWith_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
@@ -509,7 +511,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_IntersectWith_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
@@ -518,7 +519,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_IsProperSubsetOf_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
@@ -527,7 +527,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_IsProperSupersetOf_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
@@ -536,7 +535,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_IsSubsetOf_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
@@ -545,7 +543,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_IsSupersetOf_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
@@ -554,7 +551,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_Overlaps_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
@@ -563,7 +559,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_SetEquals_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
@@ -572,7 +567,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_SymmetricExceptWith_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
@@ -581,7 +575,6 @@ namespace System.Collections.Tests
         }
 
         [Fact]
-        [OuterLoop]
         public void ISet_Generic_UnionWith_LargeSet()
         {
             ISet<T> set = GenericISetFactory(ISet_Large_Capacity);

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests.cs
@@ -1,0 +1,199 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public class HashSet_Generic_Tests_string : HashSet_Generic_Tests<string>
+    {
+        protected override string CreateT(int seed)
+        {
+            int stringLength = seed % 10 + 5;
+            Random rand = new Random(seed);
+            byte[] bytes = new byte[stringLength];
+            rand.NextBytes(bytes);
+            return Convert.ToBase64String(bytes);
+        }
+    }
+
+    public class HashSet_Generic_Tests_int : HashSet_Generic_Tests<int>
+    {
+        protected override int CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return rand.Next();
+        }
+
+        protected override bool DefaultValueAllowed => true;
+    }
+
+    public class HashSet_Generic_Tests_int_With_Comparer_WrapStructural_Int : HashSet_Generic_Tests<int>
+    {
+        protected override IEqualityComparer<int> GetIEqualityComparer()
+        {
+            return new WrapStructural_Int();
+        }
+
+        protected override IComparer<int> GetIComparer()
+        {
+            return new WrapStructural_Int();
+        }
+
+        protected override int CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return rand.Next();
+        }
+
+        protected override ISet<int> GenericISetFactory()
+        {
+            return new HashSet<int>(new WrapStructural_Int());
+        }
+    }
+
+    public class HashSet_Generic_Tests_int_With_Comparer_WrapStructural_SimpleInt : HashSet_Generic_Tests<SimpleInt>
+    {
+        protected override IEqualityComparer<SimpleInt> GetIEqualityComparer()
+        {
+            return new WrapStructural_SimpleInt();
+        }
+
+        protected override IComparer<SimpleInt> GetIComparer()
+        {
+            return new WrapStructural_SimpleInt();
+        }
+
+        protected override SimpleInt CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return new SimpleInt(rand.Next());
+        }
+
+        protected override ISet<SimpleInt> GenericISetFactory()
+        {
+            return new HashSet<SimpleInt>(new WrapStructural_SimpleInt());
+        }
+    }
+
+    [OuterLoop]
+    public class HashSet_Generic_Tests_EquatableBackwardsOrder : HashSet_Generic_Tests<EquatableBackwardsOrder>
+    {
+        protected override EquatableBackwardsOrder CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return new EquatableBackwardsOrder(rand.Next());
+        }
+
+        protected override ISet<EquatableBackwardsOrder> GenericISetFactory()
+        {
+            return new HashSet<EquatableBackwardsOrder>();
+        }
+    }
+
+    [OuterLoop]
+    public class HashSet_Generic_Tests_int_With_Comparer_SameAsDefaultComparer : HashSet_Generic_Tests<int>
+    {
+        protected override IEqualityComparer<int> GetIEqualityComparer()
+        {
+            return new Comparer_SameAsDefaultComparer();
+        }
+
+        protected override int CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return rand.Next();
+        }
+
+        protected override ISet<int> GenericISetFactory()
+        {
+            return new HashSet<int>(new Comparer_SameAsDefaultComparer());
+        }
+    }
+
+    [OuterLoop]
+    public class HashSet_Generic_Tests_int_With_Comparer_HashCodeAlwaysReturnsZero : HashSet_Generic_Tests<int>
+    {
+        protected override IEqualityComparer<int> GetIEqualityComparer()
+        {
+            return new Comparer_HashCodeAlwaysReturnsZero();
+        }
+
+        protected override int CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return rand.Next();
+        }
+
+        protected override ISet<int> GenericISetFactory()
+        {
+            return new HashSet<int>(new Comparer_HashCodeAlwaysReturnsZero());
+        }
+    }
+
+    [OuterLoop]
+    public class HashSet_Generic_Tests_int_With_Comparer_ModOfInt : HashSet_Generic_Tests<int>
+    {
+        protected override IEqualityComparer<int> GetIEqualityComparer()
+        {
+            return new Comparer_ModOfInt(15000);
+        }
+
+        protected override IComparer<int> GetIComparer()
+        {
+            return new Comparer_ModOfInt(15000);
+        }
+
+        protected override int CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return rand.Next();
+        }
+
+        protected override ISet<int> GenericISetFactory()
+        {
+            return new HashSet<int>(new Comparer_ModOfInt(15000));
+        }
+    }
+
+    [OuterLoop]
+    public class HashSet_Generic_Tests_int_With_Comparer_AbsOfInt : HashSet_Generic_Tests<int>
+    {
+        protected override IEqualityComparer<int> GetIEqualityComparer()
+        {
+            return new Comparer_AbsOfInt();
+        }
+
+        protected override int CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return rand.Next();
+        }
+
+        protected override ISet<int> GenericISetFactory()
+        {
+            return new HashSet<int>(new Comparer_AbsOfInt());
+        }
+    }
+
+    [OuterLoop]
+    public class HashSet_Generic_Tests_int_With_Comparer_BadIntEqualityComparer : HashSet_Generic_Tests<int>
+    {
+        protected override IEqualityComparer<int> GetIEqualityComparer()
+        {
+            return new BadIntEqualityComparer();
+        }
+
+        protected override int CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return rand.Next();
+        }
+
+        protected override ISet<int> GenericISetFactory()
+        {
+            return new HashSet<int>(new BadIntEqualityComparer());
+        }
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.Generic.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.Generic.cs
@@ -7,12 +8,13 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
+using System;
 using System.Collections.Generic;
-using Xunit;
+using Microsoft.CodeAnalysis.Collections;
 
-namespace System.Collections.Tests
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
 {
-    public class HashSet_Generic_Tests_string : HashSet_Generic_Tests<string>
+    public class SegmentedHashSet_Generic_Tests_string : SegmentedHashSet_Generic_Tests<string>
     {
         protected override string CreateT(int seed)
         {
@@ -24,7 +26,7 @@ namespace System.Collections.Tests
         }
     }
 
-    public class HashSet_Generic_Tests_int : HashSet_Generic_Tests<int>
+    public class SegmentedHashSet_Generic_Tests_int : SegmentedHashSet_Generic_Tests<int>
     {
         protected override int CreateT(int seed)
         {
@@ -35,7 +37,7 @@ namespace System.Collections.Tests
         protected override bool DefaultValueAllowed => true;
     }
 
-    public class HashSet_Generic_Tests_int_With_Comparer_WrapStructural_Int : HashSet_Generic_Tests<int>
+    public class SegmentedHashSet_Generic_Tests_int_With_Comparer_WrapStructural_Int : SegmentedHashSet_Generic_Tests<int>
     {
         protected override IEqualityComparer<int> GetIEqualityComparer()
         {
@@ -55,11 +57,11 @@ namespace System.Collections.Tests
 
         protected override ISet<int> GenericISetFactory()
         {
-            return new HashSet<int>(new WrapStructural_Int());
+            return new SegmentedHashSet<int>(new WrapStructural_Int());
         }
     }
 
-    public class HashSet_Generic_Tests_int_With_Comparer_WrapStructural_SimpleInt : HashSet_Generic_Tests<SimpleInt>
+    public class SegmentedHashSet_Generic_Tests_int_With_Comparer_WrapStructural_SimpleInt : SegmentedHashSet_Generic_Tests<SimpleInt>
     {
         protected override IEqualityComparer<SimpleInt> GetIEqualityComparer()
         {
@@ -79,12 +81,11 @@ namespace System.Collections.Tests
 
         protected override ISet<SimpleInt> GenericISetFactory()
         {
-            return new HashSet<SimpleInt>(new WrapStructural_SimpleInt());
+            return new SegmentedHashSet<SimpleInt>(new WrapStructural_SimpleInt());
         }
     }
 
-    [OuterLoop]
-    public class HashSet_Generic_Tests_EquatableBackwardsOrder : HashSet_Generic_Tests<EquatableBackwardsOrder>
+    public class SegmentedHashSet_Generic_Tests_EquatableBackwardsOrder : SegmentedHashSet_Generic_Tests<EquatableBackwardsOrder>
     {
         protected override EquatableBackwardsOrder CreateT(int seed)
         {
@@ -94,12 +95,11 @@ namespace System.Collections.Tests
 
         protected override ISet<EquatableBackwardsOrder> GenericISetFactory()
         {
-            return new HashSet<EquatableBackwardsOrder>();
+            return new SegmentedHashSet<EquatableBackwardsOrder>();
         }
     }
 
-    [OuterLoop]
-    public class HashSet_Generic_Tests_int_With_Comparer_SameAsDefaultComparer : HashSet_Generic_Tests<int>
+    public class SegmentedHashSet_Generic_Tests_int_With_Comparer_SameAsDefaultComparer : SegmentedHashSet_Generic_Tests<int>
     {
         protected override IEqualityComparer<int> GetIEqualityComparer()
         {
@@ -114,12 +114,11 @@ namespace System.Collections.Tests
 
         protected override ISet<int> GenericISetFactory()
         {
-            return new HashSet<int>(new Comparer_SameAsDefaultComparer());
+            return new SegmentedHashSet<int>(new Comparer_SameAsDefaultComparer());
         }
     }
 
-    [OuterLoop]
-    public class HashSet_Generic_Tests_int_With_Comparer_HashCodeAlwaysReturnsZero : HashSet_Generic_Tests<int>
+    public class SegmentedHashSet_Generic_Tests_int_With_Comparer_HashCodeAlwaysReturnsZero : SegmentedHashSet_Generic_Tests<int>
     {
         protected override IEqualityComparer<int> GetIEqualityComparer()
         {
@@ -134,12 +133,11 @@ namespace System.Collections.Tests
 
         protected override ISet<int> GenericISetFactory()
         {
-            return new HashSet<int>(new Comparer_HashCodeAlwaysReturnsZero());
+            return new SegmentedHashSet<int>(new Comparer_HashCodeAlwaysReturnsZero());
         }
     }
 
-    [OuterLoop]
-    public class HashSet_Generic_Tests_int_With_Comparer_ModOfInt : HashSet_Generic_Tests<int>
+    public class SegmentedHashSet_Generic_Tests_int_With_Comparer_ModOfInt : SegmentedHashSet_Generic_Tests<int>
     {
         protected override IEqualityComparer<int> GetIEqualityComparer()
         {
@@ -159,12 +157,11 @@ namespace System.Collections.Tests
 
         protected override ISet<int> GenericISetFactory()
         {
-            return new HashSet<int>(new Comparer_ModOfInt(15000));
+            return new SegmentedHashSet<int>(new Comparer_ModOfInt(15000));
         }
     }
 
-    [OuterLoop]
-    public class HashSet_Generic_Tests_int_With_Comparer_AbsOfInt : HashSet_Generic_Tests<int>
+    public class SegmentedHashSet_Generic_Tests_int_With_Comparer_AbsOfInt : SegmentedHashSet_Generic_Tests<int>
     {
         protected override IEqualityComparer<int> GetIEqualityComparer()
         {
@@ -179,12 +176,11 @@ namespace System.Collections.Tests
 
         protected override ISet<int> GenericISetFactory()
         {
-            return new HashSet<int>(new Comparer_AbsOfInt());
+            return new SegmentedHashSet<int>(new Comparer_AbsOfInt());
         }
     }
 
-    [OuterLoop]
-    public class HashSet_Generic_Tests_int_With_Comparer_BadIntEqualityComparer : HashSet_Generic_Tests<int>
+    public class SegmentedHashSet_Generic_Tests_int_With_Comparer_BadIntEqualityComparer : SegmentedHashSet_Generic_Tests<int>
     {
         protected override IEqualityComparer<int> GetIEqualityComparer()
         {
@@ -199,7 +195,7 @@ namespace System.Collections.Tests
 
         protected override ISet<int> GenericISetFactory()
         {
-            return new HashSet<int>(new BadIntEqualityComparer());
+            return new SegmentedHashSet<int>(new BadIntEqualityComparer());
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests`1.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests`1.cs
@@ -1,0 +1,711 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    /// <summary>
+    /// Contains tests that ensure the correctness of the HashSet class.
+    /// </summary>
+    public abstract class HashSet_Generic_Tests<T> : ISet_Generic_Tests<T>
+    {
+        #region ISet<T> Helper Methods
+
+        protected override bool ResetImplemented => true;
+
+        protected override ModifyOperation ModifyEnumeratorThrows => PlatformDetection.IsNetFramework ? base.ModifyEnumeratorThrows : (base.ModifyEnumeratorAllowed & ~(ModifyOperation.Remove | ModifyOperation.Clear));
+
+        protected override ModifyOperation ModifyEnumeratorAllowed => PlatformDetection.IsNetFramework ? base.ModifyEnumeratorAllowed : ModifyOperation.Overwrite | ModifyOperation.Remove | ModifyOperation.Clear;
+
+        protected override ISet<T> GenericISetFactory()
+        {
+            return new HashSet<T>();
+        }
+
+        #endregion
+
+        #region Constructors
+
+        private static IEnumerable<int> NonSquares(int limit)
+        {
+            for (int i = 0; i != limit; ++i)
+            {
+                int root = (int)Math.Sqrt(i);
+                if (i != root * root)
+                    yield return i;
+            }
+        }
+
+        [Fact]
+        public void HashSet_Generic_Constructor()
+        {
+            HashSet<T> set = new HashSet<T>();
+            Assert.Empty(set);
+        }
+
+        [Fact]
+        public void HashSet_Generic_Constructor_IEqualityComparer()
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            HashSet<T> set = new HashSet<T>(comparer);
+            if (comparer == null)
+                Assert.Equal(EqualityComparer<T>.Default, set.Comparer);
+            else
+                Assert.Equal(comparer, set.Comparer);
+        }
+
+        [Fact]
+        public void HashSet_Generic_Constructor_NullIEqualityComparer()
+        {
+            IEqualityComparer<T> comparer = null;
+            HashSet<T> set = new HashSet<T>(comparer);
+            if (comparer == null)
+                Assert.Equal(EqualityComparer<T>.Default, set.Comparer);
+            else
+                Assert.Equal(comparer, set.Comparer);
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void HashSet_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            _ = setLength;
+            _ = numberOfMatchingElements;
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
+            HashSet<T> set = new HashSet<T>(enumerable);
+            Assert.True(set.SetEquals(enumerable));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_Constructor_IEnumerable_WithManyDuplicates(int count)
+        {
+            IEnumerable<T> items = CreateEnumerable(EnumerableType.List, null, count, 0, 0);
+            HashSet<T> hashSetFromDuplicates = new HashSet<T>(Enumerable.Range(0, 40).SelectMany(i => items).ToArray());
+            HashSet<T> hashSetFromNoDuplicates = new HashSet<T>(items);
+            Assert.True(hashSetFromNoDuplicates.SetEquals(hashSetFromDuplicates));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_Constructor_HashSet_SparselyFilled(int count)
+        {
+            HashSet<T> source = (HashSet<T>)CreateEnumerable(EnumerableType.HashSet, null, count, 0, 0);
+            List<T> sourceElements = source.ToList();
+            foreach (int i in NonSquares(count))
+                source.Remove(sourceElements[i]);// Unevenly spaced survivors increases chance of catching any spacing-related bugs.
+
+
+            HashSet<T> set = new HashSet<T>(source, GetIEqualityComparer());
+            Assert.True(set.SetEquals(source));
+        }
+
+        [Fact]
+        public void HashSet_Generic_Constructor_IEnumerable_Null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HashSet<T>((IEnumerable<T>)null));
+            Assert.Throws<ArgumentNullException>(() => new HashSet<T>((IEnumerable<T>)null, EqualityComparer<T>.Default));
+        }
+
+        [Theory]
+        [MemberData(nameof(EnumerableTestData))]
+        public void HashSet_Generic_Constructor_IEnumerable_IEqualityComparer(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
+        {
+            _ = setLength;
+            _ = numberOfMatchingElements;
+            _ = numberOfDuplicateElements;
+            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
+            HashSet<T> set = new HashSet<T>(enumerable, GetIEqualityComparer());
+            Assert.True(set.SetEquals(enumerable));
+        }
+
+        #endregion
+
+        #region RemoveWhere
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_RemoveWhere_AllElements(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+            int removedCount = set.RemoveWhere((value) => { return true; });
+            Assert.Equal(setLength, removedCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_RemoveWhere_NoElements(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+            int removedCount = set.RemoveWhere((value) => { return false; });
+            Assert.Equal(0, removedCount);
+            Assert.Equal(setLength, set.Count);
+        }
+
+        [Fact]
+        public void HashSet_Generic_RemoveWhere_NewObject() // Regression Dev10_624201
+        {
+            object[] array = new object[2];
+            object obj = new object();
+            HashSet<object> set = new HashSet<object>();
+
+            set.Add(obj);
+            set.Remove(obj);
+            foreach (object o in set) { }
+            set.CopyTo(array, 0, 2);
+            set.RemoveWhere((element) => { return false; });
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_RemoveWhere_NullMatchPredicate(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+            Assert.Throws<ArgumentNullException>(() => set.RemoveWhere(null));
+        }
+
+        #endregion
+
+        #region TrimExcess
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_TrimExcess_OnValidSetThatHasntBeenRemovedFrom(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+            set.TrimExcess();
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_TrimExcess_Repeatedly(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+            List<T> expected = set.ToList();
+            set.TrimExcess();
+            set.TrimExcess();
+            set.TrimExcess();
+            Assert.True(set.SetEquals(expected));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_TrimExcess_AfterRemovingOneElement(int setLength)
+        {
+            if (setLength > 0)
+            {
+                HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+                List<T> expected = set.ToList();
+                T elementToRemove = set.ElementAt(0);
+
+                set.TrimExcess();
+                Assert.True(set.Remove(elementToRemove));
+                expected.Remove(elementToRemove);
+                set.TrimExcess();
+
+                Assert.True(set.SetEquals(expected));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_TrimExcess_AfterClearingAndAddingSomeElementsBack(int setLength)
+        {
+            if (setLength > 0)
+            {
+                HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+                set.TrimExcess();
+                set.Clear();
+                set.TrimExcess();
+                Assert.Equal(0, set.Count);
+
+                AddToCollection(set, setLength / 10);
+                set.TrimExcess();
+                Assert.Equal(setLength / 10, set.Count);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_TrimExcess_AfterClearingAndAddingAllElementsBack(int setLength)
+        {
+            if (setLength > 0)
+            {
+                HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+                set.TrimExcess();
+                set.Clear();
+                set.TrimExcess();
+                Assert.Equal(0, set.Count);
+
+                AddToCollection(set, setLength);
+                set.TrimExcess();
+                Assert.Equal(setLength, set.Count);
+            }
+        }
+
+        #endregion
+
+        #region CopyTo
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_CopyTo_NegativeCount_ThrowsArgumentOutOfRangeException(int count)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(count);
+            T[] arr = new T[count];
+            Assert.Throws<ArgumentOutOfRangeException>(() => set.CopyTo(arr, 0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => set.CopyTo(arr, 0, int.MinValue));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_CopyTo_NoIndexDefaultsToZero(int count)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(count);
+            T[] arr1 = new T[count];
+            T[] arr2 = new T[count];
+            set.CopyTo(arr1);
+            set.CopyTo(arr2, 0);
+            Assert.True(arr1.SequenceEqual(arr2));
+        }
+
+        #endregion
+
+        #region CreateSetComparer
+
+        [Fact]
+        public void SetComparer_SetEqualsTests()
+        {
+            List<T> objects = new List<T>() { CreateT(1), CreateT(2), CreateT(3), CreateT(4), CreateT(5), CreateT(6) };
+
+            var set = new HashSet<HashSet<T>>()
+            {
+                new HashSet<T> { objects[0], objects[1], objects[2] },
+                new HashSet<T> { objects[3], objects[4], objects[5] }
+            };
+
+            var noComparerSet = new HashSet<HashSet<T>>()
+            {
+                new HashSet<T> { objects[0], objects[1], objects[2] },
+                new HashSet<T> { objects[3], objects[4], objects[5] }
+            };
+
+            var comparerSet1 = new HashSet<HashSet<T>>(HashSet<T>.CreateSetComparer())
+            {
+                new HashSet<T> { objects[0], objects[1], objects[2] },
+                new HashSet<T> { objects[3], objects[4], objects[5] }
+            };
+
+            var comparerSet2 = new HashSet<HashSet<T>>(HashSet<T>.CreateSetComparer())
+            {
+                new HashSet<T> { objects[3], objects[4], objects[5] },
+                new HashSet<T> { objects[0], objects[1], objects[2] }
+            };
+
+            Assert.False(noComparerSet.SetEquals(set));
+            Assert.True(comparerSet1.SetEquals(set));
+            Assert.True(comparerSet2.SetEquals(set));
+        }
+
+        [Fact]
+        public void SetComparer_SequenceEqualTests()
+        {
+            List<T> objects = new List<T>() { CreateT(1), CreateT(2), CreateT(3), CreateT(4), CreateT(5), CreateT(6) };
+
+            var set = new HashSet<HashSet<T>>()
+            {
+                new HashSet<T> { objects[0], objects[1], objects[2] },
+                new HashSet<T> { objects[3], objects[4], objects[5] }
+            };
+
+            var noComparerSet = new HashSet<HashSet<T>>()
+            {
+                new HashSet<T> { objects[0], objects[1], objects[2] },
+                new HashSet<T> { objects[3], objects[4], objects[5] }
+            };
+
+            var comparerSet = new HashSet<HashSet<T>>(HashSet<T>.CreateSetComparer())
+            {
+                new HashSet<T> { objects[0], objects[1], objects[2] },
+                new HashSet<T> { objects[3], objects[4], objects[5] }
+            };
+
+            Assert.False(noComparerSet.SequenceEqual(set));
+            Assert.True(noComparerSet.SequenceEqual(set, HashSet<T>.CreateSetComparer()));
+            Assert.False(comparerSet.SequenceEqual(set));
+        }
+
+        #endregion
+
+        [Fact]
+        public void CanBeCastedToISet()
+        {
+            HashSet<T> set = new HashSet<T>();
+            ISet<T> iset = (set as ISet<T>);
+            Assert.NotNull(iset);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_Constructor_int(int capacity)
+        {
+            HashSet<T> set = new HashSet<T>(capacity);
+            Assert.Equal(0, set.Count);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_Constructor_int_AddUpToAndBeyondCapacity(int capacity)
+        {
+            HashSet<T> set = new HashSet<T>(capacity);
+
+            AddToCollection(set, capacity);
+            Assert.Equal(capacity, set.Count);
+
+            AddToCollection(set, capacity + 1);
+            Assert.Equal(capacity + 1, set.Count);
+        }
+
+        [Fact]
+        public void HashSet_Generic_Constructor_Capacity_ToNextPrimeNumber()
+        {
+            // Highest pre-computed number + 1.
+            const int Capacity = 7199370;
+            var set = new HashSet<T>(Capacity);
+
+            // Assert that the HashTable's capacity is set to the descendant prime number of the given one.
+            const int NextPrime = 7199371;
+            Assert.Equal(NextPrime, set.EnsureCapacity(0));
+        }
+
+        [Fact]
+        public void HashSet_Generic_Constructor_int_Negative_ThrowsArgumentOutOfRangeException()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => new HashSet<T>(-1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => new HashSet<T>(int.MinValue));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_Constructor_int_IEqualityComparer(int capacity)
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            HashSet<T> set = new HashSet<T>(capacity, comparer);
+            Assert.Equal(0, set.Count);
+            if (comparer == null)
+                Assert.Equal(EqualityComparer<T>.Default, set.Comparer);
+            else
+                Assert.Equal(comparer, set.Comparer);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void HashSet_Generic_Constructor_int_IEqualityComparer_AddUpToAndBeyondCapacity(int capacity)
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            HashSet<T> set = new HashSet<T>(capacity, comparer);
+
+            AddToCollection(set, capacity);
+            Assert.Equal(capacity, set.Count);
+
+            AddToCollection(set, capacity + 1);
+            Assert.Equal(capacity + 1, set.Count);
+        }
+
+        [Fact]
+        public void HashSet_Generic_Constructor_int_IEqualityComparer_Negative_ThrowsArgumentOutOfRangeException()
+        {
+            IEqualityComparer<T> comparer = GetIEqualityComparer();
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => new HashSet<T>(-1, comparer));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => new HashSet<T>(int.MinValue, comparer));
+        }
+
+        #region TryGetValue
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_Contains()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue;
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same((object)value, (object)actualValue);
+            }
+        }
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_Contains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(1);
+            T actualValue = CreateT(2);
+            Assert.True(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(value, actualValue);
+            if (!typeof(T).IsValueType)
+            {
+                Assert.Same((object)value, (object)actualValue);
+            }
+        }
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_NotContains()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
+        }
+
+        [Fact]
+        public void HashSet_Generic_TryGetValue_NotContains_OverwriteOutputParam()
+        {
+            T value = CreateT(1);
+            HashSet<T> set = new HashSet<T> { value };
+            T equalValue = CreateT(2);
+            T actualValue = equalValue;
+            Assert.False(set.TryGetValue(equalValue, out actualValue));
+            Assert.Equal(default(T), actualValue);
+        }
+
+        #endregion
+
+        #region EnsureCapacity
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void EnsureCapacity_Generic_RequestingLargerCapacity_DoesNotInvalidateEnumeration(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)(GenericISetFactory(setLength));
+            var capacity = set.EnsureCapacity(0);
+            IEnumerator valuesEnum = set.GetEnumerator();
+            IEnumerator valuesListEnum = new List<T>(set).GetEnumerator();
+
+            set.EnsureCapacity(capacity + 1); // Verify EnsureCapacity does not invalidate enumeration
+
+            while (valuesEnum.MoveNext())
+            {
+                valuesListEnum.MoveNext();
+                Assert.Equal(valuesListEnum.Current, valuesEnum.Current);
+            }
+        }
+
+        [Fact]
+        public void EnsureCapacity_Generic_NegativeCapacityRequested_Throws()
+        {
+            var set = new HashSet<T>();
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("capacity", () => set.EnsureCapacity(-1));
+        }
+
+        [Fact]
+        public void EnsureCapacity_Generic_HashsetNotInitialized_RequestedZero_ReturnsZero()
+        {
+            var set = new HashSet<T>();
+            Assert.Equal(0, set.EnsureCapacity(0));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void EnsureCapacity_Generic_HashsetNotInitialized_RequestedNonZero_CapacityIsSetToAtLeastTheRequested(int requestedCapacity)
+        {
+            var set = new HashSet<T>();
+            Assert.InRange(set.EnsureCapacity(requestedCapacity), requestedCapacity, int.MaxValue);
+        }
+
+        [Theory]
+        [InlineData(3)]
+        [InlineData(7)]
+        public void EnsureCapacity_Generic_RequestedCapacitySmallerThanCurrent_CapacityUnchanged(int currentCapacity)
+        {
+            HashSet<T> set;
+
+            // assert capacity remains the same when ensuring a capacity smaller or equal than existing
+            for (int i = 0; i <= currentCapacity; i++)
+            {
+                set = new HashSet<T>(currentCapacity);
+                Assert.Equal(currentCapacity, set.EnsureCapacity(i));
+            }
+        }
+
+        [Theory]
+        [InlineData(7)]
+        [InlineData(89)]
+        public void EnsureCapacity_Generic_ExistingCapacityRequested_SameValueReturned(int capacity)
+        {
+            var set = new HashSet<T>(capacity);
+            Assert.Equal(capacity, set.EnsureCapacity(capacity));
+
+            set = (HashSet<T>)GenericISetFactory(capacity);
+            Assert.Equal(capacity, set.EnsureCapacity(capacity));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void EnsureCapacity_Generic_EnsureCapacityCalledTwice_ReturnsSameValue(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+            int capacity = set.EnsureCapacity(0);
+            Assert.Equal(capacity, set.EnsureCapacity(0));
+
+            set = (HashSet<T>)GenericISetFactory(setLength);
+            capacity = set.EnsureCapacity(setLength);
+            Assert.Equal(capacity, set.EnsureCapacity(setLength));
+
+            set = (HashSet<T>)GenericISetFactory(setLength);
+            capacity = set.EnsureCapacity(setLength + 1);
+            Assert.Equal(capacity, set.EnsureCapacity(setLength + 1));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(7)]
+        [InlineData(8)]
+        public void EnsureCapacity_Generic_HashsetNotEmpty_RequestedSmallerThanCount_ReturnsAtLeastSizeOfCount(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+            Assert.InRange(set.EnsureCapacity(setLength - 1), setLength, int.MaxValue);
+        }
+
+        [Theory]
+        [InlineData(7)]
+        [InlineData(20)]
+        public void EnsureCapacity_Generic_HashsetNotEmpty_SetsToAtLeastTheRequested(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+
+            // get current capacity
+            int currentCapacity = set.EnsureCapacity(0);
+
+            // assert we can update to a larger capacity
+            int newCapacity = set.EnsureCapacity(currentCapacity * 2);
+            Assert.InRange(newCapacity, currentCapacity * 2, int.MaxValue);
+        }
+
+        [Fact]
+        public void EnsureCapacity_Generic_CapacityIsSetToPrimeNumberLargerOrEqualToRequested()
+        {
+            var set = new HashSet<T>();
+            Assert.Equal(17, set.EnsureCapacity(17));
+
+            set = new HashSet<T>();
+            Assert.Equal(17, set.EnsureCapacity(15));
+
+            set = new HashSet<T>();
+            Assert.Equal(17, set.EnsureCapacity(13));
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(10)]
+        public void EnsureCapacity_Generic_GrowCapacityWithFreeList(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+
+            // Remove the first element to ensure we have a free list.
+            Assert.True(set.Remove(set.ElementAt(0)));
+
+            int currentCapacity = set.EnsureCapacity(0);
+            Assert.True(currentCapacity > 0);
+
+            int newCapacity = set.EnsureCapacity(currentCapacity + 1);
+            Assert.True(newCapacity > currentCapacity);
+        }
+
+        #endregion
+
+        #region Remove
+
+        [Theory]
+        [MemberData(nameof(ValidPositiveCollectionSizes))]
+        public void Remove_NonDefaultComparer_ComparerUsed(int capacity)
+        {
+            var c = new TrackingEqualityComparer<T>();
+            var set = new HashSet<T>(capacity, c);
+
+            AddToCollection(set, capacity);
+            T first = set.First();
+            c.EqualsCalls = 0;
+            c.GetHashCodeCalls = 0;
+
+            Assert.Equal(capacity, set.Count);
+            set.Remove(first);
+            Assert.Equal(capacity - 1, set.Count);
+
+            Assert.InRange(c.EqualsCalls, 1, int.MaxValue);
+            Assert.InRange(c.GetHashCodeCalls, 1, int.MaxValue);
+        }
+
+        #endregion
+
+        #region Serialization
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        public void ComparerSerialization()
+        {
+            // Strings switch between randomized and non-randomized comparers,
+            // however this should never be observable externally.
+            TestComparerSerialization(EqualityComparer<string>.Default);
+
+            // OrdinalCaseSensitiveComparer is internal and (de)serializes as OrdinalComparer
+            TestComparerSerialization(StringComparer.Ordinal, "System.OrdinalComparer");
+
+            // OrdinalIgnoreCaseComparer is internal and (de)serializes as OrdinalComparer
+            TestComparerSerialization(StringComparer.OrdinalIgnoreCase, "System.OrdinalComparer");
+            TestComparerSerialization(StringComparer.CurrentCulture);
+            TestComparerSerialization(StringComparer.CurrentCultureIgnoreCase);
+            TestComparerSerialization(StringComparer.InvariantCulture);
+            TestComparerSerialization(StringComparer.InvariantCultureIgnoreCase);
+
+            // Check other types while here, IEquatable valuetype, nullable valuetype, and non IEquatable object
+            TestComparerSerialization(EqualityComparer<int>.Default);
+            TestComparerSerialization(EqualityComparer<int?>.Default);
+            TestComparerSerialization(EqualityComparer<object>.Default);
+
+            static void TestComparerSerialization<TCompared>(IEqualityComparer<TCompared> equalityComparer, string internalTypeName = null)
+            {
+                var bf = new BinaryFormatter();
+                var s = new MemoryStream();
+
+                var dict = new HashSet<TCompared>(equalityComparer);
+
+                Assert.Same(equalityComparer, dict.Comparer);
+
+                bf.Serialize(s, dict);
+                s.Position = 0;
+                dict = (HashSet<TCompared>)bf.Deserialize(s);
+
+                if (internalTypeName == null)
+                {
+                    Assert.IsType(equalityComparer.GetType(), dict.Comparer);
+                }
+                else
+                {
+                    Assert.Equal(internalTypeName, dict.Comparer.GetType().ToString());
+                }
+
+                Assert.True(equalityComparer.Equals(dict.Comparer));
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests`1.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_Generic_Tests`1.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_IEnumerable_NonGeneric_Tests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_IEnumerable_NonGeneric_Tests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace System.Collections.Tests
+{
+    public class HashSet_IEnumerable_NonGeneric_Tests : IEnumerable_NonGeneric_Tests
+    {
+        protected override IEnumerable NonGenericIEnumerableFactory(int count)
+        {
+            var set = new HashSet<string>();
+            int seed = 12354;
+            while (set.Count < count)
+                set.Add(CreateT(set, seed++));
+            return set;
+        }
+
+        protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+
+        protected override ModifyOperation ModifyEnumeratorThrows => PlatformDetection.IsNetFramework ? base.ModifyEnumeratorThrows : (base.ModifyEnumeratorAllowed & ~ModifyOperation.Remove);
+
+        protected override ModifyOperation ModifyEnumeratorAllowed => PlatformDetection.IsNetFramework ? base.ModifyEnumeratorAllowed : ModifyOperation.Overwrite | ModifyOperation.Remove;
+
+        /// <summary>
+        /// Returns a set of ModifyEnumerable delegates that modify the enumerable passed to them.
+        /// </summary>
+        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations)
+        {
+            if ((operations & ModifyOperation.Clear) == ModifyOperation.Clear)
+            {
+                yield return (IEnumerable enumerable) =>
+                {
+                    HashSet<string> casted = ((HashSet<string>)enumerable);
+                    if (casted.Count > 0)
+                    {
+                        casted.Clear();
+                        return true;
+                    }
+                    return false;
+                };
+            }
+        }
+
+        protected string CreateT(HashSet<string> set, int seed)
+        {
+            int stringLength = seed % 10 + 5;
+            Random rand = new Random(seed);
+            byte[] bytes = new byte[stringLength];
+            rand.NextBytes(bytes);
+            string ret = Convert.ToBase64String(bytes);
+            while (set.Contains(ret))
+            {
+                rand.NextBytes(bytes);
+                ret = Convert.ToBase64String(bytes);
+            }
+            return ret;
+        }
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_IEnumerable_NonGeneric_Tests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_IEnumerable_NonGeneric_Tests.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.AsNonGenericIEnumerable.cs
@@ -7,15 +8,18 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Collections;
 
-namespace System.Collections.Tests
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
 {
-    public class HashSet_IEnumerable_NonGeneric_Tests : IEnumerable_NonGeneric_Tests
+    public class SegmentedHashSet_IEnumerable_NonGeneric_Tests : IEnumerable_NonGeneric_Tests
     {
         protected override IEnumerable NonGenericIEnumerableFactory(int count)
         {
-            var set = new HashSet<string>();
+            var set = new SegmentedHashSet<string>();
             int seed = 12354;
             while (set.Count < count)
                 set.Add(CreateT(set, seed++));
@@ -24,9 +28,9 @@ namespace System.Collections.Tests
 
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
 
-        protected override ModifyOperation ModifyEnumeratorThrows => PlatformDetection.IsNetFramework ? base.ModifyEnumeratorThrows : (base.ModifyEnumeratorAllowed & ~ModifyOperation.Remove);
+        protected override ModifyOperation ModifyEnumeratorThrows => base.ModifyEnumeratorAllowed & ~ModifyOperation.Remove;
 
-        protected override ModifyOperation ModifyEnumeratorAllowed => PlatformDetection.IsNetFramework ? base.ModifyEnumeratorAllowed : ModifyOperation.Overwrite | ModifyOperation.Remove;
+        protected override ModifyOperation ModifyEnumeratorAllowed => ModifyOperation.Overwrite | ModifyOperation.Remove;
 
         /// <summary>
         /// Returns a set of ModifyEnumerable delegates that modify the enumerable passed to them.
@@ -37,7 +41,7 @@ namespace System.Collections.Tests
             {
                 yield return (IEnumerable enumerable) =>
                 {
-                    HashSet<string> casted = ((HashSet<string>)enumerable);
+                    SegmentedHashSet<string> casted = ((SegmentedHashSet<string>)enumerable);
                     if (casted.Count > 0)
                     {
                         casted.Clear();
@@ -48,7 +52,7 @@ namespace System.Collections.Tests
             }
         }
 
-        protected string CreateT(HashSet<string> set, int seed)
+        private protected static string CreateT(SegmentedHashSet<string> set, int seed)
         {
             int stringLength = seed % 10 + 5;
             Random rand = new Random(seed);

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_IEnumerable_NonGeneric_Tests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/SegmentedHashSet_IEnumerable_NonGeneric_Tests.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.AsNonGenericIEnumerable.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 using System.Collections.Generic;
 
 namespace System.Collections.Tests

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/TestingTypes.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/TestingTypes.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/Common/tests/System/Collections/TestingTypes.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 using System.Collections.Generic;
 
 namespace System.Collections.Tests

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/TestingTypes.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/HashSet/TestingTypes.cs
@@ -1,0 +1,387 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace System.Collections.Tests
+{
+    #region Comparers and Equatables
+
+    // Use parity only as a hashcode so as to have many collisions.
+    [Serializable]
+    public class BadIntEqualityComparer : IEqualityComparer<int>
+    {
+        public bool Equals(int x, int y)
+        {
+            return x == y;
+        }
+
+        public int GetHashCode(int obj)
+        {
+            return obj % 2;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is BadIntEqualityComparer; // Equal to all other instances of this type, not to anything else.
+        }
+
+        public override int GetHashCode()
+        {
+            return unchecked((int)0xC001CAFE); // Doesn't matter as long as its constant.
+        }
+    }
+
+    [Serializable]
+    public class EquatableBackwardsOrder : IEquatable<EquatableBackwardsOrder>, IComparable<EquatableBackwardsOrder>, IComparable
+    {
+        private int _value;
+
+        public EquatableBackwardsOrder(int value)
+        {
+            _value = value;
+        }
+
+        public int CompareTo(EquatableBackwardsOrder other) //backwards from the usual integer ordering
+        {
+            return other._value - _value;
+        }
+
+        public override int GetHashCode() => _value;
+
+        public override bool Equals(object obj)
+        {
+            EquatableBackwardsOrder other = obj as EquatableBackwardsOrder;
+            return other != null && Equals(other);
+        }
+
+        public bool Equals(EquatableBackwardsOrder other)
+        {
+            return _value == other._value;
+        }
+
+        int IComparable.CompareTo(object obj)
+        {
+            if (obj != null && obj.GetType() == typeof(EquatableBackwardsOrder))
+                return ((EquatableBackwardsOrder)obj)._value - _value;
+            else return -1;
+        }
+    }
+
+    [Serializable]
+    public class Comparer_SameAsDefaultComparer : IEqualityComparer<int>, IComparer<int>
+    {
+        public int Compare(int x, int y)
+        {
+            return x - y;
+        }
+
+        public bool Equals(int x, int y)
+        {
+            return x == y;
+        }
+
+        public int GetHashCode(int obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+
+    [Serializable]
+    public class Comparer_HashCodeAlwaysReturnsZero : IEqualityComparer<int>, IComparer<int>
+    {
+        public int Compare(int x, int y)
+        {
+            return x - y;
+        }
+
+        public bool Equals(int x, int y)
+        {
+            return x == y;
+        }
+
+        public int GetHashCode(int obj)
+        {
+            return 0;
+        }
+    }
+
+    [Serializable]
+    public class Comparer_ModOfInt : IEqualityComparer<int>, IComparer<int>
+    {
+        private int _mod;
+
+        public Comparer_ModOfInt(int mod)
+        {
+            _mod = mod;
+        }
+
+        public Comparer_ModOfInt()
+        {
+            _mod = 500;
+        }
+
+        public int Compare(int x, int y)
+        {
+            return ((x % _mod) - (y % _mod));
+        }
+
+        public bool Equals(int x, int y)
+        {
+            return ((x % _mod) == (y % _mod));
+        }
+
+        public int GetHashCode(int x)
+        {
+            return (x % _mod);
+        }
+    }
+
+    [Serializable]
+    public class Comparer_AbsOfInt : IEqualityComparer<int>, IComparer<int>
+    {
+        public int Compare(int x, int y)
+        {
+            return Math.Abs(x) - Math.Abs(y);
+        }
+
+        public bool Equals(int x, int y)
+        {
+            return Math.Abs(x) == Math.Abs(y);
+        }
+
+        public int GetHashCode(int x)
+        {
+            return Math.Abs(x);
+        }
+    }
+
+    #endregion
+
+    #region TestClasses
+
+    [Serializable]
+    public struct SimpleInt : IStructuralComparable, IStructuralEquatable, IComparable, IComparable<SimpleInt>
+    {
+        private int _val;
+        public SimpleInt(int t)
+        {
+            _val = t;
+        }
+        public int Val
+        {
+            get { return _val; }
+            set { _val = value; }
+        }
+
+        public int CompareTo(SimpleInt other)
+        {
+            return other.Val - _val;
+        }
+
+        public int CompareTo(object obj)
+        {
+            if (obj.GetType() == typeof(SimpleInt))
+            {
+                return ((SimpleInt)obj).Val - _val;
+            }
+            return -1;
+        }
+
+        public int CompareTo(object other, IComparer comparer)
+        {
+            if (other.GetType() == typeof(SimpleInt))
+                return ((SimpleInt)other).Val - _val;
+            return -1;
+        }
+
+        public bool Equals(object other, IEqualityComparer comparer)
+        {
+            if (other.GetType() == typeof(SimpleInt))
+                return ((SimpleInt)other).Val == _val;
+            return false;
+        }
+
+        public int GetHashCode(IEqualityComparer comparer)
+        {
+            return comparer.GetHashCode(_val);
+        }
+    }
+
+    [Serializable]
+    public class WrapStructural_Int : IEqualityComparer<int>, IComparer<int>
+    {
+        public int Compare(int x, int y)
+        {
+            return StructuralComparisons.StructuralComparer.Compare(x, y);
+        }
+
+        public bool Equals(int x, int y)
+        {
+            return StructuralComparisons.StructuralEqualityComparer.Equals(x, y);
+        }
+
+        public int GetHashCode(int obj)
+        {
+            return StructuralComparisons.StructuralEqualityComparer.GetHashCode(obj);
+        }
+    }
+
+    [Serializable]
+    public class WrapStructural_SimpleInt : IEqualityComparer<SimpleInt>, IComparer<SimpleInt>
+    {
+        public int Compare(SimpleInt x, SimpleInt y)
+        {
+            return StructuralComparisons.StructuralComparer.Compare(x, y);
+        }
+
+        public bool Equals(SimpleInt x, SimpleInt y)
+        {
+            return StructuralComparisons.StructuralEqualityComparer.Equals(x, y);
+        }
+
+        public int GetHashCode(SimpleInt obj)
+        {
+            return StructuralComparisons.StructuralEqualityComparer.GetHashCode(obj);
+        }
+    }
+
+    public class GenericComparable : IComparable<GenericComparable>
+    {
+        private readonly int _value;
+
+        public GenericComparable(int value)
+        {
+            _value = value;
+        }
+
+        public int CompareTo(GenericComparable other) => _value.CompareTo(other._value);
+    }
+
+    public class NonGenericComparable : IComparable
+    {
+        private readonly GenericComparable _inner;
+
+        public NonGenericComparable(int value)
+        {
+            _inner = new GenericComparable(value);
+        }
+
+        public int CompareTo(object other) =>
+            _inner.CompareTo(((NonGenericComparable)other)._inner);
+    }
+
+    public class BadlyBehavingComparable : IComparable<BadlyBehavingComparable>, IComparable
+    {
+        public int CompareTo(BadlyBehavingComparable other) => 1;
+
+        public int CompareTo(object other) => -1;
+    }
+
+    public class MutatingComparable : IComparable<MutatingComparable>, IComparable
+    {
+        private int _state;
+
+        public MutatingComparable(int initialState)
+        {
+            _state = initialState;
+        }
+
+        public int State => _state;
+
+        public int CompareTo(object other) => _state++;
+
+        public int CompareTo(MutatingComparable other) => _state++;
+    }
+
+    public static class ValueComparable
+    {
+        // Convenience method so the compiler can work its type inference magic.
+        public static ValueComparable<T> Create<T>(T value) where T : IComparable<T>
+        {
+            return new ValueComparable<T>(value);
+        }
+    }
+
+    public struct ValueComparable<T> : IComparable<ValueComparable<T>> where T : IComparable<T>
+    {
+        public ValueComparable(T value)
+        {
+            Value = value;
+        }
+
+        public T Value { get; }
+
+        public int CompareTo(ValueComparable<T> other) =>
+            Value.CompareTo(other.Value);
+    }
+
+    public class Equatable : IEquatable<Equatable>
+    {
+        public Equatable(int value)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+
+        // Equals(object) is not implemented on purpose.
+        // EqualityComparer is only supposed to call through to the strongly-typed Equals since we implement IEquatable.
+
+        public bool Equals(Equatable other)
+        {
+            return other != null && Value == other.Value;
+        }
+
+        public override int GetHashCode() => Value;
+    }
+
+    public struct NonEquatableValueType
+    {
+        public NonEquatableValueType(int value)
+        {
+            Value = value;
+        }
+
+        public int Value { get; set; }
+    }
+
+    public class DelegateEquatable : IEquatable<DelegateEquatable>
+    {
+        public DelegateEquatable()
+        {
+            EqualsWorker = _ => false;
+        }
+
+        public Func<DelegateEquatable, bool> EqualsWorker { get; set; }
+
+        public bool Equals(DelegateEquatable other) => EqualsWorker(other);
+    }
+
+    public struct ValueDelegateEquatable : IEquatable<ValueDelegateEquatable>
+    {
+        public Func<ValueDelegateEquatable, bool> EqualsWorker { get; set; }
+
+        public bool Equals(ValueDelegateEquatable other) => EqualsWorker(other);
+    }
+
+    public sealed class TrackingEqualityComparer<T> : IEqualityComparer<T>
+    {
+        public int EqualsCalls;
+        public int GetHashCodeCalls;
+
+        public bool Equals(T x, T y)
+        {
+            EqualsCalls++;
+            return EqualityComparer<T>.Default.Equals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            GetHashCodeCalls++;
+            return EqualityComparer<T>.Default.GetHashCode(obj);
+        }
+    }
+
+    #endregion
+}

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/List/TestBase.Generic.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/List/TestBase.Generic.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.Collections;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Collections
@@ -99,9 +100,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
             switch (type)
             {
-                case EnumerableType.HashSet:
+                case EnumerableType.SegmentedHashSet:
                     Debug.Assert(numberOfDuplicateElements == 0, "Can not create a HashSet with duplicate elements - numberOfDuplicateElements must be zero");
-                    return CreateHashSet(enumerableToMatchTo, count, numberOfMatchingElements);
+                    return CreateSegmentedHashSet(enumerableToMatchTo, count, numberOfMatchingElements);
                 case EnumerableType.List:
                     return CreateList(enumerableToMatchTo, count, numberOfMatchingElements, numberOfDuplicateElements);
                 case EnumerableType.SortedSet:
@@ -221,16 +222,16 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         /// to it until it is full. It will begin by adding the desired number of matching,
         /// followed by random (deterministic) elements until the desired count is reached.
         /// </summary>
-        protected IEnumerable<T> CreateHashSet(IEnumerable<T>? enumerableToMatchTo, int count, int numberOfMatchingElements)
+        protected IEnumerable<T> CreateSegmentedHashSet(IEnumerable<T>? enumerableToMatchTo, int count, int numberOfMatchingElements)
         {
-            HashSet<T> set = new HashSet<T>(GetIEqualityComparer());
+            SegmentedHashSet<T> set = new SegmentedHashSet<T>(GetIEqualityComparer());
             int seed = 528;
-            List<T>? match = null;
+            SegmentedList<T>? match = null;
 
             // Add Matching elements
             if (enumerableToMatchTo != null)
             {
-                match = enumerableToMatchTo.ToList();
+                match = enumerableToMatchTo.ToSegmentedList();
                 for (int i = 0; i < numberOfMatchingElements; i++)
                     set.Add(match[i]);
             }

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/List/TestBase.NonGeneric.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/List/TestBase.NonGeneric.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
         public enum EnumerableType
         {
-            HashSet,
+            SegmentedHashSet,
             SortedSet,
             List,
             Queue,

--- a/src/Dependencies/Collections/Internal/BitHelper.cs
+++ b/src/Dependencies/Collections/Internal/BitHelper.cs
@@ -8,6 +8,8 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.Collections.Internal
 {
     internal ref struct BitHelper

--- a/src/Dependencies/Collections/Internal/BitHelper.cs
+++ b/src/Dependencies/Collections/Internal/BitHelper.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Collections.Generic
+{
+    internal ref struct BitHelper
+    {
+        private const int IntSize = sizeof(int) * 8;
+        private readonly Span<int> _span;
+
+        internal BitHelper(Span<int> span, bool clear)
+        {
+            if (clear)
+            {
+                span.Clear();
+            }
+            _span = span;
+        }
+
+        internal void MarkBit(int bitPosition)
+        {
+            int bitArrayIndex = bitPosition / IntSize;
+            if ((uint)bitArrayIndex < (uint)_span.Length)
+            {
+                _span[bitArrayIndex] |= (1 << (bitPosition % IntSize));
+            }
+        }
+
+        internal bool IsMarked(int bitPosition)
+        {
+            int bitArrayIndex = bitPosition / IntSize;
+            return
+                (uint)bitArrayIndex < (uint)_span.Length &&
+                (_span[bitArrayIndex] & (1 << (bitPosition % IntSize))) != 0;
+        }
+
+        /// <summary>How many ints must be allocated to represent n bits. Returns (n+31)/32, but avoids overflow.</summary>
+        internal static int ToIntArrayLength(int n) => n > 0 ? ((n - 1) / IntSize + 1) : 0;
+    }
+}

--- a/src/Dependencies/Collections/Internal/BitHelper.cs
+++ b/src/Dependencies/Collections/Internal/BitHelper.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/Common/src/System/Collections/Generic/BitHelper.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 namespace System.Collections.Generic
 {
     internal ref struct BitHelper

--- a/src/Dependencies/Collections/Internal/BitHelper.cs
+++ b/src/Dependencies/Collections/Internal/BitHelper.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/Common/src/System/Collections/Generic/BitHelper.cs
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
         internal void MarkBit(int bitPosition)
         {
-            int bitArrayIndex = bitPosition / IntSize;
+            var bitArrayIndex = bitPosition / IntSize;
             if ((uint)bitArrayIndex < (uint)_span.Length)
             {
                 _span[bitArrayIndex] |= (1 << (bitPosition % IntSize));
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
         internal bool IsMarked(int bitPosition)
         {
-            int bitArrayIndex = bitPosition / IntSize;
+            var bitArrayIndex = bitPosition / IntSize;
             return
                 (uint)bitArrayIndex < (uint)_span.Length &&
                 (_span[bitArrayIndex] & (1 << (bitPosition % IntSize))) != 0;

--- a/src/Dependencies/Collections/Internal/BitHelper.cs
+++ b/src/Dependencies/Collections/Internal/BitHelper.cs
@@ -7,7 +7,7 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
-namespace System.Collections.Generic
+namespace Microsoft.CodeAnalysis.Collections.Internal
 {
     internal ref struct BitHelper
     {

--- a/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
@@ -7,12 +7,12 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
-namespace System.Collections.Generic
+namespace Microsoft.CodeAnalysis.Collections.Internal
 {
     /// <summary>Equality comparer for hashsets of hashsets</summary>
-    internal sealed class HashSetEqualityComparer<T> : IEqualityComparer<HashSet<T>?>
+    internal sealed class SegmentedHashSetEqualityComparer<T> : IEqualityComparer<SegmentedHashSet<T>?>
     {
-        public bool Equals(HashSet<T>? x, HashSet<T>? y)
+        public bool Equals(SegmentedHashSet<T>? x, SegmentedHashSet<T>? y)
         {
             // If they're the exact same instance, they're equal.
             if (ReferenceEquals(x, y))
@@ -30,7 +30,7 @@ namespace System.Collections.Generic
 
             // If both sets use the same comparer, they're equal if they're the same
             // size and one is a "subset" of the other.
-            if (HashSet<T>.EqualityComparersAreEqual(x, y))
+            if (SegmentedHashSet<T>.EqualityComparersAreEqual(x, y))
             {
                 return x.Count == y.Count && y.IsSubsetOfHashSetWithSameComparer(x);
             }
@@ -57,7 +57,7 @@ namespace System.Collections.Generic
             return true;
         }
 
-        public int GetHashCode(HashSet<T>? obj)
+        public int GetHashCode(SegmentedHashSet<T>? obj)
         {
             int hashCode = 0; // default to 0 for null/empty set
 
@@ -76,7 +76,7 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself.
-        public override bool Equals(object? obj) => obj is HashSetEqualityComparer<T>;
+        public override bool Equals(object? obj) => obj is SegmentedHashSetEqualityComparer<T>;
 
         public override int GetHashCode() => EqualityComparer<T>.Default.GetHashCode();
     }

--- a/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
@@ -8,6 +8,8 @@
 // See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
 // reference implementation.
 
+using System.Collections.Generic;
+
 namespace Microsoft.CodeAnalysis.Collections.Internal
 {
     /// <summary>Equality comparer for hashsets of hashsets</summary>

--- a/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSetEqualityComparer.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 namespace System.Collections.Generic
 {
     /// <summary>Equality comparer for hashsets of hashsets</summary>

--- a/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSetEqualityComparer.cs
@@ -26,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                 return false;
             }
 
-            EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
+            var defaultComparer = EqualityComparer<T>.Default;
 
             // If both sets use the same comparer, they're equal if they're the same
             // size and one is a "subset" of the other.
@@ -36,10 +37,10 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             }
 
             // Otherwise, do an O(N^2) match.
-            foreach (T yi in y)
+            foreach (var yi in y)
             {
-                bool found = false;
-                foreach (T xi in x)
+                var found = false;
+                foreach (var xi in x)
                 {
                     if (defaultComparer.Equals(yi, xi))
                     {
@@ -59,11 +60,11 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
 
         public int GetHashCode(SegmentedHashSet<T>? obj)
         {
-            int hashCode = 0; // default to 0 for null/empty set
+            var hashCode = 0; // default to 0 for null/empty set
 
             if (obj != null)
             {
-                foreach (T t in obj)
+                foreach (var t in obj)
                 {
                     if (t != null)
                     {

--- a/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Collections.Generic
+{
+    /// <summary>Equality comparer for hashsets of hashsets</summary>
+    internal sealed class HashSetEqualityComparer<T> : IEqualityComparer<HashSet<T>?>
+    {
+        public bool Equals(HashSet<T>? x, HashSet<T>? y)
+        {
+            // If they're the exact same instance, they're equal.
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            // They're not both null, so if either is null, they're not equal.
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
+
+            // If both sets use the same comparer, they're equal if they're the same
+            // size and one is a "subset" of the other.
+            if (HashSet<T>.EqualityComparersAreEqual(x, y))
+            {
+                return x.Count == y.Count && y.IsSubsetOfHashSetWithSameComparer(x);
+            }
+
+            // Otherwise, do an O(N^2) match.
+            foreach (T yi in y)
+            {
+                bool found = false;
+                foreach (T xi in x)
+                {
+                    if (defaultComparer.Equals(yi, xi))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(HashSet<T>? obj)
+        {
+            int hashCode = 0; // default to 0 for null/empty set
+
+            if (obj != null)
+            {
+                foreach (T t in obj)
+                {
+                    if (t != null)
+                    {
+                        hashCode ^= t.GetHashCode(); // same hashcode as as default comparer
+                    }
+                }
+            }
+
+            return hashCode;
+        }
+
+        // Equals method for the comparer itself.
+        public override bool Equals(object? obj) => obj is HashSetEqualityComparer<T>;
+
+        public override int GetHashCode() => EqualityComparer<T>.Default.GetHashCode();
+    }
+}

--- a/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
+++ b/src/Dependencies/Collections/Internal/SegmentedHashSetEqualityComparer`1.cs
@@ -39,6 +39,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
             }
 
             // Otherwise, do an O(N^2) match.
+            // 🐛 This is non-symmetrical, but matches original: https://github.com/dotnet/runtime/issues/69218
             foreach (var yi in y)
             {
                 var found = false;

--- a/src/Dependencies/Collections/Internal/ThrowHelper.cs
+++ b/src/Dependencies/Collections/Internal/ThrowHelper.cs
@@ -239,6 +239,8 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                     return "dictionary";
                 case ExceptionArgument.array:
                     return "array";
+                case ExceptionArgument.info:
+                    return "info";
                 case ExceptionArgument.key:
                     return "key";
                 case ExceptionArgument.value:
@@ -269,6 +271,8 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                     return "length";
                 case ExceptionArgument.destinationArray:
                     return "destinationArray";
+                case ExceptionArgument.other:
+                    return "other";
                 default:
                     Debug.Fail("The enum value is not defined, please check the ExceptionArgument Enum.");
                     return "";
@@ -319,6 +323,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
     {
         dictionary,
         array,
+        info,
         key,
         value,
         startIndex,
@@ -334,6 +339,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
         source,
         length,
         destinationArray,
+        other,
     }
 
     //

--- a/src/Dependencies/Collections/Microsoft.CodeAnalysis.Collections.projitems
+++ b/src/Dependencies/Collections/Microsoft.CodeAnalysis.Collections.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ImmutableSegmentedDictionary`2+ValueCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ImmutableSegmentedDictionary`2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\ArraySortHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\BitHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\HashHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\ICollectionDebugView`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\IDictionaryDebugView`2.cs" />
@@ -29,12 +30,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)Internal\RoslynUnsafe.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\SegmentedArrayHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\SegmentedArraySegment`1.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\SegmentedHashSetEqualityComparer`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\ThrowHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RoslynEnumerable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RoslynImmutableInterlocked.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SegmentedArray.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SegmentedArray`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SegmentedDictionary`2.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SegmentedHashSet`1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SegmentedList`1.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Dependencies/Collections/SegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/SegmentedHashSet`1.cs
@@ -49,9 +49,7 @@ namespace Microsoft.CodeAnalysis.Collections
 
         private int[]? _buckets;
         private Entry[]? _entries;
-#if TARGET_64BIT
         private ulong _fastModMultiplier;
-#endif
         private int _count;
         private int _freeList;
         private int _freeCount;
@@ -154,9 +152,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 _freeList = source._freeList;
                 _freeCount = source._freeCount;
                 _count = source._count;
-#if TARGET_64BIT
                 _fastModMultiplier = source._fastModMultiplier;
-#endif
             }
             else
             {
@@ -295,11 +291,7 @@ namespace Microsoft.CodeAnalysis.Collections
         private ref int GetBucketRef(int hashCode)
         {
             var buckets = _buckets!;
-#if TARGET_64BIT
             return ref buckets[HashHelpers.FastMod((uint)hashCode, (uint)buckets.Length, _fastModMultiplier)];
-#else
-            return ref buckets[(uint)hashCode % (uint)buckets.Length];
-#endif
         }
 
         public bool Remove(T item)
@@ -896,9 +888,7 @@ namespace Microsoft.CodeAnalysis.Collections
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
             _buckets = new int[newSize];
-#if TARGET_64BIT
             _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);
-#endif
             for (var i = 0; i < count; i++)
             {
                 ref var entry = ref entries[i];
@@ -973,9 +963,7 @@ namespace Microsoft.CodeAnalysis.Collections
             _freeList = -1;
             _buckets = buckets;
             _entries = entries;
-#if TARGET_64BIT
             _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)size);
-#endif
 
             return size;
         }

--- a/src/Dependencies/Collections/SegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/SegmentedHashSet`1.cs
@@ -162,9 +162,9 @@ namespace Microsoft.CodeAnalysis.Collections
                 for (var i = 0; i < source._count; i++)
                 {
                     ref var entry = ref entries![i];
-                    if (entry.Next >= -1)
+                    if (entry._next >= -1)
                     {
-                        AddIfNotPresent(entry.Value, out _);
+                        AddIfNotPresent(entry._value, out _);
                     }
                 }
             }
@@ -222,11 +222,11 @@ namespace Microsoft.CodeAnalysis.Collections
                         while (i >= 0)
                         {
                             ref var entry = ref entries[i];
-                            if (entry.HashCode == hashCode && EqualityComparer<T>.Default.Equals(entry.Value, item))
+                            if (entry._hashCode == hashCode && EqualityComparer<T>.Default.Equals(entry._value, item))
                             {
                                 return i;
                             }
-                            i = entry.Next;
+                            i = entry._next;
 
                             collisionCount++;
                             if (collisionCount > (uint)entries.Length)
@@ -245,11 +245,11 @@ namespace Microsoft.CodeAnalysis.Collections
                         while (i >= 0)
                         {
                             ref var entry = ref entries[i];
-                            if (entry.HashCode == hashCode && defaultComparer.Equals(entry.Value, item))
+                            if (entry._hashCode == hashCode && defaultComparer.Equals(entry._value, item))
                             {
                                 return i;
                             }
-                            i = entry.Next;
+                            i = entry._next;
 
                             collisionCount++;
                             if (collisionCount > (uint)entries.Length)
@@ -267,11 +267,11 @@ namespace Microsoft.CodeAnalysis.Collections
                     while (i >= 0)
                     {
                         ref var entry = ref entries[i];
-                        if (entry.HashCode == hashCode && comparer.Equals(entry.Value, item))
+                        if (entry._hashCode == hashCode && comparer.Equals(entry._value, item))
                         {
                             return i;
                         }
-                        i = entry.Next;
+                        i = entry._next;
 
                         collisionCount++;
                         if (collisionCount > (uint)entries.Length)
@@ -316,23 +316,23 @@ namespace Microsoft.CodeAnalysis.Collections
                 {
                     ref var entry = ref entries[i];
 
-                    if (entry.HashCode == hashCode && (_comparer?.Equals(entry.Value, item) ?? EqualityComparer<T>.Default.Equals(entry.Value, item)))
+                    if (entry._hashCode == hashCode && (_comparer?.Equals(entry._value, item) ?? EqualityComparer<T>.Default.Equals(entry._value, item)))
                     {
                         if (last < 0)
                         {
-                            bucket = entry.Next + 1; // Value in buckets is 1-based
+                            bucket = entry._next + 1; // Value in buckets is 1-based
                         }
                         else
                         {
-                            entries[last].Next = entry.Next;
+                            entries[last]._next = entry._next;
                         }
 
                         Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
-                        entry.Next = StartOfFreeList - _freeList;
+                        entry._next = StartOfFreeList - _freeList;
 
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                         {
-                            entry.Value = default!;
+                            entry._value = default!;
                         }
 
                         _freeList = i;
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Collections
                     }
 
                     last = i;
-                    i = entry.Next;
+                    i = entry._next;
 
                     collisionCount++;
                     if (collisionCount > (uint)entries.Length)
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 var index = FindItemIndex(equalValue);
                 if (index >= 0)
                 {
-                    actualValue = _entries![index].Value;
+                    actualValue = _entries![index]._value;
                     return true;
                 }
             }
@@ -804,9 +804,9 @@ namespace Microsoft.CodeAnalysis.Collections
             for (var i = 0; i < _count && count != 0; i++)
             {
                 ref var entry = ref entries![i];
-                if (entry.Next >= -1)
+                if (entry._next >= -1)
                 {
-                    array[arrayIndex++] = entry.Value;
+                    array[arrayIndex++] = entry._value;
                     count--;
                 }
             }
@@ -825,10 +825,10 @@ namespace Microsoft.CodeAnalysis.Collections
             for (var i = 0; i < _count; i++)
             {
                 ref var entry = ref entries![i];
-                if (entry.Next >= -1)
+                if (entry._next >= -1)
                 {
                     // Cache value in case delegate removes it
-                    var value = entry.Value;
+                    var value = entry._value;
                     if (match(value))
                     {
                         // Check again that remove actually removed it.
@@ -896,10 +896,10 @@ namespace Microsoft.CodeAnalysis.Collections
             for (var i = 0; i < count; i++)
             {
                 ref var entry = ref entries[i];
-                if (entry.Next >= -1)
+                if (entry._next >= -1)
                 {
-                    ref var bucket = ref GetBucketRef(entry.HashCode);
-                    entry.Next = bucket - 1; // Value in _buckets is 1-based
+                    ref var bucket = ref GetBucketRef(entry._hashCode);
+                    entry._next = bucket - 1; // Value in _buckets is 1-based
                     bucket = i + 1;
                 }
             }
@@ -930,13 +930,13 @@ namespace Microsoft.CodeAnalysis.Collections
             var count = 0;
             for (var i = 0; i < oldCount; i++)
             {
-                var hashCode = oldEntries![i].HashCode; // At this point, we know we have entries.
-                if (oldEntries[i].Next >= -1)
+                var hashCode = oldEntries![i]._hashCode; // At this point, we know we have entries.
+                if (oldEntries[i]._next >= -1)
                 {
                     ref var entry = ref entries![count];
                     entry = oldEntries[i];
                     ref var bucket = ref GetBucketRef(hashCode);
-                    entry.Next = bucket - 1; // Value in _buckets is 1-based
+                    entry._next = bucket - 1; // Value in _buckets is 1-based
                     bucket = count + 1;
                     count++;
                 }
@@ -1006,12 +1006,12 @@ namespace Microsoft.CodeAnalysis.Collections
                     while (i >= 0)
                     {
                         ref var entry = ref entries[i];
-                        if (entry.HashCode == hashCode && EqualityComparer<T>.Default.Equals(entry.Value, value))
+                        if (entry._hashCode == hashCode && EqualityComparer<T>.Default.Equals(entry._value, value))
                         {
                             location = i;
                             return false;
                         }
-                        i = entry.Next;
+                        i = entry._next;
 
                         collisionCount++;
                         if (collisionCount > (uint)entries.Length)
@@ -1029,12 +1029,12 @@ namespace Microsoft.CodeAnalysis.Collections
                     while (i >= 0)
                     {
                         ref var entry = ref entries[i];
-                        if (entry.HashCode == hashCode && defaultComparer.Equals(entry.Value, value))
+                        if (entry._hashCode == hashCode && defaultComparer.Equals(entry._value, value))
                         {
                             location = i;
                             return false;
                         }
-                        i = entry.Next;
+                        i = entry._next;
 
                         collisionCount++;
                         if (collisionCount > (uint)entries.Length)
@@ -1053,12 +1053,12 @@ namespace Microsoft.CodeAnalysis.Collections
                 while (i >= 0)
                 {
                     ref var entry = ref entries[i];
-                    if (entry.HashCode == hashCode && comparer.Equals(entry.Value, value))
+                    if (entry._hashCode == hashCode && comparer.Equals(entry._value, value))
                     {
                         location = i;
                         return false;
                     }
-                    i = entry.Next;
+                    i = entry._next;
 
                     collisionCount++;
                     if (collisionCount > (uint)entries.Length)
@@ -1074,8 +1074,8 @@ namespace Microsoft.CodeAnalysis.Collections
             {
                 index = _freeList;
                 _freeCount--;
-                Debug.Assert((StartOfFreeList - entries![_freeList].Next) >= -1, "shouldn't overflow because `next` cannot underflow");
-                _freeList = StartOfFreeList - entries[_freeList].Next;
+                Debug.Assert((StartOfFreeList - entries![_freeList]._next) >= -1, "shouldn't overflow because `next` cannot underflow");
+                _freeList = StartOfFreeList - entries[_freeList]._next;
             }
             else
             {
@@ -1092,9 +1092,9 @@ namespace Microsoft.CodeAnalysis.Collections
 
             {
                 ref var entry = ref entries![index];
-                entry.HashCode = hashCode;
-                entry.Next = bucket - 1; // Value in _buckets is 1-based
-                entry.Value = value;
+                entry._hashCode = hashCode;
+                entry._next = bucket - 1; // Value in _buckets is 1-based
+                entry._value = value;
                 bucket = index + 1;
                 _version++;
                 location = index;
@@ -1154,9 +1154,9 @@ namespace Microsoft.CodeAnalysis.Collections
             for (var i = 0; i < _count; i++)
             {
                 ref var entry = ref entries![i];
-                if (entry.Next >= -1)
+                if (entry._next >= -1)
                 {
-                    var item = entry.Value;
+                    var item = entry._value;
                     if (!other.Contains(item))
                     {
                         Remove(item);
@@ -1200,9 +1200,9 @@ namespace Microsoft.CodeAnalysis.Collections
             for (var i = 0; i < originalCount; i++)
             {
                 ref var entry = ref _entries![i];
-                if (entry.Next >= -1 && !bitHelper.IsMarked(i))
+                if (entry._next >= -1 && !bitHelper.IsMarked(i))
                 {
-                    Remove(entry.Value);
+                    Remove(entry._value);
                 }
             }
         }
@@ -1287,7 +1287,7 @@ namespace Microsoft.CodeAnalysis.Collections
             {
                 if (itemsToRemove.IsMarked(i))
                 {
-                    Remove(_entries![i].Value);
+                    Remove(_entries![i]._value);
                 }
             }
         }
@@ -1379,14 +1379,14 @@ namespace Microsoft.CodeAnalysis.Collections
 
         private struct Entry
         {
-            public int HashCode;
+            public int _hashCode;
             /// <summary>
             /// 0-based index of next entry in chain: -1 means end of chain
             /// also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
             /// so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
             /// </summary>
-            public int Next;
-            public T Value;
+            public int _next;
+            public T _value;
         }
 
         public struct Enumerator : IEnumerator<T>
@@ -1416,9 +1416,9 @@ namespace Microsoft.CodeAnalysis.Collections
                 while ((uint)_index < (uint)_hashSet._count)
                 {
                     ref var entry = ref _hashSet._entries![_index++];
-                    if (entry.Next >= -1)
+                    if (entry._next >= -1)
                     {
-                        _current = entry.Value;
+                        _current = entry._value;
                         return true;
                     }
                 }

--- a/src/Dependencies/Collections/SegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/SegmentedHashSet`1.cs
@@ -14,13 +14,13 @@ using System.Runtime.Serialization;
 
 using Internal.Runtime.CompilerServices;
 
-namespace System.Collections.Generic
+namespace Microsoft.CodeAnalysis.Collections
 {
     [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
     [DebuggerDisplay("Count = {Count}")]
     [Serializable]
     [TypeForwardedFrom("System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public class HashSet<T> : ICollection<T>, ISet<T>, IReadOnlyCollection<T>, IReadOnlySet<T>, ISerializable, IDeserializationCallback
+    internal class SegmentedHashSet<T> : ICollection<T>, ISet<T>, IReadOnlyCollection<T>, IReadOnlySet<T>, ISerializable, IDeserializationCallback
     {
         // This uses the same array-based implementation as Dictionary<TKey, TValue>.
 
@@ -57,9 +57,9 @@ namespace System.Collections.Generic
 
         #region Constructors
 
-        public HashSet() : this((IEqualityComparer<T>?)null) { }
+        public SegmentedHashSet() : this((IEqualityComparer<T>?)null) { }
 
-        public HashSet(IEqualityComparer<T>? comparer)
+        public SegmentedHashSet(IEqualityComparer<T>? comparer)
         {
             if (comparer != null && comparer != EqualityComparer<T>.Default) // first check for null to avoid forcing default comparer instantiation unnecessarily
             {
@@ -87,25 +87,25 @@ namespace System.Collections.Generic
             }
         }
 
-        public HashSet(int capacity) : this(capacity, null) { }
+        public SegmentedHashSet(int capacity) : this(capacity, null) { }
 
-        public HashSet(IEnumerable<T> collection) : this(collection, null) { }
+        public SegmentedHashSet(IEnumerable<T> collection) : this(collection, null) { }
 
-        public HashSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer) : this(comparer)
+        public SegmentedHashSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer) : this(comparer)
         {
             if (collection == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);
             }
 
-            if (collection is HashSet<T> otherAsHashSet && EqualityComparersAreEqual(this, otherAsHashSet))
+            if (collection is SegmentedHashSet<T> otherAsHashSet && EqualityComparersAreEqual(this, otherAsHashSet))
             {
                 ConstructFrom(otherAsHashSet);
             }
             else
             {
                 // To avoid excess resizes, first set size based on collection's count. The collection may
-                // contain duplicates, so call TrimExcess if resulting HashSet is larger than the threshold.
+                // contain duplicates, so call TrimExcess if resulting SegmentedHashSet is larger than the threshold.
                 if (collection is ICollection<T> coll)
                 {
                     int count = coll.Count;
@@ -124,7 +124,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public HashSet(int capacity, IEqualityComparer<T>? comparer) : this(comparer)
+        public SegmentedHashSet(int capacity, IEqualityComparer<T>? comparer) : this(comparer)
         {
             if (capacity < 0)
             {
@@ -137,7 +137,7 @@ namespace System.Collections.Generic
             }
         }
 
-        protected HashSet(SerializationInfo info, StreamingContext context)
+        protected SegmentedHashSet(SerializationInfo info, StreamingContext context)
         {
             // We can't do anything with the keys and values until the entire graph has been
             // deserialized and we have a reasonable estimate that GetHashCode is not going to
@@ -146,8 +146,8 @@ namespace System.Collections.Generic
             _siInfo = info;
         }
 
-        /// <summary>Initializes the HashSet from another HashSet with the same element type and equality comparer.</summary>
-        private void ConstructFrom(HashSet<T> source)
+        /// <summary>Initializes the SegmentedHashSet from another SegmentedHashSet with the same element type and equality comparer.</summary>
+        private void ConstructFrom(SegmentedHashSet<T> source)
         {
             if (source.Count == 0)
             {
@@ -195,7 +195,7 @@ namespace System.Collections.Generic
 
         void ICollection<T>.Add(T item) => AddIfNotPresent(item, out _);
 
-        /// <summary>Removes all elements from the <see cref="HashSet{T}"/> object.</summary>
+        /// <summary>Removes all elements from the <see cref="SegmentedHashSet{T}"/> object.</summary>
         public void Clear()
         {
             int count = _count;
@@ -212,9 +212,9 @@ namespace System.Collections.Generic
             }
         }
 
-        /// <summary>Determines whether the <see cref="HashSet{T}"/> contains the specified element.</summary>
-        /// <param name="item">The element to locate in the <see cref="HashSet{T}"/> object.</param>
-        /// <returns>true if the <see cref="HashSet{T}"/> object contains the specified element; otherwise, false.</returns>
+        /// <summary>Determines whether the <see cref="SegmentedHashSet{T}"/> contains the specified element.</summary>
+        /// <param name="item">The element to locate in the <see cref="SegmentedHashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="SegmentedHashSet{T}"/> object contains the specified element; otherwise, false.</returns>
         public bool Contains(T item) => FindItemIndex(item) >= 0;
 
         /// <summary>Gets the index of the item in <see cref="_entries"/>, or -1 if it's not in the set.</summary>
@@ -461,11 +461,11 @@ namespace System.Collections.Generic
 
         #endregion
 
-        #region HashSet methods
+        #region SegmentedHashSet methods
 
-        /// <summary>Adds the specified element to the <see cref="HashSet{T}"/>.</summary>
+        /// <summary>Adds the specified element to the <see cref="SegmentedHashSet{T}"/>.</summary>
         /// <param name="item">The element to add to the set.</param>
-        /// <returns>true if the element is added to the <see cref="HashSet{T}"/> object; false if the element is already present.</returns>
+        /// <returns>true if the element is added to the <see cref="SegmentedHashSet{T}"/> object; false if the element is already present.</returns>
         public bool Add(T item) => AddIfNotPresent(item, out _);
 
         /// <summary>Searches the set for a given value and returns the equal value it finds, if any.</summary>
@@ -494,8 +494,8 @@ namespace System.Collections.Generic
             return false;
         }
 
-        /// <summary>Modifies the current <see cref="HashSet{T}"/> object to contain all elements that are present in itself, the specified collection, or both.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <summary>Modifies the current <see cref="SegmentedHashSet{T}"/> object to contain all elements that are present in itself, the specified collection, or both.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
         public void UnionWith(IEnumerable<T> other)
         {
             if (other == null)
@@ -509,8 +509,8 @@ namespace System.Collections.Generic
             }
         }
 
-        /// <summary>Modifies the current <see cref="HashSet{T}"/> object to contain only elements that are present in that object and in the specified collection.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <summary>Modifies the current <see cref="SegmentedHashSet{T}"/> object to contain only elements that are present in that object and in the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
         public void IntersectWith(IEnumerable<T> other)
         {
             if (other == null)
@@ -536,7 +536,7 @@ namespace System.Collections.Generic
 
                 // Faster if other is a hashset using same equality comparer; so check
                 // that other is a hashset using the same equality comparer.
-                if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+                if (other is SegmentedHashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
                 {
                     IntersectWithHashSetWithSameComparer(otherAsSet);
                     return;
@@ -546,8 +546,8 @@ namespace System.Collections.Generic
             IntersectWithEnumerable(other);
         }
 
-        /// <summary>Removes all elements in the specified collection from the current <see cref="HashSet{T}"/> object.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <summary>Removes all elements in the specified collection from the current <see cref="SegmentedHashSet{T}"/> object.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
         public void ExceptWith(IEnumerable<T> other)
         {
             if (other == null)
@@ -575,8 +575,8 @@ namespace System.Collections.Generic
             }
         }
 
-        /// <summary>Modifies the current <see cref="HashSet{T}"/> object to contain only elements that are present either in that object or in the specified collection, but not both.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <summary>Modifies the current <see cref="SegmentedHashSet{T}"/> object to contain only elements that are present either in that object or in the specified collection, but not both.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
         public void SymmetricExceptWith(IEnumerable<T> other)
         {
             if (other == null)
@@ -598,12 +598,12 @@ namespace System.Collections.Generic
                 return;
             }
 
-            // If other is a HashSet, it has unique elements according to its equality comparer,
+            // If other is a SegmentedHashSet, it has unique elements according to its equality comparer,
             // but if they're using different equality comparers, then assumption of uniqueness
             // will fail. So first check if other is a hashset using the same equality comparer;
             // symmetric except is a lot faster and avoids bit array allocations if we can assume
             // uniqueness.
-            if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+            if (other is SegmentedHashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
             {
                 SymmetricExceptWithUniqueHashSet(otherAsSet);
             }
@@ -613,9 +613,9 @@ namespace System.Collections.Generic
             }
         }
 
-        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a subset of the specified collection.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
-        /// <returns>true if the <see cref="HashSet{T}"/> object is a subset of <paramref name="other"/>; otherwise, false.</returns>
+        /// <summary>Determines whether a <see cref="SegmentedHashSet{T}"/> object is a subset of the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="SegmentedHashSet{T}"/> object is a subset of <paramref name="other"/>; otherwise, false.</returns>
         public bool IsSubsetOf(IEnumerable<T> other)
         {
             if (other == null)
@@ -632,7 +632,7 @@ namespace System.Collections.Generic
 
             // Faster if other has unique elements according to this equality comparer; so check
             // that other is a hashset using the same equality comparer.
-            if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+            if (other is SegmentedHashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
             {
                 // if this has more elements then it can't be a subset
                 if (Count > otherAsSet.Count)
@@ -649,9 +649,9 @@ namespace System.Collections.Generic
             return uniqueCount == Count && unfoundCount >= 0;
         }
 
-        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a proper subset of the specified collection.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
-        /// <returns>true if the <see cref="HashSet{T}"/> object is a proper subset of <paramref name="other"/>; otherwise, false.</returns>
+        /// <summary>Determines whether a <see cref="SegmentedHashSet{T}"/> object is a proper subset of the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="SegmentedHashSet{T}"/> object is a proper subset of <paramref name="other"/>; otherwise, false.</returns>
         public bool IsProperSubsetOf(IEnumerable<T> other)
         {
             if (other == null)
@@ -680,7 +680,7 @@ namespace System.Collections.Generic
                 }
 
                 // Faster if other is a hashset (and we're using same equality comparer).
-                if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+                if (other is SegmentedHashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
                 {
                     if (Count >= otherAsSet.Count)
                     {
@@ -697,9 +697,9 @@ namespace System.Collections.Generic
             return uniqueCount == Count && unfoundCount > 0;
         }
 
-        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a proper superset of the specified collection.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
-        /// <returns>true if the <see cref="HashSet{T}"/> object is a superset of <paramref name="other"/>; otherwise, false.</returns>
+        /// <summary>Determines whether a <see cref="SegmentedHashSet{T}"/> object is a proper superset of the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="SegmentedHashSet{T}"/> object is a superset of <paramref name="other"/>; otherwise, false.</returns>
         public bool IsSupersetOf(IEnumerable<T> other)
         {
             if (other == null)
@@ -723,7 +723,7 @@ namespace System.Collections.Generic
                 }
 
                 // Try to compare based on counts alone if other is a hashset with same equality comparer.
-                if (other is HashSet<T> otherAsSet &&
+                if (other is SegmentedHashSet<T> otherAsSet &&
                     EqualityComparersAreEqual(this, otherAsSet) &&
                     otherAsSet.Count > Count)
                 {
@@ -734,9 +734,9 @@ namespace System.Collections.Generic
             return ContainsAllElements(other);
         }
 
-        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a proper superset of the specified collection.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
-        /// <returns>true if the <see cref="HashSet{T}"/> object is a proper superset of <paramref name="other"/>; otherwise, false.</returns>
+        /// <summary>Determines whether a <see cref="SegmentedHashSet{T}"/> object is a proper superset of the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="SegmentedHashSet{T}"/> object is a proper superset of <paramref name="other"/>; otherwise, false.</returns>
         public bool IsProperSupersetOf(IEnumerable<T> other)
         {
             if (other == null)
@@ -760,7 +760,7 @@ namespace System.Collections.Generic
                 }
 
                 // Faster if other is a hashset with the same equality comparer
-                if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+                if (other is SegmentedHashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
                 {
                     if (otherAsSet.Count >= Count)
                     {
@@ -777,9 +777,9 @@ namespace System.Collections.Generic
             return uniqueCount < Count && unfoundCount == 0;
         }
 
-        /// <summary>Determines whether the current <see cref="HashSet{T}"/> object and a specified collection share common elements.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
-        /// <returns>true if the <see cref="HashSet{T}"/> object and <paramref name="other"/> share at least one common element; otherwise, false.</returns>
+        /// <summary>Determines whether the current <see cref="SegmentedHashSet{T}"/> object and a specified collection share common elements.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="SegmentedHashSet{T}"/> object and <paramref name="other"/> share at least one common element; otherwise, false.</returns>
         public bool Overlaps(IEnumerable<T> other)
         {
             if (other == null)
@@ -809,9 +809,9 @@ namespace System.Collections.Generic
             return false;
         }
 
-        /// <summary>Determines whether a <see cref="HashSet{T}"/> object and the specified collection contain the same elements.</summary>
-        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
-        /// <returns>true if the <see cref="HashSet{T}"/> object is equal to <paramref name="other"/>; otherwise, false.</returns>
+        /// <summary>Determines whether a <see cref="SegmentedHashSet{T}"/> object and the specified collection contain the same elements.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="SegmentedHashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="SegmentedHashSet{T}"/> object is equal to <paramref name="other"/>; otherwise, false.</returns>
         public bool SetEquals(IEnumerable<T> other)
         {
             if (other == null)
@@ -826,7 +826,7 @@ namespace System.Collections.Generic
             }
 
             // Faster if other is a hashset and we're using same equality comparer.
-            if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+            if (other is SegmentedHashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
             {
                 // Attempt to return early: since both contain unique elements, if they have
                 // different counts, then they can't be equal.
@@ -856,7 +856,7 @@ namespace System.Collections.Generic
 
         public void CopyTo(T[] array) => CopyTo(array, 0, Count);
 
-        /// <summary>Copies the elements of a <see cref="HashSet{T}"/> object to an array, starting at the specified array index.</summary>
+        /// <summary>Copies the elements of a <see cref="SegmentedHashSet{T}"/> object to an array, starting at the specified array index.</summary>
         /// <param name="array">The destination array.</param>
         /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         public void CopyTo(T[] array, int arrayIndex) => CopyTo(array, arrayIndex, Count);
@@ -900,7 +900,7 @@ namespace System.Collections.Generic
             }
         }
 
-        /// <summary>Removes all elements that match the conditions defined by the specified predicate from a <see cref="HashSet{T}"/> collection.</summary>
+        /// <summary>Removes all elements that match the conditions defined by the specified predicate from a <see cref="SegmentedHashSet{T}"/> collection.</summary>
         public int RemoveWhere(Predicate<T> match)
         {
             if (match == null)
@@ -1025,7 +1025,7 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
-        /// Sets the capacity of a <see cref="HashSet{T}"/> object to the actual number of elements it contains,
+        /// Sets the capacity of a <see cref="SegmentedHashSet{T}"/> object to the actual number of elements it contains,
         /// rounded up to a nearby, implementation-specific value.
         /// </summary>
         public void TrimExcess()
@@ -1067,8 +1067,8 @@ namespace System.Collections.Generic
 
         #region Helper methods
 
-        /// <summary>Returns an <see cref="IEqualityComparer"/> object that can be used for equality testing of a <see cref="HashSet{T}"/> object.</summary>
-        public static IEqualityComparer<HashSet<T>> CreateSetComparer() => new HashSetEqualityComparer<T>();
+        /// <summary>Returns an <see cref="IEqualityComparer"/> object that can be used for equality testing of a <see cref="SegmentedHashSet{T}"/> object.</summary>
+        public static IEqualityComparer<SegmentedHashSet<T>> CreateSetComparer() => new SegmentedHashSetEqualityComparer<T>();
 
         /// <summary>
         /// Initializes buckets and slots arrays. Uses suggested capacity by finding next prime
@@ -1094,7 +1094,7 @@ namespace System.Collections.Generic
         /// <summary>Adds the specified element to the set if it's not already contained.</summary>
         /// <param name="value">The element to add to the set.</param>
         /// <param name="location">The index into <see cref="_entries"/> of the element.</param>
-        /// <returns>true if the element is added to the <see cref="HashSet{T}"/> object; false if the element is already present.</returns>
+        /// <returns>true if the element is added to the <see cref="SegmentedHashSet{T}"/> object; false if the element is already present.</returns>
         private bool AddIfNotPresent(T value, out int location)
         {
             if (_buckets == null)
@@ -1258,7 +1258,7 @@ namespace System.Collections.Generic
         ///
         /// If callers are concerned about whether this is a proper subset, they take care of that.
         /// </summary>
-        internal bool IsSubsetOfHashSetWithSameComparer(HashSet<T> other)
+        internal bool IsSubsetOfHashSetWithSameComparer(SegmentedHashSet<T> other)
         {
             foreach (T item in this)
             {
@@ -1275,7 +1275,7 @@ namespace System.Collections.Generic
         /// If other is a hashset that uses same equality comparer, intersect is much faster
         /// because we can use other's Contains
         /// </summary>
-        private void IntersectWithHashSetWithSameComparer(HashSet<T> other)
+        private void IntersectWithHashSetWithSameComparer(SegmentedHashSet<T> other)
         {
             Entry[]? entries = _entries;
             for (int i = 0; i < _count; i++)
@@ -1342,7 +1342,7 @@ namespace System.Collections.Generic
         /// same equality comparer.
         /// </summary>
         /// <param name="other"></param>
-        private void SymmetricExceptWithUniqueHashSet(HashSet<T> other)
+        private void SymmetricExceptWithUniqueHashSet(SegmentedHashSet<T> other)
         {
             foreach (T item in other)
             {
@@ -1356,11 +1356,11 @@ namespace System.Collections.Generic
         /// <summary>
         /// Implementation notes:
         ///
-        /// Used for symmetric except when other isn't a HashSet. This is more tedious because
-        /// other may contain duplicates. HashSet technique could fail in these situations:
-        /// 1. Other has a duplicate that's not in this: HashSet technique would add then
+        /// Used for symmetric except when other isn't a SegmentedHashSet. This is more tedious because
+        /// other may contain duplicates. SegmentedHashSet technique could fail in these situations:
+        /// 1. Other has a duplicate that's not in this: SegmentedHashSet technique would add then
         /// remove it.
-        /// 2. Other has a duplicate that's in this: HashSet technique would remove then add it
+        /// 2. Other has a duplicate that's in this: SegmentedHashSet technique would remove then add it
         /// back.
         /// In general, its presence would be toggled each time it appears in other.
         ///
@@ -1422,7 +1422,7 @@ namespace System.Collections.Generic
 
         /// <summary>
         /// Determines counts that can be used to determine equality, subset, and superset. This
-        /// is only used when other is an IEnumerable and not a HashSet. If other is a HashSet
+        /// is only used when other is an IEnumerable and not a SegmentedHashSet. If other is a SegmentedHashSet
         /// these properties can be checked faster without use of marking because we can assume
         /// other has no duplicates.
         ///
@@ -1501,7 +1501,7 @@ namespace System.Collections.Generic
         /// speed up if it knows the other item has unique elements. I.e. if they're using
         /// different equality comparers, then uniqueness assumption between sets break.
         /// </summary>
-        internal static bool EqualityComparersAreEqual(HashSet<T> set1, HashSet<T> set2) => set1.Comparer.Equals(set2.Comparer);
+        internal static bool EqualityComparersAreEqual(SegmentedHashSet<T> set1, SegmentedHashSet<T> set2) => set1.Comparer.Equals(set2.Comparer);
 
 #endregion
 
@@ -1519,12 +1519,12 @@ namespace System.Collections.Generic
 
         public struct Enumerator : IEnumerator<T>
         {
-            private readonly HashSet<T> _hashSet;
+            private readonly SegmentedHashSet<T> _hashSet;
             private readonly int _version;
             private int _index;
             private T _current;
 
-            internal Enumerator(HashSet<T> hashSet)
+            internal Enumerator(SegmentedHashSet<T> hashSet)
             {
                 _hashSet = hashSet;
                 _version = hashSet._version;

--- a/src/Dependencies/Collections/SegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/SegmentedHashSet`1.cs
@@ -1,6 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// NOTE: This code is derived from an implementation originally in dotnet/runtime:
+// https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+//
+// See the commentary in https://github.com/dotnet/roslyn/pull/50156 for notes on incorporating changes made to the
+// reference implementation.
+
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;

--- a/src/Dependencies/Collections/SegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/SegmentedHashSet`1.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // NOTE: This code is derived from an implementation originally in dotnet/runtime:
 // https://github.com/dotnet/runtime/blob/v5.0.7/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -99,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 // contain duplicates, so call TrimExcess if resulting SegmentedHashSet is larger than the threshold.
                 if (collection is ICollection<T> coll)
                 {
-                    int count = coll.Count;
+                    var count = coll.Count;
                     if (count > 0)
                     {
                         Initialize(count);
@@ -139,8 +140,8 @@ namespace Microsoft.CodeAnalysis.Collections
                 return;
             }
 
-            int capacity = source._buckets!.Length;
-            int threshold = HashHelpers.ExpandPrime(source.Count + 1);
+            var capacity = source._buckets!.Length;
+            var threshold = HashHelpers.ExpandPrime(source.Count + 1);
 
             if (threshold >= capacity)
             {
@@ -157,10 +158,10 @@ namespace Microsoft.CodeAnalysis.Collections
             {
                 Initialize(source.Count);
 
-                Entry[]? entries = source._entries;
-                for (int i = 0; i < source._count; i++)
+                var entries = source._entries;
+                for (var i = 0; i < source._count; i++)
                 {
-                    ref Entry entry = ref entries![i];
+                    ref var entry = ref entries![i];
                     if (entry.Next >= -1)
                     {
                         AddIfNotPresent(entry.Value, out _);
@@ -180,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <summary>Removes all elements from the <see cref="SegmentedHashSet{T}"/> object.</summary>
         public void Clear()
         {
-            int count = _count;
+            var count = _count;
             if (count > 0)
             {
                 Debug.Assert(_buckets != null, "_buckets should be non-null");
@@ -202,25 +203,25 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <summary>Gets the index of the item in <see cref="_entries"/>, or -1 if it's not in the set.</summary>
         private int FindItemIndex(T item)
         {
-            int[]? buckets = _buckets;
+            var buckets = _buckets;
             if (buckets != null)
             {
-                Entry[]? entries = _entries;
+                var entries = _entries;
                 Debug.Assert(entries != null, "Expected _entries to be initialized");
 
                 uint collisionCount = 0;
-                IEqualityComparer<T>? comparer = _comparer;
+                var comparer = _comparer;
 
                 if (SupportsComparerDevirtualization && comparer == null)
                 {
-                    int hashCode = item != null ? item.GetHashCode() : 0;
+                    var hashCode = item != null ? item.GetHashCode() : 0;
                     if (typeof(T).IsValueType)
                     {
                         // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
-                        int i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
+                        var i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
                         while (i >= 0)
                         {
-                            ref Entry entry = ref entries[i];
+                            ref var entry = ref entries[i];
                             if (entry.HashCode == hashCode && EqualityComparer<T>.Default.Equals(entry.Value, item))
                             {
                                 return i;
@@ -239,11 +240,11 @@ namespace Microsoft.CodeAnalysis.Collections
                     {
                         // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize (https://github.com/dotnet/runtime/issues/10050),
                         // so cache in a local rather than get EqualityComparer per loop iteration.
-                        EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
-                        int i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
+                        var defaultComparer = EqualityComparer<T>.Default;
+                        var i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
                         while (i >= 0)
                         {
-                            ref Entry entry = ref entries[i];
+                            ref var entry = ref entries[i];
                             if (entry.HashCode == hashCode && defaultComparer.Equals(entry.Value, item))
                             {
                                 return i;
@@ -261,11 +262,11 @@ namespace Microsoft.CodeAnalysis.Collections
                 }
                 else
                 {
-                    int hashCode = item != null ? comparer.GetHashCode(item) : 0;
-                    int i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
+                    var hashCode = item != null ? comparer.GetHashCode(item) : 0;
+                    var i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
                     while (i >= 0)
                     {
-                        ref Entry entry = ref entries[i];
+                        ref var entry = ref entries[i];
                         if (entry.HashCode == hashCode && comparer.Equals(entry.Value, item))
                         {
                             return i;
@@ -289,7 +290,7 @@ namespace Microsoft.CodeAnalysis.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ref int GetBucketRef(int hashCode)
         {
-            int[] buckets = _buckets!;
+            var buckets = _buckets!;
 #if TARGET_64BIT
             return ref buckets[HashHelpers.FastMod((uint)hashCode, (uint)buckets.Length, _fastModMultiplier)];
 #else
@@ -301,19 +302,19 @@ namespace Microsoft.CodeAnalysis.Collections
         {
             if (_buckets != null)
             {
-                Entry[]? entries = _entries;
+                var entries = _entries;
                 Debug.Assert(entries != null, "entries should be non-null");
 
                 uint collisionCount = 0;
-                int last = -1;
-                int hashCode = item != null ? (_comparer?.GetHashCode(item) ?? item.GetHashCode()) : 0;
+                var last = -1;
+                var hashCode = item != null ? (_comparer?.GetHashCode(item) ?? item.GetHashCode()) : 0;
 
-                ref int bucket = ref GetBucketRef(hashCode);
-                int i = bucket - 1; // Value in buckets is 1-based
+                ref var bucket = ref GetBucketRef(hashCode);
+                var i = bucket - 1; // Value in buckets is 1-based
 
                 while (i >= 0)
                 {
-                    ref Entry entry = ref entries[i];
+                    ref var entry = ref entries[i];
 
                     if (entry.HashCode == hashCode && (_comparer?.Equals(entry.Value, item) ?? EqualityComparer<T>.Default.Equals(entry.Value, item)))
                     {
@@ -364,7 +365,7 @@ namespace Microsoft.CodeAnalysis.Collections
 
         #region IEnumerable methods
 
-        public Enumerator GetEnumerator() => new Enumerator(this);
+        public Enumerator GetEnumerator() => new(this);
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
 
@@ -393,7 +394,7 @@ namespace Microsoft.CodeAnalysis.Collections
         {
             if (_buckets != null)
             {
-                int index = FindItemIndex(equalValue);
+                var index = FindItemIndex(equalValue);
                 if (index >= 0)
                 {
                     actualValue = _entries![index].Value;
@@ -414,7 +415,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
             }
 
-            foreach (T item in other)
+            foreach (var item in other)
             {
                 AddIfNotPresent(item, out _);
             }
@@ -480,7 +481,7 @@ namespace Microsoft.CodeAnalysis.Collections
             }
 
             // Remove every element in other from this.
-            foreach (T element in other)
+            foreach (var element in other)
             {
                 Remove(element);
             }
@@ -556,7 +557,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 return IsSubsetOfHashSetWithSameComparer(otherAsSet);
             }
 
-            (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: false);
+            (var uniqueCount, var unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: false);
             return uniqueCount == Count && unfoundCount >= 0;
         }
 
@@ -604,7 +605,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 }
             }
 
-            (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: false);
+            (var uniqueCount, var unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: false);
             return uniqueCount == Count && unfoundCount > 0;
         }
 
@@ -684,7 +685,7 @@ namespace Microsoft.CodeAnalysis.Collections
             }
 
             // Couldn't fall out in the above cases; do it the long way
-            (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: true);
+            (var uniqueCount, var unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: true);
             return uniqueCount < Count && unfoundCount == 0;
         }
 
@@ -709,7 +710,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 return true;
             }
 
-            foreach (T element in other)
+            foreach (var element in other)
             {
                 if (Contains(element))
                 {
@@ -760,7 +761,7 @@ namespace Microsoft.CodeAnalysis.Collections
                     return false;
                 }
 
-                (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: true);
+                (var uniqueCount, var unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: true);
                 return uniqueCount == Count && unfoundCount == 0;
             }
         }
@@ -799,10 +800,10 @@ namespace Microsoft.CodeAnalysis.Collections
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
             }
 
-            Entry[]? entries = _entries;
-            for (int i = 0; i < _count && count != 0; i++)
+            var entries = _entries;
+            for (var i = 0; i < _count && count != 0; i++)
             {
-                ref Entry entry = ref entries![i];
+                ref var entry = ref entries![i];
                 if (entry.Next >= -1)
                 {
                     array[arrayIndex++] = entry.Value;
@@ -819,15 +820,15 @@ namespace Microsoft.CodeAnalysis.Collections
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.match);
             }
 
-            Entry[]? entries = _entries;
-            int numRemoved = 0;
-            for (int i = 0; i < _count; i++)
+            var entries = _entries;
+            var numRemoved = 0;
+            for (var i = 0; i < _count; i++)
             {
-                ref Entry entry = ref entries![i];
+                ref var entry = ref entries![i];
                 if (entry.Next >= -1)
                 {
                     // Cache value in case delegate removes it
-                    T value = entry.Value;
+                    var value = entry.Value;
                     if (match(value))
                     {
                         // Check again that remove actually removed it.
@@ -859,7 +860,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
             }
 
-            int currentCapacity = _entries == null ? 0 : _entries.Length;
+            var currentCapacity = _entries == null ? 0 : _entries.Length;
             if (currentCapacity >= capacity)
             {
                 return currentCapacity;
@@ -870,7 +871,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 return Initialize(capacity);
             }
 
-            int newSize = HashHelpers.GetPrime(capacity);
+            var newSize = HashHelpers.GetPrime(capacity);
             Resize(newSize);
             return newSize;
         }
@@ -884,7 +885,7 @@ namespace Microsoft.CodeAnalysis.Collections
 
             var entries = new Entry[newSize];
 
-            int count = _count;
+            var count = _count;
             Array.Copy(_entries, entries, count);
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
@@ -892,12 +893,12 @@ namespace Microsoft.CodeAnalysis.Collections
 #if TARGET_64BIT
             _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);
 #endif
-            for (int i = 0; i < count; i++)
+            for (var i = 0; i < count; i++)
             {
-                ref Entry entry = ref entries[i];
+                ref var entry = ref entries[i];
                 if (entry.Next >= -1)
                 {
-                    ref int bucket = ref GetBucketRef(entry.HashCode);
+                    ref var bucket = ref GetBucketRef(entry.HashCode);
                     entry.Next = bucket - 1; // Value in _buckets is 1-based
                     bucket = i + 1;
                 }
@@ -912,29 +913,29 @@ namespace Microsoft.CodeAnalysis.Collections
         /// </summary>
         public void TrimExcess()
         {
-            int capacity = Count;
+            var capacity = Count;
 
-            int newSize = HashHelpers.GetPrime(capacity);
-            Entry[]? oldEntries = _entries;
-            int currentCapacity = oldEntries == null ? 0 : oldEntries.Length;
+            var newSize = HashHelpers.GetPrime(capacity);
+            var oldEntries = _entries;
+            var currentCapacity = oldEntries == null ? 0 : oldEntries.Length;
             if (newSize >= currentCapacity)
             {
                 return;
             }
 
-            int oldCount = _count;
+            var oldCount = _count;
             _version++;
             Initialize(newSize);
-            Entry[]? entries = _entries;
-            int count = 0;
-            for (int i = 0; i < oldCount; i++)
+            var entries = _entries;
+            var count = 0;
+            for (var i = 0; i < oldCount; i++)
             {
-                int hashCode = oldEntries![i].HashCode; // At this point, we know we have entries.
+                var hashCode = oldEntries![i].HashCode; // At this point, we know we have entries.
                 if (oldEntries[i].Next >= -1)
                 {
-                    ref Entry entry = ref entries![count];
+                    ref var entry = ref entries![count];
                     entry = oldEntries[i];
-                    ref int bucket = ref GetBucketRef(hashCode);
+                    ref var bucket = ref GetBucketRef(hashCode);
                     entry.Next = bucket - 1; // Value in _buckets is 1-based
                     bucket = count + 1;
                     count++;
@@ -958,7 +959,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// </summary>
         private int Initialize(int capacity)
         {
-            int size = HashHelpers.GetPrime(capacity);
+            var size = HashHelpers.GetPrime(capacity);
             var buckets = new int[size];
             var entries = new Entry[size];
 
@@ -985,26 +986,26 @@ namespace Microsoft.CodeAnalysis.Collections
             }
             Debug.Assert(_buckets != null);
 
-            Entry[]? entries = _entries;
+            var entries = _entries;
             Debug.Assert(entries != null, "expected entries to be non-null");
 
-            IEqualityComparer<T>? comparer = _comparer;
+            var comparer = _comparer;
             int hashCode;
 
             uint collisionCount = 0;
-            ref int bucket = ref Unsafe.NullRef<int>();
+            ref var bucket = ref Unsafe.NullRef<int>();
 
             if (SupportsComparerDevirtualization && comparer == null)
             {
                 hashCode = value != null ? value.GetHashCode() : 0;
                 bucket = ref GetBucketRef(hashCode);
-                int i = bucket - 1; // Value in _buckets is 1-based
+                var i = bucket - 1; // Value in _buckets is 1-based
                 if (typeof(T).IsValueType)
                 {
                     // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
                     while (i >= 0)
                     {
-                        ref Entry entry = ref entries[i];
+                        ref var entry = ref entries[i];
                         if (entry.HashCode == hashCode && EqualityComparer<T>.Default.Equals(entry.Value, value))
                         {
                             location = i;
@@ -1024,10 +1025,10 @@ namespace Microsoft.CodeAnalysis.Collections
                 {
                     // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize (https://github.com/dotnet/runtime/issues/10050),
                     // so cache in a local rather than get EqualityComparer per loop iteration.
-                    EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
+                    var defaultComparer = EqualityComparer<T>.Default;
                     while (i >= 0)
                     {
-                        ref Entry entry = ref entries[i];
+                        ref var entry = ref entries[i];
                         if (entry.HashCode == hashCode && defaultComparer.Equals(entry.Value, value))
                         {
                             location = i;
@@ -1048,10 +1049,10 @@ namespace Microsoft.CodeAnalysis.Collections
             {
                 hashCode = value != null ? comparer.GetHashCode(value) : 0;
                 bucket = ref GetBucketRef(hashCode);
-                int i = bucket - 1; // Value in _buckets is 1-based
+                var i = bucket - 1; // Value in _buckets is 1-based
                 while (i >= 0)
                 {
-                    ref Entry entry = ref entries[i];
+                    ref var entry = ref entries[i];
                     if (entry.HashCode == hashCode && comparer.Equals(entry.Value, value))
                     {
                         location = i;
@@ -1078,7 +1079,7 @@ namespace Microsoft.CodeAnalysis.Collections
             }
             else
             {
-                int count = _count;
+                var count = _count;
                 if (count == entries.Length)
                 {
                     Resize();
@@ -1090,7 +1091,7 @@ namespace Microsoft.CodeAnalysis.Collections
             }
 
             {
-                ref Entry entry = ref entries![index];
+                ref var entry = ref entries![index];
                 entry.HashCode = hashCode;
                 entry.Next = bucket - 1; // Value in _buckets is 1-based
                 entry.Value = value;
@@ -1109,7 +1110,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// </summary>
         private bool ContainsAllElements(IEnumerable<T> other)
         {
-            foreach (T element in other)
+            foreach (var element in other)
             {
                 if (!Contains(element))
                 {
@@ -1132,7 +1133,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// </summary>
         internal bool IsSubsetOfHashSetWithSameComparer(SegmentedHashSet<T> other)
         {
-            foreach (T item in this)
+            foreach (var item in this)
             {
                 if (!other.Contains(item))
                 {
@@ -1149,13 +1150,13 @@ namespace Microsoft.CodeAnalysis.Collections
         /// </summary>
         private void IntersectWithHashSetWithSameComparer(SegmentedHashSet<T> other)
         {
-            Entry[]? entries = _entries;
-            for (int i = 0; i < _count; i++)
+            var entries = _entries;
+            for (var i = 0; i < _count; i++)
             {
-                ref Entry entry = ref entries![i];
+                ref var entry = ref entries![i];
                 if (entry.Next >= -1)
                 {
-                    T item = entry.Value;
+                    var item = entry.Value;
                     if (!other.Contains(item))
                     {
                         Remove(item);
@@ -1176,18 +1177,18 @@ namespace Microsoft.CodeAnalysis.Collections
 
             // Keep track of current last index; don't want to move past the end of our bit array
             // (could happen if another thread is modifying the collection).
-            int originalCount = _count;
+            var originalCount = _count;
             int intArrayLength = BitHelper.ToIntArrayLength(originalCount);
 
             Span<int> span = stackalloc int[StackAllocThreshold];
-            BitHelper bitHelper = intArrayLength <= StackAllocThreshold ?
+            var bitHelper = intArrayLength <= StackAllocThreshold ?
                 new BitHelper(span.Slice(0, intArrayLength), clear: true) :
                 new BitHelper(new int[intArrayLength], clear: false);
 
             // Mark if contains: find index of in slots array and mark corresponding element in bit array.
-            foreach (T item in other)
+            foreach (var item in other)
             {
-                int index = FindItemIndex(item);
+                var index = FindItemIndex(item);
                 if (index >= 0)
                 {
                     bitHelper.MarkBit(index);
@@ -1196,9 +1197,9 @@ namespace Microsoft.CodeAnalysis.Collections
 
             // If anything unmarked, remove it. Perf can be optimized here if BitHelper had a
             // FindFirstUnmarked method.
-            for (int i = 0; i < originalCount; i++)
+            for (var i = 0; i < originalCount; i++)
             {
-                ref Entry entry = ref _entries![i];
+                ref var entry = ref _entries![i];
                 if (entry.Next >= -1 && !bitHelper.IsMarked(i))
                 {
                     Remove(entry.Value);
@@ -1216,7 +1217,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <param name="other"></param>
         private void SymmetricExceptWithUniqueHashSet(SegmentedHashSet<T> other)
         {
-            foreach (T item in other)
+            foreach (var item in other)
             {
                 if (!Remove(item))
                 {
@@ -1244,23 +1245,22 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <param name="other"></param>
         private unsafe void SymmetricExceptWithEnumerable(IEnumerable<T> other)
         {
-            int originalCount = _count;
+            var originalCount = _count;
             int intArrayLength = BitHelper.ToIntArrayLength(originalCount);
 
             Span<int> itemsToRemoveSpan = stackalloc int[StackAllocThreshold / 2];
-            BitHelper itemsToRemove = intArrayLength <= StackAllocThreshold / 2 ?
+            var itemsToRemove = intArrayLength <= StackAllocThreshold / 2 ?
                 new BitHelper(itemsToRemoveSpan.Slice(0, intArrayLength), clear: true) :
                 new BitHelper(new int[intArrayLength], clear: false);
 
             Span<int> itemsAddedFromOtherSpan = stackalloc int[StackAllocThreshold / 2];
-            BitHelper itemsAddedFromOther = intArrayLength <= StackAllocThreshold / 2 ?
+            var itemsAddedFromOther = intArrayLength <= StackAllocThreshold / 2 ?
                 new BitHelper(itemsAddedFromOtherSpan.Slice(0, intArrayLength), clear: true) :
                 new BitHelper(new int[intArrayLength], clear: false);
 
-            foreach (T item in other)
+            foreach (var item in other)
             {
-                int location;
-                if (AddIfNotPresent(item, out location))
+                if (AddIfNotPresent(item, out var location))
                 {
                     // wasn't already present in collection; flag it as something not to remove
                     // *NOTE* if location is out of range, we should ignore. BitHelper will
@@ -1283,7 +1283,7 @@ namespace Microsoft.CodeAnalysis.Collections
             }
 
             // if anything marked, remove it
-            for (int i = 0; i < originalCount; i++)
+            for (var i = 0; i < originalCount; i++)
             {
                 if (itemsToRemove.IsMarked(i))
                 {
@@ -1320,8 +1320,8 @@ namespace Microsoft.CodeAnalysis.Collections
             // Need special case in case this has no elements.
             if (_count == 0)
             {
-                int numElementsInOther = 0;
-                foreach (T item in other)
+                var numElementsInOther = 0;
+                foreach (var item in other)
                 {
                     numElementsInOther++;
                     break; // break right away, all we want to know is whether other has 0 or 1 elements
@@ -1332,20 +1332,20 @@ namespace Microsoft.CodeAnalysis.Collections
 
             Debug.Assert((_buckets != null) && (_count > 0), "_buckets was null but count greater than 0");
 
-            int originalCount = _count;
+            var originalCount = _count;
             int intArrayLength = BitHelper.ToIntArrayLength(originalCount);
 
             Span<int> span = stackalloc int[StackAllocThreshold];
-            BitHelper bitHelper = intArrayLength <= StackAllocThreshold ?
+            var bitHelper = intArrayLength <= StackAllocThreshold ?
                 new BitHelper(span.Slice(0, intArrayLength), clear: true) :
                 new BitHelper(new int[intArrayLength], clear: false);
 
-            int unfoundCount = 0; // count of items in other not found in this
-            int uniqueFoundCount = 0; // count of unique items in other found in this
+            var unfoundCount = 0; // count of items in other not found in this
+            var uniqueFoundCount = 0; // count of unique items in other found in this
 
-            foreach (T item in other)
+            foreach (var item in other)
             {
-                int index = FindItemIndex(item);
+                var index = FindItemIndex(item);
                 if (index >= 0)
                 {
                     if (!bitHelper.IsMarked(index))
@@ -1375,7 +1375,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// </summary>
         internal static bool EqualityComparersAreEqual(SegmentedHashSet<T> set1, SegmentedHashSet<T> set2) => set1.Comparer.Equals(set2.Comparer);
 
-#endregion
+        #endregion
 
         private struct Entry
         {
@@ -1415,7 +1415,7 @@ namespace Microsoft.CodeAnalysis.Collections
                 // dictionary.count+1 could be negative if dictionary.count is int.MaxValue
                 while ((uint)_index < (uint)_hashSet._count)
                 {
-                    ref Entry entry = ref _hashSet._entries![_index++];
+                    ref var entry = ref _hashSet._entries![_index++];
                     if (entry.Next >= -1)
                     {
                         _current = entry.Value;

--- a/src/Dependencies/Collections/SegmentedHashSet`1.cs
+++ b/src/Dependencies/Collections/SegmentedHashSet`1.cs
@@ -1,0 +1,1582 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+
+using Internal.Runtime.CompilerServices;
+
+namespace System.Collections.Generic
+{
+    [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
+    [DebuggerDisplay("Count = {Count}")]
+    [Serializable]
+    [TypeForwardedFrom("System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+    public class HashSet<T> : ICollection<T>, ISet<T>, IReadOnlyCollection<T>, IReadOnlySet<T>, ISerializable, IDeserializationCallback
+    {
+        // This uses the same array-based implementation as Dictionary<TKey, TValue>.
+
+        // Constants for serialization
+        private const string CapacityName = "Capacity"; // Do not rename (binary serialization)
+        private const string ElementsName = "Elements"; // Do not rename (binary serialization)
+        private const string ComparerName = "Comparer"; // Do not rename (binary serialization)
+        private const string VersionName = "Version"; // Do not rename (binary serialization)
+
+        /// <summary>Cutoff point for stackallocs. This corresponds to the number of ints.</summary>
+        private const int StackAllocThreshold = 100;
+
+        /// <summary>
+        /// When constructing a hashset from an existing collection, it may contain duplicates,
+        /// so this is used as the max acceptable excess ratio of capacity to count. Note that
+        /// this is only used on the ctor and not to automatically shrink if the hashset has, e.g,
+        /// a lot of adds followed by removes. Users must explicitly shrink by calling TrimExcess.
+        /// This is set to 3 because capacity is acceptable as 2x rounded up to nearest prime.
+        /// </summary>
+        private const int ShrinkThreshold = 3;
+        private const int StartOfFreeList = -3;
+
+        private int[]? _buckets;
+        private Entry[]? _entries;
+#if TARGET_64BIT
+        private ulong _fastModMultiplier;
+#endif
+        private int _count;
+        private int _freeList;
+        private int _freeCount;
+        private int _version;
+        private IEqualityComparer<T>? _comparer;
+        private SerializationInfo? _siInfo; // temporary variable needed during deserialization
+
+        #region Constructors
+
+        public HashSet() : this((IEqualityComparer<T>?)null) { }
+
+        public HashSet(IEqualityComparer<T>? comparer)
+        {
+            if (comparer != null && comparer != EqualityComparer<T>.Default) // first check for null to avoid forcing default comparer instantiation unnecessarily
+            {
+                _comparer = comparer;
+            }
+
+            // Special-case EqualityComparer<string>.Default, StringComparer.Ordinal, and StringComparer.OrdinalIgnoreCase.
+            // We use a non-randomized comparer for improved perf, falling back to a randomized comparer if the
+            // hash buckets become unbalanced.
+
+            if (typeof(T) == typeof(string))
+            {
+                if (_comparer is null)
+                {
+                    _comparer = (IEqualityComparer<T>)NonRandomizedStringEqualityComparer.WrappedAroundDefaultComparer;
+                }
+                else if (ReferenceEquals(_comparer, StringComparer.Ordinal))
+                {
+                    _comparer = (IEqualityComparer<T>)NonRandomizedStringEqualityComparer.WrappedAroundStringComparerOrdinal;
+                }
+                else if (ReferenceEquals(_comparer, StringComparer.OrdinalIgnoreCase))
+                {
+                    _comparer = (IEqualityComparer<T>)NonRandomizedStringEqualityComparer.WrappedAroundStringComparerOrdinalIgnoreCase;
+                }
+            }
+        }
+
+        public HashSet(int capacity) : this(capacity, null) { }
+
+        public HashSet(IEnumerable<T> collection) : this(collection, null) { }
+
+        public HashSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer) : this(comparer)
+        {
+            if (collection == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);
+            }
+
+            if (collection is HashSet<T> otherAsHashSet && EqualityComparersAreEqual(this, otherAsHashSet))
+            {
+                ConstructFrom(otherAsHashSet);
+            }
+            else
+            {
+                // To avoid excess resizes, first set size based on collection's count. The collection may
+                // contain duplicates, so call TrimExcess if resulting HashSet is larger than the threshold.
+                if (collection is ICollection<T> coll)
+                {
+                    int count = coll.Count;
+                    if (count > 0)
+                    {
+                        Initialize(count);
+                    }
+                }
+
+                UnionWith(collection);
+
+                if (_count > 0 && _entries!.Length / _count > ShrinkThreshold)
+                {
+                    TrimExcess();
+                }
+            }
+        }
+
+        public HashSet(int capacity, IEqualityComparer<T>? comparer) : this(comparer)
+        {
+            if (capacity < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
+            }
+
+            if (capacity > 0)
+            {
+                Initialize(capacity);
+            }
+        }
+
+        protected HashSet(SerializationInfo info, StreamingContext context)
+        {
+            // We can't do anything with the keys and values until the entire graph has been
+            // deserialized and we have a reasonable estimate that GetHashCode is not going to
+            // fail.  For the time being, we'll just cache this.  The graph is not valid until
+            // OnDeserialization has been called.
+            _siInfo = info;
+        }
+
+        /// <summary>Initializes the HashSet from another HashSet with the same element type and equality comparer.</summary>
+        private void ConstructFrom(HashSet<T> source)
+        {
+            if (source.Count == 0)
+            {
+                // As well as short-circuiting on the rest of the work done,
+                // this avoids errors from trying to access source._buckets
+                // or source._entries when they aren't initialized.
+                return;
+            }
+
+            int capacity = source._buckets!.Length;
+            int threshold = HashHelpers.ExpandPrime(source.Count + 1);
+
+            if (threshold >= capacity)
+            {
+                _buckets = (int[])source._buckets.Clone();
+                _entries = (Entry[])source._entries!.Clone();
+                _freeList = source._freeList;
+                _freeCount = source._freeCount;
+                _count = source._count;
+#if TARGET_64BIT
+                _fastModMultiplier = source._fastModMultiplier;
+#endif
+            }
+            else
+            {
+                Initialize(source.Count);
+
+                Entry[]? entries = source._entries;
+                for (int i = 0; i < source._count; i++)
+                {
+                    ref Entry entry = ref entries![i];
+                    if (entry.Next >= -1)
+                    {
+                        AddIfNotPresent(entry.Value, out _);
+                    }
+                }
+            }
+
+            Debug.Assert(Count == source.Count);
+        }
+
+        #endregion
+
+        #region ICollection<T> methods
+
+        void ICollection<T>.Add(T item) => AddIfNotPresent(item, out _);
+
+        /// <summary>Removes all elements from the <see cref="HashSet{T}"/> object.</summary>
+        public void Clear()
+        {
+            int count = _count;
+            if (count > 0)
+            {
+                Debug.Assert(_buckets != null, "_buckets should be non-null");
+                Debug.Assert(_entries != null, "_entries should be non-null");
+
+                Array.Clear(_buckets, 0, _buckets.Length);
+                _count = 0;
+                _freeList = -1;
+                _freeCount = 0;
+                Array.Clear(_entries, 0, count);
+            }
+        }
+
+        /// <summary>Determines whether the <see cref="HashSet{T}"/> contains the specified element.</summary>
+        /// <param name="item">The element to locate in the <see cref="HashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="HashSet{T}"/> object contains the specified element; otherwise, false.</returns>
+        public bool Contains(T item) => FindItemIndex(item) >= 0;
+
+        /// <summary>Gets the index of the item in <see cref="_entries"/>, or -1 if it's not in the set.</summary>
+        private int FindItemIndex(T item)
+        {
+            int[]? buckets = _buckets;
+            if (buckets != null)
+            {
+                Entry[]? entries = _entries;
+                Debug.Assert(entries != null, "Expected _entries to be initialized");
+
+                uint collisionCount = 0;
+                IEqualityComparer<T>? comparer = _comparer;
+
+                if (comparer == null)
+                {
+                    int hashCode = item != null ? item.GetHashCode() : 0;
+                    if (typeof(T).IsValueType)
+                    {
+                        // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
+                        int i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
+                        while (i >= 0)
+                        {
+                            ref Entry entry = ref entries[i];
+                            if (entry.HashCode == hashCode && EqualityComparer<T>.Default.Equals(entry.Value, item))
+                            {
+                                return i;
+                            }
+                            i = entry.Next;
+
+                            collisionCount++;
+                            if (collisionCount > (uint)entries.Length)
+                            {
+                                // The chain of entries forms a loop, which means a concurrent update has happened.
+                                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize (https://github.com/dotnet/runtime/issues/10050),
+                        // so cache in a local rather than get EqualityComparer per loop iteration.
+                        EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
+                        int i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
+                        while (i >= 0)
+                        {
+                            ref Entry entry = ref entries[i];
+                            if (entry.HashCode == hashCode && defaultComparer.Equals(entry.Value, item))
+                            {
+                                return i;
+                            }
+                            i = entry.Next;
+
+                            collisionCount++;
+                            if (collisionCount > (uint)entries.Length)
+                            {
+                                // The chain of entries forms a loop, which means a concurrent update has happened.
+                                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    int hashCode = item != null ? comparer.GetHashCode(item) : 0;
+                    int i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
+                    while (i >= 0)
+                    {
+                        ref Entry entry = ref entries[i];
+                        if (entry.HashCode == hashCode && comparer.Equals(entry.Value, item))
+                        {
+                            return i;
+                        }
+                        i = entry.Next;
+
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
+                        {
+                            // The chain of entries forms a loop, which means a concurrent update has happened.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>Gets a reference to the specified hashcode's bucket, containing an index into <see cref="_entries"/>.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ref int GetBucketRef(int hashCode)
+        {
+            int[] buckets = _buckets!;
+#if TARGET_64BIT
+            return ref buckets[HashHelpers.FastMod((uint)hashCode, (uint)buckets.Length, _fastModMultiplier)];
+#else
+            return ref buckets[(uint)hashCode % (uint)buckets.Length];
+#endif
+        }
+
+        public bool Remove(T item)
+        {
+            if (_buckets != null)
+            {
+                Entry[]? entries = _entries;
+                Debug.Assert(entries != null, "entries should be non-null");
+
+                uint collisionCount = 0;
+                int last = -1;
+                int hashCode = item != null ? (_comparer?.GetHashCode(item) ?? item.GetHashCode()) : 0;
+
+                ref int bucket = ref GetBucketRef(hashCode);
+                int i = bucket - 1; // Value in buckets is 1-based
+
+                while (i >= 0)
+                {
+                    ref Entry entry = ref entries[i];
+
+                    if (entry.HashCode == hashCode && (_comparer?.Equals(entry.Value, item) ?? EqualityComparer<T>.Default.Equals(entry.Value, item)))
+                    {
+                        if (last < 0)
+                        {
+                            bucket = entry.Next + 1; // Value in buckets is 1-based
+                        }
+                        else
+                        {
+                            entries[last].Next = entry.Next;
+                        }
+
+                        Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                        entry.Next = StartOfFreeList - _freeList;
+
+                        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                        {
+                            entry.Value = default!;
+                        }
+
+                        _freeList = i;
+                        _freeCount++;
+                        return true;
+                    }
+
+                    last = i;
+                    i = entry.Next;
+
+                    collisionCount++;
+                    if (collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>Gets the number of elements that are contained in the set.</summary>
+        public int Count => _count - _freeCount;
+
+        bool ICollection<T>.IsReadOnly => false;
+
+        #endregion
+
+        #region IEnumerable methods
+
+        public Enumerator GetEnumerator() => new Enumerator(this);
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        #endregion
+
+        #region ISerializable methods
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.info);
+            }
+
+            info.AddValue(VersionName, _version); // need to serialize version to avoid problems with serializing while enumerating
+            info.AddValue(ComparerName, Comparer, typeof(IEqualityComparer<T>));
+            info.AddValue(CapacityName, _buckets == null ? 0 : _buckets.Length);
+
+            if (_buckets != null)
+            {
+                var array = new T[Count];
+                CopyTo(array);
+                info.AddValue(ElementsName, array, typeof(T[]));
+            }
+        }
+
+        #endregion
+
+        #region IDeserializationCallback methods
+
+        public virtual void OnDeserialization(object? sender)
+        {
+            if (_siInfo == null)
+            {
+                // It might be necessary to call OnDeserialization from a container if the
+                // container object also implements OnDeserialization. We can return immediately
+                // if this function is called twice. Note we set _siInfo to null at the end of this method.
+                return;
+            }
+
+            int capacity = _siInfo.GetInt32(CapacityName);
+            _comparer = (IEqualityComparer<T>)_siInfo.GetValue(ComparerName, typeof(IEqualityComparer<T>))!;
+            _freeList = -1;
+            _freeCount = 0;
+
+            if (capacity != 0)
+            {
+                _buckets = new int[capacity];
+                _entries = new Entry[capacity];
+#if TARGET_64BIT
+                _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)capacity);
+#endif
+
+                T[]? array = (T[]?)_siInfo.GetValue(ElementsName, typeof(T[]));
+                if (array == null)
+                {
+                    ThrowHelper.ThrowSerializationException(ExceptionResource.Serialization_MissingKeys);
+                }
+
+                // There are no resizes here because we already set capacity above.
+                for (int i = 0; i < array.Length; i++)
+                {
+                    AddIfNotPresent(array[i], out _);
+                }
+            }
+            else
+            {
+                _buckets = null;
+            }
+
+            _version = _siInfo.GetInt32(VersionName);
+            _siInfo = null;
+        }
+
+        #endregion
+
+        #region HashSet methods
+
+        /// <summary>Adds the specified element to the <see cref="HashSet{T}"/>.</summary>
+        /// <param name="item">The element to add to the set.</param>
+        /// <returns>true if the element is added to the <see cref="HashSet{T}"/> object; false if the element is already present.</returns>
+        public bool Add(T item) => AddIfNotPresent(item, out _);
+
+        /// <summary>Searches the set for a given value and returns the equal value it finds, if any.</summary>
+        /// <param name="equalValue">The value to search for.</param>
+        /// <param name="actualValue">The value from the set that the search found, or the default value of <typeparamref name="T"/> when the search yielded no match.</param>
+        /// <returns>A value indicating whether the search was successful.</returns>
+        /// <remarks>
+        /// This can be useful when you want to reuse a previously stored reference instead of
+        /// a newly constructed one (so that more sharing of references can occur) or to look up
+        /// a value that has more complete data than the value you currently have, although their
+        /// comparer functions indicate they are equal.
+        /// </remarks>
+        public bool TryGetValue(T equalValue, [MaybeNullWhen(false)] out T actualValue)
+        {
+            if (_buckets != null)
+            {
+                int index = FindItemIndex(equalValue);
+                if (index >= 0)
+                {
+                    actualValue = _entries![index].Value;
+                    return true;
+                }
+            }
+
+            actualValue = default;
+            return false;
+        }
+
+        /// <summary>Modifies the current <see cref="HashSet{T}"/> object to contain all elements that are present in itself, the specified collection, or both.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        public void UnionWith(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            foreach (T item in other)
+            {
+                AddIfNotPresent(item, out _);
+            }
+        }
+
+        /// <summary>Modifies the current <see cref="HashSet{T}"/> object to contain only elements that are present in that object and in the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        public void IntersectWith(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            // Intersection of anything with empty set is empty set, so return if count is 0.
+            // Same if the set intersecting with itself is the same set.
+            if (Count == 0 || other == this)
+            {
+                return;
+            }
+
+            // If other is known to be empty, intersection is empty set; remove all elements, and we're done.
+            if (other is ICollection<T> otherAsCollection)
+            {
+                if (otherAsCollection.Count == 0)
+                {
+                    Clear();
+                    return;
+                }
+
+                // Faster if other is a hashset using same equality comparer; so check
+                // that other is a hashset using the same equality comparer.
+                if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+                {
+                    IntersectWithHashSetWithSameComparer(otherAsSet);
+                    return;
+                }
+            }
+
+            IntersectWithEnumerable(other);
+        }
+
+        /// <summary>Removes all elements in the specified collection from the current <see cref="HashSet{T}"/> object.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        public void ExceptWith(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            // This is already the empty set; return.
+            if (Count == 0)
+            {
+                return;
+            }
+
+            // Special case if other is this; a set minus itself is the empty set.
+            if (other == this)
+            {
+                Clear();
+                return;
+            }
+
+            // Remove every element in other from this.
+            foreach (T element in other)
+            {
+                Remove(element);
+            }
+        }
+
+        /// <summary>Modifies the current <see cref="HashSet{T}"/> object to contain only elements that are present either in that object or in the specified collection, but not both.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        public void SymmetricExceptWith(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            // If set is empty, then symmetric difference is other.
+            if (Count == 0)
+            {
+                UnionWith(other);
+                return;
+            }
+
+            // Special-case this; the symmetric difference of a set with itself is the empty set.
+            if (other == this)
+            {
+                Clear();
+                return;
+            }
+
+            // If other is a HashSet, it has unique elements according to its equality comparer,
+            // but if they're using different equality comparers, then assumption of uniqueness
+            // will fail. So first check if other is a hashset using the same equality comparer;
+            // symmetric except is a lot faster and avoids bit array allocations if we can assume
+            // uniqueness.
+            if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+            {
+                SymmetricExceptWithUniqueHashSet(otherAsSet);
+            }
+            else
+            {
+                SymmetricExceptWithEnumerable(other);
+            }
+        }
+
+        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a subset of the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="HashSet{T}"/> object is a subset of <paramref name="other"/>; otherwise, false.</returns>
+        public bool IsSubsetOf(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            // The empty set is a subset of any set, and a set is a subset of itself.
+            // Set is always a subset of itself
+            if (Count == 0 || other == this)
+            {
+                return true;
+            }
+
+            // Faster if other has unique elements according to this equality comparer; so check
+            // that other is a hashset using the same equality comparer.
+            if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+            {
+                // if this has more elements then it can't be a subset
+                if (Count > otherAsSet.Count)
+                {
+                    return false;
+                }
+
+                // already checked that we're using same equality comparer. simply check that
+                // each element in this is contained in other.
+                return IsSubsetOfHashSetWithSameComparer(otherAsSet);
+            }
+
+            (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: false);
+            return uniqueCount == Count && unfoundCount >= 0;
+        }
+
+        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a proper subset of the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="HashSet{T}"/> object is a proper subset of <paramref name="other"/>; otherwise, false.</returns>
+        public bool IsProperSubsetOf(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            // No set is a proper subset of itself.
+            if (other == this)
+            {
+                return false;
+            }
+
+            if (other is ICollection<T> otherAsCollection)
+            {
+                // No set is a proper subset of an empty set.
+                if (otherAsCollection.Count == 0)
+                {
+                    return false;
+                }
+
+                // The empty set is a proper subset of anything but the empty set.
+                if (Count == 0)
+                {
+                    return otherAsCollection.Count > 0;
+                }
+
+                // Faster if other is a hashset (and we're using same equality comparer).
+                if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+                {
+                    if (Count >= otherAsSet.Count)
+                    {
+                        return false;
+                    }
+
+                    // This has strictly less than number of items in other, so the following
+                    // check suffices for proper subset.
+                    return IsSubsetOfHashSetWithSameComparer(otherAsSet);
+                }
+            }
+
+            (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: false);
+            return uniqueCount == Count && unfoundCount > 0;
+        }
+
+        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a proper superset of the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="HashSet{T}"/> object is a superset of <paramref name="other"/>; otherwise, false.</returns>
+        public bool IsSupersetOf(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            // A set is always a superset of itself.
+            if (other == this)
+            {
+                return true;
+            }
+
+            // Try to fall out early based on counts.
+            if (other is ICollection<T> otherAsCollection)
+            {
+                // If other is the empty set then this is a superset.
+                if (otherAsCollection.Count == 0)
+                {
+                    return true;
+                }
+
+                // Try to compare based on counts alone if other is a hashset with same equality comparer.
+                if (other is HashSet<T> otherAsSet &&
+                    EqualityComparersAreEqual(this, otherAsSet) &&
+                    otherAsSet.Count > Count)
+                {
+                    return false;
+                }
+            }
+
+            return ContainsAllElements(other);
+        }
+
+        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a proper superset of the specified collection.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="HashSet{T}"/> object is a proper superset of <paramref name="other"/>; otherwise, false.</returns>
+        public bool IsProperSupersetOf(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            // The empty set isn't a proper superset of any set, and a set is never a strict superset of itself.
+            if (Count == 0 || other == this)
+            {
+                return false;
+            }
+
+            if (other is ICollection<T> otherAsCollection)
+            {
+                // If other is the empty set then this is a superset.
+                if (otherAsCollection.Count == 0)
+                {
+                    // Note that this has at least one element, based on above check.
+                    return true;
+                }
+
+                // Faster if other is a hashset with the same equality comparer
+                if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+                {
+                    if (otherAsSet.Count >= Count)
+                    {
+                        return false;
+                    }
+
+                    // Now perform element check.
+                    return ContainsAllElements(otherAsSet);
+                }
+            }
+
+            // Couldn't fall out in the above cases; do it the long way
+            (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: true);
+            return uniqueCount < Count && unfoundCount == 0;
+        }
+
+        /// <summary>Determines whether the current <see cref="HashSet{T}"/> object and a specified collection share common elements.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="HashSet{T}"/> object and <paramref name="other"/> share at least one common element; otherwise, false.</returns>
+        public bool Overlaps(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            if (Count == 0)
+            {
+                return false;
+            }
+
+            // Set overlaps itself
+            if (other == this)
+            {
+                return true;
+            }
+
+            foreach (T element in other)
+            {
+                if (Contains(element))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>Determines whether a <see cref="HashSet{T}"/> object and the specified collection contain the same elements.</summary>
+        /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
+        /// <returns>true if the <see cref="HashSet{T}"/> object is equal to <paramref name="other"/>; otherwise, false.</returns>
+        public bool SetEquals(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.other);
+            }
+
+            // A set is equal to itself.
+            if (other == this)
+            {
+                return true;
+            }
+
+            // Faster if other is a hashset and we're using same equality comparer.
+            if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
+            {
+                // Attempt to return early: since both contain unique elements, if they have
+                // different counts, then they can't be equal.
+                if (Count != otherAsSet.Count)
+                {
+                    return false;
+                }
+
+                // Already confirmed that the sets have the same number of distinct elements, so if
+                // one is a superset of the other then they must be equal.
+                return ContainsAllElements(otherAsSet);
+            }
+            else
+            {
+                // If this count is 0 but other contains at least one element, they can't be equal.
+                if (Count == 0 &&
+                    other is ICollection<T> otherAsCollection &&
+                    otherAsCollection.Count > 0)
+                {
+                    return false;
+                }
+
+                (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: true);
+                return uniqueCount == Count && unfoundCount == 0;
+            }
+        }
+
+        public void CopyTo(T[] array) => CopyTo(array, 0, Count);
+
+        /// <summary>Copies the elements of a <see cref="HashSet{T}"/> object to an array, starting at the specified array index.</summary>
+        /// <param name="array">The destination array.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
+        public void CopyTo(T[] array, int arrayIndex) => CopyTo(array, arrayIndex, Count);
+
+        public void CopyTo(T[] array, int arrayIndex, int count)
+        {
+            if (array == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            }
+
+            // Check array index valid index into array.
+            if (arrayIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex), arrayIndex, SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            // Also throw if count less than 0.
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), count, SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            // Will the array, starting at arrayIndex, be able to hold elements? Note: not
+            // checking arrayIndex >= array.Length (consistency with list of allowing
+            // count of 0; subsequent check takes care of the rest)
+            if (arrayIndex > array.Length || count > array.Length - arrayIndex)
+            {
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_ArrayPlusOffTooSmall);
+            }
+
+            Entry[]? entries = _entries;
+            for (int i = 0; i < _count && count != 0; i++)
+            {
+                ref Entry entry = ref entries![i];
+                if (entry.Next >= -1)
+                {
+                    array[arrayIndex++] = entry.Value;
+                    count--;
+                }
+            }
+        }
+
+        /// <summary>Removes all elements that match the conditions defined by the specified predicate from a <see cref="HashSet{T}"/> collection.</summary>
+        public int RemoveWhere(Predicate<T> match)
+        {
+            if (match == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.match);
+            }
+
+            Entry[]? entries = _entries;
+            int numRemoved = 0;
+            for (int i = 0; i < _count; i++)
+            {
+                ref Entry entry = ref entries![i];
+                if (entry.Next >= -1)
+                {
+                    // Cache value in case delegate removes it
+                    T value = entry.Value;
+                    if (match(value))
+                    {
+                        // Check again that remove actually removed it.
+                        if (Remove(value))
+                        {
+                            numRemoved++;
+                        }
+                    }
+                }
+            }
+
+            return numRemoved;
+        }
+
+        /// <summary>Gets the <see cref="IEqualityComparer"/> object that is used to determine equality for the values in the set.</summary>
+        public IEqualityComparer<T> Comparer
+        {
+            get
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    return (IEqualityComparer<T>)IInternalStringEqualityComparer.GetUnderlyingEqualityComparer((IEqualityComparer<string?>?)_comparer);
+                }
+                else
+                {
+                    return _comparer ?? EqualityComparer<T>.Default;
+                }
+            }
+        }
+
+        /// <summary>Ensures that this hash set can hold the specified number of elements without growing.</summary>
+        public int EnsureCapacity(int capacity)
+        {
+            if (capacity < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
+            }
+
+            int currentCapacity = _entries == null ? 0 : _entries.Length;
+            if (currentCapacity >= capacity)
+            {
+                return currentCapacity;
+            }
+
+            if (_buckets == null)
+            {
+                return Initialize(capacity);
+            }
+
+            int newSize = HashHelpers.GetPrime(capacity);
+            Resize(newSize, forceNewHashCodes: false);
+            return newSize;
+        }
+
+        private void Resize() => Resize(HashHelpers.ExpandPrime(_count), forceNewHashCodes: false);
+
+        private void Resize(int newSize, bool forceNewHashCodes)
+        {
+            // Value types never rehash
+            Debug.Assert(!forceNewHashCodes || !typeof(T).IsValueType);
+            Debug.Assert(_entries != null, "_entries should be non-null");
+            Debug.Assert(newSize >= _entries.Length);
+
+            var entries = new Entry[newSize];
+
+            int count = _count;
+            Array.Copy(_entries, entries, count);
+
+            if (!typeof(T).IsValueType && forceNewHashCodes)
+            {
+                Debug.Assert(_comparer is NonRandomizedStringEqualityComparer);
+                _comparer = (IEqualityComparer<T>)((NonRandomizedStringEqualityComparer)_comparer).GetRandomizedEqualityComparer();
+
+                for (int i = 0; i < count; i++)
+                {
+                    ref Entry entry = ref entries[i];
+                    if (entry.Next >= -1)
+                    {
+                        entry.HashCode = entry.Value != null ? _comparer!.GetHashCode(entry.Value) : 0;
+                    }
+                }
+
+                if (ReferenceEquals(_comparer, EqualityComparer<T>.Default))
+                {
+                    _comparer = null;
+                }
+            }
+
+            // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
+            _buckets = new int[newSize];
+#if TARGET_64BIT
+            _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);
+#endif
+            for (int i = 0; i < count; i++)
+            {
+                ref Entry entry = ref entries[i];
+                if (entry.Next >= -1)
+                {
+                    ref int bucket = ref GetBucketRef(entry.HashCode);
+                    entry.Next = bucket - 1; // Value in _buckets is 1-based
+                    bucket = i + 1;
+                }
+            }
+
+            _entries = entries;
+        }
+
+        /// <summary>
+        /// Sets the capacity of a <see cref="HashSet{T}"/> object to the actual number of elements it contains,
+        /// rounded up to a nearby, implementation-specific value.
+        /// </summary>
+        public void TrimExcess()
+        {
+            int capacity = Count;
+
+            int newSize = HashHelpers.GetPrime(capacity);
+            Entry[]? oldEntries = _entries;
+            int currentCapacity = oldEntries == null ? 0 : oldEntries.Length;
+            if (newSize >= currentCapacity)
+            {
+                return;
+            }
+
+            int oldCount = _count;
+            _version++;
+            Initialize(newSize);
+            Entry[]? entries = _entries;
+            int count = 0;
+            for (int i = 0; i < oldCount; i++)
+            {
+                int hashCode = oldEntries![i].HashCode; // At this point, we know we have entries.
+                if (oldEntries[i].Next >= -1)
+                {
+                    ref Entry entry = ref entries![count];
+                    entry = oldEntries[i];
+                    ref int bucket = ref GetBucketRef(hashCode);
+                    entry.Next = bucket - 1; // Value in _buckets is 1-based
+                    bucket = count + 1;
+                    count++;
+                }
+            }
+
+            _count = capacity;
+            _freeCount = 0;
+        }
+
+        #endregion
+
+        #region Helper methods
+
+        /// <summary>Returns an <see cref="IEqualityComparer"/> object that can be used for equality testing of a <see cref="HashSet{T}"/> object.</summary>
+        public static IEqualityComparer<HashSet<T>> CreateSetComparer() => new HashSetEqualityComparer<T>();
+
+        /// <summary>
+        /// Initializes buckets and slots arrays. Uses suggested capacity by finding next prime
+        /// greater than or equal to capacity.
+        /// </summary>
+        private int Initialize(int capacity)
+        {
+            int size = HashHelpers.GetPrime(capacity);
+            var buckets = new int[size];
+            var entries = new Entry[size];
+
+            // Assign member variables after both arrays are allocated to guard against corruption from OOM if second fails.
+            _freeList = -1;
+            _buckets = buckets;
+            _entries = entries;
+#if TARGET_64BIT
+            _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)size);
+#endif
+
+            return size;
+        }
+
+        /// <summary>Adds the specified element to the set if it's not already contained.</summary>
+        /// <param name="value">The element to add to the set.</param>
+        /// <param name="location">The index into <see cref="_entries"/> of the element.</param>
+        /// <returns>true if the element is added to the <see cref="HashSet{T}"/> object; false if the element is already present.</returns>
+        private bool AddIfNotPresent(T value, out int location)
+        {
+            if (_buckets == null)
+            {
+                Initialize(0);
+            }
+            Debug.Assert(_buckets != null);
+
+            Entry[]? entries = _entries;
+            Debug.Assert(entries != null, "expected entries to be non-null");
+
+            IEqualityComparer<T>? comparer = _comparer;
+            int hashCode;
+
+            uint collisionCount = 0;
+            ref int bucket = ref Unsafe.NullRef<int>();
+
+            if (comparer == null)
+            {
+                hashCode = value != null ? value.GetHashCode() : 0;
+                bucket = ref GetBucketRef(hashCode);
+                int i = bucket - 1; // Value in _buckets is 1-based
+                if (typeof(T).IsValueType)
+                {
+                    // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
+                    while (i >= 0)
+                    {
+                        ref Entry entry = ref entries[i];
+                        if (entry.HashCode == hashCode && EqualityComparer<T>.Default.Equals(entry.Value, value))
+                        {
+                            location = i;
+                            return false;
+                        }
+                        i = entry.Next;
+
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
+                        {
+                            // The chain of entries forms a loop, which means a concurrent update has happened.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                    }
+                }
+                else
+                {
+                    // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize (https://github.com/dotnet/runtime/issues/10050),
+                    // so cache in a local rather than get EqualityComparer per loop iteration.
+                    EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
+                    while (i >= 0)
+                    {
+                        ref Entry entry = ref entries[i];
+                        if (entry.HashCode == hashCode && defaultComparer.Equals(entry.Value, value))
+                        {
+                            location = i;
+                            return false;
+                        }
+                        i = entry.Next;
+
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
+                        {
+                            // The chain of entries forms a loop, which means a concurrent update has happened.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                    }
+                }
+            }
+            else
+            {
+                hashCode = value != null ? comparer.GetHashCode(value) : 0;
+                bucket = ref GetBucketRef(hashCode);
+                int i = bucket - 1; // Value in _buckets is 1-based
+                while (i >= 0)
+                {
+                    ref Entry entry = ref entries[i];
+                    if (entry.HashCode == hashCode && comparer.Equals(entry.Value, value))
+                    {
+                        location = i;
+                        return false;
+                    }
+                    i = entry.Next;
+
+                    collisionCount++;
+                    if (collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop, which means a concurrent update has happened.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
+                }
+            }
+
+            int index;
+            if (_freeCount > 0)
+            {
+                index = _freeList;
+                _freeCount--;
+                Debug.Assert((StartOfFreeList - entries![_freeList].Next) >= -1, "shouldn't overflow because `next` cannot underflow");
+                _freeList = StartOfFreeList - entries[_freeList].Next;
+            }
+            else
+            {
+                int count = _count;
+                if (count == entries.Length)
+                {
+                    Resize();
+                    bucket = ref GetBucketRef(hashCode);
+                }
+                index = count;
+                _count = count + 1;
+                entries = _entries;
+            }
+
+            {
+                ref Entry entry = ref entries![index];
+                entry.HashCode = hashCode;
+                entry.Next = bucket - 1; // Value in _buckets is 1-based
+                entry.Value = value;
+                bucket = index + 1;
+                _version++;
+                location = index;
+            }
+
+            // Value types never rehash
+            if (!typeof(T).IsValueType && collisionCount > HashHelpers.HashCollisionThreshold && comparer is NonRandomizedStringEqualityComparer)
+            {
+                // If we hit the collision threshold we'll need to switch to the comparer which is using randomized string hashing
+                // i.e. EqualityComparer<string>.Default.
+                Resize(entries.Length, forceNewHashCodes: true);
+                location = FindItemIndex(value);
+                Debug.Assert(location >= 0);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if this contains of other's elements. Iterates over other's elements and
+        /// returns false as soon as it finds an element in other that's not in this.
+        /// Used by SupersetOf, ProperSupersetOf, and SetEquals.
+        /// </summary>
+        private bool ContainsAllElements(IEnumerable<T> other)
+        {
+            foreach (T element in other)
+            {
+                if (!Contains(element))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Implementation Notes:
+        /// If other is a hashset and is using same equality comparer, then checking subset is
+        /// faster. Simply check that each element in this is in other.
+        ///
+        /// Note: if other doesn't use same equality comparer, then Contains check is invalid,
+        /// which is why callers must take are of this.
+        ///
+        /// If callers are concerned about whether this is a proper subset, they take care of that.
+        /// </summary>
+        internal bool IsSubsetOfHashSetWithSameComparer(HashSet<T> other)
+        {
+            foreach (T item in this)
+            {
+                if (!other.Contains(item))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// If other is a hashset that uses same equality comparer, intersect is much faster
+        /// because we can use other's Contains
+        /// </summary>
+        private void IntersectWithHashSetWithSameComparer(HashSet<T> other)
+        {
+            Entry[]? entries = _entries;
+            for (int i = 0; i < _count; i++)
+            {
+                ref Entry entry = ref entries![i];
+                if (entry.Next >= -1)
+                {
+                    T item = entry.Value;
+                    if (!other.Contains(item))
+                    {
+                        Remove(item);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Iterate over other. If contained in this, mark an element in bit array corresponding to
+        /// its position in _slots. If anything is unmarked (in bit array), remove it.
+        ///
+        /// This attempts to allocate on the stack, if below StackAllocThreshold.
+        /// </summary>
+        private unsafe void IntersectWithEnumerable(IEnumerable<T> other)
+        {
+            Debug.Assert(_buckets != null, "_buckets shouldn't be null; callers should check first");
+
+            // Keep track of current last index; don't want to move past the end of our bit array
+            // (could happen if another thread is modifying the collection).
+            int originalCount = _count;
+            int intArrayLength = BitHelper.ToIntArrayLength(originalCount);
+
+            Span<int> span = stackalloc int[StackAllocThreshold];
+            BitHelper bitHelper = intArrayLength <= StackAllocThreshold ?
+                new BitHelper(span.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(new int[intArrayLength], clear: false);
+
+            // Mark if contains: find index of in slots array and mark corresponding element in bit array.
+            foreach (T item in other)
+            {
+                int index = FindItemIndex(item);
+                if (index >= 0)
+                {
+                    bitHelper.MarkBit(index);
+                }
+            }
+
+            // If anything unmarked, remove it. Perf can be optimized here if BitHelper had a
+            // FindFirstUnmarked method.
+            for (int i = 0; i < originalCount; i++)
+            {
+                ref Entry entry = ref _entries![i];
+                if (entry.Next >= -1 && !bitHelper.IsMarked(i))
+                {
+                    Remove(entry.Value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// if other is a set, we can assume it doesn't have duplicate elements, so use this
+        /// technique: if can't remove, then it wasn't present in this set, so add.
+        ///
+        /// As with other methods, callers take care of ensuring that other is a hashset using the
+        /// same equality comparer.
+        /// </summary>
+        /// <param name="other"></param>
+        private void SymmetricExceptWithUniqueHashSet(HashSet<T> other)
+        {
+            foreach (T item in other)
+            {
+                if (!Remove(item))
+                {
+                    AddIfNotPresent(item, out _);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Implementation notes:
+        ///
+        /// Used for symmetric except when other isn't a HashSet. This is more tedious because
+        /// other may contain duplicates. HashSet technique could fail in these situations:
+        /// 1. Other has a duplicate that's not in this: HashSet technique would add then
+        /// remove it.
+        /// 2. Other has a duplicate that's in this: HashSet technique would remove then add it
+        /// back.
+        /// In general, its presence would be toggled each time it appears in other.
+        ///
+        /// This technique uses bit marking to indicate whether to add/remove the item. If already
+        /// present in collection, it will get marked for deletion. If added from other, it will
+        /// get marked as something not to remove.
+        ///
+        /// </summary>
+        /// <param name="other"></param>
+        private unsafe void SymmetricExceptWithEnumerable(IEnumerable<T> other)
+        {
+            int originalCount = _count;
+            int intArrayLength = BitHelper.ToIntArrayLength(originalCount);
+
+            Span<int> itemsToRemoveSpan = stackalloc int[StackAllocThreshold / 2];
+            BitHelper itemsToRemove = intArrayLength <= StackAllocThreshold / 2 ?
+                new BitHelper(itemsToRemoveSpan.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(new int[intArrayLength], clear: false);
+
+            Span<int> itemsAddedFromOtherSpan = stackalloc int[StackAllocThreshold / 2];
+            BitHelper itemsAddedFromOther = intArrayLength <= StackAllocThreshold / 2 ?
+                new BitHelper(itemsAddedFromOtherSpan.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(new int[intArrayLength], clear: false);
+
+            foreach (T item in other)
+            {
+                int location;
+                if (AddIfNotPresent(item, out location))
+                {
+                    // wasn't already present in collection; flag it as something not to remove
+                    // *NOTE* if location is out of range, we should ignore. BitHelper will
+                    // detect that it's out of bounds and not try to mark it. But it's
+                    // expected that location could be out of bounds because adding the item
+                    // will increase _lastIndex as soon as all the free spots are filled.
+                    itemsAddedFromOther.MarkBit(location);
+                }
+                else
+                {
+                    // already there...if not added from other, mark for remove.
+                    // *NOTE* Even though BitHelper will check that location is in range, we want
+                    // to check here. There's no point in checking items beyond originalCount
+                    // because they could not have been in the original collection
+                    if (location < originalCount && !itemsAddedFromOther.IsMarked(location))
+                    {
+                        itemsToRemove.MarkBit(location);
+                    }
+                }
+            }
+
+            // if anything marked, remove it
+            for (int i = 0; i < originalCount; i++)
+            {
+                if (itemsToRemove.IsMarked(i))
+                {
+                    Remove(_entries![i].Value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines counts that can be used to determine equality, subset, and superset. This
+        /// is only used when other is an IEnumerable and not a HashSet. If other is a HashSet
+        /// these properties can be checked faster without use of marking because we can assume
+        /// other has no duplicates.
+        ///
+        /// The following count checks are performed by callers:
+        /// 1. Equals: checks if unfoundCount = 0 and uniqueFoundCount = _count; i.e. everything
+        /// in other is in this and everything in this is in other
+        /// 2. Subset: checks if unfoundCount >= 0 and uniqueFoundCount = _count; i.e. other may
+        /// have elements not in this and everything in this is in other
+        /// 3. Proper subset: checks if unfoundCount > 0 and uniqueFoundCount = _count; i.e
+        /// other must have at least one element not in this and everything in this is in other
+        /// 4. Proper superset: checks if unfound count = 0 and uniqueFoundCount strictly less
+        /// than _count; i.e. everything in other was in this and this had at least one element
+        /// not contained in other.
+        ///
+        /// An earlier implementation used delegates to perform these checks rather than returning
+        /// an ElementCount struct; however this was changed due to the perf overhead of delegates.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <param name="returnIfUnfound">Allows us to finish faster for equals and proper superset
+        /// because unfoundCount must be 0.</param>
+        private unsafe (int UniqueCount, int UnfoundCount) CheckUniqueAndUnfoundElements(IEnumerable<T> other, bool returnIfUnfound)
+        {
+            // Need special case in case this has no elements.
+            if (_count == 0)
+            {
+                int numElementsInOther = 0;
+                foreach (T item in other)
+                {
+                    numElementsInOther++;
+                    break; // break right away, all we want to know is whether other has 0 or 1 elements
+                }
+
+                return (UniqueCount: 0, UnfoundCount: numElementsInOther);
+            }
+
+            Debug.Assert((_buckets != null) && (_count > 0), "_buckets was null but count greater than 0");
+
+            int originalCount = _count;
+            int intArrayLength = BitHelper.ToIntArrayLength(originalCount);
+
+            Span<int> span = stackalloc int[StackAllocThreshold];
+            BitHelper bitHelper = intArrayLength <= StackAllocThreshold ?
+                new BitHelper(span.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(new int[intArrayLength], clear: false);
+
+            int unfoundCount = 0; // count of items in other not found in this
+            int uniqueFoundCount = 0; // count of unique items in other found in this
+
+            foreach (T item in other)
+            {
+                int index = FindItemIndex(item);
+                if (index >= 0)
+                {
+                    if (!bitHelper.IsMarked(index))
+                    {
+                        // Item hasn't been seen yet.
+                        bitHelper.MarkBit(index);
+                        uniqueFoundCount++;
+                    }
+                }
+                else
+                {
+                    unfoundCount++;
+                    if (returnIfUnfound)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return (uniqueFoundCount, unfoundCount);
+        }
+
+        /// <summary>
+        /// Checks if equality comparers are equal. This is used for algorithms that can
+        /// speed up if it knows the other item has unique elements. I.e. if they're using
+        /// different equality comparers, then uniqueness assumption between sets break.
+        /// </summary>
+        internal static bool EqualityComparersAreEqual(HashSet<T> set1, HashSet<T> set2) => set1.Comparer.Equals(set2.Comparer);
+
+#endregion
+
+        private struct Entry
+        {
+            public int HashCode;
+            /// <summary>
+            /// 0-based index of next entry in chain: -1 means end of chain
+            /// also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
+            /// so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
+            /// </summary>
+            public int Next;
+            public T Value;
+        }
+
+        public struct Enumerator : IEnumerator<T>
+        {
+            private readonly HashSet<T> _hashSet;
+            private readonly int _version;
+            private int _index;
+            private T _current;
+
+            internal Enumerator(HashSet<T> hashSet)
+            {
+                _hashSet = hashSet;
+                _version = hashSet._version;
+                _index = 0;
+                _current = default!;
+            }
+
+            public bool MoveNext()
+            {
+                if (_version != _hashSet._version)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                }
+
+                // Use unsigned comparison since we set index to dictionary.count+1 when the enumeration ends.
+                // dictionary.count+1 could be negative if dictionary.count is int.MaxValue
+                while ((uint)_index < (uint)_hashSet._count)
+                {
+                    ref Entry entry = ref _hashSet._entries![_index++];
+                    if (entry.Next >= -1)
+                    {
+                        _current = entry.Value;
+                        return true;
+                    }
+                }
+
+                _index = _hashSet._count + 1;
+                _current = default!;
+                return false;
+            }
+
+            public T Current => _current;
+
+            public void Dispose() { }
+
+            object? IEnumerator.Current
+            {
+                get
+                {
+                    if (_index == 0 || (_index == _hashSet._count + 1))
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
+                    }
+
+                    return _current;
+                }
+            }
+
+            void IEnumerator.Reset()
+            {
+                if (_version != _hashSet._version)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                }
+
+                _index = 0;
+                _current = default!;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a drop-in replacement for `HashSet<T>`, with equivalent semantics and algorithmic complexity but does not require the use of the Large Object Heap.