### PR TITLE
[LSP] Update underlying pull diagnostics feature flag when option changes

### DIFF
--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected void SetExperimentOption(string experimentName, bool enabled)
         {
             var mockExperimentService = ExportProvider.GetExportedValue<TestExperimentationService>();
-            mockExperimentService.SetExperimentOption(experimentName, enabled);
+            mockExperimentService.EnableExperiment(experimentName, enabled);
         }
 
         private static bool FiltersMatch(List<CompletionFilter> expectedMatchingFilters, RoslynCompletion.CompletionItem item)

--- a/src/EditorFeatures/TestUtilities/TestExperimentationService.cs
+++ b/src/EditorFeatures/TestUtilities/TestExperimentationService.cs
@@ -24,10 +24,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
         }
 
-        public void SetExperimentOption(string experimentName, bool enabled)
-            => _experimentsOptionValues[experimentName] = enabled;
-
         public bool IsExperimentEnabled(string experimentName)
             => _experimentsOptionValues.TryGetValue(experimentName, out var enabled) && enabled;
+
+        public void EnableExperiment(string experimentName, bool value)
+            => _experimentsOptionValues[experimentName] = value;
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
 
             // Ensure we get no diagnostics when feature flag is off.
             var testExperimentationService = (TestExperimentationService)testLspServer.TestWorkspace.Services.GetRequiredService<IExperimentationService>();
-            testExperimentationService.SetExperimentOption(WellKnownExperimentNames.LspPullDiagnosticsFeatureFlag, false);
+            testExperimentationService.EnableExperiment(WellKnownExperimentNames.LspPullDiagnosticsFeatureFlag, false);
 
             var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI());
             Assert.Empty(results.Single().Diagnostics);
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             await OpenDocumentAsync(testLspServer, document);
 
             var testExperimentationService = (TestExperimentationService)testLspServer.TestWorkspace.Services.GetRequiredService<IExperimentationService>();
-            testExperimentationService.SetExperimentOption(WellKnownExperimentNames.LspPullDiagnosticsFeatureFlag, true);
+            testExperimentationService.EnableExperiment(WellKnownExperimentNames.LspPullDiagnosticsFeatureFlag, true);
 
             var results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI());
             Assert.Equal("CS1513", results.Single().Diagnostics.Single().Code);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -32,9 +32,9 @@
                     
                     <CheckBox x:Name="Enable_pull_diagnostics_experimental_requires_restart"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Enable_pull_diagnostics_experimental_requires_restart}" 
-                              Checked="Enable_pull_diagnostics_experimental_requires_restart_Checked"
-                              Unchecked="Enable_pull_diagnostics_experimental_requires_restart_Unchecked"
-                              Indeterminate="Enable_pull_diagnostics_experimental_requires_restart_Indeterminate"
+                              Checked="Enable_pull_diagnostics_experimental_requires_restart_CheckedChanged"
+                              Unchecked="Enable_pull_diagnostics_experimental_requires_restart_CheckedChanged"
+                              Indeterminate="Enable_pull_diagnostics_experimental_requires_restart_CheckedChanged"
                               IsThreeState="True"/>
 
                     <CheckBox x:Name="Enable_Razor_pull_diagnostics_experimental_requires_restart"

--- a/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
+++ b/src/VisualStudio/Core/Def/Experimentation/VisualStudioExperimentationService.cs
@@ -62,6 +62,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Experimentation
             _isCachedFlightEnabledInfo = isCachedFlightEnabledInfo;
         }
 
+        public void EnableExperiment(string experimentName, bool value)
+        {
+            // We're changing the value of an experiment name, remove the cached version so we look it up again.
+            lock (_experimentEnabledMap)
+            {
+                if (_experimentEnabledMap.ContainsKey(experimentName))
+                    _experimentEnabledMap.Remove(experimentName);
+            }
+
+            var featureFlags2 = (IVsFeatureFlags2)_featureFlags;
+            featureFlags2.EnableFeatureFlag(experimentName, value);
+        }
+
         public bool IsExperimentEnabled(string experimentName)
         {
             ThisCanBeCalledOnAnyThread();

--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -25,6 +25,11 @@
 "Title"="Enable experimental C#/VB LSP completion experience"
 "PreviewPaneChannels"="IntPreview,int.main"
 
+// Corresponds to WellKnownExperimentNames.LspPullDiagnosticsFeatureFlag
+[$RootKey$\FeatureFlags\Lsp\PullDiagnostics]
+"Description"="Enables the LSP-powered diagnostics for managed .Net projects"
+"Value"=dword:00000000
+
 // The option page configuration is duplicated in RoslynPackage
 // [ProvideToolWindow(typeof(ValueTracking.ValueTrackingToolWindow))]
 [$RootKey$\ToolWindows\{60a19d42-2dd7-43f3-be90-c7a9cb7d28f4}]

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -38,13 +38,11 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string TargetTypedCompletionFilter = "Roslyn.TargetTypedCompletionFilter";
         public const string OOPServerGC = "Roslyn.OOPServerGC";
         public const string ImportsOnPasteDefaultEnabled = "Roslyn.ImportsOnPasteDefaultEnabled";
-        public const string LspTextSyncEnabled = "Roslyn.LspTextSyncEnabled";
         public const string SourceGeneratorsEnableOpeningInWorkspace = "Roslyn.SourceGeneratorsEnableOpeningInWorkspace";
         public const string RemoveUnusedReferences = "Roslyn.RemoveUnusedReferences";
         public const string LSPCompletion = "Roslyn.LSP.Completion";
         public const string CloudCache = "Roslyn.CloudCache";
         public const string UnnamedSymbolCompletionDisabled = "Roslyn.UnnamedSymbolCompletionDisabled";
-        public const string RazorLspEditorFeatureFlag = "Razor.LSP.Editor";
         public const string InheritanceMargin = "Roslyn.InheritanceMargin";
         public const string LspPullDiagnosticsFeatureFlag = "Lsp.PullDiagnostics";
         public const string OOPCoreClr = "Roslyn.OOPCoreClr";

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -12,6 +12,8 @@ namespace Microsoft.CodeAnalysis.Experiments
     internal interface IExperimentationService : IWorkspaceService
     {
         bool IsExperimentEnabled(string experimentName);
+
+        void EnableExperiment(string experimentName, bool value);
     }
 
     [ExportWorkspaceService(typeof(IExperimentationService)), Shared]
@@ -24,6 +26,8 @@ namespace Microsoft.CodeAnalysis.Experiments
         }
 
         public bool IsExperimentEnabled(string experimentName) => false;
+
+        public void EnableExperiment(string experimentName, bool value) { }
     }
 
     internal static class WellKnownExperimentNames

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteExperimentationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteExperimentationService.cs
@@ -35,5 +35,11 @@ namespace Microsoft.CodeAnalysis.Remote.Services
             isEnabledValueTask.Forget();
             return false;
         }
+
+        public void EnableExperiment(string experimentName, bool value)
+        {
+            // This should never be called out of proc
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
We need to update the underlying feature flag when the user changes the pull diagnostics option in to ensure that CPS is able to read the updated value when the option changes.  

Previously, when the user turned off the option, CPS publishing was still active, meaning that both Roslyn and CPS would be publishing build diagnostics.

As a side effect, now 'default' is only a valid option for the initial state, when the option is changed by the user the checkbox is either on or off.  This matches behavior in our other checkboxes ( e.g. show unimported types ).