### PR TITLE
Add back servicehub core host support

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -495,6 +495,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Exte
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.UnitTests", "src\Tools\ExternalAccess\OmniSharpTest\Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.UnitTests.csproj", "{3829F774-33F2-41E9-B568-AE555004FC62}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents", "src\Workspaces\Remote\ServiceHub.CoreComponents\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj", "{8FCD1B85-BE63-4A2F-8E19-37244F19BE0F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Analyzers\VisualBasic\CodeFixes\VisualBasicCodeFixes.projitems*{0141285d-8f6c-42c7-baf3-3c0ccd61c716}*SharedItemsImports = 5
@@ -1290,6 +1292,10 @@ Global
 		{3829F774-33F2-41E9-B568-AE555004FC62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3829F774-33F2-41E9-B568-AE555004FC62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3829F774-33F2-41E9-B568-AE555004FC62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8FCD1B85-BE63-4A2F-8E19-37244F19BE0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FCD1B85-BE63-4A2F-8E19-37244F19BE0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FCD1B85-BE63-4A2F-8E19-37244F19BE0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FCD1B85-BE63-4A2F-8E19-37244F19BE0F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1516,6 +1522,7 @@ Global
 		{1B73FB08-9A17-497E-97C5-FA312867D51B} = {8977A560-45C2-4EC2-A849-97335B382C74}
 		{AE976DE9-811D-4C86-AEBB-DCDC1226D754} = {8977A560-45C2-4EC2-A849-97335B382C74}
 		{3829F774-33F2-41E9-B568-AE555004FC62} = {8977A560-45C2-4EC2-A849-97335B382C74}
+		{8FCD1B85-BE63-4A2F-8E19-37244F19BE0F} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {604E6B91-7BC0-4126-AE07-D4D2FEFC3D29}

--- a/eng/targets/GeneratePkgDef.targets
+++ b/eng/targets/GeneratePkgDef.targets
@@ -102,6 +102,8 @@
         <_Audience Condition="'%(PkgDefBrokeredService.Audience)' == 'LiveShareGuest'">dword:00000400</_Audience>
         <_Audience Condition="'%(PkgDefBrokeredService.Audience)' == 'RemoteExclusiveServer'">dword:00000800</_Audience>
         <_Audience Condition="'%(PkgDefBrokeredService.Audience)' == 'AllClientsIncludingGuests'">dword:00000503</_Audience>
+        <_ServiceLocation Condition="'%(PkgDefBrokeredService.SubFolder)' == ''">"$PackageFolder$"</_ServiceLocation>
+        <_ServiceLocation Condition="'%(PkgDefBrokeredService.SubFolder)' != ''">"$PackageFolder$\%(PkgDefBrokeredService.SubFolder)"</_ServiceLocation>
       </PkgDefBrokeredService>
     </ItemGroup>
   </Target>
@@ -231,7 +233,7 @@
           <![CDATA[[$RootKey$\BrokeredServices\%(PkgDefBrokeredService.Identity)]
 @="11AD60FC-6D87-4674-8F88-9ABE79176CBE"
 "IsServiceHub"=dword:00000001
-"ServiceLocation"="$PackageFolder$"
+"ServiceLocation"=%(PkgDefBrokeredService._ServiceLocation)
 "audience"=%(PkgDefBrokeredService._Audience)
 ]]>
         </RawValue>

--- a/eng/targets/GenerateServiceHubConfigurationFiles.targets
+++ b/eng/targets/GenerateServiceHubConfigurationFiles.targets
@@ -11,14 +11,15 @@
 
   <Target Name="CalculateServiceHubConfigurationFiles">
     <ItemGroup>
-      <_ServicesWithBitness Include="@(ServiceHubService)" FileSuffix="" HostSuffix=".x86" HostIdSuffix="32" />
-      <_ServicesWithBitness Include="@(ServiceHubService)" FileSuffix="64" HostSuffix="" HostIdSuffix="" />
-      <_ServicesWithBitness Include="@(ServiceHubService)" FileSuffix="64S" HostSuffix="" HostIdSuffix="S" />
+      <_ServicesWithBitness Include="@(ServiceHubService)" FileSuffix="64" HostIdSuffix="" Runtime="desktop"/>
+      <_ServicesWithBitness Include="@(ServiceHubService)" FileSuffix="64S" HostIdSuffix="S" Runtime="desktop"/>
+      <_ServicesWithBitness Include="@(ServiceHubService)" FileSuffix="Core64" HostIdSuffix="" Runtime="core"/>
+      <_ServicesWithBitness Include="@(ServiceHubService)" FileSuffix="Core64S" HostIdSuffix="S" Runtime="core"/>
 
-      <ServiceHubServiceJsonFile Include="$(IntermediateOutputPath)%(_ServicesWithBitness.Identity)%(_ServicesWithBitness.FileSuffix).servicehub.service.json">
+      <ServiceHubServiceJsonFile Include="$(IntermediateOutputPath)%(_ServicesWithBitness.Identity)%(_ServicesWithBitness.FileSuffix).servicehub.service.json" Runtime="%(_ServicesWithBitness.Runtime)" Condition="'%(_ServicesWithBitness.Runtime)' == 'desktop'" >
         <Content>
           <![CDATA[{
-  "host": "desktopClr%(_ServicesWithBitness.HostSuffix)",
+  "host": "desktopClr",
   "hostId": "RoslynCodeAnalysisService%(_ServicesWithBitness.HostIdSuffix)",
   "hostGroupAllowed": true,
   "serviceOverride": true, 
@@ -27,6 +28,22 @@
     "fullClassName": "%(_ServicesWithBitness.ClassName)",
     "appBasePath": "%VSAPPIDDIR%",
     "configPath": "%PkgDefApplicationConfigFile%"
+  }
+}
+]]>
+        </Content>
+      </ServiceHubServiceJsonFile>
+
+      <ServiceHubServiceJsonFile Include="$(IntermediateOutputPath)%(_ServicesWithBitness.Identity)%(_ServicesWithBitness.FileSuffix).servicehub.service.json" Runtime="%(_ServicesWithBitness.Runtime)" Condition="'%(_ServicesWithBitness.Runtime)' == 'core'" >
+        <Content>
+          <![CDATA[{
+  "host": "coreClr",
+  "hostId": "RoslynCodeAnalysisService%(_ServicesWithBitness.HostIdSuffix)",
+  "hostGroupAllowed": true,
+  "serviceOverride": true, 
+  "entryPoint": {
+    "assemblyPath": "$(ServiceHubAssemblyBasePath.Replace('\', '\\'))Microsoft.CodeAnalysis.Remote.ServiceHub.dll",
+    "fullClassName": "%(_ServicesWithBitness.ClassName)"
   }
 }
 ]]>
@@ -45,7 +62,8 @@
 
     <ItemGroup>
       <FileWrites Include="@(ServiceHubServiceJsonFile->'%(Identity)')"/>
-      <VSIXSourceItem Include="@(ServiceHubServiceJsonFile->'%(Identity)')" />
+      <VSIXSourceItem Include="@(ServiceHubServiceJsonFile->'%(Identity)')" Condition="'%(ServiceHubServiceJsonFile.Runtime)' == 'core'" VSIXSubPath="$(ServiceHubCoreSubPath)" />
+      <VSIXSourceItem Include="@(ServiceHubServiceJsonFile->'%(Identity)')" Condition="'%(ServiceHubServiceJsonFile.Runtime)' == 'desktop'"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Setup/DevDivVsix/ServiceHubConfig/Roslyn.VisualStudio.Setup.ServiceHub.csproj
+++ b/src/Setup/DevDivVsix/ServiceHubConfig/Roslyn.VisualStudio.Setup.ServiceHub.csproj
@@ -27,8 +27,10 @@
           Outputs="$(_SwrFilePath)">
 
     <ItemGroup>
-      <_ServiceHubConfigFiles Include="@(ServiceHubService)" FileSuffix="" />
       <_ServiceHubConfigFiles Include="@(ServiceHubService)" FileSuffix="64" />
+      <_ServiceHubConfigFiles Include="@(ServiceHubService)" FileSuffix="64S" />
+      <_ServiceHubConfigFiles Include="@(ServiceHubService)" FileSuffix="Core64" />
+      <_ServiceHubConfigFiles Include="@(ServiceHubService)" FileSuffix="Core64S" />
       <_FileEntries Include='file source="$(IntermediateOutputPath)%(_ServiceHubConfigFiles.Identity)%(_ServiceHubConfigFiles.FileSuffix).servicehub.service.json"'/>
     </ItemGroup>
 

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -41,9 +41,6 @@
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_Razor_pull_diagnostics_experimental_requires_restart}" 
                               Checked="Enable_Razor_pull_diagnostics_experimental_requires_restart_Checked"
                               Unchecked="Enable_Razor_pull_diagnostics_experimental_requires_restart_Unchecked"/>
