### PR TITLE
Fix MakeTypeAbstract to preserve existing modifiers

### DIFF
--- a/src/EditorFeatures/CSharpTest/MakeTypeAbstract/MakeTypeAbstractTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeTypeAbstract/MakeTypeAbstractTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.MakeTypeAbstract;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -143,7 +144,8 @@ public abstract class Goo
 }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/41654"), Trait(Traits.Feature, Traits.Features.CodeActionsMakeTypeAbstract)]
+        [WorkItem(54218, "https://github.com/dotnet/roslyn/issues/54218")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeTypeAbstract)]
         public async Task TestPartialClass()
         {
             await TestInRegularAndScript1Async(
@@ -157,7 +159,7 @@ public partial class Goo
 {
 }",
 @"
-public partial abstract class Goo
+public abstract partial class Goo
 {
     public abstract void M();
 }

--- a/src/EditorFeatures/VisualBasicTest/MakeTypeAbstract/MakeTypeAbstractTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MakeTypeAbstract/MakeTypeAbstractTests.vb
@@ -139,19 +139,19 @@ End Namespace")
         <WorkItem(54218, "https://github.com/dotnet/roslyn/issues/54218")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeTypeAbstract)>
         Public Async Function TestMethod_PartialClass() As Task
-            Await TestInRegularAndScript1Async("
-Public Partial Class [|Foo|]
+            Await TestInRegularAndScriptAsync("
+Partial Public Class [|Foo|]
     Public MustOverride Sub M()
 End Class
 
-Public Partial Class Foo
+Partial Public Class Foo
 End Class",
 "
 Partial Public MustInherit Class Foo
     Public MustOverride Sub M()
 End Class
 
-Public Partial Class Foo
+Partial Public Class Foo
 End Class")
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/MakeTypeAbstract/MakeTypeAbstractTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MakeTypeAbstract/MakeTypeAbstractTests.vb
@@ -135,5 +135,24 @@ Namespace NS
     End Class
 End Namespace")
         End Function
+
+        <WorkItem(54218, "https://github.com/dotnet/roslyn/issues/54218")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeTypeAbstract)>
+        Public Async Function TestMethod_PartialClass() As Task
+            Await TestInRegularAndScript1Async("
+Public Partial Class [|Foo|]
+    Public MustOverride Sub M()
+End Class
+
+Public Partial Class Foo
+End Class",
+"
+Partial Public MustInherit Class Foo
+    Public MustOverride Sub M()
+End Class
+
+Public Partial Class Foo
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/MakeClassAbstract/AbstractMakeTypeAbstractCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeClassAbstract/AbstractMakeTypeAbstractCodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.MakeTypeAbstract
                 if (IsValidRefactoringContext(diagnostics[i].Location?.FindNode(cancellationToken), out var typeDeclaration))
                 {
                     editor.ReplaceNode(typeDeclaration,
-                        (currentTypeDeclaration, generator) => generator.WithModifiers(currentTypeDeclaration, DeclarationModifiers.Abstract));
+                        (currentTypeDeclaration, generator) => generator.WithModifiers(currentTypeDeclaration, generator.GetModifiers(currentTypeDeclaration).WithIsAbstract(true)));
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/54218