### PR TITLE
Force compiler apps to ref netstadard2.0 version of SCI and SRM

### DIFF
--- a/eng/targets/UseNetStandardOverDesktopReferences.targets
+++ b/eng/targets/UseNetStandardOverDesktopReferences.targets
@@ -1,0 +1,27 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">  
+    <!-- 
+      By default, when a project targeting net472, the desktop version of the references in NuGet pacakges will be chosen over netstandard2.0 ones
+      (See https://github.com/dotnet/sdk/issues/1791 for more details on this behavior). This is not an issue in terms of the functionality of the product.
+      However, it's causing us problem during IBC optimization. We are shipping two copies of SCI and SRM in VS, and are responsible for their optimization.
+      Our setup is authored such that their netstandard2.0 version is explicitly deployed to PrivateAssemblies folder, and the version referenced by csi
+      targeting net472 is deployed to MsBuild folder as part of the compiler toolset (see `src\NuGet\Microsoft.Net.Compilers.Toolset\DesktopCompilerArtifacts.targets`.)
+      The way our current system works is to profile both devenv and vbcscompiler processes in OptProf, and the IBC data collected are combined and used to optimize
+      both copies of SCI and SRM. But ibcmerge can't accept IBC files collected from binaries with different MVID, doing so will cause it to fail (or ignore mismatched files)
+      (see https://github.com/dotnet/roslyn/issues/53197.)
+
+      This is a workaround for the issue above:
+        - Basically we are forcing all console projects shipped as a part of Microsoft.CodeAnalysis.Compilers.vsix to take netstandard2.0 version of SCI and SRM as references.
+        - We need to do this for all those projects (instead of csi only) because the content of all sources of toolset nupkg must be consistent.
+    -->
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>$(PkgSystem_Collections_Immutable)\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>$(PkgSystem_Reflection_Metadata)\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -39,5 +39,6 @@
     </None>
   </ItemGroup>
   <Import Project="..\..\Core\CommandLine\CommandLine.projitems" Label="Shared" />
+  <Import Project="$(RepositoryEngineeringDir)targets\UseNetStandardOverDesktopReferences.targets" />
   <Import Project="$(RepositoryEngineeringDir)targets\DiaSymReaderNative.targets" />
 </Project>

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -36,5 +36,6 @@
     <InternalsVisibleTo Include="VBCSCompiler.UnitTests" />
   </ItemGroup>
   <Import Project="..\..\Core\CommandLine\CommandLine.projitems" Label="Shared" />
+  <Import Project="$(RepositoryEngineeringDir)targets\UseNetStandardOverDesktopReferences.targets" />
   <Import Project="$(RepositoryEngineeringDir)targets\DiaSymReaderNative.targets" />
 </Project>

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -37,5 +37,6 @@
     </None>
   </ItemGroup>
   <Import Project="..\..\Core\CommandLine\CommandLine.projitems" Label="Shared" />
+  <Import Project="$(RepositoryEngineeringDir)targets\UseNetStandardOverDesktopReferences.targets" />
   <Import Project="$(RepositoryEngineeringDir)targets\DiaSymReaderNative.targets" />
 </Project>

--- a/src/Interactive/csi/csi.csproj
+++ b/src/Interactive/csi/csi.csproj
@@ -16,6 +16,28 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
   </ItemGroup>
+
+  <!-- 
+    By default, when this project targeting net472, the net461 version of the references in NuGet pacakges will be chosen over netstandard2.0 ones
+    (See https://github.com/dotnet/sdk/issues/1791 for more details on this behavior). This is not an issue in terms of the functionality of the product.
+    However, it's causing us problem during IBC optimization. We are shipping two copies of SCI and SRM in VS, and are responsible for their optimization.
+    Our setup is authored such that their netstandard2.0 version is explicitly deployed to PrivateAssemblies folder, and the version referenced by csi
+    targeting net472 is deployed to MsBuild folder as part of the compiler toolset (see `src\NuGet\Microsoft.Net.Compilers.Toolset\DesktopCompilerArtifacts.targets`.)
+    The way our current system works is to profile both devenv and vbcscompiler processes in OptProf, and the IBC data collected are combined and used to optimize
+    both copies of SCI and SRM. But ibcmerge can't accept IBC files collected from binaries with different MVID, doing so will cause it to fail (or ignore mismatched files)
+    (see https://github.com/dotnet/roslyn/issues/53197.) This is a workaround for this issue, basically we are forcing csi to take netstandard2.0 version of SCI and SRM.    
+   -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" ExcludeAssets="Compile" GeneratePathProperty="true"/>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>$(PkgSystem_Collections_Immutable)\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" ExcludeAssets="Compile" GeneratePathProperty="true"/>
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>$(PkgSystem_Reflection_Metadata)\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="App.config" />
     <None Include="csi.coreclr.rsp" Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/Interactive/csi/csi.csproj
+++ b/src/Interactive/csi/csi.csproj
@@ -28,11 +28,11 @@
     (see https://github.com/dotnet/roslyn/issues/53197.) This is a workaround for this issue, basically we are forcing csi to take netstandard2.0 version of SCI and SRM.    
    -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" ExcludeAssets="Compile" GeneratePathProperty="true"/>
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
     <Reference Include="System.Collections.Immutable">
       <HintPath>$(PkgSystem_Collections_Immutable)\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" ExcludeAssets="Compile" GeneratePathProperty="true"/>
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>$(PkgSystem_Reflection_Metadata)\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
     </Reference>

--- a/src/Interactive/csi/csi.csproj
+++ b/src/Interactive/csi/csi.csproj
@@ -16,28 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
   </ItemGroup>
-
-  <!-- 
-    By default, when this project targeting net472, the net461 version of the references in NuGet pacakges will be chosen over netstandard2.0 ones
-    (See https://github.com/dotnet/sdk/issues/1791 for more details on this behavior). This is not an issue in terms of the functionality of the product.
-    However, it's causing us problem during IBC optimization. We are shipping two copies of SCI and SRM in VS, and are responsible for their optimization.
-    Our setup is authored such that their netstandard2.0 version is explicitly deployed to PrivateAssemblies folder, and the version referenced by csi
-    targeting net472 is deployed to MsBuild folder as part of the compiler toolset (see `src\NuGet\Microsoft.Net.Compilers.Toolset\DesktopCompilerArtifacts.targets`.)
-    The way our current system works is to profile both devenv and vbcscompiler processes in OptProf, and the IBC data collected are combined and used to optimize
-    both copies of SCI and SRM. But ibcmerge can't accept IBC files collected from binaries with different MVID, doing so will cause it to fail (or ignore mismatched files)
-    (see https://github.com/dotnet/roslyn/issues/53197.) This is a workaround for this issue, basically we are forcing csi to take netstandard2.0 version of SCI and SRM.    
-   -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>$(PkgSystem_Collections_Immutable)\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
-    </Reference>
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" ExcludeAssets="All" GeneratePathProperty="true"/>
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>$(PkgSystem_Reflection_Metadata)\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="App.config" />
     <None Include="csi.coreclr.rsp" Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
@@ -52,5 +30,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.Scripting.Desktop.UnitTests" />
   </ItemGroup>
+  <Import Project="$(RepositoryEngineeringDir)targets\UseNetStandardOverDesktopReferences.targets" />
   <Import Project="$(RepositoryEngineeringDir)targets\DiaSymReaderNative.targets" />
 </Project>


### PR DESCRIPTION
Address the mvid mismatch error in ibcmerge https://github.com/dotnet/roslyn/issues/53197