### PR TITLE
Unescape interpolated string literal components

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (needToCheckConversionToObject)
             {
                 TypeSymbol objectType = GetSpecialType(SpecialType.System_Object, diagnostics, unconvertedInterpolatedString.Syntax);
-                BindingDiagnosticBag conversionDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false); ;
+                BindingDiagnosticBag conversionDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false);
                 foreach (var currentPart in unconvertedInterpolatedString.Parts)
                 {
                     if (currentPart is BoundStringInsert insert)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -494,8 +494,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
+                    var boundLiteral = (BoundLiteral)part;
+                    Debug.Assert(boundLiteral.ConstantValue != null && boundLiteral.ConstantValue.IsString);
+                    var literalText = ConstantValueUtils.UnescapeInterpolatedStringLiteral(boundLiteral.ConstantValue.StringValue);
                     methodName = "AppendLiteral";
-                    argumentsBuilder.Add(part);
+                    argumentsBuilder.Add(boundLiteral.Update(ConstantValue.Create(literalText), boundLiteral.Type));
                     isLiteral = true;
                     hasAlignment = false;
                     hasFormat = false;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -213,15 +213,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We satisfy the conditions for using an interpolated string builder. Bind all the builder calls unconditionally, so that if
             // there are errors we get better diagnostics than "could not convert to object."
             var implicitBuilderReceiver = new BoundInterpolatedStringHandlerPlaceholder(unconvertedInterpolatedString.Syntax, interpolatedStringHandlerType) { WasCompilerGenerated = true };
-            var (appendCalls, usesBoolReturn, positionInfo) = BindInterpolatedStringAppendCalls(unconvertedInterpolatedString, implicitBuilderReceiver, diagnostics);
+            var (appendCalls, usesBoolReturn, positionInfo, baseStringLength, numFormatHoles) = BindInterpolatedStringAppendCalls(unconvertedInterpolatedString, implicitBuilderReceiver, diagnostics);
 
             // Prior to C# 10, all types in an interpolated string expression needed to be convertible to `object`. After 10, some types
             // (such as Span<T>) that are not convertible to `object` are permissible as interpolated string components, provided there
             // is an applicable AppendFormatted method that accepts them. To preserve langversion, we therefore make sure all components
             // are convertible to object if the current langversion is lower than the interpolation feature and we're converting this
             // interpolation into an actual string.
-            TypeSymbol? objectType = null;
-            BindingDiagnosticBag? conversionDiagnostics = null;
             bool needToCheckConversionToObject = false;
             if (isHandlerConversion)
             {
@@ -230,24 +228,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             else if (!Compilation.IsFeatureEnabled(MessageID.IDS_FeatureImprovedInterpolatedStrings) && diagnostics.AccumulatesDiagnostics)
             {
                 needToCheckConversionToObject = true;
-                objectType = GetSpecialType(SpecialType.System_Object, diagnostics, unconvertedInterpolatedString.Syntax);
-                conversionDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false);
+
             }
 
             Debug.Assert(appendCalls.Length == unconvertedInterpolatedString.Parts.Length);
             Debug.Assert(appendCalls.All(a => a is { HasErrors: true } or BoundCall { Arguments: { Length: > 0 } } or BoundDynamicInvocation));
-            int baseStringLength = 0;
-            int numFormatHoles = 0;
 
-            foreach (var currentPart in unconvertedInterpolatedString.Parts)
+            if (needToCheckConversionToObject)
             {
-                if (currentPart is BoundStringInsert insert)
+                TypeSymbol objectType = GetSpecialType(SpecialType.System_Object, diagnostics, unconvertedInterpolatedString.Syntax);
+                BindingDiagnosticBag conversionDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false); ;
+                foreach (var currentPart in unconvertedInterpolatedString.Parts)
                 {
-                    numFormatHoles++;
-
-                    if (needToCheckConversionToObject)
+                    if (currentPart is BoundStringInsert insert)
                     {
-                        Debug.Assert(conversionDiagnostics is not null);
                         var value = insert.Value;
                         bool reported = false;
                         if (value.Type is not null)
@@ -272,14 +266,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         conversionDiagnostics.Clear();
                     }
                 }
-                else
-                {
-                    Debug.Assert(currentPart is { ConstantValue: { IsString: true } } and BoundLiteral);
-                    baseStringLength += currentPart.ConstantValue.RopeValue!.Length;
-                }
+
+                conversionDiagnostics.Free();
             }
 
-            conversionDiagnostics?.Free();
 
             var intType = GetSpecialType(SpecialType.System_Int32, diagnostics, unconvertedInterpolatedString.Syntax);
             int constructorArgumentLength = 3 + additionalConstructorArguments.Length;
@@ -446,14 +436,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return partsBuilder?.ToImmutableAndFree() ?? unconvertedInterpolatedString.Parts;
         }
 
