### PR TITLE
Avoid computing unused values in lsif

### DIFF
--- a/src/Features/Core/Portable/DocumentationComments/IDocumentationCommentFormattingService.cs
+++ b/src/Features/Core/Portable/DocumentationComments/IDocumentationCommentFormattingService.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
@@ -13,7 +10,7 @@ namespace Microsoft.CodeAnalysis.DocumentationComments
 {
     internal interface IDocumentationCommentFormattingService : ILanguageService
     {
-        string Format(string rawXmlText, Compilation compilation = null);
-        ImmutableArray<TaggedText> Format(string rawXmlText, ISymbol symbol, SemanticModel semanticModel, int position, SymbolDisplayFormat format, CancellationToken cancellationToken);
+        string? Format(string? rawXmlText, Compilation? compilation = null);
+        ImmutableArray<TaggedText> Format(string? rawXmlText, ISymbol symbol, SemanticModel semanticModel, int position, SymbolDisplayFormat format, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -434,11 +435,13 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
             private IDictionary<SymbolDescriptionGroups, ImmutableArray<TaggedText>> BuildDescriptionSections()
             {
+                var includeNavigationHints = this.Workspace.Options.GetOption(QuickInfoOptions.IncludeNavigationHintsInQuickInfo);
+
                 // Merge the two maps into one final result.
                 var result = new Dictionary<SymbolDescriptionGroups, ImmutableArray<TaggedText>>(_documentationMap);
                 foreach (var (group, parts) in _groupMap)
                 {
-                    var taggedText = parts.ToTaggedText(_getNavigationHint);
+                    var taggedText = parts.ToTaggedText(_getNavigationHint, includeNavigationHints);
                     if (group == SymbolDescriptionGroups.MainDescription)
                     {
                         // Mark the main description as a code block.

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AbstractSymbolDescriptionBuilder.cs
@@ -170,6 +170,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
                 if (symbol is IParameterSymbol or ITypeParameterSymbol)
                 {
+                    // Can just defer to the standard helper here.  We only want to get the summary portion for just the
+                    // param/type-param and we have no need for remarks/returns/value.
                     _documentationMap.Add(
                         SymbolDescriptionGroups.Documentation,
                         symbol.GetDocumentationParts(_semanticModel, _position, formatter, CancellationToken));
@@ -183,6 +185,8 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                 var format = ISymbolExtensions2.CrefFormat;
                 var compilation = _semanticModel.Compilation;
 
+                // Grab the doc comment once as computing it for each portion we're concatenating can be expensive for
+                // lsif (which does this for every symbol in an entire solution).
                 var documentationComment = original is IMethodSymbol method
                     ? ISymbolExtensions2.GetMethodDocumentation(method, compilation, CancellationToken)
                     : original.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: CancellationToken);

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoOptions.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoOptions.cs
@@ -10,5 +10,8 @@ namespace Microsoft.CodeAnalysis.QuickInfo
     {
         public static readonly PerLanguageOption2<bool> ShowRemarksInQuickInfo = new(nameof(QuickInfoOptions), nameof(ShowRemarksInQuickInfo), defaultValue: true,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowRemarks"));
+
+        public static readonly Option2<bool> IncludeNavigationHintsInQuickInfo = new(nameof(QuickInfoOptions), nameof(IncludeNavigationHintsInQuickInfo), defaultValue: true,
+            storageLocations: new RoamingProfileStorageLocation("TextEditor.Specific.IncludeNavigationHintsInQuickInfo"));
     }
 }

--- a/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
@@ -181,50 +181,19 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => formatter.Format(GetDocumentation(symbol.OriginalDefinition, semanticModel.Compilation, cancellationToken),
                 symbol, semanticModel, position, CrefFormat, cancellationToken);
 
-        public static ImmutableArray<TaggedText> GetRemarksDocumentationParts(this ISymbol symbol, SemanticModel semanticModel, int position, IDocumentationCommentFormattingService formatter, CancellationToken cancellationToken)
-            => formatter.Format(GetRemarksDocumentation(symbol.OriginalDefinition, semanticModel.Compilation, cancellationToken),
-                symbol, semanticModel, position, CrefFormat, cancellationToken);
-
-        public static ImmutableArray<TaggedText> GetReturnsDocumentationParts(this ISymbol symbol, SemanticModel semanticModel, int position, IDocumentationCommentFormattingService formatter, CancellationToken cancellationToken)
-            => formatter.Format(GetReturnsDocumentation(symbol.OriginalDefinition, semanticModel.Compilation, cancellationToken),
-                symbol, semanticModel, position, CrefFormat, cancellationToken);
-
-        public static ImmutableArray<TaggedText> GetValueDocumentationParts(this ISymbol symbol, SemanticModel semanticModel, int position, IDocumentationCommentFormattingService formatter, CancellationToken cancellationToken)
-            => formatter.Format(GetValueDocumentation(symbol.OriginalDefinition, semanticModel.Compilation, cancellationToken),
-                symbol, semanticModel, position, CrefFormat, cancellationToken);
-
         private static string? GetDocumentation(ISymbol symbol, Compilation compilation, CancellationToken cancellationToken)
-            => symbol switch
+        {
+            return symbol switch
             {
-                IParameterSymbol parameter => GetParameterDocumentation(parameter, compilation, cancellationToken),
-                ITypeParameterSymbol typeParam => typeParam.ContainingSymbol.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).GetTypeParameterText(symbol.Name),
+                IParameterSymbol parameter => GetParameterDocumentation(parameter, compilation, cancellationToken)?.GetParameterText(parameter.Name),
+                ITypeParameterSymbol typeParam => typeParam.ContainingSymbol.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken)?.GetTypeParameterText(typeParam.Name),
                 IMethodSymbol method => GetMethodDocumentation(method, compilation, cancellationToken).SummaryText,
                 IAliasSymbol alias => alias.Target.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).SummaryText,
                 _ => symbol.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).SummaryText,
             };
+        }
 
-        private static string? GetRemarksDocumentation(ISymbol symbol, Compilation compilation, CancellationToken cancellationToken)
-            => symbol switch
-            {
-                IMethodSymbol method => GetMethodDocumentation(method, compilation, cancellationToken).RemarksText,
-                _ => symbol.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).RemarksText,
-            };
-
-        private static string? GetReturnsDocumentation(ISymbol symbol, Compilation compilation, CancellationToken cancellationToken)
-            => symbol switch
-            {
-                IMethodSymbol method => GetMethodDocumentation(method, compilation, cancellationToken).ReturnsText,
-                _ => symbol.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).ReturnsText,
-            };
-
-        private static string? GetValueDocumentation(ISymbol symbol, Compilation compilation, CancellationToken cancellationToken)
-            => symbol switch
-            {
-                IMethodSymbol method => GetMethodDocumentation(method, compilation, cancellationToken).ValueText,
-                _ => symbol.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).ValueText,
-            };
-
-        private static string? GetParameterDocumentation(IParameterSymbol parameter, Compilation compilation, CancellationToken cancellationToken)
+        public static DocumentationComment? GetParameterDocumentation(IParameterSymbol parameter, Compilation compilation, CancellationToken cancellationToken)
         {
             var containingSymbol = parameter.ContainingSymbol;
             if (containingSymbol.ContainingSymbol.IsDelegateType() && containingSymbol is IMethodSymbol methodSymbol)
@@ -249,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
 
             // Get the comments from the original definition of the containing symbol.
-            return containingSymbol.OriginalDefinition.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken).GetParameterText(parameter.Name);
+            return containingSymbol.OriginalDefinition.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true, cancellationToken: cancellationToken);
         }
 
         public static Func<CancellationToken, IEnumerable<TaggedText>> GetDocumentationPartsFactory(
@@ -269,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
                     SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-        private static DocumentationComment GetMethodDocumentation(IMethodSymbol method, Compilation compilation, CancellationToken cancellationToken)
+        public static DocumentationComment GetMethodDocumentation(IMethodSymbol method, Compilation compilation, CancellationToken cancellationToken)
         {
             switch (method.MethodKind)
             {


### PR DESCRIPTION
This speeds up production of lsif information on my machine for projects from 86 seconds to 29 seconds (down to 33% of the time).