### PR TITLE
Fixing inline hints quick info bug

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
@@ -231,13 +231,13 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
         /// </summary>
         private void Border_ToolTipOpening(object sender, ToolTipEventArgs e)
         {
-            var border = (Border)sender;
+            var hintUIElement = (FrameworkElement)sender;
             e.Handled = true;
 
             bool KeepOpen()
             {
-                var mousePoint = Mouse.GetPosition(border);
-                return !(mousePoint.X > border.ActualWidth || mousePoint.X < 0 || mousePoint.Y > border.ActualHeight || mousePoint.Y < 0);
+                var mousePoint = Mouse.GetPosition(hintUIElement);
+                return !(mousePoint.X > hintUIElement.ActualWidth || mousePoint.X < 0 || mousePoint.Y > hintUIElement.ActualHeight || mousePoint.Y < 0);
             }
 
             var toolTipPresenter = _toolTipService.CreatePresenter(_textView, new ToolTipParameters(trackMouse: true, ignoreBufferChange: false, KeepOpen));


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1356209
This is to fix a bug that was introduced in inline hints with my last PR. I changed the way in which we draw hints relative to the height of the line, but did not change the tooltip code that specifically looked for a border element. I made that more generic, so it looks for a FrameworkElement now.