### PR TITLE
Definite assignment, initial nullable, IOperation, and some cleanup

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1267,27 +1267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(interpolatedString.InterpolationData != null);
             var data = interpolatedString.InterpolationData.GetValueOrDefault();
-
-            uint escapeScope = GetValEscape(data.Construction, scopeOfTheContainingExpression);
-
-            if (escapeScope >= scopeOfTheContainingExpression)
-            {
-                // Can't get any worse
-                return escapeScope;
-            }
-
-            foreach (var part in interpolatedString.Parts)
-            {
-                escapeScope = Math.Max(escapeScope, GetValEscape(part, scopeOfTheContainingExpression));
-
-                if (escapeScope >= scopeOfTheContainingExpression)
-                {
-                    // Can't get any worse
-                    return escapeScope;
-                }
-            }
-
-            return escapeScope;
+            return GetValEscape(data.Construction, scopeOfTheContainingExpression);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7844,7 +7844,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MemberResolutionResult<PropertySymbol> resolutionResult = overloadResolutionResult.ValidResult;
                 PropertySymbol property = resolutionResult.Member;
                 RefKind? receiverRefKind = receiverOpt?.GetRefKind();
-                uint receiverEscapeScope = property.RequiresInstanceReceiver
+                uint receiverEscapeScope = property.RequiresInstanceReceiver && receiverOpt != null
                     ? receiverRefKind?.IsWritableReference() == true ? GetRefEscape(receiverOpt, LocalScopeDepth) : GetValEscape(receiverOpt, LocalScopeDepth)
                     : Binder.ExternalScope;
                 this.CoerceArguments<PropertySymbol>(resolutionResult, analyzedArguments.Arguments, diagnostics, receiverOpt?.Type, receiverRefKind, receiverEscapeScope);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7843,7 +7843,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 MemberResolutionResult<PropertySymbol> resolutionResult = overloadResolutionResult.ValidResult;
                 PropertySymbol property = resolutionResult.Member;
-                this.CoerceArguments<PropertySymbol>(resolutionResult, analyzedArguments.Arguments, diagnostics, receiverOpt?.Type, receiverOpt?.GetRefKind(), receiverOpt is null ? Binder.ExternalScope : GetValEscape(receiverOpt, LocalScopeDepth));
+                this.CoerceArguments<PropertySymbol>(resolutionResult, analyzedArguments.Arguments, diagnostics, receiverOpt?.Type, receiverOpt?.GetRefKind(), property.RequiresInstanceReceiver ? GetValEscape(receiverOpt, LocalScopeDepth) : Binder.ExternalScope);
 
                 var isExpanded = resolutionResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
                 var argsToParams = resolutionResult.Result.ArgsToParamsOpt;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2964,7 +2964,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics,
             TypeSymbol? receiverType,
             RefKind? receiverRefKind,
-            uint receiverValEscapeScope)
+            uint receiverEscapeScope)
             where TMember : Symbol
         {
             var result = methodResult.Result;
@@ -2982,7 +2982,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(argument is BoundUnconvertedInterpolatedString);
                     TypeWithAnnotations parameterTypeWithAnnotations = GetCorrespondingParameterTypeWithAnnotations(ref result, parameters, arg);
                     reportUnsafeIfNeeded(methodResult, diagnostics, argument, parameterTypeWithAnnotations);
-                    arguments[arg] = BindInterpolatedStringHandlerInMemberCall((BoundUnconvertedInterpolatedString)argument, arguments, parameters, ref result, arg, receiverType, receiverRefKind, receiverValEscapeScope, diagnostics);
+                    arguments[arg] = BindInterpolatedStringHandlerInMemberCall((BoundUnconvertedInterpolatedString)argument, arguments, parameters, ref result, arg, receiverType, receiverRefKind, receiverEscapeScope, diagnostics);
                 }
                 // https://github.com/dotnet/roslyn/issues/37119 : should we create an (Identity) conversion when the kind is Identity but the types differ?
                 else if (!kind.IsIdentity)
@@ -5690,7 +5690,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (succeededIgnoringAccessibility)
             {
-                this.CoerceArguments<MethodSymbol>(result.ValidResult, analyzedArguments.Arguments, diagnostics, receiverType: null, receiverRefKind: null, receiverValEscapeScope: Binder.ExternalScope);
+                this.CoerceArguments<MethodSymbol>(result.ValidResult, analyzedArguments.Arguments, diagnostics, receiverType: null, receiverRefKind: null, receiverEscapeScope: Binder.ExternalScope);
             }
 
             // Fill in the out parameter with the result, if there was one; it might be inaccessible.
@@ -7843,7 +7843,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 MemberResolutionResult<PropertySymbol> resolutionResult = overloadResolutionResult.ValidResult;
                 PropertySymbol property = resolutionResult.Member;
-                this.CoerceArguments<PropertySymbol>(resolutionResult, analyzedArguments.Arguments, diagnostics, receiverOpt?.Type, receiverOpt?.GetRefKind(), property.RequiresInstanceReceiver ? GetValEscape(receiverOpt, LocalScopeDepth) : Binder.ExternalScope);
+                RefKind? receiverRefKind = receiverOpt?.GetRefKind();
+                uint receiverEscapeScope = property.RequiresInstanceReceiver
+                    ? receiverRefKind?.IsWritableReference() == true ? GetRefEscape(receiverOpt, LocalScopeDepth) : GetValEscape(receiverOpt, LocalScopeDepth)
+                    : Binder.ExternalScope;
+                this.CoerceArguments<PropertySymbol>(resolutionResult, analyzedArguments.Arguments, diagnostics, receiverOpt?.Type, receiverRefKind, receiverEscapeScope);
 
                 var isExpanded = resolutionResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
                 var argsToParams = resolutionResult.Result.ArgsToParamsOpt;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -556,7 +556,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             int interpolatedStringArgNum,
             TypeSymbol? receiverType,
             RefKind? receiverRefKind,
