### PR TITLE
Make TypeSymbol.cs/IsTupleTypeOfCardinality internal

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -567,7 +567,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Verify if the given type is a tuple of a given cardinality, or can be used to back a tuple type 
         /// with the given cardinality. 
         /// </summary>
-        public bool IsTupleTypeOfCardinality(int targetCardinality)
+        internal bool IsTupleTypeOfCardinality(int targetCardinality)
         {
             if (IsTupleType)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/48291
`IsTupleTypeOfCardinality ` already could be used only internally, so it's just to reduce future questions.