### PR TITLE
Add a static Bitmap source cache for Inheritance margin

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/CrispImageCache.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/CrispImageCache.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph
+{
+    internal static class CrispImageCache
+    {
+        private static ImageAttributes? s_attributes;
+        private static readonly Dictionary<ImageMoniker, BitmapSource> s_ImageCache = new();
+
+        public static BitmapSource GetBitmapSource(ImageMoniker imageMoniker, ImageAttributes currentAttributes)
+        {
+            if (!currentAttributes.Equals(s_attributes))
+            {
+                s_attributes = currentAttributes;
+                var imageLibrary = CrispImage.DefaultImageLibrary;
+                s_ImageCache[KnownMonikers.Implementing] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Implementing, currentAttributes);
+                s_ImageCache[KnownMonikers.Implemented] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Implemented, currentAttributes);
+                s_ImageCache[KnownMonikers.Overridden] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Overridden, currentAttributes);
+                s_ImageCache[KnownMonikers.Overriding] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Overriding, currentAttributes);
+                s_ImageCache[KnownMonikers.ImplementingOverridden] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.ImplementingOverridden, currentAttributes);
+                s_ImageCache[KnownMonikers.ImplementingOverriding] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.ImplementingOverriding, currentAttributes);
+            }
+
+            if (s_ImageCache.TryGetValue(imageMoniker, out var bitmapSource))
+            {
+                return bitmapSource;
+            }
+
+            throw ExceptionUtilities.UnexpectedValue(imageMoniker);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/CrispImageCache.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/CrispImageCache.cs
@@ -16,24 +16,28 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
     {
         private static ImageAttributes? s_attributes;
         private static readonly Dictionary<ImageMoniker, BitmapSource> s_ImageCache = new();
+        private static object s_updateLock = new();
 
         public static BitmapSource GetBitmapSource(ImageMoniker imageMoniker, ImageAttributes currentAttributes)
         {
-            if (!currentAttributes.Equals(s_attributes))
+            lock (s_updateLock)
             {
-                s_attributes = currentAttributes;
-                var imageLibrary = CrispImage.DefaultImageLibrary;
-                s_ImageCache[KnownMonikers.Implementing] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Implementing, currentAttributes);
-                s_ImageCache[KnownMonikers.Implemented] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Implemented, currentAttributes);
-                s_ImageCache[KnownMonikers.Overridden] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Overridden, currentAttributes);
-                s_ImageCache[KnownMonikers.Overriding] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Overriding, currentAttributes);
-                s_ImageCache[KnownMonikers.ImplementingOverridden] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.ImplementingOverridden, currentAttributes);
-                s_ImageCache[KnownMonikers.ImplementingOverriding] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.ImplementingOverriding, currentAttributes);
-            }
+                if (!currentAttributes.Equals(s_attributes))
+                {
+                    s_attributes = currentAttributes;
+                    var imageLibrary = CrispImage.DefaultImageLibrary;
+                    s_ImageCache[KnownMonikers.Implementing] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Implementing, currentAttributes);
+                    s_ImageCache[KnownMonikers.Implemented] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Implemented, currentAttributes);
+                    s_ImageCache[KnownMonikers.Overridden] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Overridden, currentAttributes);
+                    s_ImageCache[KnownMonikers.Overriding] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.Overriding, currentAttributes);
+                    s_ImageCache[KnownMonikers.ImplementingOverridden] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.ImplementingOverridden, currentAttributes);
+                    s_ImageCache[KnownMonikers.ImplementingOverriding] = (BitmapSource)imageLibrary.GetImage(KnownMonikers.ImplementingOverriding, currentAttributes);
+                }
 
-            if (s_ImageCache.TryGetValue(imageMoniker, out var bitmapSource))
-            {
-                return bitmapSource;
+                if (s_ImageCache.TryGetValue(imageMoniker, out var bitmapSource))
+                {
+                    return bitmapSource;
+                }
             }
 
             throw ExceptionUtilities.UnexpectedValue(imageMoniker);

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/CrispImageSourceConverter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/CrispImageSourceConverter.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Windows.Media;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.PlatformUI;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph
+{
+    internal class CrispImageSourceConverter : MultiValueConverter<ImageMoniker, double, double, double, Color, ImageSource>
+    {
+        protected override ImageSource Convert(
+            ImageMoniker imageMoniker,
+            double height,
+            double width,
+            double dpi,
+            Color background,
+            object parameter,
+            CultureInfo culture)
+        {
+            var attributes = new ImageAttributes
+            {
+                StructSize = Marshal.SizeOf(typeof(ImageAttributes)),
+                Flags = unchecked((uint)(_ImageAttributesFlags.IAF_Size | _ImageAttributesFlags.IAF_Dpi | _ImageAttributesFlags.IAF_Type | _ImageAttributesFlags.IAF_Format | _ImageAttributesFlags.IAF_Background)),
+                LogicalHeight = (int)height,
+                LogicalWidth = (int)width,
+                Dpi = (int)dpi,
+                Format = (int)_UIDataFormat.DF_WPF,
+                ImageType = (int)_UIImageType.IT_Bitmap,
+                Background = background.ToRgba(),
+            };
+
+            return CrispImageCache.GetBitmapSource(imageMoniker, attributes);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml
@@ -75,10 +75,26 @@
     <!-- Control template only shows the image -->
     <Button.Template>
         <ControlTemplate>
-            <Border x:Name="Border" BorderThickness="1"
-                    Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background}"
-                    BorderBrush="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}">
-                <imaging:CrispImage Moniker="{Binding ImageMoniker}" ScaleFactor="{Binding ScaleFactor}" />
+            <ControlTemplate.Resources>
+                <local:CrispImageSourceConverter x:Key="ImageSourceConverter"/>
+                <Style TargetType="{x:Type imaging:CrispImage}">
+                    <Setter Property="Source">
+                        <Setter.Value>
+                            <MultiBinding Converter="{StaticResource ImageSourceConverter}" >
+                                <Binding Path="ImageMoniker" />
+                                <Binding RelativeSource="{RelativeSource Self}" Path="Height" />
+                                <Binding RelativeSource="{RelativeSource Self}" Path="Width" />
+                                <Binding RelativeSource="{RelativeSource Self}" Path="ActualDpi" />
+                                <Binding  RelativeSource="{RelativeSource Self}" Path="(platformUi:ImageThemingUtilities.ImageBackgroundColor)" />
+                            </MultiBinding>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ControlTemplate.Resources>
+                <Border x:Name="Border" BorderThickness="1"
+                        Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background}"
+                        BorderBrush="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}">
+                <imaging:CrispImage/>
             </Border>
         </ControlTemplate>
     </Button.Template>


### PR DESCRIPTION
https://github.com/dotnet/roslyn/issues/54521

As we discussed somewhere offline, this PR change the inheritance margin to our own static image cache instead of the one from the platform.