### PR TITLE
Add F# content type to always active server to support pull diagnostics

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -399,7 +399,7 @@ namespace Roslyn.Test.Utilities
 
         private static RequestDispatcher CreateRequestDispatcher(TestWorkspace workspace)
         {
-            var factory = workspace.ExportProvider.GetExportedValue<CSharpVisualBasicRequestDispatcherFactory>();
+            var factory = workspace.ExportProvider.GetExportedValue<RequestDispatcherFactory>();
             return factory.CreateRequestDispatcher();
         }
 

--- a/src/EditorFeatures/Text/ContentTypeNames.cs
+++ b/src/EditorFeatures/Text/ContentTypeNames.cs
@@ -14,5 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor
         public const string XamlContentType = "XAML";
         public const string JavaScriptContentTypeName = "JavaScript";
         public const string TypeScriptContentTypeName = "TypeScript";
+        public const string FSharpContentType = "F#";
+        public const string FSharpSignatureHelpContentType = "F# Signature Help";
     }
 }

--- a/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
@@ -14,14 +14,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer
     [Export(typeof(ILanguageServerFactory)), Shared]
     internal class CSharpVisualBasicLanguageServerFactory : ILanguageServerFactory
     {
-        public const string UserVisibleName = "C#/Visual Basic Language Server Client";
+        public const string UserVisibleName = "Roslyn Language Server Client";
 
-        private readonly CSharpVisualBasicRequestDispatcherFactory _dispatcherFactory;
+        private readonly RequestDispatcherFactory _dispatcherFactory;
         private readonly IAsynchronousOperationListenerProvider _listenerProvider;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpVisualBasicLanguageServerFactory(CSharpVisualBasicRequestDispatcherFactory dispatcherFactory,
+        public CSharpVisualBasicLanguageServerFactory(RequestDispatcherFactory dispatcherFactory,
             IAsynchronousOperationListenerProvider listenerProvider)
         {
             _dispatcherFactory = dispatcherFactory;

--- a/src/Features/LanguageServer/Protocol/RequestDispatcherFactory.cs
+++ b/src/Features/LanguageServer/Protocol/RequestDispatcherFactory.cs
@@ -11,12 +11,12 @@ using Microsoft.CodeAnalysis.LanguageServer.Handler;
 namespace Microsoft.CodeAnalysis.LanguageServer
 {
     [Shared]
-    [Export(typeof(CSharpVisualBasicRequestDispatcherFactory))]
-    internal sealed class CSharpVisualBasicRequestDispatcherFactory : AbstractRequestDispatcherFactory
+    [Export(typeof(RequestDispatcherFactory))]
+    internal sealed class RequestDispatcherFactory : AbstractRequestDispatcherFactory
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpVisualBasicRequestDispatcherFactory([ImportMany] IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders)
+        public RequestDispatcherFactory([ImportMany] IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders)
             : base(requestHandlerProviders)
         {
         }

--- a/src/Tools/ExternalAccess/FSharp/Editor/FSharpContentTypeNames.cs
+++ b/src/Tools/ExternalAccess/FSharp/Editor/FSharpContentTypeNames.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
     internal static class FSharpContentTypeNames
     {
         public const string RoslynContentType = Microsoft.CodeAnalysis.Editor.ContentTypeNames.RoslynContentType;
-        public const string FSharpContentType = "F#";
-        public const string FSharpSignatureHelpContentType = "F# Signature Help";
+        public const string FSharpContentType = CodeAnalysis.Editor.ContentTypeNames.FSharpContentType;
+        public const string FSharpSignatureHelpContentType = CodeAnalysis.Editor.ContentTypeNames.FSharpSignatureHelpContentType;
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Internal/FSharpContentTypeDefinitions.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/FSharpContentTypeDefinitions.cs
@@ -6,6 +6,7 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor;
+using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal
@@ -15,6 +16,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal
         [Export]
         [Name(FSharpContentTypeNames.FSharpContentType)]
         [BaseDefinition(FSharpContentTypeNames.RoslynContentType)]
+        [BaseDefinition(CodeRemoteContentDefinition.CodeRemoteBaseTypeName)]
         public static readonly ContentTypeDefinition FSharpContentTypeDefinition;
 
         [Export]

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
@@ -20,12 +20,13 @@ using VSShell = Microsoft.VisualStudio.Shell;
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
 {
     /// <summary>
-    /// Language client responsible for handling C# / VB LSP requests in any scenario (both local and codespaces).
+    /// Language client responsible for handling C# / VB / F# LSP requests in any scenario (both local and codespaces).
     /// This powers "LSP only" features (e.g. cntrl+Q code search) that do not use traditional editor APIs.
     /// It is always activated whenever roslyn is activated.
     /// </summary>
     [ContentType(ContentTypeNames.CSharpContentType)]
     [ContentType(ContentTypeNames.VisualBasicContentType)]
+    [ContentType(ContentTypeNames.FSharpContentType)]
     [Export(typeof(ILanguageClient))]
     [Export(typeof(AlwaysActivateInProcLanguageClient))]
     internal class AlwaysActivateInProcLanguageClient : AbstractInProcLanguageClient
@@ -35,7 +36,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
         public AlwaysActivateInProcLanguageClient(
-            CSharpVisualBasicRequestDispatcherFactory csharpVBRequestDispatcherFactory,
+            RequestDispatcherFactory csharpVBRequestDispatcherFactory,
             VisualStudioWorkspace workspace,
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActiveLanguageClientEventListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActiveLanguageClientEventListener.cs
@@ -63,8 +63,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                 // doesn't block the UI thread.
                 await TaskScheduler.Default;
 
-                await _languageClientBroker.Value.LoadAsync(
-                    new LanguageClientMetadata(new[] { ContentTypeNames.CSharpContentType, ContentTypeNames.VisualBasicContentType }), _languageClient).ConfigureAwait(false);
+                await _languageClientBroker.Value.LoadAsync(new LanguageClientMetadata(new[]
+                {
+                        ContentTypeNames.CSharpContentType,
+                        ContentTypeNames.VisualBasicContentType,
+                        ContentTypeNames.FSharpContentType
+                }), _languageClient).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndCatch(e))
             {

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/LiveShareInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/LiveShareInProcLanguageClient.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
         public LiveShareInProcLanguageClient(
-            CSharpVisualBasicRequestDispatcherFactory csharpVBRequestDispatcherFactory,
+            RequestDispatcherFactory csharpVBRequestDispatcherFactory,
             VisualStudioWorkspace workspace,
             IDiagnosticService diagnosticService,
             IAsynchronousOperationListenerProvider listenerProvider,

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorInProcLanguageClient.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Lsp
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public RazorInProcLanguageClient(
-            CSharpVisualBasicRequestDispatcherFactory csharpVBRequestDispatcherFactory,
+            RequestDispatcherFactory csharpVBRequestDispatcherFactory,
             VisualStudioWorkspace workspace,
             IDiagnosticService diagnosticService,
             IAsynchronousOperationListenerProvider listenerProvider,

--- a/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
@@ -397,7 +397,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
 
             static VisualStudioInProcLanguageServer CreateLanguageServer(Stream inputStream, Stream outputStream, TestWorkspace workspace, IDiagnosticService mockDiagnosticService)
             {
-                var dispatcherFactory = workspace.ExportProvider.GetExportedValue<CSharpVisualBasicRequestDispatcherFactory>();
+                var dispatcherFactory = workspace.ExportProvider.GetExportedValue<RequestDispatcherFactory>();
                 var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
                 var lspWorkspaceRegistrationService = workspace.ExportProvider.GetExportedValue<ILspWorkspaceRegistrationService>();
                 var capabilitiesProvider = workspace.ExportProvider.GetExportedValue<DefaultCapabilitiesProvider>();


### PR DESCRIPTION
Currently, when LSP pull diagnostics are enabled, F# diagnostics disappear because we're no longer tagging and publishing to the error list.  This fixes it by supporting F# requests for pull diagnostics.

Before (with flag enabled)
![image](https://user-images.githubusercontent.com/5749229/125006860-eec7bd00-e013-11eb-9d0d-eb37f780f15a.png)

After (with flag enabled)
![image](https://user-images.githubusercontent.com/5749229/125007115-6b5a9b80-e014-11eb-97e6-e0593e17242a.png)
