### PR TITLE
Fix diagnostics with locations in mapped files displaying at an incorrect location

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             //   1.  Razor handles span mapping for razor files on their side.
             //   2.  LSP does not allow us to report document pull diagnostics for a different file path.
             //   3.  The VS LSP client does not support document pull diagnostics for files outside our content type.
-            //   3.  This matches classic behavior where we only squiggle the original location anyway.
+            //   4.  This matches classic behavior where we only squiggle the original location anyway.
             var useMappedSpan = false;
             return new VSDiagnostic
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -308,9 +308,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
             var project = document.Project;
 
-            // Razor wants to handle all span mapping themselves.  So if we are in razor, return the raw doc spans, and
-            // do not map them.
-            var useMappedSpan = !document.IsRazorDocument();
+            // We currently do not map diagnostics spans as
+            //   1.  Razor handles span mapping for razor files on their side.
+            //   2.  LSP does not allow us to report document pull diagnostics for a different file path.
+            //   3.  The VS LSP client does not support document pull diagnostics for files outside our content type.
+            //   3.  This matches classic behavior where we only squiggle the original location anyway.
+            var useMappedSpan = false;
             return new VSDiagnostic
             {
                 Source = GetType().Name,


### PR DESCRIPTION
Previously, we only mapped the diagnostic span, so if the diagnostic was mapped to a different file it would show up at the mapped span, but in the unmapped (original) file.  The change here is to not map these diagnostics.  This matches behavior in classic scenarios as well.

Once we have the new protocol and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1342106/ it may be possible to enhance this support and actually return the mapped locations to the client.

Before:
![image](https://user-images.githubusercontent.com/5749229/124848711-3e45b480-df52-11eb-93ae-b22d624b12bf.png)

After:
![image](https://user-images.githubusercontent.com/5749229/124848831-8238b980-df52-11eb-8786-f18da80b48c2.png)

Non-LSP: 
![image](https://user-images.githubusercontent.com/5749229/124848919-a85e5980-df52-11eb-9224-c2e8782cfa04.png)
Note that in non-LSP we do show the mapped line and file name in the error list, but navigation takes you to the unmapped location anyway...


Resolves #54634