### PR TITLE
Implicitly skip compiler's nullable analysis when implicitly skipping…

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -81,7 +81,7 @@
     </PropertyGroup>
 
     <!-- PERF: For builds which are indirectly triggered inside Visual Studio from commands 
-               such as from 'Run Tests' or 'Start Debugging', we implicitly skip analyzers to speed up the build.
+               such as from 'Run Tests' or 'Start Debugging', we implicitly skip analyzers and nullable analysis to speed up the build.
                We only do so by default when 'TreatWarningsAsErrors' is not 'true'. For the scenario where
 			         'TreatWarningsAsErrors' is 'true', users can explicitly enable this functionality by setting
 			         'OptimizeImplicitlyTriggeredBuild' to 'true'.
@@ -93,6 +93,7 @@
                               ('$(TreatWarningsAsErrors)' != 'true' or '$(OptimizeImplicitlyTriggeredBuild)' == 'true')">
       <_ImplicitlySkipAnalyzers>true</_ImplicitlySkipAnalyzers>
       <_SkipAnalyzers>true</_SkipAnalyzers>
+      <Features>run-nullable-analysis=never;$(Features)</Features>
     </PropertyGroup>
 
     <!-- Display a message to inform the users about us implicitly skipping analyzers for speeding up indirect builds. -->

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -760,6 +760,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             var expectedSkipAnalyzersValue = !analyzersEnabled || expectedImplicitlySkippedAnalyzers ? "true" : "";
             var actualSkipAnalyzersValue = instance.GetPropertyValue("_SkipAnalyzers");
             Assert.Equal(expectedSkipAnalyzersValue, actualSkipAnalyzersValue);
+
+            var expectedFeaturesValue = expectedImplicitlySkippedAnalyzers ? "run-nullable-analysis=never;" : "";
+            var actualFeaturesValue = instance.GetPropertyValue("Features");
+            Assert.Equal(expectedFeaturesValue, actualFeaturesValue);
             return;
 
             static string getPropertyGroup(string propertyName, bool? propertyValue)


### PR DESCRIPTION
… analyzers

Follow-up to https://github.com/dotnet/roslyn/pull/54143
Work towards [AB#1337109](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1337109)

This improves the build time for implicitly triggered builds by approximately 7-8% when nullable has been enabled for the project.