### PR TITLE
Minor record ToString improvements

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1016,6 +1016,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             return StringLiteral(ConstantValue.Create(stringValue));
         }
 
+        public BoundLiteral CharLiteral(ConstantValue charConst)
+        {
+            Debug.Assert(charConst.IsChar || charConst.IsDefaultValue);
+            return new BoundLiteral(Syntax, charConst, SpecialType(Microsoft.CodeAnalysis.SpecialType.System_Char)) { WasCompilerGenerated = true };
+        }
+
+        public BoundLiteral CharLiteral(Char charValue)
+        {
+            return CharLiteral(ConstantValue.Create(charValue));
+        }
+
         public BoundArrayLength ArrayLength(BoundExpression array)
         {
             Debug.Assert(array.Type is { TypeKind: TypeKind.Array });

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -171,7 +171,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var member = printableMembers[i];
                     var memberHeader = $"{member.Name} = ";
                     if (i > 0)
+                    {
                         memberHeader = ", " + memberHeader;
+                    }
 
                     block.Add(makeAppendString(F, builder, memberHeader));
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -162,14 +162,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 for (var i = 0; i < printableMembers.Length; i++)
                 {
-                    // builder.Append(<name>);
-                    // builder.Append(" = ");
-                    // builder.Append((object)<value>); OR builder.Append(<value>.ToString()); for value types
-                    // builder.Append(", "); // except for last member
+                    // builder.Append(", <name> = "); // if previous members exist
+                    // builder.Append("<name> = "); // if it is the first member
+
+                    // The only printable members are fields and properties,
+                    // which cannot be generic so as to have variant names
 
                     var member = printableMembers[i];
-                    block.Add(makeAppendString(F, builder, member.Name));
-                    block.Add(makeAppendString(F, builder, " = "));
+                    var memberHeader = $"{member.Name} = ";
+                    if (i > 0)
+                        memberHeader = ", " + member;
+
+                    block.Add(makeAppendString(F, builder, memberHeader));
 
                     var value = member.Kind switch
                     {
@@ -177,6 +181,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         SymbolKind.Property => F.Property(F.This(), (PropertySymbol)member),
                         _ => throw ExceptionUtilities.UnexpectedValue(member.Kind)
                     };
+
+                    // builder.Append((object)<value>); OR builder.Append(<value>.ToString()); for value types
 
                     Debug.Assert(value.Type is not null);
                     if (value.Type.IsValueType)
@@ -192,11 +198,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             F.Call(receiver: builder,
                                 F.WellKnownMethod(WellKnownMember.System_Text_StringBuilder__AppendObject),
                                 F.Convert(F.SpecialType(SpecialType.System_Object), value))));
-                    }
-
-                    if (i < printableMembers.Length - 1)
-                    {
-                        block.Add(makeAppendString(F, builder, ", "));
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordPrintMembers.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var member = printableMembers[i];
                     var memberHeader = $"{member.Name} = ";
                     if (i > 0)
-                        memberHeader = ", " + member;
+                        memberHeader = ", " + memberHeader;
 
                     block.Add(makeAppendString(F, builder, memberHeader));
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
@@ -66,11 +66,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // builder.Append(" { ");
                 block.Add(makeAppendString(F, builderLocal, " { "));
 
-                // if (this.PrintMembers(builder)) builder.Append(" ");
-                block.Add(F.If(F.Call(F.This(), _printMethod, builderLocal), makeAppendString(F, builderLocal, " ")));
+                // if (this.PrintMembers(builder)) builder.Append(' ');
+                block.Add(F.If(F.Call(F.This(), _printMethod, builderLocal), makeAppendChar(F, builderLocal, ' ')));
 
-                // builder.Append("}");
-                block.Add(makeAppendString(F, builderLocal, "}"));
+                // builder.Append('}');
+                block.Add(makeAppendChar(F, builderLocal, '}'));
 
                 // return builder.ToString();
                 block.Add(F.Return(F.Call(builderLocal, F.SpecialMethod(SpecialMember.System_Object__ToString))));
@@ -86,6 +86,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             static BoundStatement makeAppendString(SyntheticBoundNodeFactory F, BoundLocal builder, string value)
             {
                 return F.ExpressionStatement(F.Call(receiver: builder, F.WellKnownMethod(WellKnownMember.System_Text_StringBuilder__AppendString), F.StringLiteral(value)));
+            }
+            static BoundStatement makeAppendChar(SyntheticBoundNodeFactory F, BoundLocal builder, char value)
+            {
+                return F.ExpressionStatement(F.Call(receiver: builder, F.WellKnownMethod(WellKnownMember.System_Text_StringBuilder__AppendChar), F.CharLiteral(value)));
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordToString.cs
@@ -87,6 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return F.ExpressionStatement(F.Call(receiver: builder, F.WellKnownMethod(WellKnownMember.System_Text_StringBuilder__AppendString), F.StringLiteral(value)));
             }
+
             static BoundStatement makeAppendChar(SyntheticBoundNodeFactory F, BoundLocal builder, char value)
             {
                 return F.ExpressionStatement(F.Call(receiver: builder, F.WellKnownMethod(WellKnownMember.System_Text_StringBuilder__AppendChar), F.CharLiteral(value)));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -2054,6 +2054,7 @@ namespace System
     public class String { }
     public struct Void { }
     public struct Boolean { }
+    public struct Char { }
     public struct Int32 { }
     public interface IEquatable<T> { }
 }
@@ -2070,7 +2071,8 @@ namespace System.Text
     public class StringBuilder
     {
         public StringBuilder Append(string s) => null;
-        public StringBuilder Append(object s) => null;
+        public StringBuilder Append(char c) => null;
+        public StringBuilder Append(object o) => null;
     }
 }
 ";
