### PR TITLE
Ensure we don't try and build an empty table when modifying entries

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -156,6 +156,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         }
 
         [Fact]
+        public void Node_Builder_Handles_Modification_When_Both_Tables_Have_Empty_Entries()
+        {
+            var builder = NodeStateTable<int>.Empty.ToBuilder();
+            builder.AddEntries(ImmutableArray.Create(1, 2), EntryState.Added);
+            builder.AddEntries(ImmutableArray<int>.Empty, EntryState.Added);
+            builder.AddEntries(ImmutableArray.Create(3, 4), EntryState.Added);
+            var previousTable = builder.ToImmutableAndFree();
+
+            var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added), (4, EntryState.Added));
+            AssertTableEntries(previousTable, expected);
+
+            builder = previousTable.ToBuilder();
+            Assert.True(builder.TryModifyEntries(ImmutableArray.Create(3, 2), EqualityComparer<int>.Default)); // ((3, EntryState.Modified), (2, EntryState.Cached))
+            Assert.True(builder.TryModifyEntries(ImmutableArray<int>.Empty, EqualityComparer<int>.Default)); // nothing
+            Assert.True(builder.TryModifyEntries(ImmutableArray.Create(3, 5), EqualityComparer<int>.Default)); // ((3, EntryState.Cached), (5, EntryState.Modified))
+            var newTable = builder.ToImmutableAndFree();
+
+            expected = ImmutableArray.Create((3, EntryState.Modified), (2, EntryState.Cached), (3, EntryState.Cached), (5, EntryState.Modified));
+            AssertTableEntries(newTable, expected);
+        }
+
+        [Fact]
         public void Driver_Table_Calls_Into_Node_With_Self()
         {
             DriverStateTable.Builder? passedIn = null;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -205,6 +205,14 @@ namespace Microsoft.CodeAnalysis
                 // - Added when new item position < previousTable.length
 
                 var previousEntry = _previous._states[_states.Count];
+
+                // when both entries have no items, we can short circuit
+                if (previousEntry.Count == 0 && outputs.Length == 0)
+                {
+                    _states.Add(previousEntry);
+                    return true;
+                }
+
                 var modified = new TableEntry.Builder();
                 var sharedCount = Math.Min(previousEntry.Count, outputs.Length);
 


### PR DESCRIPTION
This is https://github.com/dotnet/roslyn/pull/54639 but targeted to the correct branch (release/dev17.0)