### PR TITLE
Well known type members' code refurbish

### DIFF
--- a/src/Compilers/Core/Portable/MemberDescriptor.cs
+++ b/src/Compilers/Core/Portable/MemberDescriptor.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
             this.Signature = Signature;
         }
 
-        internal static ImmutableArray<MemberDescriptor> FromSignatureInfo(ImmutableArray<WellKnownMemberSignatureInfo> signatureInfo)
+        internal static ImmutableArray<MemberDescriptor> FromSignatureInfo(ImmutableArray<MemberSignatureInfo> signatureInfo)
         {
             int totalBytes = 0;
             for (int i = 0; i < signatureInfo.Length; i++)

--- a/src/Compilers/Core/Portable/MemberDescriptor.cs
+++ b/src/Compilers/Core/Portable/MemberDescriptor.cs
@@ -118,9 +118,19 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
             for (int i = 0; i < signatureInfo.Length; i++)
                 signatureInfo[i].SerializeToBuffer(memoryStream);
 
-            return InitializeFromStream(memoryStream, signatureInfo.SelectAsArray(sig => sig.Name).ToArray());
+            var builder = ImmutableArray.CreateBuilder<MemberDescriptor>(signatureInfo.Length);
+            var signatureBuilder = ImmutableArray.CreateBuilder<byte>();
+
+            for (int i = 0; i < signatureInfo.Length; i++)
+            {
+                builder.Add(InitializeSingleFromStream(memoryStream, signatureInfo[i].Name, signatureBuilder));
+                signatureBuilder.Clear();
+            }
+
+            return builder.ToImmutable();
         }
 
+        // TODO: Remove when both SpecialMembers and WellKnownMembers make use of the new API
         internal static ImmutableArray<MemberDescriptor> InitializeFromStream(Stream stream, string[] nameTable)
         {
             int count = nameTable.Length;

--- a/src/Compilers/Core/Portable/MemberDescriptor.cs
+++ b/src/Compilers/Core/Portable/MemberDescriptor.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.RuntimeMembers
         internal static MemberDescriptor InitializeSingleFromStream(Stream stream, string name)
         {
             var signatureBuilder = ImmutableArray.CreateBuilder<byte>();
-            return InitializeSingleFromStream(stream, name, signatureBuilder));
+            return InitializeSingleFromStream(stream, name, signatureBuilder);
         }
 
         private static MemberDescriptor InitializeSingleFromStream(Stream stream, string name, ImmutableArray<byte>.Builder signatureBuilder)

--- a/src/Compilers/Core/Portable/MemberSignatureInfo.cs
+++ b/src/Compilers/Core/Portable/MemberSignatureInfo.cs
@@ -11,17 +11,17 @@ using Microsoft.CodeAnalysis.RuntimeMembers;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal class WellKnownMemberSignatureInfo
+    internal class MemberSignatureInfo
     {
         public MemberFlags MemberFlags { get; init; }
         public WellKnownType DeclaringType { get; init; }
         public int Arity { get; init; }
         public int MethodSignature { get; init; }
         public string Name { get; init; }
-        public WellKnownMemberArgumentInfo ReturnType { get; init; }
-        public ImmutableArray<WellKnownMemberArgumentInfo> Arguments { get; init; }
+        public MemberArgumentInfo ReturnType { get; init; }
+        public ImmutableArray<MemberArgumentInfo> Arguments { get; init; }
 
-        public WellKnownMemberArgumentInfo[] ArgumentArray
+        public MemberArgumentInfo[] ArgumentArray
         {
             init => Arguments = value.ToImmutableArray();
         }
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis
                 if (!value)
                     return;
 
-                Arguments = ImmutableArray<WellKnownMemberArgumentInfo>.Empty;
+                Arguments = ImmutableArray<MemberArgumentInfo>.Empty;
             }
         }
 
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis
         }
     }
 
