### PR TITLE
Reduce timeout in richnav run

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -21,7 +21,7 @@ jobs:
     queue: BuildPool.Windows.10.Amd64.Open
   variables:
     EnableRichCodeNavigation: true
-  timeoutInMinutes: 200
+  timeoutInMinutes: 60
 
   steps:
     - task: PowerShell@2


### PR DESCRIPTION
Richnav has been taking a long time to run lately: https://dev.azure.com/dnceng/public/_build/results?buildId=1223348&view=results

When the task is well behaved, it tends to finish in maybe 40 minutes, so it feels like a 60 minute timeout on this might be reasonable.