### PR TITLE
Prefer Concat on interpolated strings with 4 or less string parts

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // We have 4 possible lowering strategies, dependent on the contents of the string, in this order:
             //  1. The string is a constant value. We can just use the final value.
-            //  2. The string is composed of 4 or less components that are all strings, we can lower to a call to string.Concat without a
+            //  2. The string is composed of 4 or fewer components that are all strings, we can lower to a call to string.Concat without a
             //     params array. This is very efficient as the runtime can allocate a buffer for the string with exactly the correct length and
             //     make no intermediate allocations.
             //  3. The WellKnownType DefaultInterpolatedStringHandler is available, and none of the interpolation holes contain an await expression.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // We have 4 possible lowering strategies, dependent on the contents of the string, in this order:
             //  1. The string is a constant value. We can just use the final value.
-            //  2. The string is composed of 4 or less components that are either all strings, we can lower to a call to string.Concat without a
+            //  2. The string is composed of 4 or less components that are all strings, we can lower to a call to string.Concat without a
             //     params array. This is very efficient as the runtime can allocate a buffer for the string with exactly the correct length and
             //     make no intermediate allocations.
             //  3. The WellKnownType DefaultInterpolatedStringHandler is available, and none of the interpolation holes contain an await expression.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return constructWithData(BindInterpolatedStringParts(unconvertedInterpolatedString, diagnostics), data: null);
             }
 
-            // Case 2. Attempt to see if all parts are either strings.
+            // Case 2. Attempt to see if all parts are strings.
             if (unconvertedInterpolatedString.Parts.Length <= 4 &&
                 unconvertedInterpolatedString.Parts.All(p => p is BoundLiteral
                                                                or BoundStringInsert { Value: { Type: { SpecialType: SpecialType.System_String } }, Alignment: null, Format: null }))

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -132,21 +132,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // We have 4 possible lowering strategies, dependent on the contents of the string, in this order:
             //  1. The string is a constant value. We can just use the final value.
-            //  2. The WellKnownType DefaultInterpolatedStringHandler is available, and none of the interpolation holes contain an await expression.
+            //  2. The string is composed of 4 or less components that are either all strings, we can lower to a call to string.Concat without a
+            //     params array. This is very efficient as the runtime can allocate a buffer for the string with exactly the correct length and
+            //     make no intermediate allocations.
+            //  3. The WellKnownType DefaultInterpolatedStringHandler is available, and none of the interpolation holes contain an await expression.
             //     The builder is a ref struct, and we can guarantee the lifetime won't outlive the stack if the string doesn't contain any
             //     awaits, but if it does we cannot use it. This builder is the only way that ref structs can be directly used as interpolation
             //     hole components, which means that ref structs components and await expressions cannot be combined. It is already illegal for
             //     the user to use ref structs in an async method today, but if that were to ever change, this would still need to be respected.
             //     We also cannot use this method if the interpolated string appears within a catch filter, as the builder is disposable and we
             //     cannot put a try/finally inside a filter block.
-            //  3. The string is composed entirely of components that are strings themselves. We can turn this into a single call to string.Concat.
-            //     We prefer the builder over this because the builder can use pooling to avoid new allocations, while this call will potentially
-            //     need to allocate a param array.
-            //  4. The string has heterogeneous data and either InterpolatedStringHandler is unavailable, or one of the holes contains an await
+            //  4. The string is composed of more than 4 components that are all strings themselves. We can turn this into a single
+            //     call to string.Concat. We prefer the builder over this because the builder can use pooling to avoid new allocations, while this
+            //     call will need to allocate a param array.
+            //  5. The string has heterogeneous data and either InterpolatedStringHandler is unavailable, or one of the holes contains an await
             //     expression. This is turned into a call to string.Format.
             //