-    internal unsafe struct WellKnownMemberArgumentInfo
+    internal unsafe struct MemberArgumentInfo
     {
         // Struct designed to be 8 bytes in total
         private fixed byte _bytes[7];
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private WellKnownMemberArgumentInfo(byte* bytes, int length, bool isSZArray, bool isByReference)
+        private MemberArgumentInfo(byte* bytes, int length, bool isSZArray, bool isByReference)
         {
             int start = 0;
             evaluateFlag(isByReference, SignatureTypeCode.ByReference, bytes, ref start);
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         // Factory methods
-        public static WellKnownMemberArgumentInfo FromSimpleSpecialType(SpecialType specialType, bool isSZArray = false, bool isByReference = false)
+        public static MemberArgumentInfo FromSimpleSpecialType(SpecialType specialType, bool isSZArray = false, bool isByReference = false)
         {
             var bytes = new[]
             {
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis
             fixed (byte* b = bytes)
                 return new(b, bytes.Length, isSZArray, isByReference);
         }
-        public static WellKnownMemberArgumentInfo FromSimpleWellKnownType(WellKnownType wellKnownType, bool isSZArray = false, bool isByReference = false)
+        public static MemberArgumentInfo FromSimpleWellKnownType(WellKnownType wellKnownType, bool isSZArray = false, bool isByReference = false)
         {
             byte[] bytes;
 
@@ -171,15 +171,15 @@ namespace Microsoft.CodeAnalysis
             fixed (byte* b = bytes)
                 return new(b, bytes.Length, isSZArray, isByReference);
         }
-        public static WellKnownMemberArgumentInfo FromGenericMethodParameter(int index, bool isSZArray = false, bool isByReference = false)
+        public static MemberArgumentInfo FromGenericMethodParameter(int index, bool isSZArray = false, bool isByReference = false)
         {
             return FromIndexedTypeCode(index, SignatureTypeCode.GenericMethodParameter, isSZArray, isByReference);
         }
-        public static WellKnownMemberArgumentInfo FromGenericTypeParameter(int index, bool isSZArray = false, bool isByReference = false)
+        public static MemberArgumentInfo FromGenericTypeParameter(int index, bool isSZArray = false, bool isByReference = false)
         {
             return FromIndexedTypeCode(index, SignatureTypeCode.GenericTypeParameter, isSZArray, isByReference);
         }
-        private static WellKnownMemberArgumentInfo FromIndexedTypeCode(int index, SignatureTypeCode typeCode, bool isSZArray, bool isByReference)
+        private static MemberArgumentInfo FromIndexedTypeCode(int index, SignatureTypeCode typeCode, bool isSZArray, bool isByReference)
         {
             var bytes = new[]
             {
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis
             fixed (byte* b = bytes)
                 return new(b, bytes.Length, isSZArray, isByReference);
         }
-        public static WellKnownMemberArgumentInfo FromGenericTypeInstance(WellKnownMemberArgumentInfo genericType, WellKnownMemberArgumentInfo[] typeArguments, bool isSZArray = false, bool isByReference = false)
+        public static MemberArgumentInfo FromGenericTypeInstance(MemberArgumentInfo genericType, MemberArgumentInfo[] typeArguments, bool isSZArray = false, bool isByReference = false)
         {
             int byteCount = genericType.Length
                           + 1 // Arity

--- a/src/Compilers/Core/Portable/WellKnownMemberSignatureInfo.cs
+++ b/src/Compilers/Core/Portable/WellKnownMemberSignatureInfo.cs
@@ -1,0 +1,205 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.RuntimeMembers;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal class WellKnownMemberSignatureInfo
+    {
+        public MemberFlags MemberFlags { get; init; }
+        public WellKnownType DeclaringType { get; init; }
+        public int Arity { get; init; }
+        public int MethodSignature { get; init; }
+        public string Name { get; init; }
+        public WellKnownMemberArgumentInfo ReturnType { get; init; }
+        public ImmutableArray<WellKnownMemberArgumentInfo> Arguments { get; init; }
+
+        public WellKnownMemberArgumentInfo[] ArgumentArray
+        {
+            init => Arguments = value.ToImmutableArray();
+        }
+
+        /// <summary>
+        /// Determines the byte count for the well-known member as it will appear in
+        /// the memory buffer when initializing the descriptors, excluding its name.
+        /// </summary>
+        /// <returns>The total serialized byte count that will be present in the memory buffer.</returns>
+        public int GetTotalSerializedByteCount()
+        {
+            int declaringTypeBytes = 1 + (DeclaringType > WellKnownType.ExtSentinel ? 1 : 0);
+            return 1 // MemberFlags
+                 + declaringTypeBytes // DeclaringType
+                 + 1 // Arity
+                 + Arguments.Length
+                 + ReturnType.Length
+                 + Arguments.Sum(arg => arg.Length);
+        }
+
+        public byte[] SerializeToByteArray()
+        {
+            var arrayBuilder = new ArrayBuilder<byte>(GetTotalSerializedByteCount());
+            SerializeToBuffer(arrayBuilder);
+            return arrayBuilder.ToArray();
+        }
+
+        public void SerializeToBuffer(ArrayBuilder<byte> bufferBuilder)
+        {
+            // MemberFlags
+            bufferBuilder.Add((byte)MemberFlags);
+
+            // DeclaringType
+            if (DeclaringType > WellKnownType.ExtSentinel)
+            {
+                bufferBuilder.Add((byte)WellKnownType.ExtSentinel);
+                bufferBuilder.Add((byte)(DeclaringType - WellKnownType.ExtSentinel));
+            }
+            else
+            {
+                bufferBuilder.Add((byte)DeclaringType);
+            }
+
+            // Arity
+            bufferBuilder.Add((byte)Arity);
+
+            // Method Signature
+            bufferBuilder.Add((byte)Arguments.Length);
+
+            // Return Type
+            AddRange(bufferBuilder, ReturnType.Bytes);
+
+            // Arguments
+            for (int i = 0; i < Arguments.Length; i++)
+                AddRange(bufferBuilder, Arguments[i].Bytes);
+        }
+
+        // This should be an extension method somewhere
+        private static void AddRange<T>(ArrayBuilder<T> builder, Span<T> span)
+            where T : unmanaged
+        {
+            for (int i = 0; i < span.Length; i++)
+                builder.Add(span[i]);
+        }
+    }
+
+    internal unsafe struct WellKnownMemberArgumentInfo
+    {
+        // Struct designed to be 8 bytes in total
+        private fixed byte _bytes[7];
+        private readonly byte _length;
+
+        public int Length => _length;
+
+        public Span<byte> Bytes
+        {
+            get
+            {
+                fixed (byte* b = _bytes)
+                    return new(b, _length);
+            }
+        }
+
+        private WellKnownMemberArgumentInfo(byte* bytes, int length, bool isSZArray, bool isByReference)
+        {
+            int start = 0;
+            EvaluateFlag(isByReference, SignatureTypeCode.ByReference, bytes, ref length, ref start);
+            EvaluateFlag(isSZArray, SignatureTypeCode.SZArray, bytes, ref length, ref start);
+
+            _length = (byte)length;
+
+            for (int i = start; i < length; i++)
+                _bytes[i] = bytes[i];
+
+            static void EvaluateFlag(bool condition, SignatureTypeCode typeCode, byte* bytes, ref int length, ref int start)
+            {
+                if (!condition)
+                    return;
+
+                bytes[start] = (byte)typeCode;
+                length++;
+                start++;
+            }
+        }
+
+        // Factory methods
+        public static WellKnownMemberArgumentInfo FromSimpleSpecialType(SpecialType specialType, bool isSZArray = false, bool isByReference = false)
+        {
+            var bytes = new[]
+            {
+                (byte)SignatureTypeCode.TypeHandle,
+                (byte)specialType
+            };
+
+            fixed (byte* b = bytes)
+                return new(b, bytes.Length, isSZArray, isByReference);
+        }
+        public static WellKnownMemberArgumentInfo FromSimpleWellKnownType(WellKnownType wellKnownType, bool isSZArray = false, bool isByReference = false)
+        {
+            byte[] bytes;
+
+            if (wellKnownType > WellKnownType.ExtSentinel)
+            {
+                bytes = new[]
+                {
+                    (byte)SignatureTypeCode.TypeHandle,
+                    (byte)WellKnownType.ExtSentinel,
+                    (byte)(wellKnownType - WellKnownType.ExtSentinel)
+                };
+
+                fixed (byte* b = bytes)
+                    return new(b, bytes.Length, isSZArray, isByReference);
+            }
+
+            bytes = new[]
+            {
+                (byte)SignatureTypeCode.TypeHandle,
+                (byte)wellKnownType
+            };
+
+            fixed (byte* b = bytes)
+                return new(b, bytes.Length, isSZArray, isByReference);
+        }
+        public static WellKnownMemberArgumentInfo FromGenericMethodParameter(int index, bool isSZArray = false, bool isByReference = false)
+        {
+            var bytes = new[]
+            {
+                (byte)SignatureTypeCode.GenericMethodParameter,
+                (byte)index
+            };
+
+            fixed (byte* b = bytes)
+                return new(b, bytes.Length, isSZArray, isByReference);
+        }
+        public static WellKnownMemberArgumentInfo FromGenericTypeInstance(WellKnownMemberArgumentInfo genericType, WellKnownMemberArgumentInfo[] typeArguments, bool isSZArray = false, bool isByReference = false)
+        {
+            int byteCount = genericType.Length
+                          + 1 // Arity
+                          + typeArguments.Sum(arg => arg.Length);
+
+            // Copy the generic type's bytes
+            var bytes = new byte[byteCount];
+            for (int i = 0; i < genericType.Length; i++)
+                bytes[i] = genericType._bytes[i];
+
+            // Copy arity
+            bytes[genericType.Length] = (byte)typeArguments.Length;
+
+            // Copy type arguments iteratively
+            int resultIndex = genericType.Length + 1;
+            for (int i = 0; i < typeArguments.Length; i++)
+            {
+                for (int argumentByte = 0; argumentByte < typeArguments[i].Length; argumentByte++, resultIndex++)
+                    bytes[resultIndex] = typeArguments[i]._bytes[argumentByte];
+            }
+
+            fixed (byte* b = bytes)
+                return new(b, byteCount, isSZArray, isByReference);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/WellKnownMemberSignatureInfo.cs
+++ b/src/Compilers/Core/Portable/WellKnownMemberSignatureInfo.cs
@@ -27,6 +27,21 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Upon set to <see langword="true"/>, sets the arguments array to an empty one.
+        /// Can be used as a shortcut instead of manually initializing with <see cref="Array.Empty{T}"/>.
+        /// </summary>
+        public bool NoArguments
+        {
+            init
+            {
+                if (!value)
+                    return;
+
+                Arguments = ImmutableArray<WellKnownMemberArgumentInfo>.Empty;
+            }
+        }
+
+        /// <summary>
         /// Determines the byte count for the well-known member as it will appear in
         /// the memory buffer when initializing the descriptors, excluding its name.
         /// </summary>
@@ -166,9 +181,17 @@ namespace Microsoft.CodeAnalysis
         }
         public static WellKnownMemberArgumentInfo FromGenericMethodParameter(int index, bool isSZArray = false, bool isByReference = false)
         {
+            return FromIndexedTypeCode(index, SignatureTypeCode.GenericMethodParameter, isSZArray, isByReference);
+        }
+        public static WellKnownMemberArgumentInfo FromGenericTypeParameter(int index, bool isSZArray = false, bool isByReference = false)
+        {
+            return FromIndexedTypeCode(index, SignatureTypeCode.GenericTypeParameter, isSZArray, isByReference);
+        }
+        private static WellKnownMemberArgumentInfo FromIndexedTypeCode(int index, SignatureTypeCode typeCode, bool isSZArray, bool isByReference)
+        {
             var bytes = new[]
             {
-                (byte)SignatureTypeCode.GenericMethodParameter,
+                (byte)typeCode,
                 (byte)index
             };
 

--- a/src/Compilers/Core/Portable/WellKnownMemberSignatureInfo.cs
+++ b/src/Compilers/Core/Portable/WellKnownMemberSignatureInfo.cs
@@ -108,21 +108,20 @@ namespace Microsoft.CodeAnalysis
         private WellKnownMemberArgumentInfo(byte* bytes, int length, bool isSZArray, bool isByReference)
         {
             int start = 0;
-            EvaluateFlag(isByReference, SignatureTypeCode.ByReference, bytes, ref length, ref start);
-            EvaluateFlag(isSZArray, SignatureTypeCode.SZArray, bytes, ref length, ref start);
+            evaluateFlag(isByReference, SignatureTypeCode.ByReference, bytes, ref start);
+            evaluateFlag(isSZArray, SignatureTypeCode.SZArray, bytes, ref start);
 
-            _length = (byte)length;
+            _length = (byte)(length + start);
 
-            for (int i = start; i < length; i++)
-                _bytes[i] = bytes[i];
+            for (int i = 0; i < length; i++)
+                _bytes[start + i] = bytes[i];
 
-            static void EvaluateFlag(bool condition, SignatureTypeCode typeCode, byte* bytes, ref int length, ref int start)
+            static void evaluateFlag(bool condition, SignatureTypeCode typeCode, byte* bytes, ref int start)
             {
                 if (!condition)
                     return;
 
                 bytes[start] = (byte)typeCode;
-                length++;
                 start++;
             }
         }

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -128,10 +128,7 @@ namespace Microsoft.CodeAnalysis
             };
             // END
 
-            var descriptorBuilder = ImmutableArray.CreateBuilder<MemberDescriptor>((int)WellKnownMember.Count);
-            for (int i = 0; i < signatureInfoArrayBuilder.Count; i++)
-                descriptorBuilder[i] = MemberDescriptor.FromSignatureInfo(signatureInfoArrayBuilder[i]);
-            s_descriptors = descriptorBuilder.ToImmutable();
+            s_descriptors = MemberDescriptor.FromSignatureInfo(signatureInfoArrayBuilder.ToImmutable());
 
             // TODO: Remove once the new API is used for all members
             return;

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis
 
         static WellKnownMembers()
         {
-            var signatureInfoArrayBuilder = ImmutableArray.CreateBuilder<WellKnownMemberSignatureInfo>((int)WellKnownMember.Count);
+            var signatureInfoArrayBuilder = ImmutableArray.CreateBuilder<MemberSignatureInfo>((int)WellKnownMember.Count);
 
             signatureInfoArrayBuilder[(int)WellKnownMember.System_Math__RoundDouble] = new()
             {
@@ -22,10 +22,10 @@ namespace Microsoft.CodeAnalysis
                 DeclaringType = WellKnownType.System_Math,
                 Name = "Round",
                 Arity = 0,
-                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                ReturnType = MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
                 ArgumentArray = new[]
                 {
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
                 },
             };
             signatureInfoArrayBuilder[(int)WellKnownMember.System_Math__PowDoubleDouble] = new()
@@ -34,11 +34,11 @@ namespace Microsoft.CodeAnalysis
                 DeclaringType = WellKnownType.System_Math,
                 Name = "Pow",
                 Arity = 0,
-                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                ReturnType = MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
                 ArgumentArray = new[]
                 {
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
                 },
             };
             signatureInfoArrayBuilder[(int)WellKnownMember.System_Array__get_Length] = new()
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis
                 DeclaringType = WellKnownType.System_Array,
                 Name = "get_Length",
                 Arity = 0,
-                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Int32),
+                ReturnType = MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Int32),
                 NoArguments = true,
             };
             signatureInfoArrayBuilder[(int)WellKnownMember.System_Array__Empty] = new()
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis
                 DeclaringType = WellKnownType.System_Array,
                 Name = "Empty",
                 Arity = 1,
-                ReturnType = WellKnownMemberArgumentInfo.FromGenericMethodParameter(0, isSZArray: true),
+                ReturnType = MemberArgumentInfo.FromGenericMethodParameter(0, isSZArray: true),
                 NoArguments = true,
             };
             // TODO: Convert the others below into the new API
@@ -68,17 +68,17 @@ namespace Microsoft.CodeAnalysis
                 DeclaringType = WellKnownType.Microsoft_VisualBasic_CompilerServices_NewLateBinding,
                 Name = "LateCall",
                 Arity = 0,
-                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Object),
+                ReturnType = MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Object),
                 ArgumentArray = new[]
                 {
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Object),
-                    WellKnownMemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Type),
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String),
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Object, isSZArray: true),
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String, isSZArray: true),
-                    WellKnownMemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Type, isSZArray: true),
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Boolean, isSZArray: true),
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Boolean),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Object),
+                    MemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Type),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Object, isSZArray: true),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String, isSZArray: true),
+                    MemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Type, isSZArray: true),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Boolean, isSZArray: true),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Boolean),
                 },
             };
             signatureInfoArrayBuilder[(int)WellKnownMember.Microsoft_VisualBasic_CompilerServices_StringType__MidStmtStr] = new()