-            uint receiverValEscapeScope,
+            uint receiverEscapeScope,
             BindingDiagnosticBag diagnostics)
         {
             var interpolatedStringConversion = memberAnalysisResult.ConversionForArg(interpolatedStringArgNum);
@@ -706,7 +706,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     case BoundInterpolatedStringArgumentPlaceholder.InstanceParameter:
                         placeholderSyntax = unconvertedString.Syntax;
-                        valSafeToEscapeScope = receiverValEscapeScope;
+                        valSafeToEscapeScope = receiverEscapeScope;
                         break;
                     case BoundInterpolatedStringArgumentPlaceholder.UnspecifiedParameter:
                         placeholderSyntax = unconvertedString.Syntax;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -179,8 +179,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result = null;
                 if (unconvertedInterpolatedString.Parts.ContainsAwaitExpression())
                 {
-                    // PROTOTYPE(interp-string): For interpolated strings used as strings, we could evaluate components eagerly
-                    // and always use the builder.
                     return false;
                 }
 
@@ -443,10 +441,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private (ImmutableArray<BoundExpression> AppendFormatCalls, bool UsesBoolReturn, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>) BindInterpolatedStringAppendCalls(BoundUnconvertedInterpolatedString source, TypeSymbol builderType, BindingDiagnosticBag diagnostics)
         {
-            // PROTOTYPE(interp-string): Update the spec with the rules around InterpolatedStringHandlerAttribute. For now, we assume that any
-            // type that makes it to this method is actually an interpolated string builder type, and we should fully report any binding errors
-            // we encounter while doing this work.
-
             if (source.Parts.IsEmpty)
             {
                 return (ImmutableArray<BoundExpression>.Empty, false, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>.Empty);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1020,7 +1020,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var receiver = ReplaceTypeOrValueReceiver(methodGroup.Receiver, !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
 
-            this.CoerceArguments(methodResult, analyzedArguments.Arguments, diagnostics, receiver?.Type, receiver?.GetRefKind(), receiver is null ? Binder.ExternalScope : GetValEscape(receiver, LocalScopeDepth));
+            this.CoerceArguments(methodResult, analyzedArguments.Arguments, diagnostics, receiver?.Type, receiver?.GetRefKind(), method.RequiresInstanceReceiver ? GetValEscape(receiver, LocalScopeDepth) : Binder.ExternalScope);
 
             var expanded = methodResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
             var argsToParams = methodResult.Result.ArgsToParamsOpt;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1021,7 +1021,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var receiver = ReplaceTypeOrValueReceiver(methodGroup.Receiver, !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
 
             var receiverRefKind = receiver?.GetRefKind();
-            uint receiverValEscapeScope = method.RequiresInstanceReceiver
+            uint receiverValEscapeScope = method.RequiresInstanceReceiver && receiver != null
                 ? receiverRefKind?.IsWritableReference() == true ? GetRefEscape(receiver, LocalScopeDepth) : GetValEscape(receiver, LocalScopeDepth)
                 : Binder.ExternalScope;
             this.CoerceArguments(methodResult, analyzedArguments.Arguments, diagnostics, receiver?.Type, receiverRefKind, receiverValEscapeScope);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1020,7 +1020,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var receiver = ReplaceTypeOrValueReceiver(methodGroup.Receiver, !method.RequiresInstanceReceiver && !invokedAsExtensionMethod, diagnostics);
 
-            this.CoerceArguments(methodResult, analyzedArguments.Arguments, diagnostics, receiver?.Type, receiver?.GetRefKind());
+            this.CoerceArguments(methodResult, analyzedArguments.Arguments, diagnostics, receiver?.Type, receiver?.GetRefKind(), receiver is null ? Binder.ExternalScope : GetValEscape(receiver, LocalScopeDepth));
 
             var expanded = methodResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
             var argsToParams = methodResult.Result.ArgsToParamsOpt;
@@ -2014,7 +2014,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 analyzedArguments.Arguments,
                 diagnostics,
                 receiverType: null,
-                receiverRefKind: null);
+                receiverRefKind: null,
+                receiverValEscapeScope: Binder.ExternalScope);
 
             var args = analyzedArguments.Arguments.ToImmutable();
             var refKinds = analyzedArguments.RefKinds.ToImmutableOrNull();

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2110,7 +2110,6 @@ outerDefault:
             }
 
             // Otherwise, prefer methods with 'val' parameters over 'in' parameters and over 'ref' parameters when the argument is an interpolated string handler.
-            // PROTOTYPE(interp-string): Document in the spec
             return PreferValOverInOrRefInterpolatedHandlerParameters(arguments, m1, m1LeastOverriddenParameters, m2, m2LeastOverriddenParameters);
         }
 
@@ -2431,7 +2430,7 @@ outerDefault:
             // C1 is a better conversion than C2 if E is a non-constant interpolated string expression, C1
             // is an interpolated string handler conversion, and C2 is not an interpolated string
             // handler conversion
-            // PROTOTYPE(interp-string): Handle binary operators composed only of added interpolated strings
+            // https://github.com/dotnet/roslyn/issues/54584 Handle binary operators composed only of added interpolated strings
             if (node is BoundUnconvertedInterpolatedString { ConstantValueOpt: null })
             {
                 switch ((conv1.Kind, conv2.Kind))
@@ -3640,7 +3639,7 @@ outerDefault:
                     {
                         // For interpolated strings handlers, we allow an interpolated string expression to be passed as if `ref` was specified
                         // in the source when the handler type is a value type.
-                        // PROTOTYPE(interp-string): allow binary additions of interpolated strings to match as well.
+                        // https://github.com/dotnet/roslyn/issues/54584 allow binary additions of interpolated strings to match as well.
                         hasInterpolatedStringRefMismatch = true;
                         argumentRefKind = parameterRefKind;
                     }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2028,6 +2028,7 @@
     <!-- The index in the containing member of the argument this is the placeholder for. Should be a positive number or
          one of the constants in the other part of the partial class. -->
     <Field Name="ArgumentIndex" Type="int" />
+    <Field Name="ValSafeToEscape" Type="uint" />
   </Node>
 
   <Node Name="BoundStringInsert" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
@@ -23,19 +23,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public readonly ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> ArgumentPlaceholders;
 
+        public readonly ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> PositionInfo;
+
         public bool HasTrailingHandlerValidityParameter => ArgumentPlaceholders.Length > 0 && ArgumentPlaceholders[^1].ArgumentIndex == BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter;
 
-        public InterpolatedStringHandlerData(TypeSymbol builderType, BoundExpression construction, bool usesBoolReturns, uint scopeOfContainingExpression, ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> placeholders)
+        public InterpolatedStringHandlerData(TypeSymbol builderType, BoundExpression construction, bool usesBoolReturns, uint scopeOfContainingExpression, ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> placeholders, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> positionInfo)
         {
             Debug.Assert(construction is BoundObjectCreationExpression or BoundDynamicObjectCreationExpression or BoundBadExpression);
             Debug.Assert(!placeholders.IsDefault);
             // Only the last placeholder may be the out parameter.
             Debug.Assert(placeholders.IsEmpty || placeholders.AsSpan()[..^1].All(item => item.ArgumentIndex != BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter));
+            Debug.Assert(!positionInfo.IsDefault);
             BuilderType = builderType;
             Construction = construction;
             UsesBoolReturns = usesBoolReturns;
             ScopeOfContainingExpression = scopeOfContainingExpression;
             ArgumentPlaceholders = placeholders;
+            PositionInfo = positionInfo;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
@@ -27,7 +27,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public bool HasTrailingHandlerValidityParameter => ArgumentPlaceholders.Length > 0 && ArgumentPlaceholders[^1].ArgumentIndex == BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter;
 
-        public InterpolatedStringHandlerData(TypeSymbol builderType, BoundExpression construction, bool usesBoolReturns, uint scopeOfContainingExpression, ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> placeholders, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> positionInfo)
+        public readonly BoundInterpolatedStringHandlerPlaceholder ReceiverPlaceholder;
+
+        public InterpolatedStringHandlerData(
+            TypeSymbol builderType,
+            BoundExpression construction,
+            bool usesBoolReturns,
+            uint scopeOfContainingExpression,
+            ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> placeholders,
+            ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> positionInfo,
+            BoundInterpolatedStringHandlerPlaceholder receiverPlaceholder)
         {
             Debug.Assert(construction is BoundObjectCreationExpression or BoundDynamicObjectCreationExpression or BoundBadExpression);
             Debug.Assert(!placeholders.IsDefault);
@@ -40,6 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ScopeOfContainingExpression = scopeOfContainingExpression;
             ArgumentPlaceholders = placeholders;
             PositionInfo = positionInfo;
+            ReceiverPlaceholder = receiverPlaceholder;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6706,4 +6706,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion" xml:space="preserve">
     <value>An expression tree may not contain an interpolated string handler conversion.</value>
   </data>
+  <data name="ERR_InterpolatedStringHandlerCreationCannotUseDynamic" xml:space="preserve">
+    <value>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1955,6 +1955,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InterpolatedStringHandlerArgumentLocatedAfterInterpolatedString = 9012,
         ERR_InterpolatedStringHandlerArgumentOptionalNotSpecified = 9013,
         ERR_ExpressionTreeContainsInterpolatedStringHandlerConversion = 9014,
+        ERR_InterpolatedStringHandlerCreationCannotUseDynamic = 9015,
 
         #endregion diagnostics introduced for C# 10.0
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1202,6 +1202,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
+                        Debug.Assert(hasTrailingValidityParameter);
                         Join(ref State, ref beforePartsState);
                     }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -32,7 +32,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    // PROTOTYPE(interp-strings): Adjust for bool-returning holes
     /// <summary>
     /// Implement C# definite assignment.
     /// </summary>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -243,6 +243,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // info is exposed to consumers.
                 return null;
             }
+
+            public override BoundNode? VisitInterpolatedString(BoundInterpolatedString node)
+            {
+
+                if (node.InterpolationData is { Construction: var construction })
+                {
+                    Visit(construction);
+                }
+                base.VisitInterpolatedString(node);
+                return null;
+            }
         }
 #endif
     }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -246,7 +246,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override BoundNode? VisitInterpolatedString(BoundInterpolatedString node)
             {
-
                 if (node.InterpolationData is { Construction: var construction })
                 {
                     Visit(construction);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -17,7 +17,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    // PROTOTYPE(interp-string): Implement TryFormat and Create method analysis.
     /// <summary>
     /// Nullability flow analysis.
     /// </summary>
@@ -6952,7 +6951,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case ConversionKind.InterpolatedStringHandler:
-                    // PROTOTYPE(interp-string): Handle
+                    // https://github.com/dotnet/roslyn/issues/54583 Handle
                     resultState = NullableFlowState.NotNull;
                     break;
 
@@ -9726,6 +9725,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitInterpolatedString(BoundInterpolatedString node)
         {
+            // https://github.com/dotnet/roslyn/issues/54583
+            // Better handle the constructor propogation
             var result = base.VisitInterpolatedString(node);
             SetResultType(node, TypeWithState.Create(node.Type, NullableFlowState.NotNull));
             return result;
@@ -9748,7 +9749,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node)
         {
-            // PROTOTYPE(interp-string): handle if necessary
+            SetNotNullResult(node);
+            return null;
+        }
+
+        public override BoundNode? VisitInterpolatedStringArgumentPlaceholder(BoundInterpolatedStringArgumentPlaceholder node)
+        {
             SetNotNullResult(node);
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -393,6 +393,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitInterpolatedStringArgumentPlaceholder(BoundInterpolatedStringArgumentPlaceholder node)
             => PlaceholderReplacement(node);
 
+        public override BoundNode? VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node)
+            => PlaceholderReplacement(node);
+
         /// <summary>
         /// Returns substitution currently used by the rewriter for a placeholder node.
         /// Each occurrence of the placeholder node is replaced with the node returned.
@@ -898,6 +901,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // either representing a user-typed expression that went through this path
                     // itself when it was originally visited, or the trailing out parameter that
                     // is passed by out.
+                    return true;
+
+                case BoundKind.InterpolatedStringHandlerPlaceholder:
+                    // A handler placeholder is the receiver of the interpolated string AppendLiteral
+                    // or AppendFormatted calls, and should never be defensively copied.
                     return true;
 
                 case BoundKind.EventAccess:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -1044,6 +1044,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
+            public override BoundNode? VisitInterpolatedStringHandlerPlaceholder(BoundInterpolatedStringHandlerPlaceholder node)
+            {
+                Fail(node);
+                return null;
+            }
+
             private void Fail(BoundNode node)
             {
                 Debug.Assert(false, $"Bound nodes of kind {node.Kind} should not survive past local rewriting");

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 using System.Diagnostics;
 using System.Linq;
-using System;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.PooledObjects;
 using System.Diagnostics;
 using System.Linq;
 using System;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -46,12 +47,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         private (ArrayBuilder<BoundExpression> HandlerPatternExpressions, BoundLocal Result) RewriteToInterpolatedStringHandlerPattern(BoundInterpolatedString node)
         {
             Debug.Assert(node.InterpolationData is { Construction: not null });
-            Debug.Assert(node.Parts.All(static p => p is BoundCall));
+            Debug.Assert(node.Parts.All(static p => p is BoundCall or BoundDynamicInvocation or BoundDynamicMemberAccess or BoundDynamicIndexerAccess));
             var data = node.InterpolationData.Value;
             var builderTempSymbol = _factory.InterpolatedStringHandlerLocal(data.BuilderType, data.ScopeOfContainingExpression, node.Syntax);
             BoundLocal builderTemp = _factory.Local(builderTempSymbol);
 
-            // PROTOTYPE(interp-string): Support dynamic creation
             // var handler = new HandlerType(baseStringLength, numFormatHoles, ...InterpolatedStringHandlerArgumentAttribute parameters, <optional> out bool appendShouldProceed);
             var construction = (BoundObjectCreationExpression)data.Construction;
 
@@ -71,64 +71,55 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var handlerConstructionAssignment = _factory.AssignmentExpression(builderTemp, (BoundExpression)VisitObjectCreationExpression(construction));
 
-            var usesBoolReturn = data.UsesBoolReturns;
+            AddPlaceholderReplacement(data.ReceiverPlaceholder, builderTemp);
+            bool usesBoolReturns = data.UsesBoolReturns;
             var resultExpressions = ArrayBuilder<BoundExpression>.GetInstance(node.Parts.Length + 1);
-            foreach (var currentPart in node.Parts)
+
+            foreach (var part in node.Parts)
             {
-                var appendCall = (BoundCall)currentPart;
-                Debug.Assert(usesBoolReturn == (appendCall.Method.ReturnType.SpecialType == SpecialType.System_Boolean));
-
-                // The append call itself could have an interpolated string conversion that uses the builder local as the receiver
-                // passed to a nested construction call. This needs to affect the current call to ensure side effects are
-                // preserved, but shouldn't affect any subsequent calls.
-                BoundExpression? appendReceiver = builderTemp;
-                Debug.Assert(appendCall.Method.RequiresInstanceReceiver);
-                var argRefKindsOpt = appendCall.ArgumentRefKindsOpt;
-
-                var rewrittenArguments = VisitArguments(
-                    appendCall.Arguments,
-                    appendCall.Method,
-                    appendCall.ArgsToParamsOpt,
-                    argRefKindsOpt,
-                    ref appendReceiver,
-                    out ArrayBuilder<LocalSymbol>? temps);
-
-                var rewrittenAppendCall = MakeArgumentsAndCall(
-                    appendCall.Syntax,
-                    appendReceiver,
-                    appendCall.Method,
-                    rewrittenArguments,
-                    appendCall.ArgumentRefKindsOpt,
-                    appendCall.Expanded,
-                    appendCall.InvokedAsExtensionMethod,
-                    appendCall.ArgsToParamsOpt,
-                    appendCall.ResultKind,
-                    appendCall.Type,
-                    temps,
-                    appendCall);
-
-                Debug.Assert(usesBoolReturn == (rewrittenAppendCall.Type!.SpecialType == SpecialType.System_Boolean));
-                resultExpressions.Add(rewrittenAppendCall);
+                if (part is BoundCall call)
+                {
+                    Debug.Assert(call.Type.SpecialType == SpecialType.System_Boolean == usesBoolReturns);
+                    resultExpressions.Add((BoundExpression)VisitCall(call));
+                }
+                else if (part is BoundDynamicInvocation dynamicInvocation)
+                {
+                    resultExpressions.Add(VisitDynamicInvocation(dynamicInvocation, resultDiscarded: !usesBoolReturns));
+                }
+                else
+                {
+                    throw ExceptionUtilities.UnexpectedValue(part.Kind);
+                }
             }
+
+            RemovePlaceholderReplacement(data.ReceiverPlaceholder);
 
             if (appendShouldProceedLocal is not null)
             {
                 RemovePlaceholderReplacement(data.ArgumentPlaceholders[^1]);
             }
 
-            if (usesBoolReturn)
+            if (usesBoolReturns)
             {
                 // We assume non-bool returns if there was no parts to the string, and code below is predicated on that.
                 Debug.Assert(!node.Parts.IsEmpty);
                 // Start the sequence with appendProceedLocal, if appropriate
                 BoundExpression? currentExpression = appendShouldProceedLocal;
 
+                var boolType = _compilation.GetSpecialType(SpecialType.System_Boolean);
+
                 foreach (var appendCall in resultExpressions)
                 {
+                    var actualCall = appendCall;
+                    if (actualCall.Type!.IsDynamic())
+                    {
+                        actualCall = _dynamicFactory.MakeDynamicConversion(actualCall, isExplicit: false, isArrayIndex: false, isChecked: false, boolType).ToExpression();
+                    }
+
                     // previousAppendCalls && appendCall
                     currentExpression = currentExpression is null
-                        ? appendCall
-                        : _factory.LogicalAnd(currentExpression, appendCall);
+                        ? actualCall
+                        : _factory.LogicalAnd(currentExpression, actualCall);
                 }
 
                 resultExpressions.Clear();

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -949,15 +949,26 @@ namespace Microsoft.CodeAnalysis.Operations
             return new LocalFunctionOperation(symbol, body, ignoredBody, _semanticModel, syntax, isImplicit);
         }
 
-        private IOperation CreateBoundConversionOperation(BoundConversion boundConversion)
+        private IOperation CreateBoundConversionOperation(BoundConversion boundConversion, bool forceOperandImplicitLiteral = false)
         {
-            bool isImplicit = boundConversion.WasCompilerGenerated || !boundConversion.ExplicitCastInCode;
+            Debug.Assert(!forceOperandImplicitLiteral || boundConversion.Operand is BoundLiteral);
+            bool isImplicit = boundConversion.WasCompilerGenerated || !boundConversion.ExplicitCastInCode || forceOperandImplicitLiteral;
             BoundExpression boundOperand = boundConversion.Operand;
+
+            if (boundConversion.ConversionKind == ConversionKind.InterpolatedStringHandler)
+            {
+                // https://github.com/dotnet/roslyn/issues/54505 Support interpolation handlers in conversions
+                Debug.Assert(!forceOperandImplicitLiteral);
+                Debug.Assert(boundOperand is BoundInterpolatedString);
+                var interpolatedString = Create(boundOperand);
+                return new NoneOperation(ImmutableArray.Create(interpolatedString), _semanticModel, boundConversion.Syntax, boundConversion.GetPublicTypeSymbol(), boundConversion.ConstantValue, isImplicit);
+            }
+
             if (boundConversion.ConversionKind == CSharp.ConversionKind.MethodGroup)
             {
                 SyntaxNode syntax = boundConversion.Syntax;
                 ITypeSymbol? type = boundConversion.GetPublicTypeSymbol();
-                ConstantValue? constantValue = boundConversion.ConstantValue;
+                Debug.Assert(!forceOperandImplicitLiteral);
 
                 if (boundConversion.Type is FunctionPointerTypeSymbol)
                 {
@@ -990,6 +1001,7 @@ namespace Microsoft.CodeAnalysis.Operations
                     Debug.Assert(boundOperand.Kind == BoundKind.BadExpression ||
                                  ((boundOperand as BoundLambda)?.Body.Statements.SingleOrDefault() as BoundReturnStatement)?.
                                      ExpressionOpt?.Kind == BoundKind.BadExpression);
+                    Debug.Assert(!forceOperandImplicitLiteral);
                     return Create(boundOperand);
                 }
 
@@ -1002,6 +1014,7 @@ namespace Microsoft.CodeAnalysis.Operations
                     {
                         // Erase this conversion, this is an artificial conversion added on top of BoundConvertedTupleLiteral
                         // in Binder.CreateTupleLiteralConversion
+                        Debug.Assert(!forceOperandImplicitLiteral);
                         return Create(boundOperand);
                     }
                     else
@@ -1046,7 +1059,9 @@ namespace Microsoft.CodeAnalysis.Operations
                     bool isTryCast = false;
                     // Checked conversions only matter if the conversion is a Numeric conversion. Don't have true unless the conversion is actually numeric.
                     bool isChecked = conversion.IsNumeric && boundConversion.Checked;
-                    IOperation operand = Create(correctedConversionNode.Operand);
+                    IOperation operand = forceOperandImplicitLiteral
+                        ? CreateBoundLiteralOperation((BoundLiteral)correctedConversionNode.Operand, @implicit: true)
+                        : Create(correctedConversionNode.Operand);
                     return new ConversionOperation(operand, conversion, isTryCast, isChecked, _semanticModel, syntax, type, constantValue, isImplicit);
                 }
             }
@@ -1973,7 +1988,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         private IInterpolatedStringOperation CreateBoundInterpolatedStringExpressionOperation(BoundInterpolatedString boundInterpolatedString)
         {
-            ImmutableArray<IInterpolatedStringContentOperation> parts = CreateBoundInterpolatedStringContentOperation(boundInterpolatedString.Parts);
+            ImmutableArray<IInterpolatedStringContentOperation> parts = CreateBoundInterpolatedStringContentOperation(boundInterpolatedString.Parts, boundInterpolatedString.InterpolationData);
             SyntaxNode syntax = boundInterpolatedString.Syntax;
             ITypeSymbol? type = boundInterpolatedString.GetPublicTypeSymbol();
             ConstantValue? constantValue = boundInterpolatedString.ConstantValue;
@@ -1981,21 +1996,132 @@ namespace Microsoft.CodeAnalysis.Operations
             return new InterpolatedStringOperation(parts, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
-        internal ImmutableArray<IInterpolatedStringContentOperation> CreateBoundInterpolatedStringContentOperation(ImmutableArray<BoundExpression> parts)
+        internal ImmutableArray<IInterpolatedStringContentOperation> CreateBoundInterpolatedStringContentOperation(ImmutableArray<BoundExpression> parts, InterpolatedStringHandlerData? data)
         {
-            var builder = ArrayBuilder<IInterpolatedStringContentOperation>.GetInstance(parts.Length);
-            foreach (var part in parts)
+            return data is { PositionInfo: var positionInfo } ? createHandlerInterpolatedStringContent(positionInfo) : createNonHandlerInterpolatedStringContent();
+
+            ImmutableArray<IInterpolatedStringContentOperation> createNonHandlerInterpolatedStringContent()
             {
-                if (part.Kind == BoundKind.StringInsert)
+                var builder = ArrayBuilder<IInterpolatedStringContentOperation>.GetInstance(parts.Length);
+                foreach (var part in parts)
                 {
-                    builder.Add((IInterpolatedStringContentOperation)Create(part));
+                    if (part.Kind == BoundKind.StringInsert)
+                    {
+                        builder.Add((IInterpolatedStringContentOperation)Create(part));
+                    }
+                    else
+                    {
+                        builder.Add(CreateBoundInterpolatedStringTextOperation((BoundLiteral)part));
+                    }
                 }
-                else
+
+                return builder.ToImmutableAndFree();
+            }
+
+            ImmutableArray<IInterpolatedStringContentOperation> createHandlerInterpolatedStringContent(ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> positionInfo)
+            {
+                // For interpolated string handlers, we want to deconstruct the `AppendLiteral`/`AppendFormatted` calls into
+                // their relevant components.
+                // https://github.com/dotnet/roslyn/issues/54505 we need to handle interpolated strings used as handler conversions.
+
+                Debug.Assert(parts.Length == positionInfo.Length);
+                var builder = ArrayBuilder<IInterpolatedStringContentOperation>.GetInstance(parts.Length);
+
+                for (int i = 0; i < parts.Length; i++)
                 {
-                    builder.Add(CreateBoundInterpolatedStringTextOperation((BoundLiteral)part));
+                    var part = parts[i];
+                    var currentPosition = positionInfo[i];
+
+                    BoundExpression value;
+                    BoundExpression? alignment;
+                    BoundExpression? format;
+
+                    switch (part)
+                    {
+                        case BoundCall call:
+                            (value, alignment, format) = getCallInfo(call.Arguments, call.ArgumentNamesOpt, currentPosition);
+                            break;
+
+                        case BoundDynamicInvocation dynamicInvocation:
+                            (value, alignment, format) = getCallInfo(dynamicInvocation.Arguments, dynamicInvocation.ArgumentNamesOpt, currentPosition);
+                            break;
+
+                        case BoundBadExpression bad:
+                            Debug.Assert(bad.ChildBoundNodes.Length ==
+                                2 + // initial value + receiver is added to the end
+                                (currentPosition.HasAlignment ? 1 : 0) +
+                                (currentPosition.HasFormat ? 1 : 0));
+
+                            value = bad.ChildBoundNodes[0];
+                            if (currentPosition.IsLiteral)
+                            {
+                                alignment = format = null;
+                            }
+                            else
+                            {
+                                alignment = currentPosition.HasAlignment ? bad.ChildBoundNodes[1] : null;
+                                format = currentPosition.HasFormat ? bad.ChildBoundNodes[^2] : null;
+                            }
+                            break;
+
+                        default:
+                            throw ExceptionUtilities.UnexpectedValue(part.Kind);
+                    }
+
+                    // We are intentionally not checking the part for implicitness here. The part is a generated AppendLiteral or AppendFormatted call,
+                    // and will always be marked as CompilerGenerated. However, our existing behavior for non-builder interpolated strings does not mark
+                    // the BoundLiteral or BoundStringInsert components as compiler generated. This generates a non-implicit IInterpolatedStringTextOperation
+                    // with an implicit literal underneath, and a non-implicit IInterpolationOperation with non-implicit underlying components.
+                    bool isImplicit = false;
+                    if (currentPosition.IsLiteral)
+                    {
+                        Debug.Assert(alignment is null);
+                        Debug.Assert(format is null);
+                        IOperation valueOperation = value switch
+                        {
+                            BoundLiteral l => CreateBoundLiteralOperation(l, @implicit: true),
+                            BoundConversion { Operand: BoundLiteral } c => CreateBoundConversionOperation(c, forceOperandImplicitLiteral: true),
+                            _ => throw ExceptionUtilities.UnexpectedValue(value.Kind),
+                        };
+
+                        Debug.Assert(valueOperation.IsImplicit);
+
+                        builder.Add(new InterpolatedStringTextOperation(valueOperation, _semanticModel, part.Syntax, isImplicit));
+                    }
+                    else
+                    {
+                        IOperation valueOperation = Create(value);
+                        IOperation? alignmentOperation = Create(alignment);
+                        IOperation? formatOperation = Create(format);
+
+                        Debug.Assert(valueOperation.Syntax != part.Syntax);
+
+                        builder.Add(new InterpolationOperation(valueOperation, alignmentOperation, formatOperation, _semanticModel, part.Syntax, isImplicit));
+                    }
+                }
+
+                return builder.ToImmutableAndFree();
+
+                static (BoundExpression Value, BoundExpression? Alignment, BoundExpression? Format) getCallInfo(ImmutableArray<BoundExpression> arguments, ImmutableArray<string> argumentNamesOpt, (bool IsLiteral, bool HasAlignment, bool HasFormat) currentPosition)
+                {
+                    BoundExpression value = arguments[0];
+
+                    if (currentPosition.IsLiteral || argumentNamesOpt.IsDefault)
+                    {
+                        // There was no alignment/format component, as binding will qualify those parameters by name
+                        return (value, null, null);
+                    }
+                    else
+                    {
+                        var alignmentIndex = argumentNamesOpt.IndexOf("alignment");
+                        BoundExpression? alignment = alignmentIndex == -1 ? null : arguments[alignmentIndex];
+                        var formatIndex = argumentNamesOpt.IndexOf("format");
+                        BoundExpression? format = formatIndex == -1 ? null : arguments[formatIndex];
+
+                        return (value, alignment, format);
+                    }
                 }
             }
-            return builder.ToImmutableAndFree();
         }
 
         private IInterpolationOperation CreateBoundInterpolationOperation(BoundStringInsert boundStringInsert)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceClonedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceClonedParameterSymbol.cs
@@ -165,7 +165,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return ImmutableHashSet<string>.Empty; }
         }
 
-        // PROTOTYPE(interp-strings): These might end up being reached during lowering. If so, we'll likely need to reinterpret in the current context
         internal override ImmutableArray<int> InterpolatedStringHandlerArgumentIndexes => throw ExceptionUtilities.Unreachable;
 
         internal override bool HasInterpolatedStringHandlerArgumentError => throw ExceptionUtilities.Unreachable;

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -562,6 +562,11 @@
         <target state="new">Parameter '{0}' is not explicitly provided, but is used as an argument to the interpolated string handler conversion on parameter '{1}'. Specify the value of '{0}' before '{1}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringHandlerCreationCannotUseDynamic">
+        <source>An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</source>
+        <target state="new">An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InterpolatedStringHandlerIncorrectNumberOfConstructorArguments">
         <source>'{0}' does not have a constructor that takes {1} arguments.</source>
         <target state="new">'{0}' does not have a constructor that takes {1} arguments.</target>

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IArgument.cs
@@ -1058,7 +1058,7 @@ IInvocationOperation ( void P.M2([System.String memberName = null], [System.Stri
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, TargetFramework.Mscorlib46, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>((source, "file.cs"), expectedOperationTree, TargetFramework.Mscorlib46, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1101,7 +1101,7 @@ IInvocationOperation ( System.Boolean P.M2([System.String memberName = null], [S
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, TargetFramework.Mscorlib46, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>((source, "file.cs"), expectedOperationTree, TargetFramework.Mscorlib46, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1144,7 +1144,7 @@ IInvocationOperation (System.Boolean P.M2([System.String memberName = null], [Sy
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, TargetFramework.Mscorlib46, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>((source, "file.cs"), expectedOperationTree, TargetFramework.Mscorlib46, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1199,7 +1199,7 @@ IInvocationOperation (System.Boolean P.M2([System.String memberName = null], [Sy
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, TargetFramework.Mscorlib46, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>((source, "file.cs"), expectedOperationTree, TargetFramework.Mscorlib46, expectedDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
@@ -1826,11 +1826,26 @@ public partial struct CustomHandler
 
             var expectedDiagnostics = new[] {
                 // (4,16): error CS9015: An interpolated string handler construction cannot use dynamic. Manually construct an instance of 'CustomHandler'.
-                // M(d, /*<bind>*/$""/*</bind>*/);
-                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerCreationCannotUseDynamic, @"$""""").WithArguments("CustomHandler").WithLocation(4, 16)
+                // M(d, /*<bind>*/$"{1}literal"/*</bind>*/);
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerCreationCannotUseDynamic, @"$""{1}literal""").WithArguments("CustomHandler").WithLocation(4, 16)
             };
 
             string expectedOperationTree = @"
+IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String, IsInvalid) (Syntax: '$""{1}literal""')
+  Parts(2):
+      IInterpolationOperation (OperationKind.Interpolation, Type: null, IsInvalid) (Syntax: '{1}')
+        Expression:
+          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsInvalid, IsImplicit) (Syntax: '1')
+            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+            Operand:
+              ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid) (Syntax: '1')
+        Alignment:
+          null
+        FormatString:
+          null
+      IInterpolatedStringTextOperation (OperationKind.InterpolatedStringText, Type: null, IsInvalid) (Syntax: 'literal')
+        Text:
+          ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""literal"", IsInvalid, IsImplicit) (Syntax: 'literal')
 ";
 
             VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(new[] { code, handler, InterpolatedStringHandlerArgumentAttribute }, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -13,9 +14,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public partial class IOperationTests : SemanticModelTestBase
     {
+        private static CSharpTestSource GetSource(string code, bool hasDefaultHandler)
+            => hasDefaultHandler 
+                ? new[] { code, GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false) }
+                : code;
+
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_Empty()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_Empty(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -34,12 +41,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_OnlyTextPart()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_OnlyTextPart(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -61,12 +69,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_OnlyInterpolationPart()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_OnlyInterpolationPart(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -92,12 +101,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_EmptyInterpolationPart()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_EmptyInterpolationPart(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -128,12 +138,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
                 Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(8, 40)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_TextAndInterpolationParts()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_TextAndInterpolationParts(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -172,12 +183,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_FormatAndAlignment()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_FormatAndAlignment(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -233,12 +245,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_InterpolationAndFormatAndAlignment()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_InterpolationAndFormatAndAlignment(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -274,12 +287,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_InvocationInInterpolation()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_InvocationInInterpolation(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -339,12 +353,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_NestedInterpolation()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_NestedInterpolation(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -392,12 +407,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
-        [Fact, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
-        public void InterpolatedStringExpression_InvalidExpressionInInterpolation()
+        [Theory, WorkItem(18300, "https://github.com/dotnet/roslyn/issues/18300")]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_InvalidExpressionInInterpolation(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -446,12 +462,13 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "Class").WithArguments("Class", "type").WithLocation(8, 65)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InterpolatedStringExpressionSyntax>(GetSource(source, hasDefaultHandler), expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_Empty_Flow()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_Empty_Flow(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -487,12 +504,13 @@ Block[B2] - Exit
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_OnlyTextPart_Flow()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_OnlyTextPart_Flow(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -531,12 +549,13 @@ Block[B2] - Exit
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_OnlyInterpolationPart_Flow()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_OnlyInterpolationPart_Flow(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -614,12 +633,13 @@ Block[B5] - Exit
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_MultipleInterpolationParts_Flow()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_MultipleInterpolationParts_Flow(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -704,12 +724,13 @@ Block[B5] - Exit
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_TextAndInterpolationParts_Flow()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_TextAndInterpolationParts_Flow(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -823,12 +844,13 @@ Block[B8] - Exit
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_FormatAndAlignment_Flow()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_FormatAndAlignment_Flow(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -906,12 +928,13 @@ Block[B5] - Exit
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_FormatAndAlignment_Flow_02()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_FormatAndAlignment_Flow_02(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -1004,12 +1027,13 @@ Block[B5] - Exit
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_FormatAndAlignment_Flow_03()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_FormatAndAlignment_Flow_03(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -1117,12 +1141,13 @@ Block[B5] - Exit
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_NestedInterpolation_Flow()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_NestedInterpolation_Flow(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -1230,12 +1255,13 @@ Block[B6] - Exit
 ";
             var expectedDiagnostics = DiagnosticDescription.None;
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_ConditionalCodeInAlignment_Flow()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_ConditionalCodeInAlignment_Flow(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -1321,12 +1347,13 @@ Block[B5] - Exit
                 Diagnostic(ErrorCode.ERR_ConstantExpected, "(a ? b : c)").WithLocation(8, 18)
             };
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
-        [Fact]
-        public void InterpolatedStringExpression_ConditionalCodeInAlignment_Flow_02()
+        [Theory]
+        [CombinatorialData]
+        public void InterpolatedStringExpression_ConditionalCodeInAlignment_Flow_02(bool hasDefaultHandler)
         {
             string source = @"
 using System;
@@ -1416,7 +1443,314 @@ Block[B5] - Exit
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "a ? b : c").WithArguments("string", "int").WithLocation(8, 20)
             };
 
-            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(GetSource(source, hasDefaultHandler), expectedFlowGraph, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void InterpolatedStringHandlerConversion_01()
+        {
+            var code = @"
+int i = 0;
+CustomHandler /*<bind>*/c = $""literal{i,1:test}""/*</bind>*/;
+";
+
+            var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false);
+
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            string expectedOperationTree = @"
+IVariableDeclaratorOperation (Symbol: CustomHandler c) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'c = $""literal{i,1:test}""')
+  Initializer: 
+    IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= $""literal{i,1:test}""')
+      IOperation:  (OperationKind.None, Type: CustomHandler, IsImplicit) (Syntax: '$""literal{i,1:test}""')
+        Children(1):
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""literal{i,1:test}""')
+              Parts(2):
+                  IInterpolatedStringTextOperation (OperationKind.InterpolatedStringText, Type: null) (Syntax: 'literal')
+                    Text: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""literal"", IsImplicit) (Syntax: 'literal')
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i,1:test}')
+                    Expression: 
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand: 
+                          ILocalReferenceOperation: i (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i')
+                    Alignment: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+                    FormatString: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""test"") (Syntax: ':test')
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(new[] { code, handler }, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
+        }
+
+        [Fact]
+        public void InterpolatedStringHandlerConversion_02()
+        {
+            var code = @"
+int i = 0;
+CustomHandler /*<bind>*/c = $""literal{i,1}""/*</bind>*/;
+";
+
+            var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false);
+
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            string expectedOperationTree = @"
+IVariableDeclaratorOperation (Symbol: CustomHandler c) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'c = $""literal{i,1}""')
+  Initializer: 
+    IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= $""literal{i,1}""')
+      IOperation:  (OperationKind.None, Type: CustomHandler, IsImplicit) (Syntax: '$""literal{i,1}""')
+        Children(1):
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""literal{i,1}""')
+              Parts(2):
+                  IInterpolatedStringTextOperation (OperationKind.InterpolatedStringText, Type: null) (Syntax: 'literal')
+                    Text: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""literal"", IsImplicit) (Syntax: 'literal')
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i,1}')
+                    Expression: 
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand: 
+                          ILocalReferenceOperation: i (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i')
+                    Alignment: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+                    FormatString: 
+                      null
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(new[] { code, handler }, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
+        }
+
+        [Fact]
+        public void InterpolatedStringHandlerConversion_03()
+        {
+            var code = @"
+int i = 0;
+CustomHandler /*<bind>*/c = $""literal{i:test}""/*</bind>*/;
+";
+
+            var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false);
+
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            string expectedOperationTree = @"
+IVariableDeclaratorOperation (Symbol: CustomHandler c) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'c = $""literal{i:test}""')
+  Initializer: 
+    IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= $""literal{i:test}""')
+      IOperation:  (OperationKind.None, Type: CustomHandler, IsImplicit) (Syntax: '$""literal{i:test}""')
+        Children(1):
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""literal{i:test}""')
+              Parts(2):
+                  IInterpolatedStringTextOperation (OperationKind.InterpolatedStringText, Type: null) (Syntax: 'literal')
+                    Text: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""literal"", IsImplicit) (Syntax: 'literal')
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i:test}')
+                    Expression: 
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand: 
+                          ILocalReferenceOperation: i (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i')
+                    Alignment: 
+                      null
+                    FormatString: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""test"") (Syntax: ':test')
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(new[] { code, handler }, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
+        }
+
+        [Fact]
+        public void InterpolatedStringHandlerConversion_04()
+        {
+            var code = @"
+int i = 0;
+CustomHandler /*<bind>*/c = $""literal{i}""/*</bind>*/;
+";
+
+            var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false);
+
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            string expectedOperationTree = @"
+IVariableDeclaratorOperation (Symbol: CustomHandler c) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'c = $""literal{i}""')
+  Initializer: 
+    IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= $""literal{i}""')
+      IOperation:  (OperationKind.None, Type: CustomHandler, IsImplicit) (Syntax: '$""literal{i}""')
+        Children(1):
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""literal{i}""')
+              Parts(2):
+                  IInterpolatedStringTextOperation (OperationKind.InterpolatedStringText, Type: null) (Syntax: 'literal')
+                    Text: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""literal"", IsImplicit) (Syntax: 'literal')
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i}')
+                    Expression: 
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand: 
+                          ILocalReferenceOperation: i (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i')
+                    Alignment: 
+                      null
+                    FormatString: 
+                      null
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(new[] { code, handler }, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
+        }
+
+        [Fact]
+        public void InterpolatedStringHandlerConversion_05()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+int i = 0;
+CustomHandler /*<bind>*/c = $""literal{i}""/*</bind>*/;
+
+[InterpolatedStringHandler]
+public struct CustomHandler {}
+";
+
+            var expectedDiagnostics = new[]
+            {
+                // (4,29): error CS1729: 'CustomHandler' does not contain a constructor that takes 2 arguments
+                // CustomHandler /*<bind>*/c = $"literal{i}"/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""literal{i}""").WithArguments("CustomHandler", "2").WithLocation(4, 29),
+                // (4,29): error CS1729: 'CustomHandler' does not contain a constructor that takes 3 arguments
+                // CustomHandler /*<bind>*/c = $"literal{i}"/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""literal{i}""").WithArguments("CustomHandler", "3").WithLocation(4, 29),
+                // (4,31): error CS1061: 'CustomHandler' does not contain a definition for 'AppendLiteral' and no accessible extension method 'AppendLiteral' accepting a first argument of type 'CustomHandler' could be found (are you missing a using directive or an assembly reference?)
+                // CustomHandler /*<bind>*/c = $"literal{i}"/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "literal").WithArguments("CustomHandler", "AppendLiteral").WithLocation(4, 31),
+                // (4,31): error CS9001: Interpolated string handler method '?.()' is malformed. It does not return 'void' or 'bool'.
+                // CustomHandler /*<bind>*/c = $"literal{i}"/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnMalformed, "literal").WithArguments("?.()").WithLocation(4, 31),
+                // (4,38): error CS1061: 'CustomHandler' does not contain a definition for 'AppendFormatted' and no accessible extension method 'AppendFormatted' accepting a first argument of type 'CustomHandler' could be found (are you missing a using directive or an assembly reference?)
+                // CustomHandler /*<bind>*/c = $"literal{i}"/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "{i}").WithArguments("CustomHandler", "AppendFormatted").WithLocation(4, 38),
+                // (4,38): error CS9001: Interpolated string handler method '?.()' is malformed. It does not return 'void' or 'bool'.
+                // CustomHandler /*<bind>*/c = $"literal{i}"/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnMalformed, "{i}").WithArguments("?.()").WithLocation(4, 38)
+            };
+
+            string expectedOperationTree = @"
+IVariableDeclaratorOperation (Symbol: CustomHandler c) (OperationKind.VariableDeclarator, Type: null, IsInvalid) (Syntax: 'c = $""literal{i}""')
+  Initializer: 
+    IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null, IsInvalid) (Syntax: '= $""literal{i}""')
+      IOperation:  (OperationKind.None, Type: CustomHandler, IsInvalid, IsImplicit) (Syntax: '$""literal{i}""')
+        Children(1):
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String, IsInvalid) (Syntax: '$""literal{i}""')
+              Parts(2):
+                  IInterpolatedStringTextOperation (OperationKind.InterpolatedStringText, Type: null, IsInvalid) (Syntax: 'literal')
+                    Text: 
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""literal"", IsInvalid, IsImplicit) (Syntax: 'literal')
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null, IsInvalid) (Syntax: '{i}')
+                    Expression: 
+                      ILocalReferenceOperation: i (OperationKind.LocalReference, Type: System.Int32, IsInvalid) (Syntax: 'i')
+                    Alignment: 
+                      null
+                    FormatString: 
+                      null
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(new[] { code, InterpolatedStringHandlerAttribute }, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
+        }
+
+        [Fact]
+        public void InterpolatedStringHandlerConversion_06()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+int i = 0;
+CustomHandler /*<bind>*/c = $""literal{i,1:test}""/*</bind>*/;
+
+[InterpolatedStringHandler]
+public struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount) {}
+    public void AppendFormatted(object o, object alignment, object format) {}
+    public void AppendLiteral(object o) {}
+}
+";
+
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            string expectedOperationTree = @"
+IVariableDeclaratorOperation (Symbol: CustomHandler c) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'c = $""literal{i,1:test}""')
+  Initializer: 
+    IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= $""literal{i,1:test}""')
+      IOperation:  (OperationKind.None, Type: CustomHandler, IsImplicit) (Syntax: '$""literal{i,1:test}""')
+        Children(1):
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""literal{i,1:test}""')
+              Parts(2):
+                  IInterpolatedStringTextOperation (OperationKind.InterpolatedStringText, Type: null) (Syntax: 'literal')
+                    Text: 
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'literal')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                        Operand: 
+                          ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""literal"", IsImplicit) (Syntax: 'literal')
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i,1:test}')
+                    Expression: 
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand: 
+                          ILocalReferenceOperation: i (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i')
+                    Alignment: 
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: '1')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand: 
+                          ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+                    FormatString: 
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: ':test')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                        Operand: 
+                          ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""test"") (Syntax: ':test')
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(new[] { code, InterpolatedStringHandlerAttribute }, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
+        }
+
+        [Fact]
+        public void InterpolatedStringHandlerConversion_07()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+CustomHandler /*<bind>*/c = $""{}""/*</bind>*/;
+
+[InterpolatedStringHandler]
+public struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount) {}
+    public void AppendFormatted(object o, object alignment, object format) {}
+    public void AppendLiteral(object o) {}
+}
+";
+
+            var expectedDiagnostics = new[] {
+                // (3,32): error CS1733: Expected expression
+                // CustomHandler /*<bind>*/c = $"{}"/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(3, 32)
+            };
+
+            string expectedOperationTree = @"
+IVariableDeclaratorOperation (Symbol: CustomHandler c) (OperationKind.VariableDeclarator, Type: null, IsInvalid) (Syntax: 'c = $""{}""')
+  Initializer: 
+    IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null, IsInvalid) (Syntax: '= $""{}""')
+      IOperation:  (OperationKind.None, Type: CustomHandler, IsInvalid, IsImplicit) (Syntax: '$""{}""')
+        Children(1):
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String, IsInvalid) (Syntax: '$""{}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null, IsInvalid) (Syntax: '{}')
+                    Expression: 
+                      IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: '')
+                        Children(0)
+                    Alignment: 
+                      null
+                    FormatString: 
+                      null
+
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(new[] { code, InterpolatedStringHandlerAttribute }, expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public partial class IOperationTests : SemanticModelTestBase
     {
         private static CSharpTestSource GetSource(string code, bool hasDefaultHandler)
-            => hasDefaultHandler 
+            => hasDefaultHandler
                 ? new[] { code, GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false) }
                 : code;
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -2079,8 +2079,6 @@ string Throw() => throw new Exception();
         [Fact]
         public void AwaitInHoles_UsesFormat()
         {
-            // PROTOTYPE(interp-string): We could make this case use the builder as well by evaluating the holes ahead of time. For DefaultInterpolatedStringHandler,
-            // we know that the framework is never going to ship a version that short circuits, so it would be a valid optimization for us to make.
             var source = @"
 using System;
 using System.Threading.Tasks;
@@ -2924,7 +2922,6 @@ value:");
                 Diagnostic(ErrorCode.ERR_FeatureInPreview, "(null, default)").WithArguments("interpolated string handlers").WithLocation(1, 29),
                 // (1,46): error CS1729: 'string' does not contain a constructor that takes 0 arguments
                 // System.Console.WriteLine($"{(null, default)}{new()}");
-                // PROTOTYPE(interp-string): This is technically a break. Should we special case this?
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, "new()").WithArguments("string", "0").WithLocation(1, 46)
             );
         }
@@ -2945,7 +2942,6 @@ System.Console.WriteLine($""{(!b ? ref i : ref i)}"");";
         [Fact]
         public void NestedInterpolatedStrings()
         {
-            // PROTOTYPE(interp-string): Should we notice the nested string and just treat it as being concated?
             var source = @"
 int i = 1;
 System.Console.WriteLine($""{$""{i}""}"");";
@@ -3735,7 +3731,7 @@ literal:Literal");
             Assert.Equal(SpecialType.System_String, semanticInfo.ConvertedType.SpecialType);
             Assert.Equal(ConversionKind.Identity, semanticInfo.ImplicitConversion.Kind);
 
-            // PROTOTYPE(interp-string): Assert cast is explicit after IOperation is implemented
+            // https://github.com/dotnet/roslyn/issues/54505 Assert cast is explicit after IOperation is implemented
 
             var verifier = CompileAndVerify(comp, expectedOutput: @"
 value:1

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -10814,7 +10814,6 @@ public ref struct CustomHandler
 }
 ";
 
-
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (17,19): error CS8352: Cannot use local 's' in this context because it may expose referenced variables outside of their declaration scope
@@ -10847,7 +10846,6 @@ public ref struct CustomHandler
 }
 ";
 
-
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
                 // (17,9): error CS8150: By-value returns may only be used in methods that return by value
@@ -10879,7 +10877,6 @@ public ref struct CustomHandler
     }
 }
 ";
-
 
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
@@ -10919,7 +10916,6 @@ public ref struct S1
     public Span<char> s;
 }
 ";
-
 
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics(
@@ -10963,7 +10959,6 @@ public ref struct S1
 }
 ";
 
-
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics();
         }
@@ -10993,7 +10988,6 @@ public ref struct CustomHandler
 }
 ";
 
-
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics();
         }
@@ -11022,7 +11016,6 @@ public ref struct CustomHandler
     public bool AppendFormatted(Span<char> s) => true;
 }
 ";
-
 
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -5474,19 +5474,6 @@ literal:Literal");
 ");
         }
 
-        private const string InterpolatedStringHandlerArgumentAttribute = @"
-namespace System.Runtime.CompilerServices
-{
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    public sealed class InterpolatedStringHandlerArgumentAttribute : Attribute
-    {
-        public InterpolatedStringHandlerArgumentAttribute(string argument) => Arguments = new string[] { argument };
-        public InterpolatedStringHandlerArgumentAttribute(params string[] arguments) => Arguments = arguments;
-        public string[] Arguments { get; }
-    }
-}
-";
-
         private const string InterpolatedStringHandlerAttributesVB = @"
 Namespace System.Runtime.CompilerServices
     <AttributeUsage(AttributeTargets.Class Or AttributeTargets.Struct, AllowMultiple:=False, Inherited:=False)>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -10240,7 +10240,7 @@ public partial class CustomHandler
 
         [Theory]
         [CombinatorialData]
-        public void DefiniteAssignment(bool useBoolReturns, bool trailingOutParameter)
+        public void DefiniteAssignment_01(bool useBoolReturns, bool trailingOutParameter)
         {
             var code = @"
 int i;
@@ -10273,6 +10273,34 @@ string M(out object o)
                     // (8,5): error CS0165: Use of unassigned local variable 's'
                     // _ = s.ToString();
                     Diagnostic(ErrorCode.ERR_UseDefViolation, "s").WithArguments("s").WithLocation(8, 5)
+                );
+            }
+            else
+            {
+                comp.VerifyDiagnostics();
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void DefiniteAssignment_02(bool useBoolReturns, bool trailingOutParameter)
+        {
+            var code = @"
+int i;
+
+CustomHandler c = $""{i = 1}"";
+_ = i.ToString();
+";
+
+            var customHandler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns, includeTrailingOutConstructorParameter: trailingOutParameter);
+            var comp = CreateCompilation(new[] { code, customHandler }, parseOptions: TestOptions.RegularPreview);
+
+            if (trailingOutParameter)
+            {
+                comp.VerifyDiagnostics(
+                    // (5,5): error CS0165: Use of unassigned local variable 'i'
+                    // _ = i.ToString();
+                    Diagnostic(ErrorCode.ERR_UseDefViolation, "i").WithArguments("i").WithLocation(5, 5)
                 );
             }
             else

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -10261,12 +10261,23 @@ string M(out object o)
             var customHandler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns, includeTrailingOutConstructorParameter: trailingOutParameter);
             var comp = CreateCompilation(new[] { code, customHandler }, parseOptions: TestOptions.RegularPreview);
 
