### PR TITLE
Reenable MSBuildWorkspace integration tests

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -233,7 +233,7 @@ function BuildSolution() {
   $ibcDropName = GetIbcDropName
 
   # Do not set this property to true explicitly, since that would override values set in projects.
-  $suppressExtensionDeployment = if (!$deployExtensions) { "/p:DeployExtension=false" } else { "" } 
+  $suppressExtensionDeployment = if (!$deployExtensions) { "/p:DeployExtension=false" } else { "" }
 
   # The warnAsError flag for MSBuild will promote all warnings to errors. This is true for warnings
   # that MSBuild output as well as ones that custom tasks output.
@@ -379,7 +379,7 @@ function TestUsingRunTests() {
   $runTests = GetProjectOutputBinary "RunTests.dll" -tfm "netcoreapp3.1"
 
   if (!(Test-Path $runTests)) {
-    Write-Host "Test runner not found: '$runTests'. Run Build.cmd first." -ForegroundColor Red 
+    Write-Host "Test runner not found: '$runTests'. Run Build.cmd first." -ForegroundColor Red
     ExitWithExitCode 1
   }
 
@@ -417,9 +417,8 @@ function TestUsingRunTests() {
     $args += " --tfm net472"
     $args += " --retry"
     $args += " --sequential"
-    # Skip VS integration tests prior to having a build of dev17 available for testing
     $args += " --include '\.IntegrationTests'"
-    # $args += " --include 'Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests'"
+    $args += " --include 'Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests'"
 
     if ($lspEditor) {
       $args += " --testfilter Editor=LanguageServerProtocol"

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
             Assert.NotNull(pref);
         }
 
-        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [ConditionalFact(typeof(VisualStudioMSBuildInstalled), AlwaysSkip = "https://github.com/dotnet/roslyn/issues/54818"), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         public async Task TestInternalsVisibleToSigned()
         {
             var solution = await SolutionAsync(

--- a/src/Workspaces/MSBuildTest/Resources/CircularProjectReferences/CircularCSharpProject1.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/CircularProjectReferences/CircularCSharpProject1.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Library1</RootNamespace>
     <AssemblyName>Library1</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/CircularProjectReferences/CircularCSharpProject2.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/CircularProjectReferences/CircularCSharpProject2.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Library2</RootNamespace>
     <AssemblyName>Library2</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AdditionalFile.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AdditionalFile.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AllOptions.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AllOptions.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AnalyzerReference.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AnalyzerReference.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject_AnalyzerReference</RootNamespace>
     <AssemblyName>CSharpProject_AnalyzerReference</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AdditionalFileItemNames>Content</AdditionalFileItemNames>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AssemblyNameIsPath.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AssemblyNameIsPath.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReproApp</RootNamespace>
     <AssemblyName>..\..\ReproApp</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AssemblyNameIsPath2.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/AssemblyNameIsPath2.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReproApp</RootNamespace>
     <AssemblyName>..\ReproApp</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/BadElement.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/BadElement.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/BadHintPath.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/BadHintPath.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/BadLink.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/BadLink.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
     <MyProperty>xyz</MyProperty>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/BadTasks.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/BadTasks.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/CSharpProject.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/CSharpProject.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicateFile.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicateFile.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicateReferences.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicateReferences.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject_ProjectToProjectReference</RootNamespace>
     <AssemblyName>CSharpProject_ProjectToProjectReference</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidLibrary1.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidLibrary1.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Library1</RootNamespace>
     <AssemblyName>Library1</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidLibrary2.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidLibrary2.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Library2</RootNamespace>
     <AssemblyName>Library2</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidLibrary3.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidLibrary3.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Library1</RootNamespace>
     <AssemblyName>Library1</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidLibrary4.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidLibrary4.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Library2</RootNamespace>
     <AssemblyName>Library2</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidReferenceTest.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidReferenceTest.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReferenceTest</RootNamespace>
     <AssemblyName>ReferenceTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidsBecomeCircularReferential.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidsBecomeCircularReferential.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReferenceTest</RootNamespace>
     <AssemblyName>ReferenceTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidsBecomeSelfReferential.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/DuplicatedGuidsBecomeSelfReferential.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReferenceTest</RootNamespace>
     <AssemblyName>ReferenceTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/Encoding.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/Encoding.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClassLibrary1</RootNamespace>
     <AssemblyName>ClassLibrary1</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <CodePage>ReplaceMe</CodePage>
     <DebugSymbols>true</DebugSymbols>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ExternAlias.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ExternAlias.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>bug13338</RootNamespace>
     <AssemblyName>bug13338</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ExternAlias2.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ExternAlias2.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>bug13338</RootNamespace>
     <AssemblyName>bug13338</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ForEmittedOutput.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ForEmittedOutput.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EmittedCSharpProject</RootNamespace>
     <AssemblyName>EmittedCSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/MallformedAdditionalFilePath.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/MallformedAdditionalFilePath.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MalformedProject</RootNamespace>
     <AssemblyName>MalformedProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/MsbuildError.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/MsbuildError.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/PortableProject.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/PortableProject.csproj
@@ -16,7 +16,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ProjectLoadErrorOnMissingDebugType.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ProjectLoadErrorOnMissingDebugType.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ProjectLoadErrorOnMissingDebugType</RootNamespace>
     <AssemblyName>ProjectLoadErrorOnMissingDebugType</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ProjectReference.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ProjectReference.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject_ProjectToProjectReference</RootNamespace>
     <AssemblyName>CSharpProject_ProjectToProjectReference</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ReferencesPortableProject.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ReferencesPortableProject.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Bug2824</RootNamespace>
     <AssemblyName>Bug2824</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ShouldUnsetParentConfigurationAndPlatform.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/ShouldUnsetParentConfigurationAndPlatform.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/Wildcards.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/Wildcards.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithDiscoverEditorConfigFiles.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithDiscoverEditorConfigFiles.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ConsoleApplication62</RootNamespace>
     <AssemblyName>ConsoleApplication62</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <DiscoverEditorConfigFiles>true</DiscoverEditorConfigFiles>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithLink.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithLink.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithPrefer32Bit.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithPrefer32Bit.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ConsoleApplication62</RootNamespace>
     <AssemblyName>ConsoleApplication62</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithSystemNumerics.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithSystemNumerics.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithXaml.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithXaml.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>bug13338</RootNamespace>
     <AssemblyName>bug13338</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithoutCSharpTargetsImported.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithoutCSharpTargetsImported.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSharpProject</RootNamespace>
     <AssemblyName>CSharpProject</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithoutPrefer32Bit.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/WithoutPrefer32Bit.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ConsoleApplication62</RootNamespace>
     <AssemblyName>ConsoleApplication62</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/AnalyzerReference.vbproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/AnalyzerReference.vbproj
@@ -13,7 +13,7 @@
     <AssemblyName>VisualBasicProject_AnalyzerReference</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <AdditionalFileItemNames>Content</AdditionalFileItemNames>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/Embed.vbproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/Embed.vbproj
@@ -13,7 +13,7 @@
     <AssemblyName>VisualBasicProject</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <VBRuntime>Embed</VBRuntime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/InvalidProjectReference.vbproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/InvalidProjectReference.vbproj
@@ -13,7 +13,7 @@
     <AssemblyName>VisualBasicProject</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/NonExistentProjectReference.vbproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/NonExistentProjectReference.vbproj
@@ -13,7 +13,7 @@
     <AssemblyName>VisualBasicProject</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/UnknownProjectExtension.vbproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/UnknownProjectExtension.vbproj
@@ -13,7 +13,7 @@
     <AssemblyName>VisualBasicProject</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/VisualBasicProject.vbproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/VisualBasicProject.vbproj
@@ -13,7 +13,7 @@
     <AssemblyName>VisualBasicProject</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/WithPrefer32Bit.vbproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/WithPrefer32Bit.vbproj
@@ -13,7 +13,7 @@
     <AssemblyName>ConsoleApplication1</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Console</MyType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/WithoutPrefer32Bit.vbproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/WithoutPrefer32Bit.vbproj
@@ -14,7 +14,7 @@
     <AssemblyName>ConsoleApplication1</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Console</MyType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/WithoutVBTargetsImported.vbproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/VisualBasic/WithoutVBTargetsImported.vbproj
@@ -13,7 +13,7 @@
     <AssemblyName>VisualBasicProject</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Since .NET v4 and v4.5 targeting packs are not installable workloads on VS2022, I've migrated the target framework version used by the various MSBuildWorkspace test projects. Those targeting v4.0 have been updated to target v4.6. The others targeting v4.5 or higher now target v4.7.2. 