-        private (ImmutableArray<BoundExpression> AppendFormatCalls, bool UsesBoolReturn, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>) BindInterpolatedStringAppendCalls(
+        private (ImmutableArray<BoundExpression> AppendFormatCalls, bool UsesBoolReturn, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>, int BaseStringLength, int NumFormatHoles) BindInterpolatedStringAppendCalls(
             BoundUnconvertedInterpolatedString source,
             BoundInterpolatedStringHandlerPlaceholder implicitBuilderReceiver,
             BindingDiagnosticBag diagnostics)
         {
             if (source.Parts.IsEmpty)
             {
-                return (ImmutableArray<BoundExpression>.Empty, false, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>.Empty);
+                return (ImmutableArray<BoundExpression>.Empty, false, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>.Empty, 0, 0);
             }
 
             bool? builderPatternExpectsBool = null;
@@ -461,6 +451,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var positionInfo = ArrayBuilder<(bool IsLiteral, bool HasAlignment, bool HasFormat)>.GetInstance(source.Parts.Length);
             var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(3);
             var parameterNamesAndLocationsBuilder = ArrayBuilder<(string, Location)?>.GetInstance(3);
+            int baseStringLength = 0;
+            int numFormatHoles = 0;
 
             foreach (var part in source.Parts)
             {
@@ -491,6 +483,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         argumentsBuilder.Add(insert.Format);
                         parameterNamesAndLocationsBuilder.Add(("format", insert.Format.Syntax.Location));
                     }
+                    numFormatHoles++;
                 }
                 else
                 {
@@ -502,6 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     isLiteral = true;
                     hasAlignment = false;
                     hasFormat = false;
+                    baseStringLength += literalText.Length;
                 }
 
                 var arguments = argumentsBuilder.ToImmutableAndClear();
@@ -548,7 +542,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             argumentsBuilder.Free();
             parameterNamesAndLocationsBuilder.Free();
-            return (builderAppendCalls.ToImmutableAndFree(), builderPatternExpectsBool ?? false, positionInfo.ToImmutableAndFree());
+            return (builderAppendCalls.ToImmutableAndFree(), builderPatternExpectsBool ?? false, positionInfo.ToImmutableAndFree(), baseStringLength, numFormatHoles);
         }
 
         private BoundExpression BindInterpolatedStringHandlerInMemberCall(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -228,7 +228,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             else if (!Compilation.IsFeatureEnabled(MessageID.IDS_FeatureImprovedInterpolatedStrings) && diagnostics.AccumulatesDiagnostics)
             {
                 needToCheckConversionToObject = true;
-
             }
 
             Debug.Assert(appendCalls.Length == unconvertedInterpolatedString.Parts.Length);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -11019,5 +11019,101 @@ public ref struct CustomHandler
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
             comp.VerifyDiagnostics();
         }
+
+        [Fact, WorkItem(54703, "https://github.com/dotnet/roslyn/issues/54703")]
+        public void BracesAreEscaped_01()
+        {
+            var code = @"
+int i = 1;
+System.Console.WriteLine($""{{ {i} }}"");";
+
+            var comp = CreateCompilation(new[] { code, GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false) });
+
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+{ 
+value:1
+ }");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       56 (0x38)
+  .maxstack  3
+  .locals init (int V_0, //i
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_1
+  IL_0004:  ldc.i4.6
+  IL_0005:  ldc.i4.1
+  IL_0006:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldstr      ""{ ""
+  IL_0012:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
+  IL_0017:  ldloca.s   V_1
+  IL_0019:  ldloc.0
+  IL_001a:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int)""
+  IL_001f:  ldloca.s   V_1
+  IL_0021:  ldstr      "" }""
+  IL_0026:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendLiteral(string)""
+  IL_002b:  ldloca.s   V_1
+  IL_002d:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
+  IL_0032:  call       ""void System.Console.WriteLine(string)""
+  IL_0037:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(54703, "https://github.com/dotnet/roslyn/issues/54703")]
+        public void BracesAreEscaped_02()
+        {
+            var code = @"
+int i = 1;
+CustomHandler c = $""{{ {i} }}"";
+System.Console.WriteLine(c.ToString());";
+
+            var comp = CreateCompilation(new[] { code, GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) });
+
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
+literal:{ 
+value:1
+alignment:0
+format:
+literal: }");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       71 (0x47)
+  .maxstack  4
+  .locals init (int V_0, //i
+                CustomHandler V_1, //c
+                CustomHandler V_2)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldloca.s   V_2
+  IL_0004:  ldc.i4.6
+  IL_0005:  ldc.i4.1
+  IL_0006:  call       ""CustomHandler..ctor(int, int)""
+  IL_000b:  ldloca.s   V_2
+  IL_000d:  ldstr      ""{ ""
+  IL_0012:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0017:  ldloca.s   V_2
+  IL_0019:  ldloc.0
+  IL_001a:  box        ""int""
+  IL_001f:  ldc.i4.0
+  IL_0020:  ldnull
+  IL_0021:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_0026:  ldloca.s   V_2
+  IL_0028:  ldstr      "" }""
+  IL_002d:  call       ""void CustomHandler.AppendLiteral(string)""
+  IL_0032:  ldloc.2
+  IL_0033:  stloc.1
+  IL_0034:  ldloca.s   V_1
+  IL_0036:  constrained. ""CustomHandler""
+  IL_003c:  callvirt   ""string object.ToString()""
+  IL_0041:  call       ""void System.Console.WriteLine(string)""
+  IL_0046:  ret
+}
+");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -11043,7 +11043,7 @@ value:1
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
-  IL_0004:  ldc.i4.6
+  IL_0004:  ldc.i4.4
   IL_0005:  ldc.i4.1
   IL_0006:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
   IL_000b:  ldloca.s   V_1
@@ -11090,7 +11090,7 @@ literal: }");
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_2
-  IL_0004:  ldc.i4.6
+  IL_0004:  ldc.i4.4
   IL_0005:  ldc.i4.1
   IL_0006:  call       ""CustomHandler..ctor(int, int)""
   IL_000b:  ldloca.s   V_2


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/54703. Spec change is at https://github.com/dotnet/csharplang/pull/4910.

Note that there is an interesting wrinkle here in that, for an interpolated string used as a string, the change in constant value makes the lowering mechanism an observable side effect. While doing this step during lowering instead of initial binding is technically feasible, it would be quite complex as there are several different ways an AppendLiteral call could get to lowering (dynamic, conversion to object, regular literal, passed by in, etc). For now, I'm opting for simple strategy of accepting this observable side-effect, and if we want to try and make that side effect invisible we can look at doing so at a later point.

Test plan https://github.com/dotnet/roslyn/issues/51499