-            if (useBoolReturns || trailingOutParameter)
+            if (trailingOutParameter)
             {
                 comp.VerifyDiagnostics(
                     // (6,5): error CS0165: Use of unassigned local variable 'i'
                     // _ = i.ToString();
                     Diagnostic(ErrorCode.ERR_UseDefViolation, "i").WithArguments("i").WithLocation(6, 5),
+                    // (7,5): error CS0165: Use of unassigned local variable 'o'
+                    // _ = o.ToString();
+                    Diagnostic(ErrorCode.ERR_UseDefViolation, "o").WithArguments("o").WithLocation(7, 5),
+                    // (8,5): error CS0165: Use of unassigned local variable 's'
+                    // _ = s.ToString();
+                    Diagnostic(ErrorCode.ERR_UseDefViolation, "s").WithArguments("s").WithLocation(8, 5)
+                );
+            }
+            else if (useBoolReturns)
+            {
+                comp.VerifyDiagnostics(
                     // (7,5): error CS0165: Use of unassigned local variable 'o'
                     // _ = o.ToString();
                     Diagnostic(ErrorCode.ERR_UseDefViolation, "o").WithArguments("o").WithLocation(7, 5),

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -6352,8 +6352,8 @@ oneMoreTime:
                     IOperation? rewrittenFormatString;
                     if (interpolation.FormatString != null)
                     {
-                        Debug.Assert(interpolation.FormatString.Kind == OperationKind.Literal);
-                        rewrittenFormatString = VisitLiteral((ILiteralOperation)interpolation.FormatString, captureIdForResult: null);
+                        Debug.Assert(interpolation.FormatString is ILiteralOperation or IConversionOperation { Operand: ILiteralOperation });
+                        rewrittenFormatString = VisitRequired(interpolation.FormatString, argument: null);
                     }
                     else
                     {
@@ -6367,8 +6367,8 @@ oneMoreTime:
                 else
                 {
                     var interpolatedStringText = (IInterpolatedStringTextOperation)element;
-                    Debug.Assert(interpolatedStringText.Text.Kind == OperationKind.Literal);
-                    var rewrittenInterpolationText = VisitLiteral((ILiteralOperation)interpolatedStringText.Text, captureIdForResult: null);
+                    Debug.Assert(interpolatedStringText.Text is ILiteralOperation or IConversionOperation { Operand: ILiteralOperation });
+                    var rewrittenInterpolationText = VisitRequired(interpolatedStringText.Text, argument: null);
                     rewrittenElement = new InterpolatedStringTextOperation(rewrittenInterpolationText, semanticModel: null, element.Syntax, IsImplicit(element));
                 }
 

--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     s = s.Replace("\"", "\"\"");
                     return @"""" + s + @"""";
                 case IFormattable formattable:
-                    return formattable.ToString(null, CultureInfo.InvariantCulture).Replace("\"", "\"\"");;
+                    return formattable.ToString(null, CultureInfo.InvariantCulture).Replace("\"", "\"\"");
                 default:
                     return constant.ToString().Replace("\"", "\"\"");
             }

--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -57,10 +57,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             char[] newLineChars = Environment.NewLine.ToCharArray();
             string actual = actualOperationTree.Trim(newLineChars);
-            actual = actual.Replace("\"", "\"\"").Replace(" \n", "\n").Replace(" \r", "\r");
+            actual = actual.Replace(" \n", "\n").Replace(" \r", "\r");
             expectedOperationTree = expectedOperationTree.Trim(newLineChars);
             expectedOperationTree = expectedOperationTree.Replace("\r\n", "\n").Replace(" \n", "\n").Replace("\n", Environment.NewLine);
-            expectedOperationTree = expectedOperationTree.Replace("\"", "\"\"");
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedOperationTree, actual);
         }