@@ -87,13 +87,13 @@ namespace Microsoft.CodeAnalysis
                 DeclaringType = WellKnownType.Microsoft_VisualBasic_CompilerServices_StringType,
                 Name = "MidStmtStr",
                 Arity = 0,
-                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Void),
+                ReturnType = MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Void),
                 ArgumentArray = new[]
                 {
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String, isSZArray: true),
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Int32),
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Int32),
-                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String, isSZArray: true),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Int32),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Int32),
+                    MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String),
                 },
             };
             signatureInfoArrayBuilder[(int)WellKnownMember.System_Runtime_CompilerServices_AsyncVoidMethodBuilder__AwaitUnsafeOnCompleted] = new()
@@ -102,11 +102,11 @@ namespace Microsoft.CodeAnalysis
                 DeclaringType = WellKnownType.System_Runtime_CompilerServices_AsyncVoidMethodBuilder,
                 Name = "AwaitUnsafeOnCompleted",
                 Arity = 2,
-                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Void),
+                ReturnType = MemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Void),
                 ArgumentArray = new[]
                 {
-                    WellKnownMemberArgumentInfo.FromGenericMethodParameter(0, isByReference: true),
-                    WellKnownMemberArgumentInfo.FromGenericMethodParameter(1, isByReference: true),
+                    MemberArgumentInfo.FromGenericMethodParameter(0, isByReference: true),
+                    MemberArgumentInfo.FromGenericMethodParameter(1, isByReference: true),
                 },
             };
             signatureInfoArrayBuilder[(int)WellKnownMember.System_Collections_Generic_IAsyncEnumerable_T__GetAsyncEnumerator] = new()