-            // We need to do the determination of 1, 2, or 3/4 up front, rather than in lowering, as it affects diagnostics (ref structs not being
-            // able to be used, for example). However, between 3 and 4, we don't need to know at this point, so that logic is deferred for lowering.
+            // We need to do the determination of 1, 2, 3, or 4/5 up front, rather than in lowering, as it affects diagnostics (ref structs not being
+            // able to be used, for example). However, between 4 and 5, we don't need to know at this point, so that logic is deferred for lowering.
 
             if (unconvertedInterpolatedString.ConstantValue is not null)
             {
@@ -155,13 +158,27 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return constructWithData(BindInterpolatedStringParts(unconvertedInterpolatedString, diagnostics), data: null);
             }
 
+            // Case 2. Attempt to see if all parts are either strings or convertible to ROS<char>. The types must be homogeneous, as there
+            // are no overloads that mix and match.
+            if (unconvertedInterpolatedString.Parts.Length <= 4 &&
+                unconvertedInterpolatedString.Parts.All(p => p is BoundLiteral 
+                                                               or BoundStringInsert 
+                                                                  { 
+                                                                      Value: { Type: { SpecialType: SpecialType.System_String } },
+                                                                      Alignment: null,
+                                                                      Format: null
+                                                                  }))
+            {
+                return constructWithData(BindInterpolatedStringParts(unconvertedInterpolatedString, diagnostics), data: null);
+            }
+
             if (tryBindAsHandlerType(out var result))
             {
-                // Case 2
+                // Case 3
                 return result;
             }
 
-            // The specifics of 3 vs 4 aren't necessary for this stage of binding. The only thing that matters is that every part needs to be convertible
+            // The specifics of 4 vs 5 aren't necessary for this stage of binding. The only thing that matters is that every part needs to be convertible
             // object.
             return constructWithData(BindInterpolatedStringParts(unconvertedInterpolatedString, diagnostics), data: null);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -161,13 +161,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Case 2. Attempt to see if all parts are either strings or convertible to ROS<char>. The types must be homogeneous, as there
             // are no overloads that mix and match.
             if (unconvertedInterpolatedString.Parts.Length <= 4 &&
-                unconvertedInterpolatedString.Parts.All(p => p is BoundLiteral 
-                                                               or BoundStringInsert 
-                                                                  { 
-                                                                      Value: { Type: { SpecialType: SpecialType.System_String } },
-                                                                      Alignment: null,
-                                                                      Format: null
-                                                                  }))
+                unconvertedInterpolatedString.Parts.All(p => p is BoundLiteral
+                                                               or BoundStringInsert { Value: { Type: { SpecialType: SpecialType.System_String } }, Alignment: null, Format: null }))
             {
                 return constructWithData(BindInterpolatedStringParts(unconvertedInterpolatedString, diagnostics), data: null);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -158,8 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return constructWithData(BindInterpolatedStringParts(unconvertedInterpolatedString, diagnostics), data: null);
             }
 
-            // Case 2. Attempt to see if all parts are either strings or convertible to ROS<char>. The types must be homogeneous, as there
-            // are no overloads that mix and match.
+            // Case 2. Attempt to see if all parts are either strings.
             if (unconvertedInterpolatedString.Parts.Length <= 4 &&
                 unconvertedInterpolatedString.Parts.All(p => p is BoundLiteral
                                                                or BoundStringInsert { Value: { Type: { SpecialType: SpecialType.System_String } }, Alignment: null, Format: null }))

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -282,7 +282,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         _factory.Binary(BinaryOperatorKind.StringConcatenation, node.Type, result, part);
                 }
 
-                if (length == 1)
+                // We need to ensure that the result of the interpolated string is not null. If the single part has a non-null constant value
+                // or is itself an interpolated string (which by proxy cannot be null), then there's nothing else that needs to be done. Otherwise,
+                // we need to test for null and ensure "" if it is.
+                if (length == 1 && result is not ({ Kind: BoundKind.InterpolatedString } or { ConstantValue: { IsString: true } }))
                 {
                     result = _factory.Coalesce(result!, _factory.StringLiteral(""));
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/54702. This does not implement any changes to prefer concat for ReadOnlySpan<char>: doing so will require a deeper change of the local rewriter's handling of string concatenation that we can revisit at a later date if we so choose.