@@ -217,22 +216,19 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
-        private static string ConstantToString(object constant, bool quoteString = true)
+        private static string ConstantToString(object constant)
         {
             switch (constant)
             {
                 case null:
                     return "null";
                 case string s:
-                    if (quoteString)
-                    {
-                        return @"""" + s + @"""";
-                    }
-                    return s;
+                    s = s.Replace("\"", "\"\"");
+                    return @"""" + s + @"""";
                 case IFormattable formattable:
-                    return formattable.ToString(null, CultureInfo.InvariantCulture);
+                    return formattable.ToString(null, CultureInfo.InvariantCulture).Replace("\"", "\"\"");;
                 default:
-                    return constant.ToString();
+                    return constant.ToString().Replace("\"", "\"\"");
             }
         }
 

--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1774,7 +1774,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             LogString(nameof(IInterpolatedStringTextOperation));
             LogCommonPropertiesAndNewLine(operation);
 
-            Assert.Equal(OperationKind.Literal, operation.Text.Kind);
+            if (operation.Text.Kind != OperationKind.Literal)
+            {
+                Assert.Equal(OperationKind.Literal, ((IConversionOperation)operation.Text).Operand.Kind);
+            }
             Visit(operation.Text, "Text");
         }
 
@@ -1787,9 +1790,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Visit(operation.Alignment, "Alignment");
             Visit(operation.FormatString, "FormatString");
 
