### PR TITLE
Enable LSP completion experiment for all internal users and change name

### DIFF
--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -21,8 +21,8 @@
 
 [$RootKey$\FeatureFlags\Roslyn\LSP\Completion]
 "Description"="Enables the LSP-powered C#/VB completion experience to operate with prototype behavior. Note this currently will not affect local C#/VB scenarios except for C# in Razor."
-"Value"=dword:00000000
-"Title"="Enable experimental C#/VB LSP completion experience"
+"Value"=dword:00000001
+"Title"="C#/VB LSP completion experience"
 "PreviewPaneChannels"="IntPreview,int.main"
 
 // The option page configuration is duplicated in RoslynPackage


### PR DESCRIPTION
A VS PM reached out and asked if I could change the name of the LSP completion experiment (using TextEdits, implemented in #51166). In the process, I thought it would be helpful to turn on the experiment for all internal Microsoft users to gather more feedback before we eventually go on-by-default for everyone. Note this flag only affects LSP scenarios and should not affect the default Roslyn completion experience. Users can also turn the flag off if they find perf is not good enough.