### PR TITLE
Emit caller argument expression parameter name in correct casing

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -44,6 +44,84 @@ class Program
         }
 
         [ConditionalFact(typeof(CoreClrOnly))]
+        public void TestGoodCallerArgumentExpressionAttribute_MultipleAttributes()
+        {
+            string source = @"
+using System;
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
+    public sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+        public string ParameterName { get; }
+    }
+}
+
+class Program
+{
+    public static void Main()
+    {
+        Log(123, 456);
+    }
+    const string p1 = nameof(p1);
+    const string p2 = nameof(p2);
+    static void Log(int p1, int p2, [CallerArgumentExpression(p1), CallerArgumentExpression(p2)] string arg = ""<default-arg>"")
+    {
+        Console.WriteLine(arg);
+    }
+}
+";
+
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(compilation, expectedOutput: "456").VerifyDiagnostics();
+        }
+
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void TestGoodCallerArgumentExpressionAttribute_MultipleAttributes_IncorrectCtor()
+        {
+            string source = @"
+using System;
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
+    public sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        public CallerArgumentExpressionAttribute(string parameterName, int extraParam)
+        {
+            ParameterName = parameterName;
+        }
+        public string ParameterName { get; }
+    }
+}
+
+class Program
+{
+    public static void Main()
+    {
+        Log(123, 456);
+    }
+    const string p1 = nameof(p1);
+    const string p2 = nameof(p2);
+    static void Log(int p1, int p2, [CallerArgumentExpression(p1, 0), CallerArgumentExpression(p2, 1)] string arg = ""<default-arg>"")
+    {
+        Console.WriteLine(arg);
+    }
+}
+";
+
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(compilation, expectedOutput: "<default-arg>").VerifyDiagnostics();
+        }
+
+        [ConditionalFact(typeof(CoreClrOnly))]
         public void TestGoodCallerArgumentExpressionAttribute_ExpressionHasTrivia()
         {
             string source = @"

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
@@ -276,6 +276,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         ' want to emit the parameter name with correct casing, so that it works with C#.
                         Dim correctedParameterName = ContainingSymbol.GetParameters()(callerArgumentExpressionParameterIndex).Name
                         Dim oldTypedConstant = attribute.CommonConstructorArguments.Single()
+                        If correctedParameterName.Equals(oldTypedConstant.Value.ToString(), StringComparison.Ordinal) Then
+                            Yield attribute
+                            Continue For
+                        End If
                         Dim newArgs = ImmutableArray.Create(New TypedConstant(oldTypedConstant.TypeInternal, oldTypedConstant.Kind, correctedParameterName))
                         Yield New SourceAttributeData(attribute.ApplicationSyntaxReference, attribute.AttributeClass, attribute.AttributeConstructor, newArgs, attribute.CommonNamedArguments, attribute.IsConditionallyOmitted, attribute.HasErrors)
                         Continue For

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
@@ -264,6 +264,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return MyBase.EarlyDecodeWellKnownAttribute(arguments)
         End Function
 
+        Friend Overrides Iterator Function GetCustomAttributesToEmit(compilationState As ModuleCompilationState) As IEnumerable(Of VisualBasicAttributeData)
+            Dim attributes = MyBase.GetCustomAttributesToEmit(compilationState)
+            For Each attribute In attributes
+                If AttributeData.IsTargetEarlyAttribute(attributeType:=attribute.AttributeClass, attributeArgCount:=attribute.CommonConstructorArguments.Length, description:=AttributeDescription.CallerArgumentExpressionAttribute) Then
+                    Dim callerArgumentExpressionParameterIndex = Me.CallerArgumentExpressionParameterIndex
+                    If callerArgumentExpressionParameterIndex <> -1 AndAlso TypeOf attribute Is SourceAttributeData Then
+                        Debug.Assert(callerArgumentExpressionParameterIndex >= 0)
+                        Debug.Assert(attribute.CommonConstructorArguments.Length = 1)
+                        ' We allow CallerArgumentExpression to have case-insensitive parameter name, but we
+                        ' want to emit the parameter name with correct casing, so that it works with C#.
+                        Dim correctedParameterName = ContainingSymbol.GetParameters()(callerArgumentExpressionParameterIndex).Name
+                        Dim oldTypedConstant = attribute.CommonConstructorArguments.Single()
+                        Dim newArgs = ImmutableArray.Create(New TypedConstant(oldTypedConstant.TypeInternal, oldTypedConstant.Kind, correctedParameterName))
+                        Yield New SourceAttributeData(attribute.ApplicationSyntaxReference, attribute.AttributeClass, attribute.AttributeConstructor, newArgs, attribute.CommonNamedArguments, attribute.IsConditionallyOmitted, attribute.HasErrors)
+                        Continue For
+                    End If
+                End If
+                Yield attribute
+            Next
+        End Function
+
         ' It is not strictly necessary to decode default value attributes early in VB,
         ' but it is necessary in C#, so this keeps the implementations consistent.
         Private Function EarlyDecodeAttributeForDefaultParameterValue(description As AttributeDescription, ByRef arguments As EarlyDecodeWellKnownAttributeArguments(Of EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation)) As VisualBasicAttributeData

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
@@ -35,6 +35,80 @@ End Module
         End Sub
 
         <ConditionalFact(GetType(CoreClrOnly))>
+        Public Sub TestGoodCallerArgumentExpressionAttribute_MultipleAttributes()
+            Dim source As String = "
+Imports System
+Imports System.Runtime.CompilerServices
+
+Namespace System.Runtime.CompilerServices
+    <AttributeUsage(AttributeTargets.Parameter, AllowMultiple:=True, Inherited:=False)>
+    Public NotInheritable Class CallerArgumentExpressionAttribute
+        Inherits Attribute
+
+        Public Sub New(parameterName As String)
+            ParameterName = parameterName
+        End Sub
+
+        Public ReadOnly Property ParameterName As String
+    End Class
+End Namespace
+
+Class Program
+    Public Shared Sub Main()
+        Log(123, 456)
+    End Sub
+
+    Const p1 As String = NameOf(p1)
+    Const p2 As String = NameOf(p2)
+
+    Private Shared Sub Log(p1 As Integer, p2 As Integer, <CallerArgumentExpression(p1), CallerArgumentExpression(p2)> ByVal Optional arg As String = ""<default-arg>"")
+        Console.WriteLine(arg)
+    End Sub
+End Class
+"
+
+            Dim compilation = CreateCompilation(source, targetFramework:=TargetFramework.NetCoreApp, references:={Net451.MicrosoftVisualBasic}, options:=TestOptions.ReleaseExe, parseOptions:=TestOptions.RegularLatest)
+            CompileAndVerify(compilation, expectedOutput:="456").VerifyDiagnostics()
+        End Sub
+
+        <ConditionalFact(GetType(CoreClrOnly))>
+        Public Sub TestGoodCallerArgumentExpressionAttribute_MultipleAttributes_IncorrectCtor()
+            Dim source As String = "
+Imports System
+Imports System.Runtime.CompilerServices
+
+Namespace System.Runtime.CompilerServices
+    <AttributeUsage(AttributeTargets.Parameter, AllowMultiple:=True, Inherited:=False)>
+    Public NotInheritable Class CallerArgumentExpressionAttribute
+        Inherits Attribute
+
+        Public Sub New(parameterName As String, extraParam As Integer)
+            ParameterName = parameterName
+        End Sub
+
+        Public ReadOnly Property ParameterName As String
+    End Class
+End Namespace
+
+Class Program
+    Public Shared Sub Main()
+        Log(123, 456)
+    End Sub
+
+    Const p1 As String = NameOf(p1)
+    Const p2 As String = NameOf(p2)
+
+    Private Shared Sub Log(p1 As Integer, p2 As Integer, <CallerArgumentExpression(p1, 0), CallerArgumentExpression(p2, 1)> ByVal Optional arg As String = ""<default-arg>"")
+        Console.WriteLine(arg)
+    End Sub
+End Class
+"
+
+            Dim compilation = CreateCompilation(source, targetFramework:=TargetFramework.NetCoreApp, references:={Net451.MicrosoftVisualBasic}, options:=TestOptions.ReleaseExe, parseOptions:=TestOptions.RegularLatest)
+            CompileAndVerify(compilation, expectedOutput:="<default-arg>").VerifyDiagnostics()
+        End Sub
+
+        <ConditionalFact(GetType(CoreClrOnly))>
         Public Sub TestGoodCallerArgumentExpressionAttribute_CaseInsensitivity()
             Dim source As String = "
 Imports System

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
@@ -158,7 +158,6 @@ End Module
     </compilation>
 
             Dim compilation = CreateCompilationWithCustomILSource(source, il, options:=TestOptions.ReleaseExe, includeVbRuntime:=True, parseOptions:=TestOptions.RegularLatest)
-            ' PROTOTYPE(caller-expr): Confirm whether this should be case-sensitive or case-insensitive.
             CompileAndVerify(compilation, expectedOutput:="0 + 1").VerifyDiagnostics()
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
@@ -39,13 +39,13 @@ End Module
             Dim source As String = "
 Imports System
 Imports System.Runtime.CompilerServices
-Module Program
+Public Module Program
     Sub Main()
         Log(123)
     End Sub
 
     Private Const P As String = NameOf(P)
-    Sub Log(p As Integer, <CallerArgumentExpression(P)> Optional arg As String = ""<default-arg>"")
+    Public Sub Log(p As Integer, <CallerArgumentExpression(P)> Optional arg As String = ""<default-arg>"")
         Console.WriteLine(arg)
     End Sub
 End Module
@@ -53,7 +53,7 @@ End Module
 
             Dim compilation = CreateCompilation(source, targetFramework:=TargetFramework.NetCoreApp, references:={Net451.MicrosoftVisualBasic}, options:=TestOptions.ReleaseExe, parseOptions:=TestOptions.RegularLatest)
             CompileAndVerify(compilation, expectedOutput:="123").VerifyDiagnostics().VerifyTypeIL("Program", "
-.class private auto ansi sealed Program
+.class public auto ansi sealed Program
 	extends [System.Runtime]System.Object
 {
 	.custom instance void [Microsoft.VisualBasic]Microsoft.VisualBasic.CompilerServices.StandardModuleAttribute::.ctor() = (
@@ -96,6 +96,8 @@ End Module
 	} // end of method Program::Log
 } // end of class Program
 ")
+            Dim csCompilation = CreateCSharpCompilation("Program.Log(5 + 2);", referencedAssemblies:=TargetFrameworkUtil.GetReferences(TargetFramework.NetCoreApp, {compilation.EmitToImageReference()}), compilationOptions:=New CSharp.CSharpCompilationOptions(OutputKind.ConsoleApplication))
+            CompileAndVerify(csCompilation, expectedOutput:="5 + 2").VerifyDiagnostics()
         End Sub
 
         <ConditionalFact(GetType(CoreClrOnly))>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
@@ -52,14 +52,50 @@ End Module
 "
 
             Dim compilation = CreateCompilation(source, targetFramework:=TargetFramework.NetCoreApp, references:={Net451.MicrosoftVisualBasic}, options:=TestOptions.ReleaseExe, parseOptions:=TestOptions.RegularLatest)
-            CompileAndVerify(compilation, expectedOutput:="123").VerifyDiagnostics()
-            ' PROTOTYPE(caller-expr): Confirm whether this should be case-sensitive or case-insensitive.
-            '            compilation.AssertTheseDiagnostics(
-            '<expected><![CDATA[
-            'BC42505: The CallerArgumentExpressionAttribute applied to parameter 'arg' will have no effect. It is applied with an invalid parameter name.
-            '    Sub Log(p As Integer, <CallerArgumentExpression(P)> Optional arg As String = "<default-arg>")
-            '                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            ']]></expected>)
+            CompileAndVerify(compilation, expectedOutput:="123").VerifyDiagnostics().VerifyTypeIL("Program", "
+.class private auto ansi sealed Program
+	extends [System.Runtime]System.Object
+{
+	.custom instance void [Microsoft.VisualBasic]Microsoft.VisualBasic.CompilerServices.StandardModuleAttribute::.ctor() = (
+		01 00 00 00
+	)
+	// Fields
+	.field private static literal string P = ""P""
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		.custom instance void [System.Runtime]System.STAThreadAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Method begins at RVA 0x2050
+		// Code size 13 (0xd)
+		.maxstack 8
+		.entrypoint
+		IL_0000: ldc.i4.s 123
+		IL_0002: ldstr ""123""
+		IL_0007: call void Program::Log(int32, string)
+		IL_000c: ret
+	} // end of method Program::Main
+	.method public static 
+		void Log (
+			int32 p,
+			[opt] string arg
+		) cil managed 
+	{
+		.param [2] = ""<default-arg>""
+			.custom instance void [System.Runtime]System.Runtime.CompilerServices.CallerArgumentExpressionAttribute::.ctor(string) = (
+				01 00 01 70 00 00
+			)
+		// Method begins at RVA 0x205e
+		// Code size 7 (0x7)
+		.maxstack 8
+		IL_0000: ldarg.1
+		IL_0001: call void [System.Console]System.Console::WriteLine(string)
+		IL_0006: ret
+	} // end of method Program::Log
+} // end of class Program
+")
         End Sub
 
         <ConditionalFact(GetType(CoreClrOnly))>


### PR DESCRIPTION
Proposal: dotnet/csharplang#287
Test plan: https://github.com/dotnet/roslyn/issues/52745

@AlekseyTs @333fred for review