### PR TITLE
Implements support for reloadable types in the compiler

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -440,7 +440,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             public override Symbol? VisitNamespace(NamespaceSymbol @namespace)
             {
                 var otherContainer = Visit(@namespace.ContainingSymbol);
-                RoslynDebug.AssertNotNull(otherContainer);
+
+                // TODO: Workaround for https://github.com/dotnet/roslyn/issues/54939.
+                // We should fail if the container can't be mapped.
+                // Currently this only occurs when determining reloadable type name for a type added to a new namespace,
+                // which is a rude edit.
+                // RoslynDebug.AssertNotNull(otherContainer);
+                if (otherContainer is null)
+                {
+                    return null;
+                }
 
                 switch (otherContainer.Kind)
                 {

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -65,7 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             }
 
             var definitionMap = moduleBeingBuilt.PreviousDefinitions;
-            var changes = moduleBeingBuilt.Changes;
+            var changes = moduleBeingBuilt.EncSymbolChanges;
+            Debug.Assert(changes != null);
 
             EmitBaseline? newBaseline = null;
 

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
@@ -85,7 +85,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             _deepTranslator = new CSharpSymbolMatcher.DeepTranslator(sourceAssembly.GetSpecialType(SpecialType.System_Object));
         }
 
-        public override int CurrentGenerationOrdinal => _previousGeneration.Ordinal + 1;
+        public override SymbolChanges? EncSymbolChanges => _changes;
+        public override EmitBaseline PreviousGeneration => _previousGeneration;
 
         internal override Cci.ITypeReference EncTranslateLocalVariableType(TypeSymbol type, DiagnosticBag diagnostics)
         {
@@ -173,11 +174,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return true;
         }
 
-        internal EmitBaseline PreviousGeneration
-        {
-            get { return _previousGeneration; }
-        }
-
         internal CSharpDefinitionMap PreviousDefinitions
         {
             get { return _previousDefinitions; }
@@ -240,11 +236,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return _previousDefinitions.TryGetAnonymousTypeName(template, out name, out index);
         }
 
-        internal SymbolChanges Changes
-        {
-            get { return _changes; }
-        }
-
         public void OnCreatedIndices(DiagnosticBag diagnostics)
         {
             var embeddedTypesManager = this.EmbeddedTypesManagerOpt;
@@ -255,11 +246,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     diagnostics.Add(new CSDiagnosticInfo(ErrorCode.ERR_EncNoPIAReference, embeddedType.AdaptedSymbol), Location.None);
                 }
             }
-        }
-
-        internal override bool IsEncDelta
-        {
-            get { return true; }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -491,7 +491,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_AttributeUsageAttribute__Inherited, diagnostics, Location.None);
         }
     }
-
+#nullable enable
     internal sealed class PEAssemblyBuilder : PEAssemblyBuilderBase
     {
         public PEAssemblyBuilder(
@@ -504,6 +504,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
         }
 
-        public override int CurrentGenerationOrdinal => 0;
+        public override EmitBaseline? PreviousGeneration => null;
+        public override SymbolChanges? EncSymbolChanges => null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -365,11 +365,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal virtual bool IgnoreAccessibility => false;
 
         /// <summary>
-        /// True if this module is an ENC update.
-        /// </summary>
-        internal virtual bool IsEncDelta => false;
-
-        /// <summary>
         /// Override the dynamic operation context type for all dynamic calls in the module.
         /// </summary>
         internal virtual NamedTypeSymbol GetDynamicOperationContextType(NamedTypeSymbol contextType)

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -537,9 +537,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     continue;
                 }
 
+                // exported types are not emitted in EnC deltas (hence generation 0):
                 string fullEmittedName = MetadataHelpers.BuildQualifiedName(
                     ((Cci.INamespaceTypeReference)type.GetCciAdapter()).NamespaceName,
-                    Cci.MetadataWriter.GetMangledName(type.GetCciAdapter()));
+                    Cci.MetadataWriter.GetMangledName(type.GetCciAdapter(), generation: 0));
 
                 // First check against types declared in the primary module
                 if (ContainsTopLevelType(fullEmittedName))

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PENetModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PENetModuleBuilder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -37,8 +35,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             throw ExceptionUtilities.Unreachable;
         }
 
-        public override int CurrentGenerationOrdinal => 0;
+        public override EmitBaseline? PreviousGeneration => null;
+        public override SymbolChanges? EncSymbolChanges => null;
+
         public override IEnumerable<Cci.IFileReference> GetFiles(EmitContext context) => SpecializedCollections.EmptyEnumerable<Cci.IFileReference>();
-        public override ISourceAssemblySymbolInternal SourceAssemblyOpt => null;
+        public override ISourceAssemblySymbolInternal? SourceAssemblyOpt => null;
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
@@ -139,59 +139,30 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             return MetadataTokens.Handle(table, rowNumber);
         }
 
+        private static bool IsDefinition(HandleKind kind)
+            => kind is not (HandleKind.AssemblyReference or HandleKind.ModuleReference or HandleKind.TypeReference or HandleKind.MemberReference);
+
         internal static void CheckEncLog(MetadataReader reader, params EditAndContinueLogEntry[] rows)
         {
             AssertEx.Equal(rows, reader.GetEditAndContinueLogEntries(), itemInspector: EncLogRowToString);
         }
 