@@ -2146,6 +2148,7 @@ namespace System
     public class String { }
     public struct Void { }
     public struct Boolean { }
+    public struct Char { }
     public struct Int32 { }
     public interface IEquatable<T> { }
 }
@@ -2162,7 +2165,8 @@ namespace System.Text
     public class StringBuilder
     {
         public StringBuilder Append(string s) => null;
-        public StringBuilder Append(object s) => null;
+        public StringBuilder Append(char c) => null;
+        public StringBuilder Append(object o) => null;
     }
 }
 ";
@@ -4069,6 +4073,7 @@ namespace System
     public class String { }
     public struct Void { }
     public struct Boolean { }
+    public struct Char { }
     public struct Int32 { }
     public interface IEquatable<T> { }
 }
@@ -4085,7 +4090,8 @@ namespace System.Text
     public class StringBuilder
     {
         public StringBuilder Append(string s) => null;
-        public StringBuilder Append(object s) => null;
+        public StringBuilder Append(char c) => null;
+        public StringBuilder Append(object o) => null;
     }
 }
 ";
@@ -4320,6 +4326,7 @@ namespace System
     public class String { }
     public struct Void { }
     public struct Boolean { }
+    public struct Char { }
     public struct Int32 { }
     public interface IEquatable<T> { }
 }
@@ -4336,7 +4343,8 @@ namespace System.Text
     public class StringBuilder
     {
         public StringBuilder Append(string s) => null;
-        public StringBuilder Append(object s) => null;
+        public StringBuilder Append(char c) => null;
+        public StringBuilder Append(object o) => null;
     }
 }
 ";
@@ -4707,7 +4715,7 @@ record struct C1;
 ");
             v.VerifyIL("C1." + WellKnownMemberNames.ObjectToString, @"
 {
-  // Code size       70 (0x46)
+  // Code size       64 (0x40)
   .maxstack  2
   .locals init (System.Text.StringBuilder V_0)
   IL_0000:  newobj     ""System.Text.StringBuilder..ctor()""
@@ -4723,18 +4731,18 @@ record struct C1;
   IL_001e:  ldarg.0
   IL_001f:  ldloc.0
   IL_0020:  call       ""bool C1.PrintMembers(System.Text.StringBuilder)""
-  IL_0025:  brfalse.s  IL_0033
+  IL_0025:  brfalse.s  IL_0030
   IL_0027:  ldloc.0
-  IL_0028:  ldstr      "" ""
-  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0032:  pop
-  IL_0033:  ldloc.0
-  IL_0034:  ldstr      ""}""
-  IL_0039:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_003e:  pop
-  IL_003f:  ldloc.0
-  IL_0040:  callvirt   ""string object.ToString()""
-  IL_0045:  ret
+  IL_0028:  ldc.i4.s   32
+  IL_002a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_002f:  pop
+  IL_0030:  ldloc.0
+  IL_0031:  ldc.i4.s   125
+  IL_0033:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_0038:  pop
+  IL_0039:  ldloc.0
+  IL_003a:  callvirt   ""string object.ToString()""
+  IL_003f:  ret
 }
 ");
         }
