### PR TITLE
Use IsKind instead of type checking in syntax normalizer (little performance gain)

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -11,6 +11,44 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
+    internal static class Extensions
+    {
+        public static bool IsKind(this SyntaxNode? node, SyntaxKind kind1, SyntaxKind kind2)
+        {
+            return node is not null &&
+                (node.RawKind == (int)kind1 ||
+                node.RawKind == (int)kind2);
+        }
+
+        public static bool IsKind(this SyntaxNode? node, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3)
+        {
+            return node is not null &&
+                (node.RawKind == (int)kind1 ||
+                node.RawKind == (int)kind2 ||
+                node.RawKind == (int)kind3);
+        }
+
+        public static bool IsKind(this SyntaxNode? node, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3, SyntaxKind kind4)
+        {
+            return node is not null &&
+                (node.RawKind == (int)kind1 ||
+                node.RawKind == (int)kind2 ||
+                node.RawKind == (int)kind3 ||
+                node.RawKind == (int)kind4);
+        }
+        public static bool IsKind(this SyntaxNode? node, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3, SyntaxKind kind4, SyntaxKind kind5, SyntaxKind kind6, SyntaxKind kind7)
+        {
+            return node is not null &&
+                (node.RawKind == (int)kind1 ||
+                node.RawKind == (int)kind2 ||
+                node.RawKind == (int)kind3 ||
+                node.RawKind == (int)kind4 ||
+                node.RawKind == (int)kind5 ||
+                node.RawKind == (int)kind6 ||
+                node.RawKind == (int)kind7);
+        }
+    }
+
     internal class SyntaxNormalizer : CSharpSyntaxRewriter
     {
         private readonly TextSpan _consideredSpan;
@@ -240,7 +278,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     return LineBreaksAfterSemicolon(currentToken, nextToken);
 
                 case SyntaxKind.CommaToken:
-                    return currentToken.Parent.IsKind(SyntaxKind.EnumDeclaration) || currentToken.Parent.IsKind(SyntaxKind.SwitchExpression) ? 1 : 0;
+                    return currentToken.Parent.IsKind(SyntaxKind.EnumDeclaration, SyntaxKind.SwitchExpression) ? 1 : 0;
                 case SyntaxKind.ElseKeyword:
                     return !nextToken.IsKind(SyntaxKind.IfKeyword) ? 1 : 0;
                 case SyntaxKind.ColonToken:
@@ -294,8 +332,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         private static int LineBreaksBeforeOpenBrace(SyntaxToken openBraceToken)
         {
             Debug.Assert(openBraceToken.IsKind(SyntaxKind.OpenBraceToken));
-            if (openBraceToken.Parent.IsKind(SyntaxKind.Interpolation) ||
-                openBraceToken.Parent.IsKind(SyntaxKind.PropertyPatternClause) ||
+            if (openBraceToken.Parent.IsKind(SyntaxKind.Interpolation, SyntaxKind.PropertyPatternClause) ||
                 openBraceToken.Parent is InitializerExpressionSyntax ||
                 IsAccessorListWithoutAccessorsWithBlockBody(openBraceToken.Parent))
             {
@@ -310,8 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         private static int LineBreaksBeforeCloseBrace(SyntaxToken closeBraceToken)
         {
             Debug.Assert(closeBraceToken.IsKind(SyntaxKind.CloseBraceToken));
-            if (closeBraceToken.Parent.IsKind(SyntaxKind.Interpolation) ||
-                closeBraceToken.Parent.IsKind(SyntaxKind.PropertyPatternClause) ||
+            if (closeBraceToken.Parent.IsKind(SyntaxKind.Interpolation, SyntaxKind.PropertyPatternClause) ||
                 closeBraceToken.Parent is InitializerExpressionSyntax)
             {
                 return 0;
@@ -324,8 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         private static int LineBreaksAfterOpenBrace(SyntaxToken currentToken, SyntaxToken nextToken)
         {
-            if (currentToken.Parent.IsKind(SyntaxKind.PropertyPatternClause) ||
-                currentToken.Parent.IsKind(SyntaxKind.Interpolation) ||
+            if (currentToken.Parent.IsKind(SyntaxKind.PropertyPatternClause, SyntaxKind.Interpolation) ||
                 currentToken.Parent is InitializerExpressionSyntax ||
                 IsAccessorListWithoutAccessorsWithBlockBody(currentToken.Parent))
             {
@@ -339,9 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         private static int LineBreaksAfterCloseBrace(SyntaxToken currentToken, SyntaxToken nextToken)
         {
-            if (currentToken.Parent.IsKind(SyntaxKind.SwitchExpression) ||
-                currentToken.Parent.IsKind(SyntaxKind.PropertyPatternClause) ||
-                currentToken.Parent.IsKind(SyntaxKind.Interpolation) ||
+            if (currentToken.Parent.IsKind(SyntaxKind.SwitchExpression, SyntaxKind.PropertyPatternClause, SyntaxKind.Interpolation) ||
                 currentToken.Parent is InitializerExpressionSyntax ||
                 currentToken.Parent?.Parent is AnonymousFunctionExpressionSyntax ||
                 IsAccessorListFollowedByInitializer(currentToken.Parent))
@@ -599,15 +632,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
             if (token.IsKind(SyntaxKind.ColonToken))
             {
-                return !token.Parent.IsKind(SyntaxKind.InterpolationFormatClause) &&
-                    !token.Parent.IsKind(SyntaxKind.XmlPrefix);
+                return !token.Parent.IsKind(SyntaxKind.InterpolationFormatClause, SyntaxKind.XmlPrefix);
             }
 
             if (next.IsKind(SyntaxKind.ColonToken))
             {
-                if (next.Parent.IsKind(SyntaxKind.BaseList) ||
-                    next.Parent.IsKind(SyntaxKind.TypeParameterConstraintClause) ||
-                    next.Parent is ConstructorInitializerSyntax)
+                if (next.Parent.IsKind(SyntaxKind.BaseList, SyntaxKind.TypeParameterConstraintClause, SyntaxKind.BaseConstructorInitializer, SyntaxKind.ThisConstructorInitializer))
                 {
                     return true;
                 }
@@ -1189,13 +1219,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                         return parentDepth + 1;
                     }
 
-                    if (node.IsKind(SyntaxKind.TypeParameterConstraintClause) ||
-                        node.IsKind(SyntaxKind.SwitchSection) ||
-                        node.IsKind(SyntaxKind.SwitchExpressionArm) ||
-                        node.IsKind(SyntaxKind.UsingDirective) ||
-                        node.IsKind(SyntaxKind.ExternAliasDirective) ||
-                        node.IsKind(SyntaxKind.QueryExpression) ||
-                        node.IsKind(SyntaxKind.QueryContinuation) ||
+                    if (node.IsKind(SyntaxKind.TypeParameterConstraintClause,
+                            SyntaxKind.SwitchSection,
+                            SyntaxKind.SwitchExpressionArm,
+                            SyntaxKind.UsingDirective,
+                            SyntaxKind.ExternAliasDirective,
+                            SyntaxKind.QueryExpression,
+                            SyntaxKind.QueryContinuation) ||
                         node is MemberDeclarationSyntax or AccessorDeclarationSyntax)
                     {
                         return parentDepth + 1;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         public override SyntaxToken VisitToken(SyntaxToken token)
         {
-            if (token.Kind() == SyntaxKind.None || (token.IsMissing && token.FullWidth == 0))
+            if (token.IsKind(SyntaxKind.None) || (token.IsMissing && token.FullWidth == 0))
             {
                 return token;
             }
@@ -130,8 +130,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
             // get next token, skipping zero width tokens except for end-of-directive tokens
             var nextToken = token.GetNextToken(
-                t => SyntaxToken.NonZeroWidth(t) || t.Kind() == SyntaxKind.EndOfDirectiveToken,
-                t => t.Kind() == SyntaxKind.SkippedTokensTrivia);
+                t => SyntaxToken.NonZeroWidth(t) || t.IsKind(SyntaxKind.EndOfDirectiveToken),
+                t => t.IsKind(SyntaxKind.SkippedTokensTrivia));
 
             if (_consideredSpan.Contains(nextToken.FullSpan))
             {
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return 1;
             }
 
-            if (nextToken.Kind() == SyntaxKind.None)
+            if (nextToken.IsKind(SyntaxKind.None))
             {
                 return 0;
             }
@@ -226,8 +226,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     // Note: the `where` case handles constraints on method declarations
                     //  and also `where` clauses (consistently with other LINQ cases below)
                     return (((currentToken.Parent is StatementSyntax) && nextToken.Parent != currentToken.Parent)
-                        || nextToken.Kind() == SyntaxKind.OpenBraceToken
-                        || nextToken.Kind() == SyntaxKind.WhereKeyword) ? 1 : 0;
+                        || nextToken.IsKind(SyntaxKind.OpenBraceToken)
+                        || nextToken.IsKind(SyntaxKind.WhereKeyword)) ? 1 : 0;
 
                 case SyntaxKind.CloseBracketToken:
                     if (currentToken.Parent.IsKind(SyntaxKind.AttributeList) && !currentToken.Parent.Parent.IsKind(SyntaxKind.Parameter))
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 case SyntaxKind.CommaToken:
                     return currentToken.Parent.IsKind(SyntaxKind.EnumDeclaration) || currentToken.Parent.IsKind(SyntaxKind.SwitchExpression) ? 1 : 0;
                 case SyntaxKind.ElseKeyword:
-                    return nextToken.Kind() != SyntaxKind.IfKeyword ? 1 : 0;
+                    return !nextToken.IsKind(SyntaxKind.IfKeyword) ? 1 : 0;
                 case SyntaxKind.ColonToken:
                     if (currentToken.Parent.IsKind(SyntaxKind.LabeledStatement) || currentToken.Parent is SwitchLabelSyntax)
                     {
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return false;
             }
 
-            if (next.Kind() == SyntaxKind.EndOfDirectiveToken)
+            if (next.IsKind(SyntaxKind.EndOfDirectiveToken))
             {
                 // In a directive, there's often no token between the directive keyword and 
                 // the end-of-directive, so we may need a separator.
@@ -579,8 +579,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return true;
             }
 
-            if (token.Kind() == SyntaxKind.SemicolonToken
-                && !(next.Kind() == SyntaxKind.SemicolonToken || next.Kind() == SyntaxKind.CloseParenToken))
+            if (token.IsKind(SyntaxKind.SemicolonToken)
+                && !(next.IsKind(SyntaxKind.SemicolonToken) || next.IsKind(SyntaxKind.CloseParenToken)))
             {
                 return true;
             }
@@ -1079,17 +1079,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         private static bool IsLineBreak(SyntaxToken token)
         {
-            return token.Kind() == SyntaxKind.XmlTextLiteralNewLineToken;
+            return token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken);
         }
 
         private static bool EndsInLineBreak(SyntaxTrivia trivia)
         {
-            if (trivia.Kind() == SyntaxKind.EndOfLineTrivia)
+            if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
             {
                 return true;
             }
 
-            if (trivia.Kind() == SyntaxKind.PreprocessingMessageTrivia || trivia.Kind() == SyntaxKind.DisabledTextTrivia)
+            if (trivia.IsKind(SyntaxKind.PreprocessingMessageTrivia) || trivia.IsKind(SyntaxKind.DisabledTextTrivia))
             {
                 var text = trivia.ToFullString();
                 return text.Length > 0 && SyntaxFacts.IsNewLine(text.Last());
@@ -1210,7 +1210,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         public override SyntaxNode? VisitInterpolatedStringExpression(InterpolatedStringExpressionSyntax node)
         {
-            if (node.StringStartToken.Kind() == SyntaxKind.InterpolatedStringStartToken)
+            if (node.StringStartToken.IsKind(SyntaxKind.InterpolatedStringStartToken))
             {
                 //Just for non verbatim strings we want to make sure that the formatting of interpolations does not emit line breaks.
                 //See: https://github.com/dotnet/roslyn/issues/50742

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -263,9 +263,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     }
                     // Note: the `where` case handles constraints on method declarations
                     //  and also `where` clauses (consistently with other LINQ cases below)
-                    return (((currentToken.Parent is StatementSyntax) && nextToken.Parent != currentToken.Parent)
-                        || nextToken.IsKind(SyntaxKind.OpenBraceToken)
-                        || nextToken.IsKind(SyntaxKind.WhereKeyword)) ? 1 : 0;
+                    return (nextToken.IsKind(SyntaxKind.OpenBraceToken) ||
+                        nextToken.IsKind(SyntaxKind.WhereKeyword) ||
+                        (currentToken.Parent is StatementSyntax && nextToken.Parent != currentToken.Parent)) ? 1 : 0;
 
                 case SyntaxKind.CloseBracketToken:
                     if (currentToken.Parent.IsKind(SyntaxKind.AttributeList) && !currentToken.Parent.Parent.IsKind(SyntaxKind.Parameter))
@@ -1213,7 +1213,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     }
 
                     if (node.Parent.IsKind(SyntaxKind.Block) ||
-                        (node is StatementSyntax && !node.IsKind(SyntaxKind.Block)))
+                        (!node.IsKind(SyntaxKind.Block) && node is StatementSyntax))
                     {
                         // all nested statements are indented one level
                         return parentDepth + 1;


### PR DESCRIPTION
There seem to be a *very little* performance gain here:

**Before first commit (run on 3.8.0):**

|               Method |      Mean |    Error |   StdDev |    Median |       Min |       Max | Gen 0 |     Gen 1 | Gen 2 | Allocated |
|--------------------- |----------:|---------:|---------:|----------:|----------:|----------:|-----------:|----------:|------:|----------:|
|  NormalizeWhitespace | 815.74 ms | 7.782 ms | 6.898 ms | 814.23 ms | 807.54 ms | 832.21 ms | 25000.0000 | 7000.0000 |     - |    146 MB |



**After first commit:**

|               Method |      Mean |    Error |   StdDev |    Median |       Min |       Max | Gen 0 |     Gen 1 | Gen 2 | Allocated |
|--------------------- |----------:|---------:|---------:|----------:|----------:|----------:|-----------:|----------:|------:|----------:|
|  NormalizeWhitespace | 769.77 ms | 1.871 ms | 1.563 ms | 769.94 ms | 767.83 ms | 773.58 ms | 16000.0000 | 4000.0000 |     - |     94 MB |

Here is how I benchmarked (based on dotnet/performance):

```csharp
    [BenchmarkCategory("Roslyn")]
    public class RoslynApis
    {
        private SyntaxNode _root;

        [GlobalSetup]
        public void InitializeRoot()
        {
            // benchmark is run against a well-formatted file, not sure if it does matter.
            _root = SyntaxFactory.ParseCompilationUnit(File.ReadAllText(@"C:\Users\PC\Desktop\Roslyn\src\Compilers\CSharp\Portable\Generated\CSharpSyntaxGenerator\CSharpSyntaxGenerator.SourceGenerator\Syntax.xml.Internal.Generated.cs"));
        }

        [Benchmark]
        public SyntaxNode NormalizeWhitespace()
        {
            return _root.NormalizeWhitespace();
        }
    }
}
```

---

Another benchmark with a tree with no trivia (i.e, have the syntax normalizer do actual work and put trivia):

**Before:**

|              Method |     Mean |   Error |  StdDev |   Median |      Min |      Max |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|--------:|--------:|---------:|---------:|---------:|-----------:|----------:|------:|----------:|
| NormalizeWhitespace | 772.7 ms | 4.39 ms | 3.89 ms | 772.7 ms | 767.4 ms | 781.2 ms | 24000.0000 | 8000.0000 |     - |    140 MB |

**After:**

|              Method |     Mean |   Error |  StdDev |   Median |      Min |      Max |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|--------:|--------:|---------:|---------:|---------:|-----------:|----------:|------:|----------:|
| NormalizeWhitespace | 743.7 ms | 3.01 ms | 2.67 ms | 744.4 ms | 738.2 ms | 747.1 ms | 15000.0000 | 4000.0000 |     - |     89 MB |

Updated benchmark code:

```csharp
  public class TriviaRemover : CSharpSyntaxRewriter
    {
        public override SyntaxNode Visit(SyntaxNode node) => base.Visit(node)?.WithoutTrivia();

        public override SyntaxTrivia VisitTrivia(SyntaxTrivia trivia) => default;
    }

    [BenchmarkCategory("Roslyn")]
    public class RoslynApis
    {
        private SyntaxNode _root;

        [GlobalSetup]
        public void InitializeRoot()
        {
            _root = SyntaxFactory.ParseCompilationUnit(File.ReadAllText(@"C:\Users\PC\Desktop\Roslyn\src\Compilers\CSharp\Portable\Generated\CSharpSyntaxGenerator\CSharpSyntaxGenerator.SourceGenerator\Syntax.xml.Internal.Generated.cs"));
            _root = ((CSharpSyntaxNode)_root).Accept(new TriviaRemover());
        }

        [Benchmark]
        public SyntaxNode NormalizeWhitespace()
        {
            return _root.NormalizeWhitespace();
        }
    }
}
```

---

After commit 3 (introducing IsKind with multiple kinds) added an extra improvement:

|              Method |     Mean |   Error |  StdDev |   Median |      Min |      Max |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|--------:|--------:|---------:|---------:|---------:|-----------:|----------:|------:|----------:|
| NormalizeWhitespace | 723.8 ms | 4.16 ms | 3.48 ms | 723.4 ms | 717.5 ms | 729.8 ms | 15000.0000 | 4000.0000 |     - |     89 MB |

---