-            if (operation.FormatString != null)
+            if (operation.FormatString != null && operation.FormatString.Kind != OperationKind.Literal)
             {
-                Assert.Equal(OperationKind.Literal, operation.FormatString.Kind);
+                Assert.Equal(OperationKind.Literal, ((IConversionOperation)operation.FormatString).Operand.Kind);
             }
         }
 

--- a/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
+++ b/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
@@ -1105,7 +1105,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public override void VisitInterpolatedStringText(IInterpolatedStringTextOperation operation)
         {
             Assert.Equal(OperationKind.InterpolatedStringText, operation.Kind);
-            Assert.Equal(OperationKind.Literal, operation.Text.Kind);
+            if (operation.Text.Kind != OperationKind.Literal)
+            { 
+                Assert.Equal(OperationKind.Literal, ((IConversionOperation)operation.Text).Operand.Kind);
+            }
             Assert.Same(operation.Text, operation.Children.Single());
         }
 
@@ -1120,7 +1123,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             if (operation.FormatString != null)
             {
-                Assert.Equal(OperationKind.Literal, operation.FormatString.Kind);
+                if (operation.FormatString.Kind != OperationKind.Literal)
+                {
+                    Assert.Equal(OperationKind.Literal, ((IConversionOperation)operation.FormatString).Operand.Kind);
+                }
                 children = children.Concat(new[] { operation.FormatString });
             }
 