@@ -4903,25 +4911,21 @@ record struct C1
 
             v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       50 (0x32)
+  // Code size       38 (0x26)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""field""
+  IL_0001:  ldstr      ""field = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  ldflda     ""int C1.field""
-  IL_001f:  constrained. ""int""
-  IL_0025:  callvirt   ""string object.ToString()""
-  IL_002a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_002f:  pop
-  IL_0030:  ldc.i4.1
-  IL_0031:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  ldflda     ""int C1.field""
+  IL_0013:  constrained. ""int""
+  IL_0019:  callvirt   ""string object.ToString()""
+  IL_001e:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0023:  pop
+  IL_0024:  ldc.i4.1
+  IL_0025:  ret
 }
 ");
         }
@@ -4945,25 +4949,21 @@ record struct C1<T> where T : struct
 
             v.VerifyIL("C1<T>." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       50 (0x32)
+  // Code size       38 (0x26)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""field""
+  IL_0001:  ldstr      ""field = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  ldflda     ""T C1<T>.field""
-  IL_001f:  constrained. ""T""
-  IL_0025:  callvirt   ""string object.ToString()""
-  IL_002a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_002f:  pop
-  IL_0030:  ldc.i4.1
-  IL_0031:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  ldflda     ""T C1<T>.field""
+  IL_0013:  constrained. ""T""
+  IL_0019:  callvirt   ""string object.ToString()""
+  IL_001e:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0023:  pop
+  IL_0024:  ldc.i4.1
+  IL_0025:  ret
 }
 ");
         }
@@ -4987,23 +4987,19 @@ record struct C1
 
             v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       39 (0x27)
+  // Code size       27 (0x1b)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""field""
+  IL_0001:  ldstr      ""field = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  ldfld      ""string C1.field""
-  IL_001f:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
-  IL_0024:  pop
-  IL_0025:  ldc.i4.1
-  IL_0026:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  ldfld      ""string C1.field""
+  IL_0013:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
+  IL_0018:  pop
+  IL_0019:  ldc.i4.1
+  IL_001a:  ret
 }
 ");
         }
@@ -5035,62 +5031,42 @@ record struct C1(int I)
 
             v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size      151 (0x97)
+  // Code size       91 (0x5b)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""I""
+  IL_0001:  ldstr      ""I = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  call       ""readonly int C1.I.get""
-  IL_001f:  stloc.0
-  IL_0020:  ldloca.s   V_0
-  IL_0022:  constrained. ""int""
-  IL_0028:  callvirt   ""string object.ToString()""
+  IL_000d:  ldarg.0
+  IL_000e:  call       ""readonly int C1.I.get""
+  IL_0013:  stloc.0
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  constrained. ""int""
+  IL_001c:  callvirt   ""string object.ToString()""
+  IL_0021:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0026:  pop
+  IL_0027:  ldarg.1
+  IL_0028:  ldstr      "", field1 = ""
   IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_0032:  pop
   IL_0033:  ldarg.1
-  IL_0034:  ldstr      "", ""
-  IL_0039:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_003e:  pop
-  IL_003f:  ldarg.1
-  IL_0040:  ldstr      ""field1""
-  IL_0045:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_004a:  pop
-  IL_004b:  ldarg.1
-  IL_004c:  ldstr      "" = ""
-  IL_0051:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0056:  pop
-  IL_0057:  ldarg.1
-  IL_0058:  ldarg.0
-  IL_0059:  ldfld      ""string C1.field1""
-  IL_005e:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
-  IL_0063:  pop
-  IL_0064:  ldarg.1
-  IL_0065:  ldstr      "", ""
-  IL_006a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_006f:  pop
-  IL_0070:  ldarg.1
-  IL_0071:  ldstr      ""field2""
-  IL_0076:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_007b:  pop
-  IL_007c:  ldarg.1
-  IL_007d:  ldstr      "" = ""
-  IL_0082:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0087:  pop
-  IL_0088:  ldarg.1
-  IL_0089:  ldarg.0
-  IL_008a:  ldfld      ""string C1.field2""
-  IL_008f:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
-  IL_0094:  pop
-  IL_0095:  ldc.i4.1
-  IL_0096:  ret
+  IL_0034:  ldarg.0
+  IL_0035:  ldfld      ""string C1.field1""
+  IL_003a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
+  IL_003f:  pop
+  IL_0040:  ldarg.1
+  IL_0041:  ldstr      "", field2 = ""
+  IL_0046:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_004b:  pop
+  IL_004c:  ldarg.1
+  IL_004d:  ldarg.0
+  IL_004e:  ldfld      ""string C1.field2""
+  IL_0053:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
+  IL_0058:  pop
+  IL_0059:  ldc.i4.1
+  IL_005a:  ret
 }
 ");
         }
