### PR TITLE
Add generator driver cache to VBCSCompiler

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly CommandLineDiagnosticFormatter _diagnosticFormatter;
         private readonly string? _tempDirectory;
 
-        protected CSharpCompiler(CSharpCommandLineParser parser, string? responseFile, string[] args, BuildPaths buildPaths, string? additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
-            : base(parser, responseFile, args, buildPaths, additionalReferenceDirectories, assemblyLoader)
+        protected CSharpCompiler(CSharpCommandLineParser parser, string? responseFile, string[] args, BuildPaths buildPaths, string? additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader, GeneratorDriverCache? driverCache = null)
+            : base(parser, responseFile, args, buildPaths, additionalReferenceDirectories, assemblyLoader, driverCache)
         {
             _diagnosticFormatter = new CommandLineDiagnosticFormatter(buildPaths.WorkingDirectory, Arguments.PrintFullPaths, Arguments.ShouldIncludeErrorEndLocation);
             _tempDirectory = buildPaths.TempDirectory;
@@ -372,12 +372,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private protected override Compilation RunGenerators(Compilation input, ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider analyzerConfigProvider, ImmutableArray<AdditionalText> additionalTexts, DiagnosticBag diagnostics)
+        private protected override GeneratorDriver CreateGeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider, ImmutableArray<AdditionalText> additionalTexts)
         {
-            var driver = CSharpGeneratorDriver.Create(generators, additionalTexts, (CSharpParseOptions)parseOptions, analyzerConfigProvider);
-            driver.RunGeneratorsAndUpdateCompilation(input, out var compilationOut, out var generatorDiagnostics);
-            diagnostics.AddRange(generatorDiagnostics);
-            return compilationOut;
+            return CSharpGeneratorDriver.Create(generators, additionalTexts, (CSharpParseOptions)parseOptions, analyzerConfigOptionsProvider);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTestBase.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTestBase.cs
@@ -54,15 +54,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             return CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory, additionalReferenceDirectories);
         }
 
-        internal MockCSharpCompiler CreateCSharpCompiler(string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null)
+        internal MockCSharpCompiler CreateCSharpCompiler(string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null, GeneratorDriverCache driverCache = null)
         {
-            return CreateCSharpCompiler(null, WorkingDirectory, args, analyzers, generators, loader);
+            return CreateCSharpCompiler(null, WorkingDirectory, args, analyzers, generators, loader, driverCache);
         }
 
-        internal MockCSharpCompiler CreateCSharpCompiler(string responseFile, string workingDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null)
+        internal MockCSharpCompiler CreateCSharpCompiler(string responseFile, string workingDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null, GeneratorDriverCache driverCache = null)
         {
             var buildPaths = RuntimeUtilities.CreateBuildPaths(workingDirectory, sdkDirectory: SdkDirectory);
-            return new MockCSharpCompiler(responseFile, buildPaths, args, analyzers, generators, loader);
+            return new MockCSharpCompiler(responseFile, buildPaths, args, analyzers, generators, loader, driverCache);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9940,6 +9940,22 @@ class C
             RunWithCacheDisabled();
             Assert.Equal(3, sourceCallbackCount);
 
+            // now clear the cache as well as disabling, and verify we don't put any entries into it either
+            cache = new GeneratorDriverCache();
+            sourceCallbackCount = 0;
+
+            RunWithCacheDisabled();
+            Assert.Equal(1, sourceCallbackCount);
+            Assert.Equal(0, cache.CacheSize);
+
+            RunWithCacheDisabled();
+            Assert.Equal(2, sourceCallbackCount);
+            Assert.Equal(0, cache.CacheSize);
+
+            RunWithCacheDisabled();
+            Assert.Equal(3, sourceCallbackCount);
+            Assert.Equal(0, cache.CacheSize);
+
             // Clean up temp files
             CleanupAllGeneratedFiles(src.Path);
             Directory.Delete(dir.Path, true);
@@ -9950,7 +9966,7 @@ class C
         }
 
         [Fact]