--- a/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
+++ b/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
@@ -1106,7 +1106,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             Assert.Equal(OperationKind.InterpolatedStringText, operation.Kind);
             if (operation.Text.Kind != OperationKind.Literal)
-            { 
+            {
                 Assert.Equal(OperationKind.Literal, ((IConversionOperation)operation.Text).Operand.Kind);
             }
             Assert.Same(operation.Text, operation.Children.Single());

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -2482,13 +2482,15 @@ public class CultureInfoNormalizer
 }
 ";
 
+            var nameWithGenericsTrimmed = name.IndexOf("<") is not -1 and var index ? name[..index] : name;
+
             return (includeOneTimeHelpers ? "using System.Globalization;\n" : "") + @"
 using System.Text;
 [System.Runtime.CompilerServices.InterpolatedStringHandler]
 public " + type + " " + name + @"
 {
     private readonly StringBuilder _builder;
-    public " + name + @"(int literalLength, int formattedCount" + (includeTrailingOutConstructorParameter ? ", out bool success" : "") + @")
+    public " + nameWithGenericsTrimmed + @"(int literalLength, int formattedCount" + (includeTrailingOutConstructorParameter ? ", out bool success" : "") + @")
     {
         " + (includeTrailingOutConstructorParameter ? "success = true;" : "") + @"
         _builder = new();
@@ -2509,6 +2511,19 @@ public " + type + " " + name + @"
 }
 " + (includeOneTimeHelpers ? InterpolatedStringHandlerAttribute + cultureInfoHandler : "");
         }
