### PR TITLE
Add telemetry for cursor position changes when applying rename

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -783,7 +783,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                 void LogPositionChanged(object sender, CaretPositionChangedEventArgs e)
                 {
-                    FatalError.ReportAndCatch(new InvalidOperationException("Caret position changed during application of rename"));
+                    try
+                    {
+                        throw new InvalidOperationException("Caret position changed during application of rename");
+                    }
+                    catch (InvalidOperationException ex) when (FatalError.ReportAndCatch(ex))
+                    {
+                        // Unreachable code due to ReportAndCatch
+                        Contract.ThrowIfTrue(true);
+                    }
                 }
             }
         }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -771,11 +771,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 Dismiss(rollbackTemporaryEdits: true);
                 CancelAllOpenDocumentTrackingTasks();
 
+                _triggerView.Caret.PositionChanged += LogPositionChanged;
+
                 ApplyRename(newSolution, operationContext);
 
                 LogRenameSession(RenameLogMessage.UserActionOutcome.Committed, previewChanges);
 
                 EndRenameSession();
+
+                _triggerView.Caret.PositionChanged -= LogPositionChanged;
+
+                void LogPositionChanged(object sender, CaretPositionChangedEventArgs e)
+                {
+                    FatalError.ReportAndCatch(new InvalidOperationException("Caret position changed during application of rename"));
+                }
             }
         }
 


### PR DESCRIPTION
We're getting reports of a number of issues where cursor position is changing after applying rename. There has not been a consistent repro, so adding some faults for when we think this is happening to better understand the problem. 