-                    
-                    <CheckBox x:Name="Use_64bit_analysis_process"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_use_64bit_analysis_process}" />
 
                     <CheckBox x:Name="Show_Remove_Unused_References_command_in_Solution_Explorer_experimental"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_Remove_Unused_References_command_in_Solution_Explorer_experimental}" />

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -47,7 +47,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects, LanguageNames.CSharp);
             BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution, LanguageNames.CSharp);
             BindToOption(Enable_navigation_to_decompiled_sources, FeatureOnOffOptions.NavigateToDecompiledSources);
-            BindToOption(Use_64bit_analysis_process, RemoteHostOptions.OOP64Bit);
             BindToOption(Enable_file_logging_for_diagnostics, InternalDiagnosticsOptions.EnableFileLoggingForDiagnostics);
             BindToOption(Skip_analyzers_for_implicitly_triggered_builds, FeatureOnOffOptions.SkipAnalyzersForImplicitlyTriggeredBuilds);
             BindToOption(Show_Remove_Unused_References_command_in_Solution_Explorer_experimental, FeatureOnOffOptions.OfferRemoveUnusedReferences, () =>

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -34,9 +34,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_Enable_Razor_pull_diagnostics_experimental_requires_restart
             => ServicesVSResources.Enable_Razor_pull_diagnostics_experimental_requires_restart;
 
-        public static string Option_use_64bit_analysis_process
-            => ServicesVSResources.Use_64_bit_process_for_code_analysis_requires_restart;
-
         public static string Option_Inline_Hints_experimental
             => ServicesVSResources.Inline_Hints_experimental;
 

--- a/src/VisualStudio/Core/Def/ExternalAccess/UnitTesting/Api/UnitTestingRemoteHostOptionsAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/UnitTesting/Api/UnitTestingRemoteHostOptionsAccessor.cs
@@ -4,16 +4,17 @@
 
 #nullable disable
 
-using System.Linq;
+using System;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Storage;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
 {
     internal static class UnitTestingRemoteHostOptionsAccessor
     {
-        public static Option<bool> OOP64Bit => new(
-            RemoteHostOptions.OOP64Bit.Feature, RemoteHostOptions.OOP64Bit.Name, defaultValue: RemoteHostOptions.OOP64Bit.DefaultValue,
-            storageLocations: RemoteHostOptions.OOP64Bit.StorageLocations.ToArray());
+        [Obsolete("OOP is now 64bit only.")]
+        public static readonly Option2<bool> OOP64Bit = new(
+            "InternalFeatureOnOffOptions", nameof(OOP64Bit), defaultValue: true,
+            storageLocations: new LocalUserProfileStorageLocation(StorageOptions.LocalRegistryPath + nameof(OOP64Bit)));
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/VisualStudioRemoteHostClientProvider.cs
@@ -50,8 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             {
                 // We don't want to bring up the OOP process in a VS cloud environment client instance
                 // Avoids proffering brokered services on the client instance.
-                if (!RemoteHostOptions.IsUsingServiceHubOutOfProcess(workspaceServices) ||
-                    workspaceServices.Workspace is not VisualStudioWorkspace ||
+                if (workspaceServices.Workspace is not VisualStudioWorkspace ||
                     workspaceServices.GetRequiredService<IWorkspaceContextService>().IsCloudEnvironmentClient())
                 {
                     // Run code in the current process

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -182,10 +182,13 @@
 
   <Target Name="GeneratePkgDefServiceRegistrations" BeforeTargets="GeneratePkgDef">
     <ItemGroup>
-      <!-- Add registrations for 32-bit, 64-bit, and 64-bit Server GC -->
-      <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" />
+      <!-- Add registrations 64-bit, and 64-bit Server GC on desktop host -->
       <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)64')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" />
       <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)64S')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" />
+      
+      <!-- Add registrations for 64-bit and 64-bit Server GC on .Net Core host -->
+      <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)Core64')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" SubFolder="$(ServiceHubCoreSubPath)"/>
+      <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)Core64S')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" SubFolder="$(ServiceHubCoreSubPath)"/>
 
       <PkgDefBrokeredService Include="@(InProcService)" ProfferingPackageId="$(RoslynPackageGuid)" />
     </ItemGroup>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1516,9 +1516,6 @@ I agree to all of the foregoing:</value>
   <data name="Bitness64" xml:space="preserve">
     <value>64-bit</value>
   </data>
-  <data name="Use_64_bit_process_for_code_analysis_requires_restart" xml:space="preserve">
-    <value>Use 64-bit process for code analysis (requires restart)</value>
-  </data>
   <data name="Extract_Base_Class" xml:space="preserve">
     <value>Extract Base Class</value>
   </data>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">Aktualizuje se závažnost.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">Pro analýzu kódu použít 64bitový proces (vyžaduje restartování)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">Pro výrazy lambda používat text výrazu</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">Der Schweregrad wird aktualisiert.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">64-Bit-Prozess für die Codeanalyse verwenden (Neustart erforderlich)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">Ausdruckskörper für Lambdaausdrücke verwenden</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">Actualizando la gravedad</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">Usar el proceso de 64 bits para el análisis de código (requiere reiniciar)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">Usar cuerpo de expresión para lambdas</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">Mise à jour de la gravité</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">Utiliser le processus 64 bits pour l'analyse du code (redémarrage nécessaire)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">Utiliser un corps d'expression pour les expressions lambda</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">Aggiornamento della gravità</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">Usa il processo a 64 bit per l'analisi codice (richiede il riavvio)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">Usa il corpo dell'espressione per le espressioni lambda</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">重要度を更新しています</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">コード分析に 64 ビット プロセスを使用する (再起動が必要)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">ラムダに式本体を使用します</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">심각도를 업데이트하는 중</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">코드 분석에 64비트 프로세스 사용(다시 시작 필요)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">람다에 식 본문 사용</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">Aktualizowanie ważności</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">Użyj procesu 64-bitowego do analizy kodu (wymaga ponownego uruchomienia)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">Użyj treści wyrażenia dla wyrażeń lambda</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">Atualizando a severidade</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">Usar o processo de 64 bits para análise de código (requer reinicialização)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">Usar o corpo da expressão para lambdas</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">Обновление уровня серьезности</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">Использовать 64-разрядный процесс для анализа кода (требуется перезапуск)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">Использовать тело выражения для лямбда-выражений</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">Önem derecesi güncelleştiriliyor</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">Kod analizi için 64 bit işlemi kullanın (yeniden başlatma gerekir)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">Lambdalar için ifade gövdesi kullan</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">正在更新严重性</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">对代码分析使用 64 位进程(需要重启)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">使用 lambdas 的表达式主体</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1192,11 +1192,6 @@
         <target state="translated">正在更新嚴重性</target>
         <note />
       </trans-unit>
-      <trans-unit id="Use_64_bit_process_for_code_analysis_requires_restart">
-        <source>Use 64-bit process for code analysis (requires restart)</source>
-        <target state="translated">使用 64 位元處理序進行程式碼分析 (需要重新啟動)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Use_expression_body_for_lambdas">
         <source>Use expression body for lambdas</source>
         <target state="translated">使用 lambda 的運算式主體</target>

--- a/src/VisualStudio/Directory.Build.props
+++ b/src/VisualStudio/Directory.Build.props
@@ -3,6 +3,6 @@
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <!-- Subfolder relative to the root package folder where all servicehub assemblies for .NET Core host are located -->
-    <ServiceHubCoreSubPath>ServiceHubCore</ServiceHubCoreSubPath>
+    <ServiceHubCoreSubPath>Core</ServiceHubCoreSubPath>
   </PropertyGroup>
 </Project>

--- a/src/VisualStudio/Directory.Build.props
+++ b/src/VisualStudio/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <!-- Subfolder relative to the root package folder where all servicehub assemblies for .NET Core host are located -->
+    <ServiceHubCoreSubPath>ServiceHubCore</ServiceHubCoreSubPath>
   </PropertyGroup>
 </Project>

--- a/src/VisualStudio/Setup/Directory.Build.targets
+++ b/src/VisualStudio/Setup/Directory.Build.targets
@@ -25,8 +25,12 @@
     
     <PropertyGroup>
       <_Placeholder><![CDATA[<!--#SERVICEHUB_ASSETS#-->]]></_Placeholder>
-      <_Replacement>@(ServiceHubServiceJsonFile->'&lt;Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="%(FileName)%(Extension)" /&gt;', '
-    ')</_Replacement>
+      <_ReplacementDesktop Condition="'%(ServiceHubServiceJsonFile.Runtime)' == 'desktop'">@(ServiceHubServiceJsonFile->'&lt;Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="%(FileName)%(Extension)" /&gt;', '
+    ')</_ReplacementDesktop>
+      <_ReplacementCore Condition="'%(ServiceHubServiceJsonFile.Runtime)' == 'core'">@(ServiceHubServiceJsonFile->'&lt;Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="$(ServiceHubCoreSubPath)\%(FileName)%(Extension)" /&gt;', '
+    ')</_ReplacementCore>
+      <_Replacement>$(_ReplacementDesktop)
+$(_ReplacementCore)</_Replacement>
     </PropertyGroup>
     
     <Copy SourceFiles="$(VsixSourceManifestPath)" DestinationFiles="$(_GeneratedVsixManifestPath)" />

--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -226,11 +226,23 @@
       <PkgDefEntry>BindingRedirect</PkgDefEntry>
     </ProjectReference>
     <ProjectReference Include="..\..\Workspaces\Remote\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.csproj">
-      <Name>ServiceHub</Name>
+      <Name>ServiceHub.Desktop</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <PkgDefEntry>BindingRedirect</PkgDefEntry>
       <NgenPriority>1</NgenPriority>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Workspaces\Remote\ServiceHub.CoreComponents\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj">
+      <Name>ServiceHub.Core</Name>
+      <!-- This project targets netcoreapp -->
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <IncludeOutputGroupsInVSIX>PublishProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
+      <Private>false</Private>
+      <VSIXSubPath>$(ServiceHubCoreSubPath)</VSIXSubPath>
+      <!-- Disable NGEN. Core assemblies are crossgened. -->
+      <Ngen>false</Ngen>
     </ProjectReference>
     <ProjectReference Include="..\..\Scripting\Core\Microsoft.CodeAnalysis.Scripting.csproj">
       <Name>Scripting</Name>

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -28,8 +28,6 @@
                                               x:Name="Background_analysis_scope_full_solution"
                                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Full_Solution}"/>
                     </StackPanel>
-                    <CheckBox x:Name="Use_64bit_analysis_process"
-                              Content="{x:Static local:AdvancedOptionPageStrings.Option_use_64bit_analysis_process}" />
                     <CheckBox x:Name="Show_Remove_Unused_References_command_in_Solution_Explorer_experimental"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_Remove_Unused_References_command_in_Solution_Explorer_experimental}" />
                     <CheckBox x:Name="Enable_file_logging_for_diagnostics"

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -46,7 +46,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(Background_analysis_scope_active_file, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.ActiveFile, LanguageNames.VisualBasic)
             BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects, LanguageNames.VisualBasic)
             BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution, LanguageNames.VisualBasic)
-            BindToOption(Use_64bit_analysis_process, RemoteHostOptions.OOP64Bit)
             BindToOption(Enable_file_logging_for_diagnostics, InternalDiagnosticsOptions.EnableFileLoggingForDiagnostics)
             BindToOption(Skip_analyzers_for_implicitly_triggered_builds, FeatureOnOffOptions.SkipAnalyzersForImplicitlyTriggeredBuilds)
             BindToOption(Show_Remove_Unused_References_command_in_Solution_Explorer_experimental, FeatureOnOffOptions.OfferRemoveUnusedReferences,

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -27,9 +27,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         Public ReadOnly Property Option_Background_Analysis_Scope_Full_Solution As String =
             ServicesVSResources.Entire_solution
 
-        Public ReadOnly Property Option_use_64bit_analysis_process As String =
-            ServicesVSResources.Use_64_bit_process_for_code_analysis_requires_restart
-
         Public ReadOnly Property Option_DisplayLineSeparators As String =
             BasicVSResources.Show_procedure_line_separators
 

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -44,5 +44,6 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string InheritanceMargin = "Roslyn.InheritanceMargin";
         public const string LspPullDiagnosticsFeatureFlag = "Lsp.PullDiagnostics";
         public const string AsynchronousQuickActions = "Roslyn.AsynchronousQuickActions";
+        public const string OOPCoreClr = "Roslyn.OOPCoreClr";
     }
 }

--- a/src/Workspaces/Core/Portable/Remote/RemoteServiceName.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteServiceName.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Remote
         internal const string Prefix = "roslyn";
         internal const string Suffix64 = "64";
         internal const string SuffixServerGC = "S";
+        internal const string SuffixCoreClr = "Core";
         internal const string IntelliCodeServiceName = "pythia";
         internal const string RazorServiceName = "razorLanguageService";
         internal const string UnitTestingAnalysisServiceName = "UnitTestingAnalysis";
@@ -43,29 +44,30 @@ namespace Microsoft.CodeAnalysis.Remote
             CustomServiceName = customServiceName;
         }
 
-        public string ToString(bool isRemoteHost64Bit, bool isRemoteHostServerGC)
+        public string ToString(bool isRemoteHostServerGC, bool isRemoteHostCoreClr)
         {
-            return CustomServiceName ?? (WellKnownService, isRemoteHost64Bit, isRemoteHostServerGC) switch
+            if (CustomServiceName is not null)
             {
-                (WellKnownServiceHubService.RemoteHost, false, _) => Prefix + nameof(WellKnownServiceHubService.RemoteHost),
-                (WellKnownServiceHubService.RemoteHost, true, false) => Prefix + nameof(WellKnownServiceHubService.RemoteHost) + Suffix64,
-                (WellKnownServiceHubService.RemoteHost, true, true) => Prefix + nameof(WellKnownServiceHubService.RemoteHost) + Suffix64 + SuffixServerGC,
+                return CustomServiceName;
+            }
 
-                (WellKnownServiceHubService.IntelliCode, false, _) => IntelliCodeServiceName,
-                (WellKnownServiceHubService.IntelliCode, true, false) => IntelliCodeServiceName + Suffix64,
-                (WellKnownServiceHubService.IntelliCode, true, true) => IntelliCodeServiceName + Suffix64 + SuffixServerGC,
-                (WellKnownServiceHubService.Razor, false, _) => RazorServiceName,
-                (WellKnownServiceHubService.Razor, true, false) => RazorServiceName + Suffix64,
-                (WellKnownServiceHubService.Razor, true, true) => RazorServiceName + Suffix64 + SuffixServerGC,
-                (WellKnownServiceHubService.UnitTestingAnalysisService, false, _) => UnitTestingAnalysisServiceName,
-                (WellKnownServiceHubService.UnitTestingAnalysisService, true, false) => UnitTestingAnalysisServiceName + Suffix64,
-                (WellKnownServiceHubService.UnitTestingAnalysisService, true, true) => UnitTestingAnalysisServiceName + Suffix64 + SuffixServerGC,
-                (WellKnownServiceHubService.LiveUnitTestingBuildService, false, _) => LiveUnitTestingBuildServiceName,
-                (WellKnownServiceHubService.LiveUnitTestingBuildService, true, false) => LiveUnitTestingBuildServiceName + Suffix64,
-                (WellKnownServiceHubService.LiveUnitTestingBuildService, true, true) => LiveUnitTestingBuildServiceName + Suffix64 + SuffixServerGC,
-                (WellKnownServiceHubService.UnitTestingSourceLookupService, false, _) => UnitTestingSourceLookupServiceName,
-                (WellKnownServiceHubService.UnitTestingSourceLookupService, true, false) => UnitTestingSourceLookupServiceName + Suffix64,
-                (WellKnownServiceHubService.UnitTestingSourceLookupService, true, true) => UnitTestingSourceLookupServiceName + Suffix64 + SuffixServerGC,
+            var suffix = (isRemoteHostServerGC, isRemoteHostCoreClr) switch
+            {
+                (false, false) => Suffix64,
+                (true, false) => Suffix64 + SuffixServerGC,
+                (false, true) => SuffixCoreClr + Suffix64,
+                (true, true) => SuffixCoreClr + Suffix64 + SuffixServerGC,
+            };
+
+            return WellKnownService switch
+            {
+                WellKnownServiceHubService.RemoteHost => Prefix + nameof(WellKnownServiceHubService.RemoteHost) + suffix,
+
+                WellKnownServiceHubService.IntelliCode => IntelliCodeServiceName + suffix,
+                WellKnownServiceHubService.Razor => RazorServiceName + suffix,
+                WellKnownServiceHubService.UnitTestingAnalysisService => UnitTestingAnalysisServiceName + suffix,
+                WellKnownServiceHubService.LiveUnitTestingBuildService => LiveUnitTestingBuildServiceName + suffix,
+                WellKnownServiceHubService.UnitTestingSourceLookupService => UnitTestingSourceLookupServiceName + suffix,
 
                 _ => throw ExceptionUtilities.UnexpectedValue(WellKnownService),
             };

--- a/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
+++ b/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
@@ -28,13 +28,13 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
     {
         public static IEnumerable<object[]> AllServiceDescriptors
             => ServiceDescriptors.Instance.GetTestAccessor().Descriptors
-                .Select(descriptor => new object[] { descriptor.Key, descriptor.Value.descriptor32, descriptor.Value.descriptor64, descriptor.Value.descriptor64ServerGC });
+                .Select(descriptor => new object[] { descriptor.Key, descriptor.Value.descriptor64, descriptor.Value.descriptor64ServerGC, descriptor.Value.descriptorCoreClr64, descriptor.Value.descriptorCoreClr64ServerGC });
 
         private static Dictionary<Type, MemberInfo> GetAllParameterTypesOfRemoteApis()
         {
             var interfaces = new List<Type>();
 
-            foreach (var (serviceType, (descriptor, _, _)) in ServiceDescriptors.Instance.GetTestAccessor().Descriptors)
+            foreach (var (serviceType, (descriptor, _, _, _)) in ServiceDescriptors.Instance.GetTestAccessor().Descriptors)
             {
                 interfaces.Add(serviceType);
                 if (descriptor.ClientInterface != null)
@@ -165,17 +165,22 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
         [Theory]
         [MemberData(nameof(AllServiceDescriptors))]
-        internal void GetFeatureDisplayName(Type serviceInterface, ServiceDescriptor descriptor32, ServiceDescriptor descriptor64, ServiceDescriptor descriptor64ServerGC)
+        internal void GetFeatureDisplayName(
+            Type serviceInterface,
+            ServiceDescriptor descriptor64,
+            ServiceDescriptor descriptor64ServerGC,
+            ServiceDescriptor descriptorCoreClr64,
+            ServiceDescriptor descriptorCoreClr64ServerGC)
         {
             Assert.NotNull(serviceInterface);
-
-            var expectedName = descriptor32.GetFeatureDisplayName();
+            var expectedName = descriptor64.GetFeatureDisplayName();
 
             // The service name couldn't be found. It may need to be added to RemoteWorkspacesResources.resx as FeatureName_{name}
             Assert.False(string.IsNullOrEmpty(expectedName), $"Service name for '{serviceInterface.GetType()}' not available.");
 
-            Assert.Equal(expectedName, descriptor64.GetFeatureDisplayName());
             Assert.Equal(expectedName, descriptor64ServerGC.GetFeatureDisplayName());
+            Assert.Equal(expectedName, descriptorCoreClr64.GetFeatureDisplayName());
+            Assert.Equal(expectedName, descriptorCoreClr64ServerGC.GetFeatureDisplayName());
         }
 
         [Fact]
@@ -185,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var callbackDispatchers = ((IMefHostExportProvider)hostServices).GetExports<IRemoteServiceCallbackDispatcher, RemoteServiceCallbackDispatcherRegistry.ExportMetadata>();
 
             var descriptorsWithCallbackServiceTypes = ServiceDescriptors.Instance.GetTestAccessor().Descriptors
-                .Where(d => d.Value.descriptor32.ClientInterface != null).Select(d => d.Key);
+                .Where(d => d.Value.descriptor64.ClientInterface != null).Select(d => d.Key);
 
             var callbackDispatcherServiceTypes = callbackDispatchers.Select(d => d.Metadata.ServiceInterface);
             AssertEx.SetEqual(descriptorsWithCallbackServiceTypes, callbackDispatcherServiceTypes);

--- a/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/Workspaces/CoreTestUtilities/Remote/InProcRemostHostClient.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
 using System.Runtime;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.EditAndContinue;
@@ -104,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
 
         public override RemoteServiceConnection<T> CreateConnection<T>(object? callbackTarget) where T : class
         {
-            var descriptor = ServiceDescriptors.Instance.GetServiceDescriptor(typeof(T), isRemoteHost64Bit: IntPtr.Size == 8, isRemoteHostServerGC: GCSettings.IsServerGC);
+            var descriptor = ServiceDescriptors.Instance.GetServiceDescriptor(typeof(T), isRemoteHostServerGC: GCSettings.IsServerGC, isRemoteHostCoreClr: RemoteHostOptions.IsCurrentProcessRunningOnCoreClr());
             var callbackDispatcher = (descriptor.ClientInterface != null) ? _callbackDispatchers.GetDispatcher(typeof(T)) : null;
 
             return new BrokeredServiceConnection<T>(
@@ -282,7 +283,8 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
             public void RegisterService(RemoteServiceName name, Func<Stream, IServiceProvider, ServiceActivationOptions, ServiceBase> serviceFactory)
             {
                 _factoryMap.Add(name, serviceFactory);
-                _serviceNameMap.Add(name.ToString(isRemoteHost64Bit: IntPtr.Size == 8, isRemoteHostServerGC: GCSettings.IsServerGC), name.WellKnownService);
+                _serviceNameMap.Add(name.ToString(isRemoteHostServerGC: GCSettings.IsServerGC,
+                                                  isRemoteHostCoreClr: RemoteHostOptions.IsCurrentProcessRunningOnCoreClr()), name.WellKnownService);
             }
 
             public Task<Stream> RequestServiceAsync(RemoteServiceName serviceName)

--- a/src/Workspaces/Remote/Core/ServiceDescriptors.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptors.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Remote
         });
 
         internal readonly RemoteSerializationOptions Options;
-        private readonly ImmutableDictionary<Type, (ServiceDescriptor descriptor32, ServiceDescriptor descriptor64, ServiceDescriptor descriptor64ServerGC)> _descriptors;
+        private readonly ImmutableDictionary<Type, (ServiceDescriptor descriptor64, ServiceDescriptor descriptor64ServerGC, ServiceDescriptor descriptorCoreClr64, ServiceDescriptor descriptorCoreClr64ServerGC)> _descriptors;
         private readonly string _componentName;
         private readonly Func<string, string> _featureDisplayNameProvider;
 
@@ -105,28 +105,31 @@ namespace Microsoft.CodeAnalysis.Remote
         internal string GetQualifiedServiceName(Type serviceInterface)
             => ServiceNameTopLevelPrefix + _componentName + "." + GetServiceName(serviceInterface);
 
-        private (ServiceDescriptor, ServiceDescriptor, ServiceDescriptor) CreateDescriptors(Type serviceInterface, Type? callbackInterface)
+        private (ServiceDescriptor, ServiceDescriptor, ServiceDescriptor, ServiceDescriptor) CreateDescriptors(Type serviceInterface, Type? callbackInterface)
         {
             Contract.ThrowIfFalse(callbackInterface == null || callbackInterface.IsInterface);
 
             var qualifiedServiceName = GetQualifiedServiceName(serviceInterface);
-            var descriptor32 = ServiceDescriptor.CreateRemoteServiceDescriptor(qualifiedServiceName, Options, _featureDisplayNameProvider, callbackInterface);
             var descriptor64 = ServiceDescriptor.CreateRemoteServiceDescriptor(qualifiedServiceName + RemoteServiceName.Suffix64, Options, _featureDisplayNameProvider, callbackInterface);
             var descriptor64ServerGC = ServiceDescriptor.CreateRemoteServiceDescriptor(qualifiedServiceName + RemoteServiceName.Suffix64 + RemoteServiceName.SuffixServerGC, Options, _featureDisplayNameProvider, callbackInterface);
-            return (descriptor32, descriptor64, descriptor64ServerGC);
+            var descriptorCoreClr64 = ServiceDescriptor.CreateRemoteServiceDescriptor(qualifiedServiceName + RemoteServiceName.SuffixCoreClr + RemoteServiceName.Suffix64, Options, _featureDisplayNameProvider, callbackInterface);
+            var descriptorCoreClr64ServerGC = ServiceDescriptor.CreateRemoteServiceDescriptor(qualifiedServiceName + RemoteServiceName.SuffixCoreClr + RemoteServiceName.Suffix64 + RemoteServiceName.SuffixServerGC, Options, _featureDisplayNameProvider, callbackInterface);
+
+            return (descriptor64, descriptor64ServerGC, descriptorCoreClr64, descriptorCoreClr64ServerGC);
         }
 
         public ServiceDescriptor GetServiceDescriptorForServiceFactory(Type serviceType)
-            => GetServiceDescriptor(serviceType, isRemoteHost64Bit: IntPtr.Size == 8, isRemoteHostServerGC: GCSettings.IsServerGC);
+            => GetServiceDescriptor(serviceType, isRemoteHostServerGC: GCSettings.IsServerGC, isRemoteHostCoreClr: RemoteHostOptions.IsCurrentProcessRunningOnCoreClr());
 
-        public ServiceDescriptor GetServiceDescriptor(Type serviceType, bool isRemoteHost64Bit, bool isRemoteHostServerGC)
+        public ServiceDescriptor GetServiceDescriptor(Type serviceType, bool isRemoteHostServerGC, bool isRemoteHostCoreClr)
         {
-            var (descriptor32, descriptor64, descriptor64ServerGC) = _descriptors[serviceType];
-            return (isRemoteHost64Bit, isRemoteHostServerGC) switch
+            var (descriptor64, descriptor64ServerGC, descriptorCoreClr64, descriptorCoreClr64ServerGC) = _descriptors[serviceType];
+            return (isRemoteHostServerGC, isRemoteHostCoreClr) switch
             {
-                (true, false) => descriptor64,
-                (true, true) => descriptor64ServerGC,
-                _ => descriptor32,
+                (false, false) => descriptor64,
+                (false, true) => descriptorCoreClr64,
+                (true, false) => descriptor64ServerGC,
+                (true, true) => descriptorCoreClr64ServerGC,
             };
         }
 
@@ -135,9 +138,28 @@ namespace Microsoft.CodeAnalysis.Remote
             var prefixLength = qualifiedServiceName.LastIndexOf('.') + 1;
             Contract.ThrowIfFalse(prefixLength > 0);
 
-            var suffixLength = qualifiedServiceName.EndsWith(RemoteServiceName.Suffix64, StringComparison.Ordinal)
-                ? RemoteServiceName.Suffix64.Length
-                : qualifiedServiceName.EndsWith(RemoteServiceName.Suffix64 + RemoteServiceName.SuffixServerGC, StringComparison.Ordinal) ? RemoteServiceName.Suffix64.Length + RemoteServiceName.SuffixServerGC.Length : 0;
+            int suffixLength;
+            if (qualifiedServiceName.EndsWith(RemoteServiceName.SuffixCoreClr + RemoteServiceName.Suffix64, StringComparison.Ordinal))
+            {
+                suffixLength = RemoteServiceName.SuffixCoreClr.Length + RemoteServiceName.Suffix64.Length;
+            }
+            else if (qualifiedServiceName.EndsWith(RemoteServiceName.SuffixCoreClr + RemoteServiceName.Suffix64 + RemoteServiceName.SuffixServerGC, StringComparison.Ordinal))
+            {
+                suffixLength = RemoteServiceName.SuffixCoreClr.Length + RemoteServiceName.Suffix64.Length + RemoteServiceName.SuffixServerGC.Length;
+            }
+            else if (qualifiedServiceName.EndsWith(RemoteServiceName.Suffix64, StringComparison.Ordinal))
+            {
+                suffixLength = RemoteServiceName.Suffix64.Length;
+            }
+            else if (qualifiedServiceName.EndsWith(RemoteServiceName.Suffix64 + RemoteServiceName.SuffixServerGC, StringComparison.Ordinal))
+            {
+                suffixLength = RemoteServiceName.Suffix64.Length + RemoteServiceName.SuffixServerGC.Length;
+            }
+            else
+            {
+                suffixLength = 0;
+            }
+
             var shortName = qualifiedServiceName.Substring(prefixLength, qualifiedServiceName.Length - prefixLength - suffixLength);
 
             return RemoteWorkspacesResources.GetResourceString("FeatureName_" + shortName);
@@ -153,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Remote
             internal TestAccessor(ServiceDescriptors serviceDescriptors)
                 => _serviceDescriptors = serviceDescriptors;
 
-            public ImmutableDictionary<Type, (ServiceDescriptor descriptor32, ServiceDescriptor descriptor64, ServiceDescriptor descriptor64ServerGC)> Descriptors
+            public ImmutableDictionary<Type, (ServiceDescriptor descriptor64, ServiceDescriptor descriptor64ServerGC, ServiceDescriptor descriptorCoreClr64, ServiceDescriptor descriptorCoreClr64ServerGC)> Descriptors
                 => _serviceDescriptors._descriptors;
         }
     }

--- a/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
+++ b/src/Workspaces/Remote/Core/ServiceHubRemoteHostClient.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.Remote
         private readonly IRemoteServiceCallbackDispatcherProvider _callbackDispatcherProvider;
 
         private readonly ConnectionPools? _connectionPools;
-        private readonly bool _isRemoteHost64Bit;
         private readonly bool _isRemoteHostServerGC;
+        private readonly bool _isRemoteHostCoreClr;
 
         private ServiceHubRemoteHostClient(
             HostWorkspaceServices services,
@@ -72,8 +72,8 @@ namespace Microsoft.CodeAnalysis.Remote
             _serializer = services.GetRequiredService<ISerializerService>();
             _errorReportingService = services.GetService<IErrorReportingService>();
             _shutdownCancellationService = services.GetService<IRemoteHostClientShutdownCancellationService>();
-            _isRemoteHost64Bit = RemoteHostOptions.IsServiceHubProcess64Bit(services);
             _isRemoteHostServerGC = RemoteHostOptions.IsServiceHubProcessServerGC(services);
+            _isRemoteHostCoreClr = RemoteHostOptions.IsServiceHubProcessCoreClr(services);
         }
 
         private void OnUnexpectedExceptionThrown(Exception unexpectedException)
@@ -123,13 +123,13 @@ namespace Microsoft.CodeAnalysis.Remote
             RemoteServiceName serviceName,
             CancellationToken cancellationToken)
         {
-            var is64bit = RemoteHostOptions.IsServiceHubProcess64Bit(services);
             var isServerGC = RemoteHostOptions.IsServiceHubProcessServerGC(services);
+            var isCoreClr = RemoteHostOptions.IsServiceHubProcessCoreClr(services);
 
             // Make sure we are on the thread pool to avoid UI thread dependencies if external code uses ConfigureAwait(true)
             await TaskScheduler.Default;
 
-            var descriptor = new ServiceHub.Client.ServiceDescriptor(serviceName.ToString(is64bit, isServerGC));
+            var descriptor = new ServiceHub.Client.ServiceDescriptor(serviceName.ToString(isServerGC, isCoreClr));
             try
             {
                 return await client.RequestServiceAsync(descriptor, cancellationToken).ConfigureAwait(false);
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         internal RemoteServiceConnection<T> CreateConnection<T>(ServiceDescriptors descriptors, IRemoteServiceCallbackDispatcherProvider callbackDispatcherProvider, object? callbackTarget) where T : class
         {
-            var descriptor = descriptors.GetServiceDescriptor(typeof(T), _isRemoteHost64Bit, _isRemoteHostServerGC);
+            var descriptor = descriptors.GetServiceDescriptor(typeof(T), _isRemoteHostServerGC, _isRemoteHostCoreClr);
             var callbackDispatcher = (descriptor.ClientInterface != null) ? callbackDispatcherProvider.GetDispatcher(typeof(T)) : null;
 
             return new BrokeredServiceConnection<T>(

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- The purpose of this project is to include all dependecies of Microsoft.CodeAnalysis.Remote.ServiceHub targeting .Net Core -->
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- These references need to be deployed to the vsix subfolder containing servicehub bits for .Net Core -->
+    <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVisualStudioTelemetryVersion)" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawbundle_greenVersion)" />
+  </ItemGroup>
+
+  <Target Name="PublishProjectOutputGroup" DependsOnTargets="Publish" Returns="@(_PublishedFiles)">
+    <ItemGroup>
+      <!-- Need to include and then update items (https://github.com/microsoft/msbuild/issues/1053) -->
+      <_PublishedFiles Include="$(PublishDir)**\*.*" Exclude="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.*"/>
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Extension)' == '.pdb'" />
+      <!-- we want to use Microsoft.Win32.Registry provided by runtime, not the netstandard2.0 version from the NuGet package -->
+      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.Win32.Registry.dll'" />
+
+      <!-- Set TargetPath -->
+      <_PublishedFiles Update="@(_PublishedFiles)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  </Target>
+</Project>

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/Program.cs
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/Program.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents
+{
+    internal static class Program
+    {
+#pragma warning disable IDE0060 // Remove unused parameter
+        public static void Main(string[] args)
+#pragma warning restore IDE0060 // Remove unused parameter
+        {
+        }
+    }
+}


### PR DESCRIPTION
Originally added in https://github.com/dotnet/roslyn/pull/53571, which was reverted due to required test failure in insertions. The cause seems to be the "path too long error" during installation in the test.

log from test runs
```
 [0940:000d][2021-07-07T01:38:15] Package Log: C:\Windows\TEMP\dd_setup_20210707013434_063_Microsoft.CodeAnalysis.VisualStudio.Setup.log
[0940:000d][2021-07-07T01:38:15] Creating vsix certificateInformation.dat in 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\ManagedLanguages\VBCSharp\LanguageServices'
[0940:000d][2021-07-07T01:38:19] Completed: Installing Microsoft.CodeAnalysis.VisualStudio.Setup
[0940:000d][2021-07-07T01:38:19] Error: Package 'Microsoft.CodeAnalysis.VisualStudio.Setup,version=4.0.0.2132401,productarch=Neutral' failed to install. System.IO.PathTooLongException: The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters.
   at System.IO.PathHelper.GetFullPathName()
   at System.IO.Path.LegacyNormalizePath(String path, Boolean fullCheck, Int32 maxPathLength, Boolean expandShortPaths)
   at System.IO.Path.GetFullPathInternal(String path)
   at Microsoft.VisualStudio.Setup.Installer.VsixInstaller.<InstallCoreInternal>g__install|31_1(PackagePart part, Boolean saveExtensionManifest, <>c__DisplayClass31_0& , <>c__DisplayClass31_1& , <>c__DisplayClass31_2& , <>c__DisplayClass31_3& , <>c__DisplayClass31_4& )
   at Microsoft.VisualStudio.Setup.Installer.VsixInstaller.InstallCoreInternal(String localPath, String installDir, InstallablePackage pkg)
   at Microsoft.VisualStudio.Setup.Installer.FileInstaller.DoAction(Func`1 action)
   at Microsoft.VisualStudio.Setup.Installer.InstallerBase.InstallHelper(InstallData installData)
```