-        public void Adding_Or_Removing_A_Genertor_Invalidates_Cache()
+        public void Adding_Or_Removing_A_Generator_Invalidates_Cache()
         {
             var dir = Temp.CreateDirectory();
             var src = dir.CreateFile("temp.cs").WriteAllText(@"
@@ -9994,8 +10010,9 @@ class C
             Assert.Equal(2, sourceCallbackCount);
             Assert.Equal(1, sourceCallbackCount2);
 
-            // this seems counterintuitive, but when the only thing to change is the generator, its valid to use the previously cached 
-            // driver. Thus the first generator will still use the cached results and not run
+            // this seems counterintuitive, but when the only thing to change is the generator, we end up back at the state of the project when 
+            // we just ran a single generator. Thus we already have an entry in the cache we can use (the one created by the original call to
+            // RunWithOneGenerator above) meaning we can use the previously cached results and not run.
             RunWithOneGenerator();
             Assert.Equal(2, sourceCallbackCount);
             Assert.Equal(1, sourceCallbackCount2);

--- a/src/Compilers/CSharp/Test/CommandLine/DriverCacheTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/DriverCacheTests.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Immutable;
+using Xunit;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Test.Utilities.TestGenerators;
+using System.IO;
+using static Roslyn.Test.Utilities.SharedResourceHelpers;
+
+namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
+{
+    public class DriverCacheTests : CommandLineTestBase
+    {
+
+        [Fact]
+        public void DriverCache_Returns_Null_For_No_Match()
+        {
+            var driverCache = new GeneratorDriverCache();
+            var driver = driverCache.TryGetDriver("0");
+
+            Assert.Null(driver);
+        }
+
+        [Fact]
+        public void DriverCache_Returns_Cached_Driver()
+        {
+            var drivers = GetDrivers(1);
+            var driverCache = new GeneratorDriverCache();
+            driverCache.CacheGenerator("0", drivers[0]);
+
+            var driver = driverCache.TryGetDriver("0");
+            Assert.Same(driver, drivers[0]);
+        }
+
+        [Fact]
+        public void DriverCache_Can_Cache_Multiple_Drivers()
+        {
+            var drivers = GetDrivers(3);
+
+            var driverCache = new GeneratorDriverCache();
+            driverCache.CacheGenerator("0", drivers[0]);
+            driverCache.CacheGenerator("1", drivers[1]);
+            driverCache.CacheGenerator("2", drivers[2]);
+
+            var driver = driverCache.TryGetDriver("0");
+            Assert.Same(driver, drivers[0]);
+
+            driver = driverCache.TryGetDriver("1");
+            Assert.Same(driver, drivers[1]);
+
+            driver = driverCache.TryGetDriver("2");
+            Assert.Same(driver, drivers[2]);
+        }
+
+        [Fact]
+        public void DriverCache_Evicts_Least_Recently_Used()
+        {
+            var drivers = GetDrivers(GeneratorDriverCache.MaxCacheSize + 2);
+            var driverCache = new GeneratorDriverCache();
+
+            // put n+1 drivers into the cache
+            for (int i = 0; i < GeneratorDriverCache.MaxCacheSize + 1; i++)
+            {
+                driverCache.CacheGenerator(i.ToString(), drivers[i]);
+            }
+            // current cache state is 
+            // (10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+            // now try and retreive the first driver which should no longer be in the cache
+            var driver = driverCache.TryGetDriver("0");
+            Assert.Null(driver);
+
+            // add it back
+            driverCache.CacheGenerator("0", drivers[0]);
+
+            // current cache state is 
+            // (0, 10, 9, 8, 7, 6, 5, 4, 3, 2)
+
+            // access some drivers in the middle
+            driver = driverCache.TryGetDriver("7");
+            driver = driverCache.TryGetDriver("4");
+            driver = driverCache.TryGetDriver("2");
+
+            // current cache state is 
+            // (2, 4, 7, 0, 10, 9, 8, 6, 5, 3)
+
+            // try and get a new driver that was never in the cache
+            driver = driverCache.TryGetDriver("11");
+            Assert.Null(driver);
+            driverCache.CacheGenerator("11", drivers[11]);
+
+            // current cache state is 
+            // (11, 2, 4, 7, 0, 10, 9, 8, 6, 5)
+
+            // get a driver that has been evicted
+            driver = driverCache.TryGetDriver("3");
+            Assert.Null(driver);
+        }
+
+        private GeneratorDriver[] GetDrivers(int count) =>  Enumerable.Range(0, count).Select(i => CSharpGeneratorDriver.Create(Array.Empty<ISourceGenerator>())).ToArray();
+    }
+}

--- a/src/Compilers/CSharp/Test/CommandLine/DriverCacheTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/DriverCacheTests.cs
@@ -104,6 +104,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             Assert.Null(driver);
         }
 
-        private GeneratorDriver[] GetDrivers(int count) =>  Enumerable.Range(0, count).Select(i => CSharpGeneratorDriver.Create(Array.Empty<ISourceGenerator>())).ToArray();
+        private GeneratorDriver[] GetDrivers(int count) => Enumerable.Range(0, count).Select(i => CSharpGeneratorDriver.Create(Array.Empty<ISourceGenerator>())).ToArray();
     }
 }