@@ -5111,33 +5087,29 @@ readonly record struct C1(int I);
 
             v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       53 (0x35)
+  // Code size       41 (0x29)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""I""
+  IL_0001:  ldstr      ""I = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  call       ""int C1.I.get""
-  IL_001f:  stloc.0
-  IL_0020:  ldloca.s   V_0
-  IL_0022:  constrained. ""int""
-  IL_0028:  callvirt   ""string object.ToString()""
-  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0032:  pop
-  IL_0033:  ldc.i4.1
-  IL_0034:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  call       ""int C1.I.get""
+  IL_0013:  stloc.0
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  constrained. ""int""
+  IL_001c:  callvirt   ""string object.ToString()""
+  IL_0021:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0026:  pop
+  IL_0027:  ldc.i4.1
+  IL_0028:  ret
 }
 ");
             v.VerifyIL("C1." + WellKnownMemberNames.ObjectToString, @"
 {
-  // Code size       70 (0x46)
+  // Code size       64 (0x40)
   .maxstack  2
   .locals init (System.Text.StringBuilder V_0)
   IL_0000:  newobj     ""System.Text.StringBuilder..ctor()""
@@ -5153,18 +5125,18 @@ readonly record struct C1(int I);
   IL_001e:  ldarg.0
   IL_001f:  ldloc.0
   IL_0020:  call       ""bool C1.PrintMembers(System.Text.StringBuilder)""
-  IL_0025:  brfalse.s  IL_0033
+  IL_0025:  brfalse.s  IL_0030
   IL_0027:  ldloc.0
-  IL_0028:  ldstr      "" ""
-  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0032:  pop
-  IL_0033:  ldloc.0
-  IL_0034:  ldstr      ""}""
-  IL_0039:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_003e:  pop
-  IL_003f:  ldloc.0
-  IL_0040:  callvirt   ""string object.ToString()""
-  IL_0045:  ret
+  IL_0028:  ldc.i4.s   32
+  IL_002a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_002f:  pop
+  IL_0030:  ldloc.0
+  IL_0031:  ldc.i4.s   125
+  IL_0033:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_0038:  pop
+  IL_0039:  ldloc.0
+  IL_003a:  callvirt   ""string object.ToString()""
+  IL_003f:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -5002,7 +5002,7 @@ record C1;
 ");
             v.VerifyIL("C1." + WellKnownMemberNames.ObjectToString, @"
 {
-  // Code size       70 (0x46)
+  // Code size       64 (0x40)
   .maxstack  2
   .locals init (System.Text.StringBuilder V_0)
   IL_0000:  newobj     ""System.Text.StringBuilder..ctor()""
@@ -5018,18 +5018,18 @@ record C1;
   IL_001e:  ldarg.0
   IL_001f:  ldloc.0
   IL_0020:  callvirt   ""bool C1.PrintMembers(System.Text.StringBuilder)""
-  IL_0025:  brfalse.s  IL_0033
+  IL_0025:  brfalse.s  IL_0030
   IL_0027:  ldloc.0
-  IL_0028:  ldstr      "" ""
-  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0032:  pop
-  IL_0033:  ldloc.0
-  IL_0034:  ldstr      ""}""
-  IL_0039:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_003e:  pop
-  IL_003f:  ldloc.0
-  IL_0040:  callvirt   ""string object.ToString()""
-  IL_0045:  ret
+  IL_0028:  ldc.i4.s   32
+  IL_002a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_002f:  pop
+  IL_0030:  ldloc.0
+  IL_0031:  ldc.i4.s   125
+  IL_0033:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_0038:  pop
+  IL_0039:  ldloc.0
+  IL_003a:  callvirt   ""string object.ToString()""
+  IL_003f:  ret
 }
 ");
         }
