### PR TITLE
Fix ModifyEntry() when applied multiple times + add test

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 Debug.Assert(_previous._states[_states.Count].Count == 1);
-                _states.Add(new TableEntry(value, comparer.Equals(_previous._states[0].GetItem(0), value) ? EntryState.Cached : EntryState.Modified));
+                _states.Add(new TableEntry(value, comparer.Equals(_previous._states[_states.Count].GetItem(0), value) ? EntryState.Cached : EntryState.Modified));
                 return true;
             }
 


### PR DESCRIPTION
Fixes a bug I found during razor investigations. Doesn't affect correctness but does impact performance as we incorrectly mark things as being modified when they're not.