+
+        internal const string InterpolatedStringHandlerArgumentAttribute = @"
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public sealed class InterpolatedStringHandlerArgumentAttribute : Attribute
+    {
+        public InterpolatedStringHandlerArgumentAttribute(string argument) => Arguments = new string[] { argument };
+        public InterpolatedStringHandlerArgumentAttribute(params string[] arguments) => Arguments = arguments;
+        public string[] Arguments { get; }
+    }
+}
+";
 
         #endregion
 

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestSource.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestSource.cs
@@ -36,6 +36,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
                 case string[] sources:
                     Debug.Assert(string.IsNullOrEmpty(sourceFileName));
                     return CSharpTestBase.Parse(parseOptions, sources);
+                case (string source, string fileName):
+                    Debug.Assert(string.IsNullOrEmpty(sourceFileName));
+                    return new[] { CSharpTestBase.Parse(source, fileName, parseOptions) };
+                case (string Source, string FileName)[] sources:
+                    Debug.Assert(string.IsNullOrEmpty(sourceFileName));
+                    return sources.Select(source => CSharpTestBase.Parse(source.Source, source.FileName, parseOptions)).ToArray();
                 case SyntaxTree tree:
                     Debug.Assert(parseOptions == null);
                     Debug.Assert(string.IsNullOrEmpty(sourceFileName));
@@ -55,6 +61,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 
         public static implicit operator CSharpTestSource(string source) => new CSharpTestSource(source);
         public static implicit operator CSharpTestSource(string[] source) => new CSharpTestSource(source);
+        public static implicit operator CSharpTestSource((string Source, string FileName) source) => new CSharpTestSource(source);
+        public static implicit operator CSharpTestSource((string Source, string FileName)[] source) => new CSharpTestSource(source);
         public static implicit operator CSharpTestSource(SyntaxTree source) => new CSharpTestSource(source);
         public static implicit operator CSharpTestSource(SyntaxTree[] source) => new CSharpTestSource(source);
         public static implicit operator CSharpTestSource(List<SyntaxTree> source) => new CSharpTestSource(source.ToArray());


### PR DESCRIPTION
Implements support for definite assignment, initial nullable support, initial IOperation support, and does a bit of prototype comment cleanup. Next week I'll add some additional commits cleaning up the rest of the prototype comments in this branch, they're mainly around adding tests for dynamic to be sure of behavior, ref escape behavior custom interpolated string handler arguments, and condensing message numbers for merge.

Test plan: https://github.com/dotnet/roslyn/issues/51499