@@ -5077,7 +5077,7 @@ record C2 : C1
 ");
             v.VerifyIL("C1." + WellKnownMemberNames.ObjectToString, @"
 {
-  // Code size       70 (0x46)
+  // Code size       64 (0x40)
   .maxstack  2
   .locals init (System.Text.StringBuilder V_0)
   IL_0000:  newobj     ""System.Text.StringBuilder..ctor()""
@@ -5093,18 +5093,18 @@ record C2 : C1
   IL_001e:  ldarg.0
   IL_001f:  ldloc.0
   IL_0020:  callvirt   ""bool C1.PrintMembers(System.Text.StringBuilder)""
-  IL_0025:  brfalse.s  IL_0033
+  IL_0025:  brfalse.s  IL_0030
   IL_0027:  ldloc.0
-  IL_0028:  ldstr      "" ""
-  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0032:  pop
-  IL_0033:  ldloc.0
-  IL_0034:  ldstr      ""}""
-  IL_0039:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_003e:  pop
-  IL_003f:  ldloc.0
-  IL_0040:  callvirt   ""string object.ToString()""
-  IL_0045:  ret
+  IL_0028:  ldc.i4.s   32
+  IL_002a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_002f:  pop
+  IL_0030:  ldloc.0
+  IL_0031:  ldc.i4.s   125
+  IL_0033:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_0038:  pop
+  IL_0039:  ldloc.0
+  IL_003a:  callvirt   ""string object.ToString()""
+  IL_003f:  ret
 }
 ");
         }
@@ -5156,7 +5156,7 @@ record C2 : C1
 ");
             v.VerifyIL("C1." + WellKnownMemberNames.ObjectToString, @"
 {
-  // Code size       70 (0x46)
+  // Code size       64 (0x40)
   .maxstack  2
   .locals init (System.Text.StringBuilder V_0)
   IL_0000:  newobj     ""System.Text.StringBuilder..ctor()""
@@ -5172,18 +5172,18 @@ record C2 : C1
   IL_001e:  ldarg.0
   IL_001f:  ldloc.0
   IL_0020:  callvirt   ""bool Base.PrintMembers(System.Text.StringBuilder)""
-  IL_0025:  brfalse.s  IL_0033
+  IL_0025:  brfalse.s  IL_0030
   IL_0027:  ldloc.0
-  IL_0028:  ldstr      "" ""
-  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0032:  pop
-  IL_0033:  ldloc.0
-  IL_0034:  ldstr      ""}""
-  IL_0039:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_003e:  pop
-  IL_003f:  ldloc.0
-  IL_0040:  callvirt   ""string object.ToString()""
-  IL_0045:  ret
+  IL_0028:  ldc.i4.s   32
+  IL_002a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_002f:  pop
+  IL_0030:  ldloc.0
+  IL_0031:  ldc.i4.s   125
+  IL_0033:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(char)""
+  IL_0038:  pop
+  IL_0039:  ldloc.0
+  IL_003a:  callvirt   ""string object.ToString()""
+  IL_003f:  ret
 }
 ");
         }
@@ -5251,6 +5251,26 @@ record C1(int P);
 
             var comp = CreateCompilation(src);
             comp.MakeMemberMissing(WellKnownMember.System_Text_StringBuilder__AppendString);
