### PR TITLE
Fix a couple of bugs in SG

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
 using Roslyn.Test.Utilities.TestGenerators;
+using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 {
@@ -349,7 +350,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             AssertTableEntries(table, new[] { (1, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Cached) });
         }
 
-
         private void AssertTableEntries<T>(NodeStateTable<T> table, IList<(T item, EntryState state)> expected)
         {
             int index = 0;
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             int index = 0;
             foreach (var entry in table)
             {
-                Assert.Equal(expected[index].item, (IEnumerable<T>)entry.item);
+                AssertEx.Equal(expected[index].item, entry.item);
                 Assert.Equal(expected[index].state, entry.state);
                 index++;
             }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             DriverStateTable.Builder dstBuilder = GetBuilder(DriverStateTable.Empty);
             _ = dstBuilder.GetLatestStateTableForNode(batchNode);
 
-            // second time through should show as cached
+            // second time through should show as modified
             dstBuilder = GetBuilder(dstBuilder.ToImmutable());
             var table = dstBuilder.GetLatestStateTableForNode(batchNode);
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
+using Roslyn.Test.Utilities.TestGenerators;
 
 namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 {
@@ -295,12 +296,77 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             Assert.Equal(2, callCount);
         }
 
+        [Fact]
+        public void Batch_Node_Is_Cached_If_All_Inputs_Are_Cached()
+        {
+            var inputNode = new InputNode<int>((_) => ImmutableArray.Create(1, 2, 3));
+            BatchNode<int> batchNode = new BatchNode<int>(inputNode);
+
+            // first time through will always be added (because it's not been run before)
+            DriverStateTable.Builder dstBuilder = GetBuilder(DriverStateTable.Empty);
+            _ = dstBuilder.GetLatestStateTableForNode(batchNode);
+
+            // second time through should show as cached
+            dstBuilder = GetBuilder(dstBuilder.ToImmutable());
+            var table = dstBuilder.GetLatestStateTableForNode(batchNode);
+
+            AssertTableEntries(table, new[] { (ImmutableArray.Create(1, 2, 3), EntryState.Cached) });
+        }
+
+        [Fact]
+        public void Batch_Node_Is_Not_Cached_When_Inputs_Are_Changed()
+        {
+            int third = 3;
+
+            var inputNode = new InputNode<int>((_) => ImmutableArray.Create(1, 2, third++));
+            BatchNode<int> batchNode = new BatchNode<int>(inputNode);
+
+            // first time through will always be added (because it's not been run before)
+            DriverStateTable.Builder dstBuilder = GetBuilder(DriverStateTable.Empty);
+            _ = dstBuilder.GetLatestStateTableForNode(batchNode);
+
+            // second time through should show as cached
+            dstBuilder = GetBuilder(dstBuilder.ToImmutable());
+            var table = dstBuilder.GetLatestStateTableForNode(batchNode);
+
+            AssertTableEntries(table, new[] { (ImmutableArray.Create(1, 2, 4), EntryState.Modified) });
+        }
+
+        [Fact]
+        public void User_Comparer_Is_Not_Used_To_Determine_Inputs()
+        {
+            var inputNode = new InputNode<int>((_) => ImmutableArray.Create(1, 2, 3))
+                                .WithComparer(new LambdaComparer<int>((a, b) => false));
+
+            // first time through will always be added (because it's not been run before)
+            DriverStateTable.Builder dstBuilder = GetBuilder(DriverStateTable.Empty);
+            _ = dstBuilder.GetLatestStateTableForNode(inputNode);
+
+            // second time through should show as cached, even though we supplied a comparer (comparer should only used to turn modified => cached)
+            dstBuilder = GetBuilder(dstBuilder.ToImmutable());
+            var table = dstBuilder.GetLatestStateTableForNode(inputNode);
+
+            AssertTableEntries(table, new[] { (1, EntryState.Cached), (2, EntryState.Cached), (3, EntryState.Cached) });
+        }
+
+
         private void AssertTableEntries<T>(NodeStateTable<T> table, IList<(T item, EntryState state)> expected)
         {
             int index = 0;
             foreach (var entry in table)
             {
                 Assert.Equal(expected[index].item, entry.item);
+                Assert.Equal(expected[index].state, entry.state);
+                index++;
+            }
+        }
+
+        private void AssertTableEntries<T>(NodeStateTable<ImmutableArray<T>> table, IList<(ImmutableArray<T> item, EntryState state)> expected)
+        {
+            int index = 0;
+            foreach (var entry in table)
+            {
+                Assert.Equal(expected[index].item, (IEnumerable<T>)entry.item);
                 Assert.Equal(expected[index].state, entry.state);
                 index++;
             }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
@@ -34,13 +34,16 @@ namespace Microsoft.CodeAnalysis
             // - Added when the previous table was empty
             // - Modified otherwise
 
-            var source = ImmutableArray.Create(sourceTable.Batch());
+            var source = sourceTable.Batch();
 
             // update the table 
             var newTable = previousTable.ToBuilder();
-            if (!newTable.TryModifyEntries(source, _comparer))
+            if (!sourceTable.IsCached || !newTable.TryUseCachedEntries())
             {
-                newTable.AddEntries(source, EntryState.Added);
+                if (!newTable.TryModifyEntry(source, _comparer))
+                {
+                    newTable.AddEntry(source, EntryState.Added);
+                }
             }
 
             return newTable.ToImmutableAndFree();

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis
             var inputItems = _getInput(graphState);
 
             // create a mutable hashset of the new items we can check against
-            HashSet<T> itemsSet = new HashSet<T>(_comparer);
+            HashSet<T> itemsSet = new HashSet<T>();
             foreach (var item in inputItems)
             {
                 var added = itemsSet.Add(item);


### PR DESCRIPTION
- Ensure that `.Collect()` reports as cached if all the inputs are cached
- Don't use user comparer for matching inputs

Fixes https://github.com/dotnet/roslyn/issues/54855