--- a/src/Compilers/CSharp/Test/CommandLine/GeneratorDriverCacheTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/GeneratorDriverCacheTests.cs
@@ -3,20 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Collections.Immutable;
 using Xunit;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Test.Utilities.TestGenerators;
-using System.IO;
-using static Roslyn.Test.Utilities.SharedResourceHelpers;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
 {
-    public class DriverCacheTests : CommandLineTestBase
+    public class GeneratorDriverCacheTests : CommandLineTestBase
     {
 
         [Fact]
@@ -73,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             // current cache state is 
             // (10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
 
-            // now try and retreive the first driver which should no longer be in the cache
+            // now try and retrieve the first driver which should no longer be in the cache
             var driver = driverCache.TryGetDriver("0");
             Assert.Null(driver);
 
@@ -104,6 +96,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             Assert.Null(driver);
         }
 
-        private GeneratorDriver[] GetDrivers(int count) => Enumerable.Range(0, count).Select(i => CSharpGeneratorDriver.Create(Array.Empty<ISourceGenerator>())).ToArray();
+        private static GeneratorDriver[] GetDrivers(int count) => Enumerable.Range(0, count).Select(i => CSharpGeneratorDriver.Create(Array.Empty<ISourceGenerator>())).ToArray();
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -761,6 +761,13 @@ namespace Microsoft.CodeAnalysis
             {
                 Debug.Assert(!string.IsNullOrWhiteSpace(Arguments.OutputFileName));
 
+                // CONSIDER: The only piece of the cache key that is requried for correctness is the generators that were used.
+                //           We set up the graph statically based on the generators, so as long as the generator inputs havn't
+                //           changed we can run technically run any project against anothers cache and still get the correct results.
+                //           Obviously that would remove the point of the cache, so we also key off of the output file name
+                //           and output path so that collisions are unlikely and we'll usually get the correct cache for any 
+                //           given compilation. 
+
                 PooledStringBuilder sb = PooledStringBuilder.GetInstance();
                 sb.Builder.Append(Arguments.GetOutputFilePath(Arguments.OutputFileName));
                 foreach (var generator in generators)

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -761,9 +761,9 @@ namespace Microsoft.CodeAnalysis
             {
                 Debug.Assert(!string.IsNullOrWhiteSpace(Arguments.OutputFileName));
 
-                // CONSIDER: The only piece of the cache key that is requried for correctness is the generators that were used.
-                //           We set up the graph statically based on the generators, so as long as the generator inputs havn't
-                //           changed we can run technically run any project against anothers cache and still get the correct results.
+                // CONSIDER: The only piece of the cache key that is required for correctness is the generators that were used.
+                //           We set up the graph statically based on the generators, so as long as the generator inputs haven't
+                //           changed we can technically run any project against another's cache and still get the correct results.
                 //           Obviously that would remove the point of the cache, so we also key off of the output file name
                 //           and output path so that collisions are unlikely and we'll usually get the correct cache for any 
                 //           given compilation. 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -740,7 +740,7 @@ namespace Microsoft.CodeAnalysis
         {
             GeneratorDriver? driver = null;
             string cacheKey = string.Empty;
-            bool disableCache = Arguments.ParseOptions.Features.ContainsKey("disable-generator-cache");
+            bool disableCache = Arguments.ParseOptions.Features.ContainsKey("disable-generator-cache") || string.IsNullOrWhiteSpace(Arguments.OutputFileName);
             if (this.DriverCache is object && !disableCache)
             {
                 cacheKey = deriveCacheKey();
@@ -759,8 +759,10 @@ namespace Microsoft.CodeAnalysis
 
             string deriveCacheKey()
             {
+                Debug.Assert(!string.IsNullOrWhiteSpace(Arguments.OutputFileName));
+
                 StringBuilder sb = new StringBuilder();
-                sb.Append(Arguments.GetOutputFilePath(GetOutputFileName(input, cancellationToken: default)));
+                sb.Append(Arguments.GetOutputFilePath(Arguments.OutputFileName));
                 foreach (var generator in generators)
                 {
                     // append the generator FQN and the MVID of the assembly it came from, so any changes will invalidate the cache

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverCache.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverCache.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal class GeneratorDriverCache
+    {
+        internal const int MaxCacheSize = 10;
+
+        private readonly (string cacheKey, GeneratorDriver driver)[] _cachedDrivers = new (string, GeneratorDriver)[MaxCacheSize];
+
+        private readonly object _cacheLock = new object();
+
+        private int _cacheSize = 0;
+
+        public GeneratorDriver? TryGetDriver(string cacheKey)
+        {
+            lock (_cacheLock)
+            {
+                int i = 0;
+                GeneratorDriver? driver = null;
+
+                for (; i < _cacheSize; i++)
+                {
+                    if (_cachedDrivers[i].cacheKey == cacheKey)
+                    {
+                        driver = _cachedDrivers[i].driver;
+                        break;
+                    }
+                }
+
+                if (driver is not null)
+                {
+                    // update the cache so that the found driver is at the head
+                    for (; i > 0; i--)
+                    {
+                        _cachedDrivers[i] = _cachedDrivers[i - 1];
+                    }
+                    _cachedDrivers[0] = (cacheKey, driver);
+                }
+
+                return driver;
+            }
+        }
+
+        public void CacheGenerator(string cacheKey, GeneratorDriver driver)
+        {
+            lock (_cacheLock)
+            {
+                // try and find the driver if it's present
+                int i = 0;
+                for (; i < _cacheSize; i++)
+                {
+                    if (_cachedDrivers[i].cacheKey == cacheKey)
+                    {
+                        break;
+                    }
+                }
+
+                // update the cache so that the driver is at the head
+                for (i = Math.Min(i, MaxCacheSize - 1); i > 0; i--)
+                {
+                    _cachedDrivers[i] = _cachedDrivers[i - 1];
+                }
+                _cachedDrivers[0] = (cacheKey, driver);
+                _cacheSize = Math.Min(MaxCacheSize, _cacheSize + 1);
+            }
+        }
+    }
+}

--- a/src/Compilers/Server/VBCSCompiler/CSharpCompilerServer.cs
+++ b/src/Compilers/Server/VBCSCompiler/CSharpCompilerServer.cs
@@ -16,13 +16,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _metadataProvider;
 
-        internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
-            : this(metadataProvider, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader)
+        internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader, GeneratorDriverCache driverCache)
+            : this(metadataProvider, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader, driverCache)
         {
         }
 
-        internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string? responseFile, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
-            : base(CSharpCommandLineParser.Default, responseFile, args, buildPaths, libDirectory, analyzerLoader)
+        internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string? responseFile, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader, GeneratorDriverCache driverCache)
+            : base(CSharpCommandLineParser.Default, responseFile, args, buildPaths, libDirectory, analyzerLoader, driverCache)
         {
             _metadataProvider = metadataProvider;
         }

--- a/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         public ICompilerServerLogger Logger { get; }
 
         /// <summary>
-        /// A persistent cache that can store generator drivers in order to enable incrementalism across builds.
+        /// A cache that can store generator drivers in order to enable incrementalism across builds for the lifetime of the server.
         /// </summary>
         private readonly GeneratorDriverCache _driverCache = new GeneratorDriverCache();
 

--- a/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
@@ -62,6 +62,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         public ICompilerServerLogger Logger { get; }
 
+        /// <summary>
+        /// A persistent cache that can store generator drivers in order to enable incrementalism across builds.
+        /// </summary>
+        private readonly GeneratorDriverCache _driverCache = new GeneratorDriverCache();
+
         internal CompilerServerHost(string clientDirectory, string sdkDirectory, ICompilerServerLogger logger)
         {
             ClientDirectory = clientDirectory;
@@ -84,7 +89,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                         args: request.Arguments,
                         buildPaths: buildPaths,
                         libDirectory: request.LibDirectory,
-                        analyzerLoader: AnalyzerAssemblyLoader);
+                        analyzerLoader: AnalyzerAssemblyLoader,
+                        _driverCache);
                     return true;
                 case LanguageNames.VisualBasic:
                     compiler = new VisualBasicCompilerServer(
@@ -92,7 +98,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                         args: request.Arguments,
                         buildPaths: buildPaths,
                         libDirectory: request.LibDirectory,
-                        analyzerLoader: AnalyzerAssemblyLoader);
+                        analyzerLoader: AnalyzerAssemblyLoader,
+                        _driverCache);
                     return true;
                 default:
                     compiler = null;

--- a/src/Compilers/Server/VBCSCompiler/VisualBasicCompilerServer.cs
+++ b/src/Compilers/Server/VBCSCompiler/VisualBasicCompilerServer.cs
@@ -18,13 +18,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _metadataProvider;
 
-        internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
-            : this(metadataProvider, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader)
+        internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader, GeneratorDriverCache driverCache)
+            : this(metadataProvider, Path.Combine(buildPaths.ClientDirectory, ResponseFileName), args, buildPaths, libDirectory, analyzerLoader, driverCache)
         {
         }
 
-        internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string? responseFile, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
-            : base(VisualBasicCommandLineParser.Default, responseFile, args, buildPaths, libDirectory, analyzerLoader)
+        internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string? responseFile, string[] args, BuildPaths buildPaths, string? libDirectory, IAnalyzerAssemblyLoader analyzerLoader, GeneratorDriverCache driverCache)
+            : base(VisualBasicCommandLineParser.Default, responseFile, args, buildPaths, libDirectory, analyzerLoader, driverCache)
         {
             _metadataProvider = metadataProvider;
         }

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -67,7 +67,8 @@ End Class
                     new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
                     new BuildPaths(clientDirectory, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
                     s_libDirectory,
-                    new TestAnalyzerAssemblyLoader());
+                    new TestAnalyzerAssemblyLoader(),
+                    driverCache: null);
 
                 List<string> expectedReads;
                 List<string> expectedWrites;