+            comp.VerifyEmitDiagnostics(
+                // (2,1): error CS0656: Missing compiler required member 'System.Text.StringBuilder.Append'
+                // record C1(int P);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "record C1(int P);").WithArguments("System.Text.StringBuilder", "Append").WithLocation(2, 1),
+                // (2,1): error CS0656: Missing compiler required member 'System.Text.StringBuilder.Append'
+                // record C1(int P);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "record C1(int P);").WithArguments("System.Text.StringBuilder", "Append").WithLocation(2, 1)
+                );
+        }
+
+        [Fact]
+        public void ToString_TopLevelRecord_OneProperty_MissingStringBuilderAppendStringAndChar()
+        {
+            var src = @"
+record C1(int P);
+";
+
+            var comp = CreateCompilation(src);
+            comp.MakeMemberMissing(WellKnownMember.System_Text_StringBuilder__AppendString);
+            comp.MakeMemberMissing(WellKnownMember.System_Text_StringBuilder__AppendChar);
             comp.VerifyEmitDiagnostics(
                 // (2,1): error CS0656: Missing compiler required member 'System.Text.StringBuilder.Append'
                 // record C1(int P);
@@ -5541,25 +5561,21 @@ record C1
 
             v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       50 (0x32)
+  // Code size       38 (0x26)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""field""
+  IL_0001:  ldstr      ""field = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  ldflda     ""int C1.field""
-  IL_001f:  constrained. ""int""
-  IL_0025:  callvirt   ""string object.ToString()""
-  IL_002a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_002f:  pop
-  IL_0030:  ldc.i4.1
-  IL_0031:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  ldflda     ""int C1.field""
+  IL_0013:  constrained. ""int""
+  IL_0019:  callvirt   ""string object.ToString()""
+  IL_001e:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0023:  pop
+  IL_0024:  ldc.i4.1
+  IL_0025:  ret
 }
 ");
         }
@@ -5583,25 +5599,21 @@ record C1<T> where T : struct
 
             v.VerifyIL("C1<T>." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       50 (0x32)
+  // Code size       38 (0x26)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""field""
+  IL_0001:  ldstr      ""field = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  ldflda     ""T C1<T>.field""
-  IL_001f:  constrained. ""T""
-  IL_0025:  callvirt   ""string object.ToString()""
-  IL_002a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_002f:  pop
-  IL_0030:  ldc.i4.1
-  IL_0031:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  ldflda     ""T C1<T>.field""
+  IL_0013:  constrained. ""T""
+  IL_0019:  callvirt   ""string object.ToString()""
+  IL_001e:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0023:  pop
+  IL_0024:  ldc.i4.1
+  IL_0025:  ret
 }
 ");
         }
@@ -5625,23 +5637,19 @@ record C1
 
             v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       39 (0x27)
+  // Code size       27 (0x1b)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""field""
+  IL_0001:  ldstr      ""field = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  ldfld      ""string C1.field""
-  IL_001f:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
-  IL_0024:  pop
-  IL_0025:  ldc.i4.1
-  IL_0026:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  ldfld      ""string C1.field""
+  IL_0013:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
+  IL_0018:  pop
+  IL_0019:  ldc.i4.1
+  IL_001a:  ret
 }
 ");
         }
@@ -5669,24 +5677,20 @@ record C1<T>
 
             v.VerifyIL("C1<T>." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       44 (0x2c)
+  // Code size       32 (0x20)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""field""
+  IL_0001:  ldstr      ""field = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  ldfld      ""T C1<T>.field""
-  IL_001f:  box        ""T""
-  IL_0024:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
-  IL_0029:  pop
-  IL_002a:  ldc.i4.1
-  IL_002b:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  ldfld      ""T C1<T>.field""
+  IL_0013:  box        ""T""
+  IL_0018:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
+  IL_001d:  pop
+  IL_001e:  ldc.i4.1
+  IL_001f:  ret
 }
 ");
         }
@@ -5754,40 +5758,28 @@ record C1
 
             v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       88 (0x58)
+  // Code size       52 (0x34)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""field1""
+  IL_0001:  ldstr      ""field1 = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  ldfld      ""string C1.field1""
-  IL_001f:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
+  IL_000d:  ldarg.0
+  IL_000e:  ldfld      ""string C1.field1""
+  IL_0013:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
+  IL_0018:  pop
+  IL_0019:  ldarg.1
+  IL_001a:  ldstr      "", field2 = ""
+  IL_001f:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_0024:  pop
   IL_0025:  ldarg.1
-  IL_0026:  ldstr      "", ""
-  IL_002b:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0030:  pop
-  IL_0031:  ldarg.1
-  IL_0032:  ldstr      ""field2""
-  IL_0037:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_003c:  pop
-  IL_003d:  ldarg.1
-  IL_003e:  ldstr      "" = ""
-  IL_0043:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0048:  pop
-  IL_0049:  ldarg.1
-  IL_004a:  ldarg.0
-  IL_004b:  ldfld      ""string C1.field2""
-  IL_0050:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
-  IL_0055:  pop
-  IL_0056:  ldc.i4.1
-  IL_0057:  ret
+  IL_0026:  ldarg.0
+  IL_0027:  ldfld      ""string C1.field2""
+  IL_002c:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(object)""
+  IL_0031:  pop
+  IL_0032:  ldc.i4.1
+  IL_0033:  ret
 }
 ");
         }