+        /// <summary>
+        /// Checks that the EncLog contains specified definition rows. References are ignored as they are usually not interesting to validate. They are emitted as needed.
+        /// </summary>
         internal static void CheckEncLogDefinitions(MetadataReader reader, params EditAndContinueLogEntry[] rows)
         {
-            AssertEx.Equal(rows, reader.GetEditAndContinueLogEntries().Where(IsDefinition), itemInspector: EncLogRowToString);
-        }
-
-        private static bool IsDefinition(EditAndContinueLogEntry entry)
-        {
-            TableIndex index;
-            Assert.True(MetadataTokens.TryGetTableIndex(entry.Handle.Kind, out index));
-
-            switch (index)
-            {
-                case TableIndex.MethodDef:
-                case TableIndex.Field:
-                case TableIndex.Constant:
-                case TableIndex.GenericParam:
-                case TableIndex.GenericParamConstraint:
-                case TableIndex.Event:
-                case TableIndex.CustomAttribute:
-                case TableIndex.DeclSecurity:
-                case TableIndex.Assembly:
-                case TableIndex.MethodImpl:
-                case TableIndex.Param:
-                case TableIndex.Property:
-                case TableIndex.TypeDef:
-                case TableIndex.ExportedType:
-                case TableIndex.StandAloneSig:
-                case TableIndex.ClassLayout:
-                case TableIndex.FieldLayout:
-                case TableIndex.FieldMarshal:
-                case TableIndex.File:
-                case TableIndex.ImplMap:
-                case TableIndex.InterfaceImpl:
-                case TableIndex.ManifestResource:
-                case TableIndex.MethodSemantics:
-                case TableIndex.Module:
-                case TableIndex.NestedClass:
-                case TableIndex.EventMap:
-                case TableIndex.PropertyMap:
-                    return true;
-            }
-
-            return false;
+            AssertEx.Equal(rows, reader.GetEditAndContinueLogEntries().Where(e => IsDefinition(e.Handle.Kind)), itemInspector: EncLogRowToString);
         }
 
         internal static void CheckEncMap(MetadataReader reader, params EntityHandle[] handles)
         {
             AssertEx.Equal(handles, reader.GetEditAndContinueMapEntries(), itemInspector: EncMapRowToString);
+        }
+
+        internal static void CheckEncMapDefinitions(MetadataReader reader, params EntityHandle[] handles)
+        {
+            AssertEx.Equal(handles, reader.GetEditAndContinueMapEntries().Where(e => IsDefinition(e.Kind)), itemInspector: EncMapRowToString);
         }
 
         internal static void CheckAttributes(MetadataReader reader, params CustomAttributeRow[] rows)

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
         }
 
         private static bool IsDefinition(HandleKind kind)
-            => kind is not (HandleKind.AssemblyReference or HandleKind.ModuleReference or HandleKind.TypeReference or HandleKind.MemberReference);
+            => kind is not (HandleKind.AssemblyReference or HandleKind.ModuleReference or HandleKind.TypeReference or HandleKind.MemberReference or HandleKind.TypeSpecification or HandleKind.MethodSpecification);
 
         internal static void CheckEncLog(MetadataReader reader, params EditAndContinueLogEntry[] rows)
         {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -2087,6 +2087,227 @@ class C
         }
 
         [Fact]
+        public void UpdateType_AddAttributes()
+        {
+            var source0 = @"
+class C
+{
+}";
+            var source1 = @"
+[System.ComponentModel.Description(""C"")]
+class C
+{
+}";
+            var source2 = @"
+[System.ComponentModel.Description(""C"")]
+[System.ObsoleteAttribute]
+class C
+{
+}";
+
+            var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll, targetFramework: TargetFramework.NetStandard20);
+            var compilation1 = compilation0.WithSource(source1);
+            var compilation2 = compilation1.WithSource(source2);
+
+            var c0 = compilation0.GetMember<NamedTypeSymbol>("C");
+            var c1 = compilation1.GetMember<NamedTypeSymbol>("C");
+            var c2 = compilation2.GetMember<NamedTypeSymbol>("C");
+
+            // Verify full metadata contains expected rows.
+            var bytes0 = compilation0.EmitToArray();
+            using var md0 = ModuleMetadata.CreateFromImage(bytes0);
+            var reader0 = md0.MetadataReader;
+
+            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C");
+
+            Assert.Equal(3, reader0.CustomAttributes.Count);
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(
+                md0,
+                EmptyLocalsProvider);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, c0, c1)));
+
+            // Verify delta metadata contains expected rows.
+            using var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+            var readers = new[] { reader0, reader1 };
+
+            CheckNames(readers, reader1.GetTypeDefNames(), "C");
+
+            Assert.Equal(1, reader1.CustomAttributes.Count);
+
+            CheckEncLogDefinitions(reader1,
+                Row(2, TableIndex.TypeDef, EditAndContinueOperation.Default),
+                Row(4, TableIndex.CustomAttribute, EditAndContinueOperation.Default));
+
+            CheckEncMapDefinitions(reader1,
+                Handle(2, TableIndex.TypeDef),
+                Handle(4, TableIndex.CustomAttribute));
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, c1, c2)));
+
+            // Verify delta metadata contains expected rows.
+            using var md2 = diff2.GetMetadata();
+            var reader2 = md2.Reader;
+            readers = new[] { reader0, reader1, reader2 };
+
+            CheckNames(readers, reader2.GetTypeDefNames(), "C");
+
+            Assert.Equal(2, reader2.CustomAttributes.Count);
+
+            CheckEncLogDefinitions(reader2,
+                Row(2, TableIndex.TypeDef, EditAndContinueOperation.Default),
+                Row(4, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(5, TableIndex.CustomAttribute, EditAndContinueOperation.Default));
+
+            CheckEncMapDefinitions(reader2,
+                Handle(2, TableIndex.TypeDef),
+                Handle(4, TableIndex.CustomAttribute),
+                Handle(5, TableIndex.CustomAttribute));
+        }
+
+        [Fact]
+        public void ReplaceType()
+        {
+            var source0 = @"
+class C 
+{
+    void F(int x) {}
+}
+";
+            var source1 = @"
+class C
+{
+    void F(int x, int y) { }
+}";
+            var source2 = @"
+class C
+{
+    void F(int x, int y) { System.Console.WriteLine(1); }
+}";
+            var source3 = @"
+[System.Obsolete]
+class C
+{
+    void F(int x, int y) { System.Console.WriteLine(2); }
+}";
+
+            var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll, targetFramework: TargetFramework.NetStandard20);
+            var compilation1 = compilation0.WithSource(source1);
+            var compilation2 = compilation1.WithSource(source2);
+            var compilation3 = compilation2.WithSource(source3);
+
+            var c0 = compilation0.GetMember<NamedTypeSymbol>("C");
+            var c1 = compilation1.GetMember<NamedTypeSymbol>("C");
+            var c2 = compilation2.GetMember<NamedTypeSymbol>("C");
+            var c3 = compilation3.GetMember<NamedTypeSymbol>("C");
+            var f2 = c2.GetMember<MethodSymbol>("F");
+            var f3 = c3.GetMember<MethodSymbol>("F");
+
+            // Verify full metadata contains expected rows.
+            var bytes0 = compilation0.EmitToArray();
+            using var md0 = ModuleMetadata.CreateFromImage(bytes0);
+            var reader0 = md0.MetadataReader;
+
+            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(
+                md0,
+                EmptyLocalsProvider);
+
+            // This update emulates "Reloadable" type behavior - a new type is generated instead of updating the existing one.
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Replace, null, c1)));
+
+            // Verify delta metadata contains expected rows.
+            using var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+            var readers = new[] { reader0, reader1 };
+
+            CheckNames(readers, reader1.GetTypeDefNames(), "C#1");
+
+            CheckEncLogDefinitions(reader1,
+                Row(3, TableIndex.TypeDef, EditAndContinueOperation.Default),
+                Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(2, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(3, TableIndex.Param, EditAndContinueOperation.Default));
+
+            CheckEncMapDefinitions(reader1,
+                Handle(3, TableIndex.TypeDef),
+                Handle(3, TableIndex.MethodDef),
+                Handle(4, TableIndex.MethodDef),
+                Handle(2, TableIndex.Param),
+                Handle(3, TableIndex.Param));
+
+            // This update emulates "Reloadable" type behavior - a new type is generated instead of updating the existing one.
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Replace, null, c2)));
+
+            // Verify delta metadata contains expected rows.
+            using var md2 = diff2.GetMetadata();
+            var reader2 = md2.Reader;
+            readers = new[] { reader0, reader1, reader2 };
+
+            CheckNames(readers, reader2.GetTypeDefNames(), "C#2");
+
+            CheckEncLogDefinitions(reader2,
+                Row(4, TableIndex.TypeDef, EditAndContinueOperation.Default),
+                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(5, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(4, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(5, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(5, TableIndex.Param, EditAndContinueOperation.Default));
+
+            CheckEncMapDefinitions(reader2,
+                Handle(4, TableIndex.TypeDef),
+                Handle(5, TableIndex.MethodDef),
+                Handle(6, TableIndex.MethodDef),
+                Handle(4, TableIndex.Param),
+                Handle(5, TableIndex.Param));
+
+            // This update is an EnC update - even reloadable types are update in-place
+            var diff3 = compilation3.EmitDifference(
+                diff2.NextGeneration,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Update, c2, c3),
+                    SemanticEdit.Create(SemanticEditKind.Update, f2, f3)));
+
+            // Verify delta metadata contains expected rows.
+            using var md3 = diff3.GetMetadata();
+            var reader3 = md3.Reader;
+            readers = new[] { reader0, reader1, reader2, reader3 };
+
+            CheckNames(readers, reader3.GetTypeDefNames(), "C#2");
+
+            CheckEncLogDefinitions(reader3,
+                Row(4, TableIndex.TypeDef, EditAndContinueOperation.Default),
+                Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(4, TableIndex.CustomAttribute, EditAndContinueOperation.Default));
+
+            CheckEncMapDefinitions(reader3,
+                Handle(4, TableIndex.TypeDef),
+                Handle(5, TableIndex.MethodDef),
+                Handle(4, TableIndex.CustomAttribute));
+        }
+
+        [Fact]
         public void AddNestedTypeAndMembers()
         {
             var source0 =

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -3137,7 +3137,7 @@ namespace Microsoft.CodeAnalysis
 
                     nativePdbWriter?.WriteTo(pdbStream);
 
-                    return diagnostics.HasAnyErrors() ? null : writer.GetDelta(baseline, this, encId, metadataSizes);
+                    return diagnostics.HasAnyErrors() ? null : writer.GetDelta(this, encId, metadataSizes);
                 }
                 catch (SymUnmanagedWriterException e)
                 {

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Emit
             return ImmutableArray.Create(sizes);
         }
 
