### PR TITLE
Set [Skip-SymbolCheck] suffix in insertion tool

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -295,7 +295,6 @@ stages:
 - stage: insert
   dependsOn:
   - build
-  - publish_using_darc
   displayName: Insert to VS
 
   jobs:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -59,6 +59,8 @@ variables:
     value: true
   - name: Insertion.TitlePrefix
     value: '[Auto Insertion]'
+  - name: Insertion.TitleSuffix
+    value: '[Skip-SymbolCheck]'
 
 stages:
 - stage: build
@@ -358,6 +360,7 @@ stages:
           -insertionCount "1" `
           -insertToolset "$(Insertion.InsertToolset)" `
           -titlePrefix "$(Insertion.TitlePrefix)" `
+          -titleSuffix "$(Insertion.TitleSuffix)" `
           -queueValidation "true" `
           -requiredValueSentinel "REQUIRED" `
           -reviewerGUID "6c25b447-1d90-4840-8fde-d8b22cb8733e" `


### PR DESCRIPTION
Depends on dotnet/roslyn-tools#1029

Symbol checks are too slow for us to be able to insert as quickly as we'd like. Currently we artificially slow down the insertion by making the insert stage depend on the publish_using_darc stage. This change makes it so we just always skip the symbol check in insertions, which we've judged to be low-risk, and make the insert stage depend only on the build stage. This change makes our insertions show up ~30 minutes faster.