@@ -5819,28 +5811,24 @@ record C1(int Property)
 
             v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       53 (0x35)
+  // Code size       41 (0x29)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      ""Property""
+  IL_0001:  ldstr      ""Property = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
-  IL_000d:  ldstr      "" = ""
-  IL_0012:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0017:  pop
-  IL_0018:  ldarg.1
-  IL_0019:  ldarg.0
-  IL_001a:  call       ""int C1.Property.get""
-  IL_001f:  stloc.0
-  IL_0020:  ldloca.s   V_0
-  IL_0022:  constrained. ""int""
-  IL_0028:  callvirt   ""string object.ToString()""
-  IL_002d:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0032:  pop
-  IL_0033:  ldc.i4.1
-  IL_0034:  ret
+  IL_000d:  ldarg.0
+  IL_000e:  call       ""int C1.Property.get""
+  IL_0013:  stloc.0
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  constrained. ""int""
+  IL_001c:  callvirt   ""string object.ToString()""
+  IL_0021:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0026:  pop
+  IL_0027:  ldc.i4.1
+  IL_0028:  ret
 }
 ");
         }
@@ -5885,9 +5873,9 @@ record C1(int A1, int B1) : Base(A1)
             comp.VerifyEmitDiagnostics();
             var v = CompileAndVerify(comp, expectedOutput: "C1 { A1 = 42, A2 = 100, B1 = 43, B2 = 101 }", verify: Verification.Skipped /* init-only */);
 
-            v.VerifyIL("C1.PrintMembers", @"
+            v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size      134 (0x86)
+  // Code size       98 (0x62)
   .maxstack  2
   .locals init (int V_0)
   IL_0000:  ldarg.0
@@ -5899,43 +5887,31 @@ record C1(int A1, int B1) : Base(A1)
   IL_000f:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_0014:  pop
   IL_0015:  ldarg.1
-  IL_0016:  ldstr      ""B1""
+  IL_0016:  ldstr      ""B1 = ""
   IL_001b:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_0020:  pop
   IL_0021:  ldarg.1
-  IL_0022:  ldstr      "" = ""
-  IL_0027:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_002c:  pop
-  IL_002d:  ldarg.1
-  IL_002e:  ldarg.0
-  IL_002f:  call       ""int C1.B1.get""
-  IL_0034:  stloc.0
-  IL_0035:  ldloca.s   V_0
-  IL_0037:  constrained. ""int""
-  IL_003d:  callvirt   ""string object.ToString()""
+  IL_0022:  ldarg.0
+  IL_0023:  call       ""int C1.B1.get""
+  IL_0028:  stloc.0
+  IL_0029:  ldloca.s   V_0
+  IL_002b:  constrained. ""int""
+  IL_0031:  callvirt   ""string object.ToString()""
+  IL_0036:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_003b:  pop
+  IL_003c:  ldarg.1
+  IL_003d:  ldstr      "", B2 = ""
   IL_0042:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_0047:  pop
   IL_0048:  ldarg.1
-  IL_0049:  ldstr      "", ""
-  IL_004e:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0053:  pop
-  IL_0054:  ldarg.1
-  IL_0055:  ldstr      ""B2""
+  IL_0049:  ldarg.0
+  IL_004a:  ldflda     ""int C1.B2""
+  IL_004f:  constrained. ""int""
+  IL_0055:  callvirt   ""string object.ToString()""
   IL_005a:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_005f:  pop
-  IL_0060:  ldarg.1
-  IL_0061:  ldstr      "" = ""
-  IL_0066:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_006b:  pop
-  IL_006c:  ldarg.1
-  IL_006d:  ldarg.0
-  IL_006e:  ldflda     ""int C1.B2""
-  IL_0073:  constrained. ""int""
-  IL_0079:  callvirt   ""string object.ToString()""
-  IL_007e:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0083:  pop
-  IL_0084:  ldc.i4.1
-  IL_0085:  ret
+  IL_0060:  ldc.i4.1
+  IL_0061:  ret
 }
 ");
         }
