### PR TITLE
Reduce allocations in CSharp command line parsing

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -2001,7 +2001,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             string? baseDirectory,
             IList<Diagnostic> diagnostics,
             bool embedded) =>
-            ParseResourceDescription(arg, resourceDescriptor, baseDirectory, diagnostics, embedded);
+            ParseResourceDescription(arg, resourceDescriptor.AsMemory(), baseDirectory, diagnostics, embedded);
 
         internal static ResourceDescription? ParseResourceDescription(
             string arg,

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -895,7 +895,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 continue;
                             }
 
-                            if (valueMemory.Value.Length is 0)
+                            if (valueMemory is not { Length: > 0 })
                             {
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsNumber, name);
                             }
@@ -2073,10 +2073,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             value = value.Unquote();
             var parts = ArrayBuilder<ReadOnlyMemory<char>>.GetInstance();
+
+            var nullableSpan = "nullable".AsSpan();
             ParseSeparatedStrings(value, s_warningSeparators, removeEmptyEntries: true, parts);
             foreach (ReadOnlyMemory<char> part in parts)
             {
-                if (part.Span.Equals("nullable".AsSpan(), StringComparison.OrdinalIgnoreCase))
+                if (part.Span.Equals(nullableSpan, StringComparison.OrdinalIgnoreCase))
                 {
                     foreach (var errorCode in ErrorFacts.NullableWarnings)
                     {

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1311,7 +1311,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             filePathBuilder.Free();
                             continue;
-                     case "analyzerconfig":
+                        case "analyzerconfig":
                             if (valueMemory is not { Length: > 0 })
                             {
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_SwitchNeedsString, "<file list>", name);

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -824,18 +824,6 @@ class C
             CleanupAllGeneratedFiles(tmpFileName);
         }
 
-        internal static IEnumerable<string> ParseResponseLines(IEnumerable<string> lines)
-        {
-            List<string> arguments = new List<string>();
-
-            foreach (string line in lines)
-            {
-                arguments.AddRange(CommandLineUtilities.SplitCommandLineIntoArguments(line, removeHashComments: true));
-            }
-
-            return arguments;
-        }
-
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
         public void Win32ResQuotes()
         {
@@ -843,21 +831,21 @@ class C
                 @" /win32res:d:\\""abc def""\a""b c""d\a.res",
             };
 
-            CSharpCommandLineArguments args = DefaultParse(ParseResponseLines(responseFile), @"c:\");
+            CSharpCommandLineArguments args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
             Assert.Equal(@"d:\abc def\ab cd\a.res", args.Win32ResourceFile);
 
             responseFile = new string[] {
                 @" /win32icon:d:\\""abc def""\a""b c""d\a.ico",
             };
 
-            args = DefaultParse(ParseResponseLines(responseFile), @"c:\");
+            args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
             Assert.Equal(@"d:\abc def\ab cd\a.ico", args.Win32Icon);
 
             responseFile = new string[] {
                 @" /win32manifest:d:\\""abc def""\a""b c""d\a.manifest",
             };
 
-            args = DefaultParse(ParseResponseLines(responseFile), @"c:\");
+            args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
             Assert.Equal(@"d:\abc def\ab cd\a.manifest", args.Win32Manifest);
         }
 
@@ -6355,7 +6343,7 @@ class myClass
                 @"hello world # this is a comment"
             };
 
-            IEnumerable<string> args = ParseResponseLines(responseFile);
+            IEnumerable<string> args = CSharpCommandLineParser.ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { "a.cs", "b.cs", @"c.cs e.cs", "hello", "world" }, args);
 
             // Check comment handling; comment character only counts at beginning of argument
@@ -6368,28 +6356,28 @@ class myClass
                 @"  ""#g.cs #h.cs"""
             };
 
-            args = ParseResponseLines(responseFile);
+            args = CSharpCommandLineParser.ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { "a.cs", "b#.cs", "c#d.cs", "#f.cs", "#g.cs #h.cs" }, args);
 
             // Check backslash escaping
             responseFile = new string[] {
                 @"a\b\c d\\e\\f\\ \\\g\\\h\\\i \\\\ \\\\\k\\\\\",
             };