-        internal EmitBaseline GetDelta(EmitBaseline baseline, Compilation compilation, Guid encId, MetadataSizes metadataSizes)
+        internal EmitBaseline GetDelta(Compilation compilation, Guid encId, MetadataSizes metadataSizes)
         {
             var addedOrChangedMethodsByIndex = new Dictionary<int, AddedOrChangedMethodInfo>();
             foreach (var pair in _addedOrChangedMethods)
@@ -172,22 +172,35 @@ namespace Microsoft.CodeAnalysis.Emit
 
             // If the previous generation is 0 (metadata) get the synthesized members from the current compilation's builder,
             // otherwise members from the current compilation have already been merged into the baseline.
-            var synthesizedMembers = (baseline.Ordinal == 0) ? module.GetAllSynthesizedMembers() : baseline.SynthesizedMembers;
+            var synthesizedMembers = (_previousGeneration.Ordinal == 0) ? module.GetAllSynthesizedMembers() : _previousGeneration.SynthesizedMembers;
 
-            return baseline.With(
+            var currentGenerationOrdinal = _previousGeneration.Ordinal + 1;
+
+            var addedTypes = _typeDefs.GetAdded();
+            var generationOrdinals = CreateDictionary(_previousGeneration.GenerationOrdinals, SymbolEquivalentEqualityComparer.Instance);
+            foreach (var (addedType, _) in addedTypes)
+            {
+                if (_changes.IsReplaced(addedType))
+                {
+                    generationOrdinals[addedType] = currentGenerationOrdinal;
+                }
+            }
+
+            return _previousGeneration.With(
                 compilation,
                 module,
-                baseline.Ordinal + 1,
+                currentGenerationOrdinal,
                 encId,
-                typesAdded: AddRange(_previousGeneration.TypesAdded, _typeDefs.GetAdded(), comparer: Cci.SymbolEquivalentEqualityComparer.Instance),
-                eventsAdded: AddRange(_previousGeneration.EventsAdded, _eventDefs.GetAdded(), comparer: Cci.SymbolEquivalentEqualityComparer.Instance),
-                fieldsAdded: AddRange(_previousGeneration.FieldsAdded, _fieldDefs.GetAdded(), comparer: Cci.SymbolEquivalentEqualityComparer.Instance),
-                methodsAdded: AddRange(_previousGeneration.MethodsAdded, _methodDefs.GetAdded(), comparer: Cci.SymbolEquivalentEqualityComparer.Instance),
-                propertiesAdded: AddRange(_previousGeneration.PropertiesAdded, _propertyDefs.GetAdded(), comparer: Cci.SymbolEquivalentEqualityComparer.Instance),
+                generationOrdinals,
+                typesAdded: AddRange(_previousGeneration.TypesAdded, addedTypes, comparer: SymbolEquivalentEqualityComparer.Instance),
+                eventsAdded: AddRange(_previousGeneration.EventsAdded, _eventDefs.GetAdded(), comparer: SymbolEquivalentEqualityComparer.Instance),
+                fieldsAdded: AddRange(_previousGeneration.FieldsAdded, _fieldDefs.GetAdded(), comparer: SymbolEquivalentEqualityComparer.Instance),
+                methodsAdded: AddRange(_previousGeneration.MethodsAdded, _methodDefs.GetAdded(), comparer: SymbolEquivalentEqualityComparer.Instance),
+                propertiesAdded: AddRange(_previousGeneration.PropertiesAdded, _propertyDefs.GetAdded(), comparer: SymbolEquivalentEqualityComparer.Instance),
                 eventMapAdded: AddRange(_previousGeneration.EventMapAdded, _eventMap.GetAdded()),
                 propertyMapAdded: AddRange(_previousGeneration.PropertyMapAdded, _propertyMap.GetAdded()),
                 methodImplsAdded: AddRange(_previousGeneration.MethodImplsAdded, _methodImpls.GetAdded()),
-                customAttributesAdded: AddRange(_previousGeneration.CustomAttributesAdded, _customAttributesAdded, replace: true),
+                customAttributesAdded: AddRange(_previousGeneration.CustomAttributesAdded, _customAttributesAdded),
                 tableEntriesAdded: ImmutableArray.Create(tableSizes),
                 // Blob stream is concatenated aligned.
                 blobStreamLengthAdded: metadataSizes.GetAlignedHeapSize(HeapIndex.Blob) + _previousGeneration.BlobStreamLengthAdded,
@@ -199,12 +212,24 @@ namespace Microsoft.CodeAnalysis.Emit
                 guidStreamLengthAdded: metadataSizes.HeapSizes[(int)HeapIndex.Guid],
                 anonymousTypeMap: ((IPEDeltaAssemblyBuilder)module).GetAnonymousTypeMap(),
                 synthesizedMembers: synthesizedMembers,
-                addedOrChangedMethods: AddRange(_previousGeneration.AddedOrChangedMethods, addedOrChangedMethodsByIndex, replace: true),
-                debugInformationProvider: baseline.DebugInformationProvider,
-                localSignatureProvider: baseline.LocalSignatureProvider);
+                addedOrChangedMethods: AddRange(_previousGeneration.AddedOrChangedMethods, addedOrChangedMethodsByIndex),
+                debugInformationProvider: _previousGeneration.DebugInformationProvider,
+                localSignatureProvider: _previousGeneration.LocalSignatureProvider);
         }
 
