### PR TITLE
Reduce telemetry output from find document in workspace

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             TextDocumentIdentifier? textDocument,
             string? clientName,
             ILspLogger _logger,
+            RequestTelemetryLogger telemetryLogger,
             ClientCapabilities clientCapabilities,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
             Dictionary<Workspace, (Solution workspaceSolution, Solution lspSolution)>? solutionCache,
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 // There are multiple possible solutions that we could be interested in, so we need to find the document
                 // first and then get the solution from there. If we're not given a document, this will return the default
                 // solution
-                document = FindDocument(_logger, lspWorkspaceRegistrationService, textDocument, clientName);
+                document = FindDocument(_logger, telemetryLogger, lspWorkspaceRegistrationService, textDocument, clientName);
 
                 if (document is not null)
                 {
@@ -84,7 +85,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             return new RequestContext(lspSolution, _logger.TraceInformation, clientCapabilities, clientName, document, documentChangeTracker);
         }
 
-        private static Document? FindDocument(ILspLogger logger, ILspWorkspaceRegistrationService lspWorkspaceRegistrationService, TextDocumentIdentifier textDocument, string? clientName)
+        private static Document? FindDocument(
+            ILspLogger logger,
+            RequestTelemetryLogger telemetryLogger,
+            ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
+            TextDocumentIdentifier textDocument,
+            string? clientName)
         {
             logger.TraceInformation($"Finding document corresponding to {textDocument.Uri}");
 
@@ -98,14 +104,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 {
                     var document = documents.FindDocumentInProjectContext(textDocument);
                     logger.TraceInformation($"Found document in workspace {workspace.Kind}: {document.FilePath}");
-
-                    Logger.Log(FunctionId.FindDocumentInWorkspace, KeyValueLogMessage.Create(LogType.Trace, m =>
-                    {
-                        m["WorkspaceKind"] = workspace.Kind;
-                        m["FoundInWorkspace"] = true;
-                        m["DocumentUriHashCode"] = textDocument.Uri.GetHashCode();
-                    }));
-
+                    telemetryLogger.UpdateFindDocumentTelemetryData(success: true, workspace.Kind);
                     return document;
                 }
             }
@@ -113,12 +112,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var searchedWorkspaceKinds = string.Join(";", workspaceKinds.ToImmutableAndClear());
             logger.TraceWarning($"No document found after looking in {searchedWorkspaceKinds} workspaces, but request did contain a document uri");
 
-            Logger.Log(FunctionId.FindDocumentInWorkspace, KeyValueLogMessage.Create(LogType.Trace, m =>
-            {
-                m["AvailableWorkspaceKinds"] = searchedWorkspaceKinds;
-                m["FoundInWorkspace"] = false;
-                m["DocumentUriHashCode"] = textDocument.Uri.GetHashCode();
-            }));
+            telemetryLogger.UpdateFindDocumentTelemetryData(success: false, workspaceKind: null);
 
             return null;
         }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -142,11 +142,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
                 Logger.Log(FunctionId.LSP_FindDocumentInWorkspace, KeyValueLogMessage.Create(LogType.Trace, m =>
                 {
+                    m["server"] = _serverTypeName;
                     foreach (var kvp in _findDocumentResults)
                     {
                         var info = kvp.Key.ToString();
                         m[info] = kvp.Value.GetCount();
-                        m["server"] = _serverTypeName;
                     }
                 }));
 

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.Internal.Log;
 
@@ -42,10 +44,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             /// </summary>
             private readonly ConcurrentDictionary<string, Counter> _requestCounters;
 
+            private readonly LogAggregator _findDocumentResults;
+
             public RequestTelemetryLogger(string serverTypeName)
             {
                 _serverTypeName = serverTypeName;
-                _requestCounters = new ConcurrentDictionary<string, Counter>();
+                _requestCounters = new();
+                _findDocumentResults = new();
 
                 // Buckets queued duration into 10ms buckets with the last bucket starting at 1000ms.
                 // Queue times are relatively short and fall under 50ms, so tracking past 1000ms is not useful.
@@ -56,7 +61,21 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 _requestDurationLogAggregator = new HistogramLogAggregator(bucketSize: 1, maxBucketValue: 40);
             }
 
-            public void UpdateTelemetryData(string methodName, TimeSpan queuedDuration, TimeSpan requestDuration, Result result)
+            public void UpdateFindDocumentTelemetryData(bool success, string? workspaceKind)
+            {
+                var workspaceKindTelemetryProperty = success ? workspaceKind : "Failed";
+
+                if (workspaceKindTelemetryProperty != null)
+                {
+                    _findDocumentResults.IncreaseCount(workspaceKindTelemetryProperty);
+                }
+            }
+
+            public void UpdateTelemetryData(
+                string methodName,
+                TimeSpan queuedDuration,
+                TimeSpan requestDuration,
+                Result result)
             {
                 // Find the bucket corresponding to the queued duration and update the count of durations in that bucket.
                 // This is not broken down per method as time in queue is not specific to an LSP method.
@@ -120,6 +139,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         m["bucketdata_logms"] = requestExecutionDuration?.GetBucketsAsString();
                     }));
                 }
+
+                Logger.Log(FunctionId.LSP_FindDocumentInWorkspace, KeyValueLogMessage.Create(LogType.Trace, m =>
+                {
+                    foreach (var kvp in _findDocumentResults)
+                    {
+                        var info = kvp.Key.ToString();
+                        m[info] = kvp.Value.GetCount();
+                        m["server"] = _serverTypeName;
+                    }
+                }));
 
                 // Clear telemetry we've published in case dispose is called multiple times.
                 _requestCounters.Clear();

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -288,6 +288,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 queueItem.TextDocument,
                 queueItem.ClientName,
                 _logger,
+                _requestTelemetryLogger,
                 queueItem.ClientCapabilities,
                 _workspaceRegistrationService,
                 _lspSolutionCache,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -526,6 +526,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         InheritanceMargin_GetInheritanceMemberItems = 492,
 
-        LSP_FindDocumentInWorkspace = 481,
+        LSP_FindDocumentInWorkspace = 493,
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -504,7 +504,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         CommandHandler_Paste_ImportsOnPaste = 470,
 
-        FindDocumentInWorkspace = 480,
+        // Superseded by LSP_FindDocumentInWorkspace
+        // obsolete: FindDocumentInWorkspace = 480,
         RegisterWorkspace = 481,
 
         LSP_RequestCounter = 482,
@@ -524,5 +525,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         ValueTracking_TrackValueSource = 491,
 
         InheritanceMargin_GetInheritanceMemberItems = 492,
+
+        LSP_FindDocumentInWorkspace = 481,
     }
 }


### PR DESCRIPTION
We've been notified that this event is one of the highest volume telemetry events in VS.  

In order to reduce volume from d16 we've already suppressed the original event.  This change aggregates also the telemetry data per server so that we only send this event once per session (under a new function id).