@@ -16362,6 +16338,7 @@ public record B : A {
     public abstract class ValueType { }
     public struct Void { }
     public struct Boolean { }
+    public struct Char { }
     public struct Int32 { }
     public interface IEquatable<T>
     {
@@ -16373,7 +16350,8 @@ namespace System.Text
     public class StringBuilder
     {
         public StringBuilder Append(string s) => null;
-        public StringBuilder Append(object s) => null;
+        public StringBuilder Append(char c) => null;
+        public StringBuilder Append(object o) => null;
     }
 }
 ";
@@ -17305,6 +17283,7 @@ public record B : A {
     public abstract class ValueType { }
     public struct Void { }
     public struct Boolean { }
+    public struct Char { }
     public struct Int32 { }
     public interface IEquatable<T>
     {
@@ -17316,7 +17295,8 @@ namespace System.Text
     public class StringBuilder
     {
         public StringBuilder Append(string s) => null;
-        public StringBuilder Append(object s) => null;
+        public StringBuilder Append(char c) => null;
+        public StringBuilder Append(object o) => null;
     }
 }
 
@@ -17403,6 +17383,7 @@ public record A {
     public abstract class ValueType { }
     public struct Void { }
     public struct Boolean { }
+    public struct Char { }
     public struct Int32 { }
     public interface IEquatable<T>
     {
@@ -17414,7 +17395,8 @@ namespace System.Text
     public class StringBuilder
     {
         public StringBuilder Append(string s) => null;
-        public StringBuilder Append(object s) => null;
+        public StringBuilder Append(char c) => null;
+        public StringBuilder Append(object o) => null;
     }
 }
 ";
@@ -17497,6 +17479,7 @@ public record A {
     public abstract class ValueType { }
     public struct Void { }
     public struct Boolean { }
+    public struct Char { }
     public struct Int32 { }
     public interface IEquatable<T>
     {
@@ -17508,7 +17491,8 @@ namespace System.Text
     public class StringBuilder
     {
         public StringBuilder Append(string s) => null;
-        public StringBuilder Append(object s) => null;
+        public StringBuilder Append(char c) => null;
+        public StringBuilder Append(object o) => null;
     }
 }
 ";

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -508,9 +508,9 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags,
 
         System_Text_StringBuilder__AppendString,
+        System_Text_StringBuilder__AppendChar,
         System_Text_StringBuilder__AppendObject,
         System_Text_StringBuilder__ctor,
-        System_Text_StringBuilder__AppendChar,
 
         Count
 

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -510,6 +510,7 @@ namespace Microsoft.CodeAnalysis
         System_Text_StringBuilder__AppendString,
         System_Text_StringBuilder__AppendObject,
         System_Text_StringBuilder__ctor,
+        System_Text_StringBuilder__AppendChar,
 
         Count
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3489,6 +3489,14 @@ namespace Microsoft.CodeAnalysis
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Text_StringBuilder - WellKnownType.ExtSentinel), // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
+                    
+                // System_Text_StringBuilder__AppendChar
+                (byte)MemberFlags.Method,                                                                                   // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Text_StringBuilder - WellKnownType.ExtSentinel),    // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Text_StringBuilder - WellKnownType.ExtSentinel), // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Char,
 
                 // System_Text_StringBuilder__AppendObject
                 (byte)MemberFlags.Method,                                                                                   // Flags
@@ -3942,6 +3950,7 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_NativeIntegerAttribute__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags
                 "Append",                                   // System_Text_StringBuilder__AppendString
+                "Append",                                   // System_Text_StringBuilder__AppendChar
                 "Append",                                   // System_Text_StringBuilder__AppendObject
                 ".ctor",                                    // System_Text_StringBuilder__ctor
             };


### PR DESCRIPTION
Closes #54600 

This implements all the mentioned improvements
- reduced calls to `Append(string)`
- preferring usage of `Append(char)`

Additionally, also changes some tests to comfort to the new changes to the emitted IL and diagnostics.

# Effects
As measured from the diffs of the expected emitted IL tests:
- `ToString` gets a -6 byte code size
- `PrintMembers` gets -12 byte code size for 1 member, -36 for 2, expected formula: `-12 - 24 * (members - 1)`