-        private static IReadOnlyDictionary<K, V> AddRange<K, V>(IReadOnlyDictionary<K, V> previous, IReadOnlyDictionary<K, V> current, bool replace = false, IEqualityComparer<K>? comparer = null)
+        private static Dictionary<K, V> CreateDictionary<K, V>(IReadOnlyDictionary<K, V> dictionary, IEqualityComparer<K>? comparer)
+            where K : notnull
+        {
+            var result = new Dictionary<K, V>(comparer);
+            foreach (var pair in dictionary)
+            {
+                result.Add(pair.Key, pair.Value);
+            }
+
+            return result;
+        }
+
+        private static IReadOnlyDictionary<K, V> AddRange<K, V>(IReadOnlyDictionary<K, V> previous, IReadOnlyDictionary<K, V> current, IEqualityComparer<K>? comparer = null)
             where K : notnull
         {
             if (previous.Count == 0)
@@ -217,15 +242,10 @@ namespace Microsoft.CodeAnalysis.Emit
                 return previous;
             }
 
-            var result = new Dictionary<K, V>(comparer);
-            foreach (var pair in previous)
-            {
-                result.Add(pair.Key, pair.Value);
-            }
-
+            var result = CreateDictionary(previous, comparer);
             foreach (var pair in current)
             {
-                Debug.Assert(replace || !previous.ContainsKey(pair.Key));
+                // Use the latest symbol.
                 result[pair.Key] = pair.Value;
             }
 

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Emit
         internal readonly Guid EncId;
 
         /// <summary>
-        /// The latest generation number of each symbol added via <see cref="SemanticEditKind.InsertExisting"/> edit.
+        /// The latest generation number of each symbol added via <see cref="SemanticEditKind.Replace"/> edit.
         /// </summary>
         internal readonly IReadOnlyDictionary<Cci.IDefinition, int> GenerationOrdinals;
 

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -204,6 +204,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 ordinal: 0,
                 encId: default,
                 hasPortablePdb: hasPortableDebugInformation,
+                generationOrdinals: new Dictionary<Cci.IDefinition, int>(),
                 typesAdded: new Dictionary<Cci.ITypeDefinition, int>(),
                 eventsAdded: new Dictionary<Cci.IEventDefinition, int>(),
                 fieldsAdded: new Dictionary<Cci.IFieldDefinition, int>(),
@@ -254,6 +255,11 @@ namespace Microsoft.CodeAnalysis.Emit
         /// if full metadata.
         /// </summary>
         internal readonly Guid EncId;
+
+        /// <summary>
+        /// The latest generation number of each symbol added via <see cref="SemanticEditKind.InsertExisting"/> edit.
+        /// </summary>
+        internal readonly IReadOnlyDictionary<Cci.IDefinition, int> GenerationOrdinals;
 
         internal readonly IReadOnlyDictionary<Cci.ITypeDefinition, int> TypesAdded;
         internal readonly IReadOnlyDictionary<Cci.IEventDefinition, int> EventsAdded;
@@ -311,6 +317,7 @@ namespace Microsoft.CodeAnalysis.Emit
             int ordinal,
             Guid encId,
             bool hasPortablePdb,
+            IReadOnlyDictionary<Cci.IDefinition, int> generationOrdinals,
             IReadOnlyDictionary<Cci.ITypeDefinition, int> typesAdded,
             IReadOnlyDictionary<Cci.IEventDefinition, int> eventsAdded,
             IReadOnlyDictionary<Cci.IFieldDefinition, int> fieldsAdded,
@@ -372,6 +379,7 @@ namespace Microsoft.CodeAnalysis.Emit
             EncId = encId;
             HasPortablePdb = hasPortablePdb;
 
+            GenerationOrdinals = generationOrdinals;
             TypesAdded = typesAdded;
             EventsAdded = eventsAdded;
             FieldsAdded = fieldsAdded;
@@ -403,6 +411,7 @@ namespace Microsoft.CodeAnalysis.Emit
             CommonPEModuleBuilder moduleBuilder,
             int ordinal,
             Guid encId,
+            IReadOnlyDictionary<Cci.IDefinition, int> generationOrdinals,
             IReadOnlyDictionary<Cci.ITypeDefinition, int> typesAdded,
             IReadOnlyDictionary<Cci.IEventDefinition, int> eventsAdded,
             IReadOnlyDictionary<Cci.IFieldDefinition, int> fieldsAdded,
@@ -435,6 +444,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 ordinal,
                 encId,
                 HasPortablePdb,
+                generationOrdinals,
                 typesAdded,
                 eventsAdded,
                 fieldsAdded,

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -24,13 +24,27 @@ namespace Microsoft.CodeAnalysis.Emit
         /// </summary>
         private readonly IReadOnlyDictionary<ISymbol, SymbolChange> _changes;
 
