### PR TITLE
Remove file count limitation in server build

### DIFF
--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -69,13 +69,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             CompilerHash = compilerHash;
 
             Debug.Assert(!string.IsNullOrWhiteSpace(CompilerHash), "A hash value is required to communicate with the server");
-
-            if (Arguments.Count > ushort.MaxValue)
-            {
-                throw new ArgumentOutOfRangeException(nameof(arguments),
-                    "Too many arguments: maximum of "
-                    + ushort.MaxValue + " arguments allowed.");
-            }
         }
 
         public static BuildRequest Create(RequestLanguage language,


### PR DESCRIPTION
The server protocol used to enforce a max of 65,535 files passed to the
compilation. This isn't due to any limitation in the compiler but
instead a guard against a bug in one of our internal build systems. It
provided graceful failure when a build authoring bug caused the contents
of the file system to be passed to the compiler.

That is no longer an issue and the existing limit is blocking real
customer scenarios. Should it become an issue again there is code we
could insert into the customer targets to add a similar guard.

I thought for a bit on what a new limit should be and eventually decided
there wasn't a reasonable one. The compiler server already has a
protocol guard on the size of the message payload. The batch compiler
generally doesn't enforce limits of this nature, insead we attempt to
scale to the build requested by the user. Hence just removed the
limitation entirely

closes #54775