-            args = ParseResponseLines(responseFile);
+            args = CSharpCommandLineParser.ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { @"a\b\c", @"d\\e\\f\\", @"\\\g\\\h\\\i", @"\\\\", @"\\\\\k\\\\\" }, args);
 
             // More backslash escaping and quoting
             responseFile = new string[] {
                 @"a\""a b\\""b c\\\""c d\\\\""d e\\\\\""e f"" g""",
             };
-            args = ParseResponseLines(responseFile);
+            args = CSharpCommandLineParser.ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { @"a\""a", @"b\\""b c\\\""c d\\\\""d", @"e\\\\\""e", @"f"" g""" }, args);
 
             // Quoting inside argument is valid.
             responseFile = new string[] {
                 @"  /o:""goo.cs"" /o:""abc def""\baz ""/o:baz bar""bing",
             };
-            args = ParseResponseLines(responseFile);
+            args = CSharpCommandLineParser.ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { @"/o:""goo.cs""", @"/o:""abc def""\baz", @"""/o:baz bar""bing" }, args);
         }
 
@@ -6400,7 +6388,7 @@ class myClass
                 @"d:\\""abc def""\baz.cs ab""c d""e.cs",
             };
 
-            CSharpCommandLineArguments args = DefaultParse(ParseResponseLines(responseFile), @"c:\");
+            CSharpCommandLineArguments args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
             AssertEx.Equal(new[] { @"d:\abc def\baz.cs", @"c:\abc de.cs" }, args.SourceFiles.Select(file => file.Path));
         }
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -25,6 +25,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -6207,6 +6208,63 @@ class myClass
 
             CleanupAllGeneratedFiles(source);
             CleanupAllGeneratedFiles(rsp);
+        }
+
+        [Fact]
+        public void ResponseFileOrdering()
+        {
+            var rspFilePath1 = Temp.CreateFile().WriteAllText(@"
+/b
+/c
+").Path;
+
+            assertOrder(
+                new[] { "/a", "/b", "/c", "/d" },
+                new[] { "/a", @$"@""{rspFilePath1}""", "/d" });
+
+            var rspFilePath2 = Temp.CreateFile().WriteAllText(@"
+/c
+/d
+").Path;
+
+            rspFilePath1 = Temp.CreateFile().WriteAllText(@$"
+/b
+@""{rspFilePath2}""
+").Path;
+
+            assertOrder(
+                new[] { "/a", "/b", "/c", "/d", "/e" },
+                new[] { "/a", @$"@""{rspFilePath1}""", "/e" });
+
+            rspFilePath1 = Temp.CreateFile().WriteAllText(@$"
+/b
+").Path;
+
+            rspFilePath2 = Temp.CreateFile().WriteAllText(@"
+# this will be ignored
+/c
+/d
+").Path;
+
+            assertOrder(
+                new[] { "/a", "/b", "/c", "/d", "/e" },
+                new[] { "/a", @$"@""{rspFilePath1}""", $@"@""{rspFilePath2}""", "/e" });
+
+            void assertOrder(string[] expected, string[] args)
+            {
+                var flattenedArgs = ArrayBuilder<string>.GetInstance();
+                var diagnostics = new List<Diagnostic>();
+                CSharpCommandLineParser.Default.FlattenArgs(
+                    args,
+                    diagnostics,
+                    flattenedArgs,
+                    scriptArgsOpt: null,
+                    @"c:\");
+
+                Assert.Empty(diagnostics);
+                Assert.Equal(expected, flattenedArgs);
+                flattenedArgs.Free();
+            }
         }
 
         [WorkItem(545832, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545832")]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -936,7 +936,7 @@ class C
             Assert.Null(desc);
             diags.Clear();
 
-            desc = CSharpCommandLineParser.ParseResourceDescription("", null, WorkingDirectory, diags, embedded: false);
+            desc = CSharpCommandLineParser.ParseResourceDescription("", (string)null, WorkingDirectory, diags, embedded: false);
             diags.Verify(Diagnostic(ErrorCode.ERR_NoFileSpec).WithArguments(""));
             Assert.Null(desc);
             diags.Clear();

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -824,6 +824,18 @@ class C
             CleanupAllGeneratedFiles(tmpFileName);
         }
 
+        internal static IEnumerable<string> ParseResponseLines(IEnumerable<string> lines)
+        {
+            List<string> arguments = new List<string>();
+
+            foreach (string line in lines)
+            {
+                arguments.AddRange(CommandLineUtilities.SplitCommandLineIntoArguments(line, removeHashComments: true));
+            }
+
+            return arguments;
+        }
+
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
         public void Win32ResQuotes()
         {
@@ -831,21 +843,21 @@ class C
                 @" /win32res:d:\\""abc def""\a""b c""d\a.res",
             };
 
-            CSharpCommandLineArguments args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
+            CSharpCommandLineArguments args = DefaultParse(ParseResponseLines(responseFile), @"c:\");
             Assert.Equal(@"d:\abc def\ab cd\a.res", args.Win32ResourceFile);
 
             responseFile = new string[] {
                 @" /win32icon:d:\\""abc def""\a""b c""d\a.ico",
             };
 
-            args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
+            args = DefaultParse(ParseResponseLines(responseFile), @"c:\");
             Assert.Equal(@"d:\abc def\ab cd\a.ico", args.Win32Icon);
 
             responseFile = new string[] {
                 @" /win32manifest:d:\\""abc def""\a""b c""d\a.manifest",
             };
 
-            args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
+            args = DefaultParse(ParseResponseLines(responseFile), @"c:\");
             Assert.Equal(@"d:\abc def\ab cd\a.manifest", args.Win32Manifest);
         }
 
@@ -6343,7 +6355,7 @@ class myClass
                 @"hello world # this is a comment"
             };
 
-            IEnumerable<string> args = CSharpCommandLineParser.ParseResponseLines(responseFile);
+            IEnumerable<string> args = ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { "a.cs", "b.cs", @"c.cs e.cs", "hello", "world" }, args);
 
             // Check comment handling; comment character only counts at beginning of argument
@@ -6356,28 +6368,28 @@ class myClass
                 @"  ""#g.cs #h.cs"""
             };
 
-            args = CSharpCommandLineParser.ParseResponseLines(responseFile);
+            args = ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { "a.cs", "b#.cs", "c#d.cs", "#f.cs", "#g.cs #h.cs" }, args);
 
             // Check backslash escaping
             responseFile = new string[] {
                 @"a\b\c d\\e\\f\\ \\\g\\\h\\\i \\\\ \\\\\k\\\\\",
             };
-            args = CSharpCommandLineParser.ParseResponseLines(responseFile);
+            args = ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { @"a\b\c", @"d\\e\\f\\", @"\\\g\\\h\\\i", @"\\\\", @"\\\\\k\\\\\" }, args);
 
             // More backslash escaping and quoting
             responseFile = new string[] {
                 @"a\""a b\\""b c\\\""c d\\\\""d e\\\\\""e f"" g""",
             };
-            args = CSharpCommandLineParser.ParseResponseLines(responseFile);
+            args = ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { @"a\""a", @"b\\""b c\\\""c d\\\\""d", @"e\\\\\""e", @"f"" g""" }, args);
 
             // Quoting inside argument is valid.
             responseFile = new string[] {
                 @"  /o:""goo.cs"" /o:""abc def""\baz ""/o:baz bar""bing",
             };
-            args = CSharpCommandLineParser.ParseResponseLines(responseFile);
+            args = ParseResponseLines(responseFile);
             AssertEx.Equal(new[] { @"/o:""goo.cs""", @"/o:""abc def""\baz", @"""/o:baz bar""bing" }, args);
         }
 
@@ -6388,7 +6400,7 @@ class myClass
                 @"d:\\""abc def""\baz.cs ab""c d""e.cs",
             };
 
-            CSharpCommandLineArguments args = DefaultParse(CSharpCommandLineParser.ParseResponseLines(responseFile), @"c:\");
+            CSharpCommandLineArguments args = DefaultParse(ParseResponseLines(responseFile), @"c:\");
             AssertEx.Equal(new[] { @"d:\abc def\baz.cs", @"c:\abc de.cs" }, args.SourceFiles.Select(file => file.Path));
         }
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -6259,7 +6259,7 @@ class myClass
                     diagnostics,
                     flattenedArgs,
                     scriptArgsOpt: null,
-                    @"c:\");
+                    baseDirectory: Path.DirectorySeparatorChar == '\\' ? @"c:\" : "/");
 
                 Assert.Empty(diagnostics);
                 Assert.Equal(expected, flattenedArgs);

--- a/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
@@ -5,9 +5,12 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1106,20 +1109,23 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(expected: include2.Path, actual: includePaths[2]);
         }
 
+        private string[] ParseSeparatedStrings(string arg, char[] separators, bool removeEmptyEntries = true)
+        {
+            var builder = ArrayBuilder<ReadOnlyMemory<char>>.GetInstance();
+            CommandLineParser.ParseSeparatedStrings(arg.AsMemory(), separators, removeEmptyEntries, builder);
+            return builder.Select(x => x.ToString()).ToArray();
+        }
+
         [Fact]
         public void ParseSeparatedStrings_ExcludeSeparatorChar()
         {
             Assert.Equal(
-                CommandLineParser.ParseSeparatedStrings(@"a,b", new[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
-                new[] { "a", "b" });
+                ParseSeparatedStrings(@"a,b", new[] { ',' }),
+                new[] { "a", "b" }); ;
 
             Assert.Equal(
-                CommandLineParser.ParseSeparatedStrings(@"a,,b", new[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
+                ParseSeparatedStrings(@"a,,b", new[] { ',' }),
                 new[] { "a", "b" });
-
-            Assert.Equal(
-                CommandLineParser.ParseSeparatedStrings(@"a,,b", new[] { ',' }, StringSplitOptions.None),
-                new[] { "a", "", "b" });
         }
 
         /// <summary>
@@ -1130,15 +1136,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void ParseSeparatedStrings_IncludeQuotes()
         {
             Assert.Equal(
-                CommandLineParser.ParseSeparatedStrings(@"""a"",b", new[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
+                ParseSeparatedStrings(@"""a"",b", new[] { ',' }),
                 new[] { @"""a""", "b" });
 
             Assert.Equal(
-                CommandLineParser.ParseSeparatedStrings(@"""a,b""", new[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
+                ParseSeparatedStrings(@"""a,b""", new[] { ',' }),
                 new[] { @"""a,b""" });
 
             Assert.Equal(
-                CommandLineParser.ParseSeparatedStrings(@"""a"",""b", new[] { ',' }, StringSplitOptions.RemoveEmptyEntries),
+                ParseSeparatedStrings(@"""a"",""b", new[] { ',' }),
                 new[] { @"""a""", @"""b" });
         }
 
@@ -1228,7 +1234,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         /// as \"\\test.cs\". 
         /// </remarks>
         [Fact]
-        public void RemoveQuotes()
+        public void RemoveQuotesAndSlashes()
         {
             Assert.Equal(@"\\test.cs", CommandLineParser.RemoveQuotesAndSlashes(@"\\test.cs"));
             Assert.Equal(@"\\test.cs", CommandLineParser.RemoveQuotesAndSlashes(@"""\\test.cs"""));
@@ -1240,6 +1246,27 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(@"a"" mid ""b.cs", CommandLineParser.RemoveQuotesAndSlashes(@"a\"" mid \""b.cs"));
             Assert.Equal(@"a mid b.cs", CommandLineParser.RemoveQuotesAndSlashes(@"a"" mid ""b.cs"));
             Assert.Equal(@"a.cs", CommandLineParser.RemoveQuotesAndSlashes(@"""a.cs"""));
+            Assert.Equal(@"C:""My Folder\MyBinary.xml", CommandLineParser.RemoveQuotesAndSlashes(@"C:\""My Folder""\MyBinary.xml"));
+        }
+
+        /// <summary>
+        /// Verify that for the standard cases we do not allocate new memory but instead 
+        /// return a <see cref="ReadOnlyMemory{T}"/> to the existing string
+        /// </summary>
+        [Fact]
+        public void RemoveQuotesAndSlashes_NoAllocation()
+        {
+            assertSame(@"c:\test.cs");
+            assertSame(@"""c:\test.cs""");
+            assertSame(@"""c:\\\\\\\\\test.cs""");
+            assertSame(@"""c:\\\\\\\\\test.cs""");
+
+            void assertSame(string arg)
+            {
+                var memory = CommandLineParser.RemoveQuotesAndSlashesEx(arg.AsMemory());
+                Assert.True(MemoryMarshal.TryGetString(memory, out var memoryString, out _, out _));
+                Assert.Same(arg, memoryString);
+            }
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
@@ -1121,7 +1121,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             Assert.Equal(
                 ParseSeparatedStrings(@"a,b", new[] { ',' }),
-                new[] { "a", "b" }); ;
+                new[] { "a", "b" });
 
             Assert.Equal(
                 ParseSeparatedStrings(@"a,,b", new[] { ',' }),

--- a/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -55,6 +55,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" ExcludeAssets="Runtime" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Build.Tasks.CodeAnalysis.UnitTests" />

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" ExcludeAssets="Runtime" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Build.Tasks.CodeAnalysis.UnitTests" />

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis
             if (TryParseOption(arg, out ReadOnlyMemory<char> nameMemory, out ReadOnlyMemory<char>? valueMemory))
             {
                 name = nameMemory.ToString().ToLowerInvariant();
-                value = valueMemory is { } m ? m.ToString() : null;
+                value = valueMemory?.ToString();
                 return true;
             }
 
@@ -857,9 +857,9 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         [return: NotNullIfNotNull(parameterName: "arg")]
         internal static string? RemoveQuotesAndSlashes(string? arg) =>
-            arg is null
-                ? null
-                : RemoveQuotesAndSlashes(arg?.AsMemory());
+            arg is object
+                ? RemoveQuotesAndSlashes(arg.AsMemory())
+                : null;
 
         internal static string RemoveQuotesAndSlashes(ReadOnlyMemory<char> argMemory) =>
             RemoveQuotesAndSlashesEx(argMemory).ToString();
@@ -1078,13 +1078,6 @@ namespace Microsoft.CodeAnalysis
             }
 
             return new CommandLineSourceFile(resolvedPath, isScriptFile, isInputRedirected);
-        }
-
-        internal IEnumerable<string> ParseFileArgument(string arg, string? baseDirectory, IList<Diagnostic> errors)
-        {
-            var builder = ArrayBuilder<string>.GetInstance();
-            ParseFileArgument(arg.AsMemory(), baseDirectory, builder, errors);
-            return builder;
         }
 
         internal void ParseFileArgument(ReadOnlyMemory<char> arg, string? baseDirectory, ArrayBuilder<string> filePathBuilder, IList<Diagnostic> errors)

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
@@ -590,7 +590,7 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 var stringBuilder = PooledStringBuilder.GetInstance();
-                var splitList = ArrayBuilder<string>.GetInstance();
+                var splitList = new List<string>();
                 foreach (var line in lines)
                 {
                     stringBuilder.Builder.Length = 0;
@@ -623,11 +623,20 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
-                splitList.Free();
                 stringBuilder.Free();
                 lines.Free();
             }
+        }
 
+        internal static IEnumerable<string> ParseResponseLines(IEnumerable<string> lines)
+        {
+            var arguments = new List<string>();
+            foreach (string line in lines)
+            {
+                arguments.AddRange(CommandLineUtilities.SplitCommandLineIntoArguments(line, removeHashComments: true));
+            }
+
+            return arguments;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
@@ -890,7 +890,7 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         [return: NotNullIfNotNull(parameterName: "arg")]
         internal static string? RemoveQuotesAndSlashes(string? arg) =>
-            arg is object
+            arg is not null
                 ? RemoveQuotesAndSlashes(arg.AsMemory())
                 : null;
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1626,7 +1626,7 @@ namespace Microsoft.CodeAnalysis
         private static string CreateDeterminismKey(CommandLineArguments args, string[] rawArgs, string baseDirectory, CommandLineParser parser)
         {
             List<Diagnostic> diagnostics = new List<Diagnostic>();
-            List<string> flattenedArgs = new List<string>();
+            var flattenedArgs = ArrayBuilder<string>.GetInstance();
             parser.FlattenArgs(rawArgs, diagnostics, flattenedArgs, null, baseDirectory);
 
             var builder = new StringBuilder();
@@ -1662,6 +1662,7 @@ namespace Microsoft.CodeAnalysis
                 builder.AppendLine($"\t{sourceFileName} - {hashValue}");
             }
 
+            flattenedArgs.Free();
             return builder.ToString();
         }
     }

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -93,6 +93,11 @@ namespace Roslyn.Utilities
             return FileNameUtilities.GetExtension(path);
         }
 
+        public static ReadOnlyMemory<char> GetExtension(ReadOnlyMemory<char> path)
+        {
+            return FileNameUtilities.GetExtension(path);
+        }
+
         public static string ChangeExtension(string path, string? extension)
         {
             return FileNameUtilities.ChangeExtension(path, extension);

--- a/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Roslyn.Utilities
 {
@@ -52,10 +53,16 @@ namespace Roslyn.Utilities
 
         public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, out char? illegalChar)
         {
-            var builder = new StringBuilder(commandLine.Length);
-            var list = new List<string>();
+            var list = ArrayBuilder<string>.GetInstance();
+            SplitCommandLineIntoArguments(commandLine, removeHashComments, new StringBuilder(), list, out illegalChar);
+            return list.ToArrayAndFree();
+        }
+
+        public static void SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, StringBuilder builder, ArrayBuilder<string> list, out char? illegalChar)
+        {
             var i = 0;
 
+            builder.Length = 0;
             illegalChar = null;
             while (i < commandLine.Length)
             {
@@ -146,8 +153,6 @@ namespace Roslyn.Utilities
                     list.Add(builder.ToString());
                 }
             }
-
-            return list;
         }
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -53,11 +54,11 @@ namespace Roslyn.Utilities
         public static List<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, out char? illegalChar)
         {
             var list = new List<string>();
-            SplitCommandLineIntoArguments(commandLine, removeHashComments, new StringBuilder(), list, out illegalChar);
+            SplitCommandLineIntoArguments(commandLine.AsSpan(), removeHashComments, new StringBuilder(), list, out illegalChar);
             return list;
         }
 
-        public static void SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, StringBuilder builder, List<string> list, out char? illegalChar)
+        public static void SplitCommandLineIntoArguments(ReadOnlySpan<char> commandLine, bool removeHashComments, StringBuilder builder, List<string> list, out char? illegalChar)
         {
             var i = 0;
 

--- a/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CommandLineUtilities.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Roslyn.Utilities
 {
@@ -46,19 +45,19 @@ namespace Roslyn.Utilities
         /// and the double quotation mark is "escaped" by the remaining backslash, 
         /// causing a literal double quotation mark (") to be placed in argv.
         /// </remarks>
-        public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments)
+        public static List<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments)
         {
             return SplitCommandLineIntoArguments(commandLine, removeHashComments, out _);
         }
 
-        public static IEnumerable<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, out char? illegalChar)
+        public static List<string> SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, out char? illegalChar)
         {
-            var list = ArrayBuilder<string>.GetInstance();
+            var list = new List<string>();
             SplitCommandLineIntoArguments(commandLine, removeHashComments, new StringBuilder(), list, out illegalChar);
-            return list.ToArrayAndFree();
+            return list;
         }
 
-        public static void SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, StringBuilder builder, ArrayBuilder<string> list, out char? illegalChar)
+        public static void SplitCommandLineIntoArguments(string commandLine, bool removeHashComments, StringBuilder builder, List<string> list, out char? illegalChar)
         {
             var i = 0;
 

--- a/src/Compilers/Core/Portable/InternalUtilities/FileNameUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FileNameUtilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Roslyn.Utilities
@@ -39,13 +40,13 @@ namespace Roslyn.Utilities
         /// Returns 0 for path ".goo".
         /// Returns -1 for path "goo.".
         /// </remarks>
-        private static int IndexOfExtension(string? path)
-        {
-            if (path == null)
-            {
-                return -1;
-            }
+        private static int IndexOfExtension(string? path) =>
+            path is null
+                ? -1
+                : IndexOfExtension(path.AsSpan());
 
+        private static int IndexOfExtension(ReadOnlySpan<char> path)
+        {
             int length = path.Length;
             int i = length;
 
@@ -88,6 +89,12 @@ namespace Roslyn.Utilities
 
             int index = IndexOfExtension(path);
             return (index >= 0) ? path.Substring(index) : string.Empty;
+        }
+
+        internal static ReadOnlyMemory<char> GetExtension(ReadOnlyMemory<char> path)
+        {
+            int index = IndexOfExtension(path.Span);
+            return (index >= 0) ? path.Slice(index) : default;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/MemoryExtensions.cs
+++ b/src/Compilers/Core/Portable/MemoryExtensions.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class MemoryExtensions
+    {
+        public static int IndexOfAny(this ReadOnlySpan<char> span, char[] characters)
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                var c = span[i];
+                foreach (var target in characters)
+                {
+                    if (c == target)
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        internal static bool IsNullOrEmpty(this ReadOnlyMemory<char>? memory) =>
+            memory is not { Length: > 0 };
+
+        internal static bool IsNullOrWhiteSpace(this ReadOnlyMemory<char>? memory)
+        {
+            if (memory is not { } m)
+            {
+                return true;
+            }
+
+            var span = m.Span;
+            foreach (var c in span)
+            {
+                if (!char.IsWhiteSpace(c))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/MemoryExtensions.cs
+++ b/src/Compilers/Core/Portable/MemoryExtensions.cs
@@ -75,6 +75,8 @@ namespace Microsoft.CodeAnalysis
             return true;
         }
 
+        internal static bool StartsWith(this ReadOnlyMemory<char> memory, char c) => memory.Length > 0 && memory.Span[0] == c;
+
         internal static ReadOnlyMemory<char> Unquote(this ReadOnlyMemory<char> memory)
         {
             var span = memory.Span;

--- a/src/Compilers/Core/Portable/MemoryExtensions.cs
+++ b/src/Compilers/Core/Portable/MemoryExtensions.cs
@@ -27,17 +27,43 @@ namespace Microsoft.CodeAnalysis
             return -1;
         }
 
+#if !NETCOREAPP
+        internal static ReadOnlyMemory<char> TrimStart(this ReadOnlyMemory<char> memory)
+        {
+            var span = memory.Span;
+            var index = 0;
+            while (index < span.Length && char.IsWhiteSpace(span[index]))
+            {
+                index++;
+            }
+
+            return memory.Slice(index, span.Length);
+        }
+
+        internal static ReadOnlyMemory<char> TrimEnd(this ReadOnlyMemory<char> memory)
+        {
+            var span = memory.Span;
+            var length = span.Length;
+            while (length - 1 >= 0 && char.IsWhiteSpace(span[length - 1]))
+            {
+                length--;
+            }
+
+            return memory.Slice(0, length);
+        }
+
+        internal static ReadOnlyMemory<char> Trim(this ReadOnlyMemory<char> memory) => memory.TrimStart().TrimEnd();
+#endif
+
         internal static bool IsNullOrEmpty(this ReadOnlyMemory<char>? memory) =>
             memory is not { Length: > 0 };
 
-        internal static bool IsNullOrWhiteSpace(this ReadOnlyMemory<char>? memory)
-        {
-            if (memory is not { } m)
-            {
-                return true;
-            }
+        internal static bool IsNullOrWhiteSpace(this ReadOnlyMemory<char>? memory) =>
+            memory is not { } m || IsWhiteSpace(m);
 
-            var span = m.Span;
+        internal static bool IsWhiteSpace(this ReadOnlyMemory<char> memory)
+        {
+            var span = memory.Span;
             foreach (var c in span)
             {
                 if (!char.IsWhiteSpace(c))
@@ -47,6 +73,17 @@ namespace Microsoft.CodeAnalysis
             }
 
             return true;
+        }
+
+        internal static ReadOnlyMemory<char> Unquote(this ReadOnlyMemory<char> memory)
+        {
+            var span = memory.Span;
+            if (span.Length > 1 && span[0] == '"' && span[span.Length - 1] == '"')
+            {
+                return memory.Slice(1, memory.Length - 2);
+            }
+
+            return memory;
         }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -193,9 +193,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim name As String = Nothing
                 Dim value As String = Nothing
                 If Not TryParseOption(arg, name, value) Then
-                    For Each path In ParseFileArgument(arg, baseDirectory, diagnostics)
+                    Dim builder = ArrayBuilder(Of String).GetInstance()
+                    ParseFileArgument(arg.AsMemory(), baseDirectory, builder, diagnostics)
+                    For Each path In builder
                         sourceFiles.Add(ToCommandLineSourceFile(path))
                     Next
+                    builder.Free()
                     hasSourceFiles = True
                     Continue For
                 End If

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Const GenerateFileNameForDocComment As String = "USE-OUTPUT-NAME"
 
             Dim diagnostics As List(Of Diagnostic) = New List(Of Diagnostic)()
-            Dim flattenedArgs As List(Of String) = New List(Of String)()
+            Dim flattenedArgs = ArrayBuilder(Of String).GetInstance()
             Dim scriptArgs As List(Of String) = If(IsScriptCommandLineParser, New List(Of String)(), Nothing)
 
             ' normalized paths to directories containing response files:
@@ -574,7 +574,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "errorlog", ErrorLogOptionFormat)
                             Else
                                 Dim diagnosticAlreadyReported As Boolean
-                                errorLogOptions = ParseErrorLogOptions(unquoted, diagnostics, baseDirectory, diagnosticAlreadyReported)
+                                errorLogOptions = ParseErrorLogOptions(unquoted.AsMemory(), diagnostics, baseDirectory, diagnosticAlreadyReported)
                                 If errorLogOptions Is Nothing And Not diagnosticAlreadyReported Then
                                     AddDiagnostic(diagnostics, ERRID.ERR_BadSwitchValue, unquoted, "errorlog", ErrorLogOptionFormat)
                                     Continue For
@@ -1377,6 +1377,8 @@ lVbRuntimePlus:
                 AddDiagnostic(diagnostics, ERRID.ERR_NoSourcesOut)
             End If
 
+            flattenedArgs.Free()
+
             Dim parseOptions = New VisualBasicParseOptions(
                 languageVersion:=languageVersion,
                 documentationMode:=If(parseDocumentationComments, DocumentationMode.Diagnose, DocumentationMode.None),
@@ -1682,7 +1684,7 @@ lVbRuntimePlus:
             Dim accessibility As String = Nothing
 
             ParseResourceDescription(
-                resourceDescriptor,
+                resourceDescriptor.AsMemory(),
                 baseDirectory,
                 True,
                 filePath,


### PR DESCRIPTION
Context #53570

The C# parser is used by the project system in scenarios like solution
open. That means the allocations in command line parsing can contribute
significantly to Visual Studio performance. This PR reduces the
allocations significantly.

Note: in the below explanations when I refer to the "99% case" I am
referring to how command lines are structured when created by
MSBuild based builds. That is the **overwhelming** case for the compiler
and is advantageous because it normalizes many items like lower casing
all option names, having one reference per option, etc ...  The remaining
1% are hand authored build files and these should not impact Visual
Studio scenarios.

The first fix is to simply avoid iterators in the parse hot paths. Most
of the iterators in the parser return a single element in the 99% case
hence the iterator is wasted allocations. These were switched to take
pooled builder arguments.

The next, and more siginificant fix, is to use `ReadOnlyMemory<char>`
instead of `string` on our hot parsing paths. This allows us to parse
the command line arguments without actually allocating memory for the
values until actually needed by lower level APIs. This allowed for APIs
like `RemoveQuotesAndSlashes` to become allocation free in the 99% case
(it's just a slicing operation now, not a string allocation).

The hot paths in our parsing were updated to employ these techniques.

The one downside of the change is that I had to touch virtually every
`case "someOption"` where the option value was used. The value is now
held in a `ReadOnlyMemory<char>` until it's actually needed as a
`string`. Hence every one of these cases either needed to use the new
`ReadOnlyMemory<char>` APIs or force the allocation of the `string`.
That made the change longer than I would've liked but it's also fairly
mechanical.

To test out the changes I created a benchmark which parsed a couple of
command lines:

- Command line for building Microsoft.CodeAnalysis.CSharp
- Command line for a simple razor app

The results are below and represent a significant win in both
allocations and in simple performance. There are a few more places we
could get some wins but getting into the realm of diminishing returns at
this point.

Before

|                          Method |       Mean |    Error |   StdDev |    Gen 0 |    Gen 1 | Gen 2 | Allocated |
|-------------------------------- |-----------:|---------:|---------:|---------:|---------:|------:|----------:|
|  ParseCSharpCompilerCommandLine | 1,101.9 us | 16.05 us | 14.23 us | 242.1875 |  80.0781 |     - |    876 KB |
| ParseCSharpCompilerResponseFile | 1,916.7 us | 18.26 us | 14.26 us | 353.5156 | 175.7813 |     - |  2,082 KB |
|   ParseRazorCompilerCommandLine |   467.3 us |  2.27 us |  2.02 us | 350.5859 |  53.7109 |     - |    571 KB |
|  ParseRazorCompilerResponseFile |   850.6 us |  8.09 us |  7.17 us | 327.1484 | 102.5391 |     - |    953 KB |


After
|                          Method |       Mean |    Error |   StdDev |    Gen 0 |   Gen 1 |  Gen 2 | Allocated |
|-------------------------------- |-----------:|---------:|---------:|---------:|--------:|-------:|----------:|
|  ParseCSharpCompilerCommandLine |   833.7 us | 16.53 us | 31.04 us | 111.3281 | 18.5547 |      - |    200 KB |
| ParseCSharpCompilerResponseFile | 1,631.5 us | 11.42 us | 10.69 us | 167.9688 | 78.1250 | 1.9531 |    891 KB |
|   ParseRazorCompilerCommandLine |   257.6 us |  3.44 us |  3.05 us |  80.0781 | 14.6484 |      - |    136 KB |
|  ParseRazorCompilerResponseFile |   600.0 us |  5.59 us |  5.23 us | 119.1406 | 33.2031 |      - |    364 KB |

There is a Gen2 increase here but I believe that is just the new usage of pooled builders.

Closes #53570