+        /// <summary>
+        /// A set of symbols whose name emitted to metadata must include a "#{generation}" suffix to avoid naming collisions with existing types.
+        /// Populated based on semantic edits with <see cref="SemanticEditKind.Replace"/>.
+        /// </summary>
+        private readonly ISet<ISymbol> _replacedSymbols;
+
         private readonly Func<ISymbol, bool> _isAddedSymbol;
 
         protected SymbolChanges(DefinitionMap definitionMap, IEnumerable<SemanticEdit> edits, Func<ISymbol, bool> isAddedSymbol)
         {
             _definitionMap = definitionMap;
             _isAddedSymbol = isAddedSymbol;
-            _changes = CalculateChanges(edits);
+            CalculateChanges(edits, out _changes, out _replacedSymbols);
+        }
+
+        public DefinitionMap DefinitionMap => _definitionMap;
+
+        public bool IsReplaced(IDefinition definition)
+        {
+            var symbol = definition.GetInternalSymbol();
+            return symbol is not null && _replacedSymbols.Contains(symbol.GetISymbol());
         }
 
         /// <summary>
@@ -221,9 +235,10 @@ namespace Microsoft.CodeAnalysis.Emit
         /// Note that these changes only include user-defined source symbols, not synthesized symbols since those will be 
         /// generated during lowering of the changed user-defined symbols.
         /// </summary>
-        private static IReadOnlyDictionary<ISymbol, SymbolChange> CalculateChanges(IEnumerable<SemanticEdit> edits)
+        private static void CalculateChanges(IEnumerable<SemanticEdit> edits, out IReadOnlyDictionary<ISymbol, SymbolChange> changes, out ISet<ISymbol> replaceSymbols)
         {
-            var changes = new Dictionary<ISymbol, SymbolChange>();
+            var changesBuilder = new Dictionary<ISymbol, SymbolChange>();
+            HashSet<ISymbol>? lazyReplaceSymbolsBuilder = null;
 
             foreach (var edit in edits)
             {
@@ -236,6 +251,12 @@ namespace Microsoft.CodeAnalysis.Emit
                         break;
 
                     case SemanticEditKind.Insert:
+                        change = SymbolChange.Added;
+                        break;
+
+                    case SemanticEditKind.Replace:
+                        Debug.Assert(edit.NewSymbol != null);
+                        (lazyReplaceSymbolsBuilder ??= new HashSet<ISymbol>()).Add(edit.NewSymbol);
                         change = SymbolChange.Added;
                         break;
 
@@ -267,11 +288,12 @@ namespace Microsoft.CodeAnalysis.Emit
                     }
                 }
 
-                AddContainingTypesAndNamespaces(changes, member);
-                changes.Add(member, change);
+                AddContainingTypesAndNamespaces(changesBuilder, member);
+                changesBuilder.Add(member, change);
             }
 
-            return changes;
+            changes = changesBuilder;
+            replaceSymbols = lazyReplaceSymbolsBuilder ?? SpecializedCollections.EmptySet<ISymbol>();
         }
 
         private static void AddContainingTypesAndNamespaces(Dictionary<ISymbol, SymbolChange> changes, ISymbol symbol)

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolMatcher.cs
@@ -37,12 +37,14 @@ namespace Microsoft.CodeAnalysis.Emit
             var fieldsAdded = MapDefinitions(baseline.FieldsAdded);
             var methodsAdded = MapDefinitions(baseline.MethodsAdded);
             var propertiesAdded = MapDefinitions(baseline.PropertiesAdded);
+            var generationOrdinals = MapDefinitions(baseline.GenerationOrdinals);
 
             return baseline.With(
                 targetCompilation,
                 targetModuleBuilder,
                 baseline.Ordinal,
                 baseline.EncId,
+                generationOrdinals,
                 typesAdded,
                 eventsAdded,
                 fieldsAdded,

--- a/src/Compilers/Core/Portable/Emit/SemanticEdit.cs
+++ b/src/Compilers/Core/Portable/Emit/SemanticEdit.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Emit
     /// Describes a symbol edit between two compilations. 
     /// For example, an addition of a method, an update of a method, removal of a type, etc.
     /// </summary>
-    public struct SemanticEdit : IEquatable<SemanticEdit>
+    public readonly struct SemanticEdit : IEquatable<SemanticEdit>
     {
         /// <summary>
         /// The type of edit.
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Emit
         /// </exception>
         public SemanticEdit(SemanticEditKind kind, ISymbol? oldSymbol, ISymbol? newSymbol, Func<SyntaxNode, SyntaxNode?>? syntaxMap = null, bool preserveLocalVariables = false)
         {
-            if (oldSymbol == null && kind != SemanticEditKind.Insert)
+            if (oldSymbol == null && kind is not (SemanticEditKind.Insert or SemanticEditKind.Replace))
             {
                 throw new ArgumentNullException(nameof(oldSymbol));
             }
@@ -84,40 +84,36 @@ namespace Microsoft.CodeAnalysis.Emit
                 throw new ArgumentNullException(nameof(newSymbol));
             }
 
-            if (kind <= SemanticEditKind.None || kind > SemanticEditKind.Delete)
+            if (kind <= SemanticEditKind.None || kind > SemanticEditKind.Replace)
             {
                 throw new ArgumentOutOfRangeException(nameof(kind));
             }
 
-            this.Kind = kind;
-            this.OldSymbol = oldSymbol;
-            this.NewSymbol = newSymbol;
-            this.PreserveLocalVariables = preserveLocalVariables;
-            this.SyntaxMap = syntaxMap;
+            Kind = kind;
+            OldSymbol = oldSymbol;
+            NewSymbol = newSymbol;
+            PreserveLocalVariables = preserveLocalVariables;
+            SyntaxMap = syntaxMap;
         }
 
         internal static SemanticEdit Create(SemanticEditKind kind, ISymbolInternal oldSymbol, ISymbolInternal newSymbol, Func<SyntaxNode, SyntaxNode>? syntaxMap = null, bool preserveLocalVariables = false)
-        {
-            return new SemanticEdit(kind, oldSymbol?.GetISymbol(), newSymbol?.GetISymbol(), syntaxMap, preserveLocalVariables);
-        }
+            => new SemanticEdit(kind, oldSymbol?.GetISymbol(), newSymbol?.GetISymbol(), syntaxMap, preserveLocalVariables);
 
         public override int GetHashCode()
-        {
-            return Hash.Combine(OldSymbol,
-                   Hash.Combine(NewSymbol,
-                   (int)Kind));
-        }
+            => Hash.Combine(OldSymbol, Hash.Combine(NewSymbol, (int)Kind));
 
         public override bool Equals(object? obj)
-        {
-            return obj is SemanticEdit && Equals((SemanticEdit)obj);
-        }
+            => obj is SemanticEdit other && Equals(other);
 
         public bool Equals(SemanticEdit other)
-        {
-            return this.Kind == other.Kind
-                && (this.OldSymbol == null ? other.OldSymbol == null : this.OldSymbol.Equals(other.OldSymbol))
-                && (this.NewSymbol == null ? other.NewSymbol == null : this.NewSymbol.Equals(other.NewSymbol));
-        }
+            => Kind == other.Kind
+                && (OldSymbol == null ? other.OldSymbol == null : OldSymbol.Equals(other.OldSymbol))
+                && (NewSymbol == null ? other.NewSymbol == null : NewSymbol.Equals(other.NewSymbol));
+
+        public static bool operator ==(SemanticEdit left, SemanticEdit right)
+            => left.Equals(right);
+
+        public static bool operator !=(SemanticEdit left, SemanticEdit right)
+            => !(left == right);
     }
 }