@@ -116,7 +117,8 @@ End Class
                     new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
                     new BuildPaths(clientDirectory, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
                     s_libDirectory,
-                    new TestAnalyzerAssemblyLoader());
+                    new TestAnalyzerAssemblyLoader(),
+                    driverCache: null);
 
                 List<string> expectedReads;
                 List<string> expectedWrites;

--- a/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp/MockCSharpCompiler.cs
@@ -26,8 +26,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         {
         }
 
-        public MockCSharpCompiler(string responseFile, BuildPaths buildPaths, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null)
-            : base(CSharpCommandLineParser.Default, responseFile, args, buildPaths, Environment.GetEnvironmentVariable("LIB"), loader ?? new DefaultAnalyzerAssemblyLoader())
+        public MockCSharpCompiler(string responseFile, BuildPaths buildPaths, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers = default, ImmutableArray<ISourceGenerator> generators = default, AnalyzerAssemblyLoader loader = null, GeneratorDriverCache driverCache = null)
+            : base(CSharpCommandLineParser.Default, responseFile, args, buildPaths, Environment.GetEnvironmentVariable("LIB"), loader ?? new DefaultAnalyzerAssemblyLoader(), driverCache)
         {
             _analyzers = analyzers.NullToEmpty();
             _generators = generators.NullToEmpty();

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -22,8 +22,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _tempDirectory As String
         Private _additionalTextFiles As ImmutableArray(Of AdditionalTextFile)
 
-        Protected Sub New(parser As VisualBasicCommandLineParser, responseFile As String, args As String(), buildPaths As BuildPaths, additionalReferenceDirectories As String, analyzerLoader As IAnalyzerAssemblyLoader)
-            MyBase.New(parser, responseFile, args, buildPaths, additionalReferenceDirectories, analyzerLoader)
+        Protected Sub New(parser As VisualBasicCommandLineParser, responseFile As String, args As String(), buildPaths As BuildPaths, additionalReferenceDirectories As String, analyzerLoader As IAnalyzerAssemblyLoader, Optional driverCache As GeneratorDriverCache = Nothing)
+            MyBase.New(parser, responseFile, args, buildPaths, additionalReferenceDirectories, analyzerLoader, driverCache)
 
             _diagnosticFormatter = New CommandLineDiagnosticFormatter(buildPaths.WorkingDirectory, AddressOf GetAdditionalTextFiles)
             _additionalTextFiles = Nothing
@@ -298,12 +298,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Next
         End Sub
 
-        Private Protected Overrides Function RunGenerators(input As Compilation, parseOptions As ParseOptions, generators As ImmutableArray(Of ISourceGenerator), analyzerConfigOptionsProvider As AnalyzerConfigOptionsProvider, additionalTexts As ImmutableArray(Of AdditionalText), diagnostics As DiagnosticBag) As Compilation
-            Dim driver = VisualBasicGeneratorDriver.Create(generators, additionalTexts, DirectCast(parseOptions, VisualBasicParseOptions), analyzerConfigOptionsProvider)
-            Dim compilationOut As Compilation = Nothing, generatorDiagnostics As ImmutableArray(Of Diagnostic) = Nothing
-            driver.RunGeneratorsAndUpdateCompilation(input, compilationOut, generatorDiagnostics)
-            diagnostics.AddRange(generatorDiagnostics)
-            Return compilationOut
+        Private Protected Overrides Function CreateGeneratorDriver(parseOptions As ParseOptions, generators As ImmutableArray(Of ISourceGenerator), analyzerConfigOptionsProvider As AnalyzerConfigOptionsProvider, additionalTexts As ImmutableArray(Of AdditionalText)) As GeneratorDriver
+            Return VisualBasicGeneratorDriver.Create(generators, additionalTexts, DirectCast(parseOptions, VisualBasicParseOptions), analyzerConfigOptionsProvider)
         End Function
 
     End Class


### PR DESCRIPTION
- Create a new cache type
- Make the compiler optionally take it
- Pass in the cache when running on the server
- Check the cache (if there is one) for a generator driver before creating a new one

This enables incrementalism in the compiler server so that subsequent command line builds will be faster when using incremental generators.