### PR TITLE
Remove unneeded prototype

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -1410,7 +1410,7 @@ class Program
             CompileAndVerify(compilation, expectedOutput: @"s1: s1-arg
 s2: s2-arg
 s3: 
-s4: _").VerifyDiagnostics(); // PROTOTYPE(caller-arg): Should 'out' keyword be included?
+s4: _").VerifyDiagnostics();
         }
 
 


### PR DESCRIPTION
Proposal: dotnet/csharplang#287
Test plan: https://github.com/dotnet/roslyn/issues/52745

I think current behavior matches LDM decision:
https://github.com/dotnet/csharplang/blob/d91eab3660ef80159cecd76ad89456cc2607cadd/meetings/2021/LDM-2021-06-14.md#span-of-the-expression

> **Conclusion**
> Option 3: we go from the start of real C# executable code to the end of the expression, not including any leading or trailing trivia.