--- a/src/Compilers/Core/Portable/Emit/SemanticEditKind.cs
+++ b/src/Compilers/Core/Portable/Emit/SemanticEditKind.cs
@@ -12,18 +12,23 @@ namespace Microsoft.CodeAnalysis.Emit
         None = 0,
 
         /// <summary>
-        /// Node value was updated.
+        /// Symbol is updated.
         /// </summary>
         Update = 1,
 
         /// <summary>
-        /// Node was inserted.
+        /// Symbol is inserted.
         /// </summary>
         Insert = 2,
 
         /// <summary>
-        /// Node was deleted.
+        /// Symbol is deleted.
         /// </summary>
         Delete = 3,
+
+        /// <summary>
+        /// Existing symbol is replaced by its new version.
+        /// </summary>
+        Replace = 4
     }
 }

--- a/src/Compilers/Core/Portable/NativePdbWriter/SymWriterMetadataProvider.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/SymWriterMetadataProvider.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Cci
             }
             else
             {
-                typeName = MetadataWriter.GetMangledName((INamedTypeReference)t);
+                int generation = (t is INamedTypeDefinition namedType) ? _writer.Module.GetTypeDefinitionGeneration(namedType) : 0;
+                typeName = MetadataWriter.GetMangledName((INamedTypeReference)t, generation);
 
                 INamespaceTypeDefinition namespaceTypeDef;
                 if ((namespaceTypeDef = t.AsNamespaceTypeDefinition(_writer.Context)) != null)

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -931,7 +931,7 @@ namespace Microsoft.Cci
             return (uint)result;
         }
 
-        public static string GetMangledName(INamedTypeReference namedType, int generation = 0)
+        public static string GetMangledName(INamedTypeReference namedType, int generation)
         {
             string unmangledName = (generation == 0) ? namedType.Name : namedType.Name + "#" + generation;
 
@@ -2232,7 +2232,9 @@ namespace Microsoft.Cci
 
                 if ((namespaceTypeRef = exportedType.Type.AsNamespaceTypeReference) != null)
                 {
-                    string mangledTypeName = GetMangledName(namespaceTypeRef);
+                    // exported types are not emitted in EnC deltas (hence generation 0):
+                    string mangledTypeName = GetMangledName(namespaceTypeRef, generation: 0);
+
                     typeName = GetStringHandleForNameAndCheckLength(mangledTypeName, namespaceTypeRef);
                     typeNamespace = GetStringHandleForNamespaceAndCheckLength(namespaceTypeRef, mangledTypeName);
                     implementation = GetExportedTypeImplementation(namespaceTypeRef);
@@ -2242,7 +2244,10 @@ namespace Microsoft.Cci
                 {
                     Debug.Assert(exportedType.ParentIndex != -1);
 
-                    typeName = GetStringHandleForNameAndCheckLength(GetMangledName(nestedRef), nestedRef);
+                    // exported types are not emitted in EnC deltas (hence generation 0):
+                    string mangledTypeName = GetMangledName(nestedRef, generation: 0);
+
+                    typeName = GetStringHandleForNameAndCheckLength(mangledTypeName, nestedRef);
                     typeNamespace = default(StringHandle);
                     implementation = MetadataTokens.ExportedTypeHandle(exportedType.ParentIndex + 1);
                     attributes = exportedType.IsForwarder ? TypeAttributes.NotPublic : TypeAttributes.NestedPublic;
@@ -2717,27 +2722,7 @@ namespace Microsoft.Cci
                 INamespaceTypeDefinition namespaceType = typeDef.AsNamespaceTypeDefinition(Context);
 
                 var moduleBuilder = Context.Module;
-                int generation = 0;
-
-                if (moduleBuilder.PreviousGeneration != null)
-                {
-                    var symbolChanges = moduleBuilder.EncSymbolChanges!;
-
-                    if (symbolChanges.IsReplaced(typeDef))
-                    {
-                        // Type emitted with Replace semantics in this delta, it's name should have the current generation ordinal suffix.
-                        generation = moduleBuilder.CurrentGenerationOrdinal;
-                    }
-                    else
-                    {
-                        var previousTypeDef = symbolChanges.DefinitionMap.MapDefinition(typeDef);
-                        if (previousTypeDef != null && moduleBuilder.PreviousGeneration.GenerationOrdinals.TryGetValue(previousTypeDef, out int lastEmittedOrdinal))
-                        {
-                            // Type previously emitted with Replace semantics is now updated in-place. Use the ordinal used to emit the last version of the type.
-                            generation = lastEmittedOrdinal;
-                        }
-                    }
-                }
+                int generation = moduleBuilder.GetTypeDefinitionGeneration(typeDef);
 
                 string mangledTypeName = GetMangledName(typeDef, generation);
                 ITypeReference baseType = typeDef.GetBaseClass(Context);
@@ -2811,7 +2796,12 @@ namespace Microsoft.Cci
                     }
 
                     resolutionScope = GetTypeReferenceHandle(scopeTypeRef);
-                    name = this.GetStringHandleForNameAndCheckLength(GetMangledName(nestedTypeRef), nestedTypeRef);
+
+                    // It's not possible to reference newer versions of reloadable types from another assembly, hence generation 0:
+                    // TODO: https://github.com/dotnet/roslyn/issues/54981
+                    string mangledTypeName = GetMangledName(nestedTypeRef, generation: 0);
+
+                    name = this.GetStringHandleForNameAndCheckLength(mangledTypeName, nestedTypeRef);
                     @namespace = default(StringHandle);
                 }
                 else
@@ -2823,7 +2813,11 @@ namespace Microsoft.Cci
                     }
 
                     resolutionScope = this.GetResolutionScopeHandle(namespaceTypeRef.GetUnit(Context));
