### PR TITLE
Fix RPS issues in Razor options service

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/Razor/Api/Extensions.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Razor/Api/Extensions.cs
@@ -4,7 +4,7 @@
 
 using Microsoft.CodeAnalysis.Host;
 
-namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Api
 {
     internal static class Extensions
     {

--- a/src/Features/Core/Portable/ExternalAccess/Razor/Api/IRazorDocumentOptions.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Razor/Api/IRazorDocumentOptions.cs
@@ -4,7 +4,7 @@
 
 using Microsoft.CodeAnalysis.Options;
 
-namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Api
 {
     internal interface IRazorDocumentOptions
     {

--- a/src/Features/Core/Portable/ExternalAccess/Razor/Api/IRazorDocumentOptionsService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Razor/Api/IRazorDocumentOptionsService.cs
@@ -4,9 +4,8 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host;
 
-namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Api
 {
     internal interface IRazorDocumentOptionsService
     {

--- a/src/Features/Core/Portable/ExternalAccess/Razor/Api/RazorDocumentOptionsProviderFactory.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Razor/Api/RazorDocumentOptionsProviderFactory.cs
@@ -8,12 +8,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.VisualStudio.Utilities;
 
-namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Api
 {
     [Shared]
     [Export(typeof(IDocumentOptionsProviderFactory))]
+    [Order(Before = PredefinedDocumentOptionsProviderNames.EditorConfig)]
     internal sealed class RazorDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
     {
         private readonly Lazy<IRazorDocumentOptionsService> _innerRazorDocumentOptionsService;
@@ -32,28 +33,28 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         }
 
         public IDocumentOptionsProvider? TryCreate(Workspace workspace)
-        {
-            var optionsService = _innerRazorDocumentOptionsService.Value;
-            return new RazorDocumentOptionsProvider(optionsService);
-        }
+            => new RazorDocumentOptionsProvider(_innerRazorDocumentOptionsService);
 
         private sealed class RazorDocumentOptionsProvider : IDocumentOptionsProvider
         {
-            public readonly IRazorDocumentOptionsService RazorDocumentOptionsService;
+            public readonly Lazy<IRazorDocumentOptionsService> RazorDocumentOptionsService;
 
-            public RazorDocumentOptionsProvider(IRazorDocumentOptionsService razorDocumentOptionsService)
+            public RazorDocumentOptionsProvider(Lazy<IRazorDocumentOptionsService> razorDocumentOptionsService)
             {
                 RazorDocumentOptionsService = razorDocumentOptionsService;
             }
 
-            public async Task<IDocumentOptions?> GetOptionsForDocumentAsync(Document document, CancellationToken cancellationToken)
+            public async Task<IDocumentOptions?> GetOptionsForDocumentAsync(
+                Document document,
+                CancellationToken cancellationToken)
             {
                 if (!document.IsRazorDocument())
                 {
                     return null;
                 }
 
-                var options = await RazorDocumentOptionsService.GetOptionsForDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+                var options = await RazorDocumentOptionsService.Value.GetOptionsForDocumentAsync(
+                    document, cancellationToken).ConfigureAwait(false);
                 return new RazorDocumentOptions(options);
             }
         }

--- a/src/Features/Core/Portable/ExternalAccess/Razor/Api/RazorDocumentOptionsProviderFactory.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Razor/Api/RazorDocumentOptionsProviderFactory.cs
@@ -8,13 +8,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Api
 {
     [Shared]
     [Export(typeof(IDocumentOptionsProviderFactory))]
-    [Order(Before = PredefinedDocumentOptionsProviderNames.EditorConfig)]
+    [ExtensionOrder(Before = PredefinedDocumentOptionsProviderNames.EditorConfig)]
     internal sealed class RazorDocumentOptionsProviderFactory : IDocumentOptionsProviderFactory
     {
         private readonly Lazy<IRazorDocumentOptionsService> _innerRazorDocumentOptionsService;

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -105,6 +105,8 @@
     <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.IntelliCode.CSharp" Partner="Pythia" Key="$(IntelliCodeCSharpKey)" />
     <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.IntelliCode.CSharp.Extraction" Partner="Pythia" Key="$(IntelliCodeCSharpKey)" />
     <RestrictedInternalsVisibleTo Include="dotnet-watch" Partner="Watch" Key="$(AspNetCoreKey)" />
+    <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServerClient.Razor" Partner="Razor" Key="$(RazorKey)" />
+    <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServerClient.Razor.Test" Partner="Razor" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="IdeCoreBenchmarks" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Razor.UnitTests" />
@@ -127,6 +129,7 @@
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.AnalyzerUtilities" Version="$(MicrosoftCodeAnalysisAnalyzerUtilitiesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Contracts" Version="$(MicrosoftVisualStudioDebuggerContractsVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(VisualStudioEditorPackagesVersion)" />
   </ItemGroup>
   <Import Project="..\..\..\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems" Label="Shared" />
   <Import Project="..\..\..\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems" Label="Shared" />

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -129,7 +129,6 @@
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.AnalyzerUtilities" Version="$(MicrosoftCodeAnalysisAnalyzerUtilitiesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Contracts" Version="$(MicrosoftVisualStudioDebuggerContractsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(VisualStudioEditorPackagesVersion)" />
   </ItemGroup>
   <Import Project="..\..\..\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems" Label="Shared" />
   <Import Project="..\..\..\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems" Label="Shared" />


### PR DESCRIPTION
Fixes Razor RPS regressions by lazily loading `LanguageServerClient.Razor.dll` and moves `ExternalAccess.Razor.dll` inside an existing dll. 

See Taylor's comment in this PR for additional details on the issue: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/332314