@@ -115,15 +115,15 @@ namespace Microsoft.CodeAnalysis
                 DeclaringType = WellKnownType.System_Collections_Generic_IAsyncEnumerable_T,
                 Name = "GetAsyncEnumerator",
                 Arity = 0,
-                ReturnType = WellKnownMemberArgumentInfo.FromGenericTypeInstance(
-                    WellKnownMemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Collections_Generic_IAsyncEnumerator_T),
+                ReturnType = MemberArgumentInfo.FromGenericTypeInstance(
+                    MemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Collections_Generic_IAsyncEnumerator_T),
                     new[]
                     {
-                        WellKnownMemberArgumentInfo.FromGenericTypeParameter(0),
+                        MemberArgumentInfo.FromGenericTypeParameter(0),
                     }),
                 ArgumentArray = new[]
                 {
-                    WellKnownMemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Threading_CancellationToken),
+                    MemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Threading_CancellationToken),
                 },
             };
             // END

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -14,6 +14,31 @@ namespace Microsoft.CodeAnalysis
 
         static WellKnownMembers()
         {
+            var signatureInfoArrayBuilder = ImmutableArray.CreateBuilder<WellKnownMemberSignatureInfo>((int)WellKnownMember.Count);
+
+            signatureInfoArrayBuilder[(int)WellKnownMember.System_Math__RoundDouble] = new WellKnownMemberSignatureInfo
+            {
+                MemberFlags = MemberFlags.Method | MemberFlags.Static,
+                DeclaringType = WellKnownType.System_Math,
+                Arity = 0,
+                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                ArgumentArray = new[]
+                {
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                },
+                Name = "Round",
+            };
+            // TODO: Convert the others below into the new API
+
+            var descriptorBuilder = ImmutableArray.CreateBuilder<MemberDescriptor>((int)WellKnownMember.Count);
+            for (int i = 0; i < signatureInfoArrayBuilder.Count; i++)
+                descriptorBuilder[i] = MemberDescriptor.FromSignatureInfo(signatureInfoArrayBuilder[i]);
+            s_descriptors = descriptorBuilder.ToImmutable();
+
+            // TODO: Remove once the new API is used for all members
+            return;
+
+            // Old implementation that must be gotten rid of
             byte[] initializationBytes = new byte[]
             {
                 // System_Math__RoundDouble

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -16,19 +16,117 @@ namespace Microsoft.CodeAnalysis
         {
             var signatureInfoArrayBuilder = ImmutableArray.CreateBuilder<WellKnownMemberSignatureInfo>((int)WellKnownMember.Count);
 
-            signatureInfoArrayBuilder[(int)WellKnownMember.System_Math__RoundDouble] = new WellKnownMemberSignatureInfo
+            signatureInfoArrayBuilder[(int)WellKnownMember.System_Math__RoundDouble] = new()
             {
                 MemberFlags = MemberFlags.Method | MemberFlags.Static,
                 DeclaringType = WellKnownType.System_Math,
+                Name = "Round",
                 Arity = 0,
                 ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
                 ArgumentArray = new[]
                 {
                     WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
                 },
-                Name = "Round",
+            };
+            signatureInfoArrayBuilder[(int)WellKnownMember.System_Math__PowDoubleDouble] = new()
+            {
+                MemberFlags = MemberFlags.Method | MemberFlags.Static,
+                DeclaringType = WellKnownType.System_Math,
+                Name = "Pow",
+                Arity = 0,
+                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                ArgumentArray = new[]
+                {
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Double),
+                },
+            };
+            signatureInfoArrayBuilder[(int)WellKnownMember.System_Array__get_Length] = new()
+            {
+                MemberFlags = MemberFlags.PropertyGet,
+                DeclaringType = WellKnownType.System_Array,
+                Name = "get_Length",
+                Arity = 0,
+                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Int32),
+                NoArguments = true,
+            };
+            signatureInfoArrayBuilder[(int)WellKnownMember.System_Array__Empty] = new()
+            {
+                MemberFlags = MemberFlags.Method | MemberFlags.Static,
+                DeclaringType = WellKnownType.System_Array,
+                Name = "Empty",
+                Arity = 1,
+                ReturnType = WellKnownMemberArgumentInfo.FromGenericMethodParameter(0, isSZArray: true),
+                NoArguments = true,
             };
             // TODO: Convert the others below into the new API
+
+            // BEGIN API functionality stress test (also discover new edge cases)
+            signatureInfoArrayBuilder[(int)WellKnownMember.Microsoft_VisualBasic_CompilerServices_NewLateBinding__LateCall] = new()
+            {
+                MemberFlags = MemberFlags.Method | MemberFlags.Static,
+                DeclaringType = WellKnownType.Microsoft_VisualBasic_CompilerServices_NewLateBinding,
+                Name = "LateCall",
+                Arity = 0,
+                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Object),
+                ArgumentArray = new[]
+                {
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Object),
+                    WellKnownMemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Type),
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String),
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Object, isSZArray: true),
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String, isSZArray: true),
+                    WellKnownMemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Type, isSZArray: true),
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Boolean, isSZArray: true),
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Boolean),
+                },
+            };
+            signatureInfoArrayBuilder[(int)WellKnownMember.Microsoft_VisualBasic_CompilerServices_StringType__MidStmtStr] = new()
+            {
+                MemberFlags = MemberFlags.Method | MemberFlags.Static,
+                DeclaringType = WellKnownType.Microsoft_VisualBasic_CompilerServices_StringType,
+                Name = "MidStmtStr",
+                Arity = 0,
+                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Void),
+                ArgumentArray = new[]
+                {
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String, isSZArray: true),
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Int32),
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Int32),
+                    WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_String),
+                },
+            };
+            signatureInfoArrayBuilder[(int)WellKnownMember.System_Runtime_CompilerServices_AsyncVoidMethodBuilder__AwaitUnsafeOnCompleted] = new()
+            {
+                MemberFlags = MemberFlags.Method | MemberFlags.Static,
+                DeclaringType = WellKnownType.System_Runtime_CompilerServices_AsyncVoidMethodBuilder,
+                Name = "AwaitUnsafeOnCompleted",
+                Arity = 2,
+                ReturnType = WellKnownMemberArgumentInfo.FromSimpleSpecialType(SpecialType.System_Void),
+                ArgumentArray = new[]
+                {
+                    WellKnownMemberArgumentInfo.FromGenericMethodParameter(0, isByReference: true),
+                    WellKnownMemberArgumentInfo.FromGenericMethodParameter(1, isByReference: true),
+                },
+            };
+            signatureInfoArrayBuilder[(int)WellKnownMember.System_Collections_Generic_IAsyncEnumerable_T__GetAsyncEnumerator] = new()
+            {
+                MemberFlags = MemberFlags.Method | MemberFlags.Virtual,
+                DeclaringType = WellKnownType.System_Collections_Generic_IAsyncEnumerable_T,
+                Name = "GetAsyncEnumerator",
+                Arity = 0,
+                ReturnType = WellKnownMemberArgumentInfo.FromGenericTypeInstance(
+                    WellKnownMemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Collections_Generic_IAsyncEnumerator_T),
+                    new[]
+                    {
+                        WellKnownMemberArgumentInfo.FromGenericTypeParameter(0),
+                    }),
+                ArgumentArray = new[]
+                {
+                    WellKnownMemberArgumentInfo.FromSimpleWellKnownType(WellKnownType.System_Threading_CancellationToken),
+                },
+            };
+            // END
 
             var descriptorBuilder = ImmutableArray.CreateBuilder<MemberDescriptor>((int)WellKnownMember.Count);
             for (int i = 0; i < signatureInfoArrayBuilder.Count; i++)


### PR DESCRIPTION
Related PR as discussed from #54668

# Goals

- [x] Introduce new API to handle the method descriptors
- [ ] Ensure that all the features are ported into the API
- [ ] Convert all the old code into code that uses the API
- [ ] Ensure nothing is broken

# Considerations

- ~~This new API creates objects that describe information about the well-known types' methods in a more human-friendly way, however each object is converted into a serialized buffer of bytes, creating a new array for each object, which introduces overhead. A much better alternative would be to batch serialize all objects into a massive array whose length is calculated based on the objects themselves, as provided in the `GetTotalSerializedByteCount()` method.~~<br/>
~~Ideally it would be a wrapper that internally contains an array that is filled with such signature info objects, and when asked to serialize it all into a single buffer, it does so by iterating the objects themselves for the total byte size and then compiles each item in the order they are to appear.~~<br/>
**DONE**