### PR TITLE
Increase timeout for macOS debug

### DIFF
--- a/eng/pipelines/test-unix-job.yml
+++ b/eng/pipelines/test-unix-job.yml
@@ -27,7 +27,7 @@ jobs:
     # a thin client that kicks off a helix job and waits for it to complete.
     # Thus we don't use a helix queue to run the job here, and instead use the plentiful AzDO vmImages.
     vmImage: ubuntu-20.04
-  timeoutInMinutes: 40
+  timeoutInMinutes: 90
   steps:
     - checkout: none
 


### PR DESCRIPTION
The macOS debug task has timed out pretty often over the past few days. First responders have looked into the issue and recommended increasing the timeout time from 40 to 90 minutes as it primarily seems to be a queue capacity issue.