-                    string mangledTypeName = GetMangledName(namespaceTypeRef);
+
+                    // It's not possible to reference newer versions of reloadable types from another assembly, hence generation 0:
+                    // TODO: https://github.com/dotnet/roslyn/issues/54981
+                    string mangledTypeName = GetMangledName(namespaceTypeRef, generation: 0);
+
                     name = this.GetStringHandleForNameAndCheckLength(mangledTypeName, namespaceTypeRef);
                     @namespace = this.GetStringHandleForNamespaceAndCheckLength(namespaceTypeRef, mangledTypeName);
                 }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -931,9 +931,9 @@ namespace Microsoft.Cci
             return (uint)result;
         }
 
-        public static string GetMangledName(INamedTypeReference namedType)
+        public static string GetMangledName(INamedTypeReference namedType, int generation = 0)
         {
-            string unmangledName = namedType.Name;
+            string unmangledName = (generation == 0) ? namedType.Name : namedType.Name + "#" + generation;
 
             return namedType.MangleName
                 ? MetadataHelpers.ComposeAritySuffixedMetadataName(unmangledName, namedType.GenericParameterCount)
@@ -2715,7 +2715,31 @@ namespace Microsoft.Cci
             foreach (INamedTypeDefinition typeDef in typeDefs)
             {
                 INamespaceTypeDefinition namespaceType = typeDef.AsNamespaceTypeDefinition(Context);
-                string mangledTypeName = GetMangledName(typeDef);
+
+                var moduleBuilder = Context.Module;
+                int generation = 0;
+
+                if (moduleBuilder.PreviousGeneration != null)
+                {
+                    var symbolChanges = moduleBuilder.EncSymbolChanges!;
+
+                    if (symbolChanges.IsReplaced(typeDef))
+                    {
+                        // Type emitted with Replace semantics in this delta, it's name should have the current generation ordinal suffix.
+                        generation = moduleBuilder.CurrentGenerationOrdinal;
+                    }
+                    else
+                    {
+                        var previousTypeDef = symbolChanges.DefinitionMap.MapDefinition(typeDef);
+                        if (previousTypeDef != null && moduleBuilder.PreviousGeneration.GenerationOrdinals.TryGetValue(previousTypeDef, out int lastEmittedOrdinal))
+                        {
+                            // Type previously emitted with Replace semantics is now updated in-place. Use the ordinal used to emit the last version of the type.
+                            generation = lastEmittedOrdinal;
+                        }
+                    }
+                }
+
+                string mangledTypeName = GetMangledName(typeDef, generation);
                 ITypeReference baseType = typeDef.GetBaseClass(Context);
 
                 metadata.AddTypeDefinition(

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@ const Microsoft.CodeAnalysis.WellKnownMemberNames.PrintMembersMethodName = "Prin
 Microsoft.CodeAnalysis.Compilation.EmitDifference(Microsoft.CodeAnalysis.Emit.EmitBaseline! baseline, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Emit.SemanticEdit>! edits, System.Func<Microsoft.CodeAnalysis.ISymbol!, bool>! isAddedSymbol, System.IO.Stream! metadataStream, System.IO.Stream! ilStream, System.IO.Stream! pdbStream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.Emit.EmitDifferenceResult!
 Microsoft.CodeAnalysis.Emit.EmitDifferenceResult.UpdatedMethods.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle>
 Microsoft.CodeAnalysis.Emit.EmitDifferenceResult.UpdatedTypes.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.TypeDefinitionHandle>
+Microsoft.CodeAnalysis.Emit.SemanticEditKind.Replace = 4 -> Microsoft.CodeAnalysis.Emit.SemanticEditKind
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string! firstLanguage, params string![]! additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string![]!
 Microsoft.CodeAnalysis.GeneratorDriver.ReplaceAdditionalText(Microsoft.CodeAnalysis.AdditionalText! oldText, Microsoft.CodeAnalysis.AdditionalText! newText) -> Microsoft.CodeAnalysis.GeneratorDriver!
@@ -88,6 +89,8 @@ override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.GetGenerators(
 override Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference.GetGeneratorsForAllLanguages() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator!>
 override Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.DefaultVisit(Microsoft.CodeAnalysis.IOperation! operation, TArgument argument) -> object?
 override Microsoft.CodeAnalysis.Operations.OperationWalker<TArgument>.Visit(Microsoft.CodeAnalysis.IOperation? operation, TArgument argument) -> object?
+static Microsoft.CodeAnalysis.Emit.SemanticEdit.operator !=(Microsoft.CodeAnalysis.Emit.SemanticEdit left, Microsoft.CodeAnalysis.Emit.SemanticEdit right) -> bool
+static Microsoft.CodeAnalysis.Emit.SemanticEdit.operator ==(Microsoft.CodeAnalysis.Emit.SemanticEdit left, Microsoft.CodeAnalysis.Emit.SemanticEdit right) -> bool
 static Microsoft.CodeAnalysis.FileLinePositionSpan.operator !=(Microsoft.CodeAnalysis.FileLinePositionSpan left, Microsoft.CodeAnalysis.FileLinePositionSpan right) -> bool
 static Microsoft.CodeAnalysis.FileLinePositionSpan.operator ==(Microsoft.CodeAnalysis.FileLinePositionSpan left, Microsoft.CodeAnalysis.FileLinePositionSpan right) -> bool
 static Microsoft.CodeAnalysis.GeneratorExtensions.AsSourceGenerator(this Microsoft.CodeAnalysis.IIncrementalGenerator! incrementalGenerator) -> Microsoft.CodeAnalysis.ISourceGenerator!

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             End If
 
             Dim definitionMap = moduleBeingBuilt.PreviousDefinitions
-            Dim changes = moduleBeingBuilt.Changes
+            Dim changes = moduleBeingBuilt.EncSymbolChanges
 
             Dim newBaseline As EmitBaseline = Nothing
 

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -87,9 +87,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return Translate(If(visited, type), Nothing, diagnostics)
         End Function
 
-        Public Overrides ReadOnly Property CurrentGenerationOrdinal As Integer
+        Public Overrides ReadOnly Property EncSymbolChanges As SymbolChanges
             Get
-                Return _previousGeneration.Ordinal + 1
+                Return _changes
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property PreviousGeneration As EmitBaseline
+            Get
+                Return _previousGeneration
             End Get
         End Property
 
@@ -189,12 +195,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return New AnonymousTypeKey(parameters.ToImmutableAndFree(), isDelegate:=True)
         End Function
 
-        Friend ReadOnly Property PreviousGeneration As EmitBaseline
-            Get
-                Return _previousGeneration
-            End Get
-        End Property
-
         Friend ReadOnly Property PreviousDefinitions As VisualBasicDefinitionMap
             Get
                 Return _previousDefinitions
@@ -232,12 +232,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Debug.Assert(Compilation Is template.DeclaringCompilation)
             Return _previousDefinitions.TryGetAnonymousTypeName(template, name, index)
         End Function
-
-        Friend ReadOnly Property Changes As SymbolChanges
-            Get
-                Return _changes
-            End Get
-        End Property
 
         Public Overrides Iterator Function GetTopLevelTypeDefinitions(context As EmitContext) As IEnumerable(Of Cci.INamespaceTypeDefinition)
             For Each typeDef In GetAnonymousTypeDefinitions(context)

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -365,7 +365,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
             Public Overrides Function VisitNamespace([namespace] As NamespaceSymbol) As Symbol
                 Dim otherContainer As Symbol = Visit([namespace].ContainingSymbol)
-                Debug.Assert(otherContainer IsNot Nothing)
+
+                ' TODO: Workaround for https//github.com/dotnet/roslyn/issues/54939.
+                ' We should fail if the container can't be mapped.
+                ' Currently this only occurs when determining reloadable type name for a type added to a New namespace,
+                ' which Is a rude edit.
+                ' Debug.Assert(otherContainer IsNot Nothing)
+                If otherContainer Is Nothing Then
+                    Return Nothing
+                End If
+
 
                 Select Case otherContainer.Kind
                     Case SymbolKind.NetModule

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -368,8 +368,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
                 ' TODO: Workaround for https//github.com/dotnet/roslyn/issues/54939.
                 ' We should fail if the container can't be mapped.
-                ' Currently this only occurs when determining reloadable type name for a type added to a New namespace,
-                ' which Is a rude edit.
+                ' Currently this only occurs when determining reloadable type name for a type added to a new namespace,
+                ' which is a rude edit.
                 ' Debug.Assert(otherContainer IsNot Nothing)
                 If otherContainer Is Nothing Then
                     Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Emit/PEAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEAssemblyBuilder.vb
@@ -173,9 +173,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             End Get
         End Property
 
-        Public Overrides ReadOnly Property CurrentGenerationOrdinal As Integer
+        Public Overrides ReadOnly Property EncSymbolChanges As SymbolChanges
             Get
-                Return 0
+                Return Nothing
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property PreviousGeneration As EmitBaseline
+            Get
+                Return Nothing
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -441,9 +441,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                     Continue For
                 End If
 
+                ' exported types are not emitted in EnC deltas (hence generation 0):
                 Dim fullEmittedName As String = MetadataHelpers.BuildQualifiedName(
                     DirectCast(typeReference, Cci.INamespaceTypeReference).NamespaceName,
-                    Cci.MetadataWriter.GetMangledName(DirectCast(typeReference, Cci.INamedTypeReference)))
+                    Cci.MetadataWriter.GetMangledName(DirectCast(typeReference, Cci.INamedTypeReference), generation:=0))
 
                 ' First check against types declared in the primary module
                 If ContainsTopLevelType(fullEmittedName) Then

--- a/src/Compilers/VisualBasic/Portable/Emit/PENetModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PENetModuleBuilder.vb
@@ -32,9 +32,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             End Get
         End Property
 
-        Public Overrides ReadOnly Property CurrentGenerationOrdinal As Integer
+        Public Overrides ReadOnly Property EncSymbolChanges As SymbolChanges
             Get
-                Return 0
+                Return Nothing
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property PreviousGeneration As EmitBaseline
+            Get
+                Return Nothing
             End Get
         End Property
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
@@ -65,13 +65,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         }
 
         internal override bool IgnoreAccessibility => true;
+        public override EmitBaseline? PreviousGeneration => null;
+        public override SymbolChanges? EncSymbolChanges => null;
 
         internal override NamedTypeSymbol GetDynamicOperationContextType(NamedTypeSymbol contextType)
         {
             return _getDynamicOperationContextType(contextType);
         }
-
-        public override int CurrentGenerationOrdinal => 0;
 
         internal override VariableSlotAllocator? TryCreateVariableSlotAllocator(MethodSymbol symbol, MethodSymbol topLevelMethod, DiagnosticBag diagnostics)
             => (symbol is EEMethodSymbol method) ? new SlotAllocator(GetLocalDefinitions(method.Locals, diagnostics)) : null;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -1546,7 +1546,8 @@ namespace System
                 }
             }
 
-            public override int CurrentGenerationOrdinal => _builder.CurrentGenerationOrdinal;
+            public override SymbolChanges EncSymbolChanges => _builder.EncSymbolChanges;
+            public override EmitBaseline PreviousGeneration => _builder.PreviousGeneration;
 
             public override ISourceAssemblySymbolInternal SourceAssemblyOpt => _builder.SourceAssemblyOpt;
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
@@ -70,9 +70,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
-        Public Overrides ReadOnly Property CurrentGenerationOrdinal As Integer
+        Public Overrides ReadOnly Property EncSymbolChanges As SymbolChanges
             Get
-                Return 0
+                Return Nothing
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property PreviousGeneration As EmitBaseline
+            Get
+                Return Nothing
             End Get
         End Property
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ReferencedModulesTests.vb
@@ -964,9 +964,15 @@ End Class"
                 Next
             End Function
 
-            Public Overrides ReadOnly Property CurrentGenerationOrdinal As Integer
+            Public Overrides ReadOnly Property EncSymbolChanges As SymbolChanges
                 Get
-                    Return _builder.CurrentGenerationOrdinal
+                    Return _builder.EncSymbolChanges
+                End Get
+            End Property
+
+            Public Overrides ReadOnly Property PreviousGeneration As EmitBaseline
+                Get
+                    Return Nothing
                 End Get
             End Property
 


### PR DESCRIPTION
When a type marked as "reloadable" is edited a new type with synthesized name `{original-name}#{N}` is emitted instead of updating the original type in-place (N is the generation ordinal).

Implements compiler support for emitting EnC deltas with reloadable types in EmitDifference. Adds a new `SemanticEditKind.Replace` to mark an edit as a replacement an existing type with its new version.

IDE changes using this API will come in a follow-up PR.

Contributes to https://github.com/dotnet/roslyn/issues/49006