### PR TITLE
inheritdoc order fixes #54494

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6931,6 +6931,129 @@ public interface ICloneable<T>
                 Documentation("Clones a Test<T>."));
         }
 
+        [WorkItem(54494, "https://github.com/dotnet/roslyn/issues/54494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestInheritdocWithExplicitSummaryOveride()
+        {
+            var markup =
+@"
+/// <summary>hello world</summary>
+/// <typeparam name=""T"">hello world</typeparam>
+public class A<T> { }
+
+/// <inheritdoc/>
+/// <summary>goodbye world</summary>
+public class $$B<T> : A<T> { }
+";
+
+            await TestAsync(markup,
+                MainDescription("class B<T>"),
+                Documentation("goodbye world"));
+        }
+
+        [WorkItem(54494, "https://github.com/dotnet/roslyn/issues/54494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestInheritdocWithExplicitTypeParamOveride()
+        {
+            var markup =
+@"
+/// <summary>hello world</summary>
+/// <typeparam name=""T"">hello world</typeparam>
+public class A<T> { }
+
+/// <inheritdoc/>
+/// <typeparam name=""T"">goodbye world</typeparam>
+public class B<$$T> : A<T> { }
+";
+
+            await TestAsync(markup,
+                MainDescription("T in B<T>"),
+                Documentation("goodbye world"));
+        }
+
+        [WorkItem(54494, "https://github.com/dotnet/roslyn/issues/54494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestInheritdocWithExplicitReturnsOveride()
+        {
+            var markup =
+@"
+/// <summary>hello world</summary>
+/// <returns>hello world</returns>
+public object A() { }
+
+/// <inheritdoc cref=""A""/>
+/// <returns>goodbye world</returns>
+public object $$B() { }
+";
+
+            await TestInClassAsync(markup,
+                MainDescription("object C.B()"),
+                Documentation("hello world"),
+                Returns("\r\nReturns:\r\n  goodbye world"));
+        }
+
+        [WorkItem(54494, "https://github.com/dotnet/roslyn/issues/54494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestInheritdocWithExplicitRemarksOveride()
+        {
+            var markup =
+@"
+/// <summary>hello world</summary>
+/// <remarks>hello world</remarks>
+public object A() { }
+
+/// <inheritdoc cref=""A""/>
+/// <remarks>goodbye world</remarks>
+public object $$B() { }
+";
+
+            await TestInClassAsync(markup,
+                MainDescription("object C.B()"),
+                Documentation("hello world"),
+                Remarks("\r\ngoodbye world"));
+        }
+
+        [WorkItem(54494, "https://github.com/dotnet/roslyn/issues/54494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestInheritdocWithExplicitParamOveride()
+        {
+            var markup =
+@"
+/// <summary>hello world</summary>
+/// <param name=""a"">hello world</param>
+public void A(object a) { }
+
+/// <inheritdoc/>
+/// <param name=""a"">goodbye world</param>
+public void B(object $$a) { }
+";
+
+            await TestInClassAsync(markup,
+                MainDescription("(parameter) object a"),
+                Documentation("goodbye world"));
+        }
+
+        [WorkItem(54494, "https://github.com/dotnet/roslyn/issues/54494")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestInheritdocWithExplicitValueOveride()
+        {
+            var markup =
+@"
+/// <summary>hello world</summary>
+/// <value>hello world</value>
+public object A;
+
+/// <inheritdoc cref=""A""/>
+/// <value>goodbye world</value>
+public object $$B;
+";
+
+            await TestInClassAsync(markup,
+                MainDescription("(field) object C.B"),
+                Documentation("hello world"),
+                Value("\r\nValue:\r\n  goodbye world"));
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task TestInheritdocCycle1()
         {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -356,9 +356,18 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var result = new List<XNode>();
             foreach (var child in nodes)
             {
-                result.AddRange(RewriteInheritdocElements(symbol, visitedSymbols, compilation, child, cancellationToken));
+                if (!(child.NodeType == XmlNodeType.Element && ElementNameIs((XElement)child, DocumentationCommentXmlNames.InheritdocElementName)))
+                {
+                    result.AddRange(RewriteInheritdocElements(symbol, visitedSymbols, compilation, child, cancellationToken));
+                }
             }
-
+            foreach (var child in nodes)
+            {
+                if (child.NodeType == XmlNodeType.Element && ElementNameIs((XElement)child, DocumentationCommentXmlNames.InheritdocElementName))
+                {
+                    result.AddRange(RewriteInheritdocElements(symbol, visitedSymbols, compilation, child, cancellationToken));
+                }
+            }
             return result.ToArray();
         }
 


### PR DESCRIPTION
This PR add ordering to the logic of processing `inheritdoc`s to ensure that explicit XML on members overrides XML from `inheritdoc`s. fixes #54494

Coinsidering this is my first PR to https://github.com/dotnet/roslyn, I'm opening this as a draft PR until it is reviewed.