### PR TITLE
Support binary interpolation addition

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1262,13 +1262,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal static uint GetInterpolatedStringHandlerConversionEscapeScope(
-            BoundInterpolatedString interpolatedString,
+            InterpolatedStringHandlerData data,
             uint scopeOfTheContainingExpression)
-        {
-            Debug.Assert(interpolatedString.InterpolationData != null);
-            var data = interpolatedString.InterpolationData.GetValueOrDefault();
-            return GetValEscape(data.Construction, scopeOfTheContainingExpression);
-        }
+            => GetValEscape(data.Construction, scopeOfTheContainingExpression);
 
         /// <summary>
         /// Computes the scope to which the given invocation can escape
@@ -2672,7 +2668,13 @@ moreArguments:
 
                     if (conversion.ConversionKind == ConversionKind.InterpolatedStringHandler)
                     {
-                        return GetInterpolatedStringHandlerConversionEscapeScope((BoundInterpolatedString)conversion.Operand, scopeOfTheContainingExpression);
+                        var data = conversion.Operand switch
+                        {
+                            BoundInterpolatedString { InterpolationData: { } d } => d,
+                            BoundBinaryOperator { InterpolatedStringHandlerData: { } d } => d,
+                            _ => throw ExceptionUtilities.UnexpectedValue(conversion.Operand.Kind)
+                        };
+                        return GetInterpolatedStringHandlerConversionEscapeScope(data, scopeOfTheContainingExpression);
                     }
 
                     return GetValEscape(conversion.Operand, scopeOfTheContainingExpression);
@@ -3110,7 +3112,7 @@ moreArguments:
 
                     if (conversion.ConversionKind == ConversionKind.InterpolatedStringHandler)
                     {
-                        return CheckInterpolatedStringHandlerConversionEscape((BoundInterpolatedString)conversion.Operand, escapeFrom, escapeTo, diagnostics);
+                        return CheckInterpolatedStringHandlerConversionEscape(conversion.Operand, escapeFrom, escapeTo, diagnostics);
                     }
 
                     return CheckValEscape(node, conversion.Operand, escapeFrom, escapeTo, checkingReceiver: false, diagnostics: diagnostics);
@@ -3383,38 +3385,73 @@ moreArguments:
             return true;
         }
 
-        private static bool CheckInterpolatedStringHandlerConversionEscape(BoundInterpolatedString interpolatedString, uint escapeFrom, uint escapeTo, BindingDiagnosticBag diagnostics)
+        private static bool CheckInterpolatedStringHandlerConversionEscape(BoundExpression expression, uint escapeFrom, uint escapeTo, BindingDiagnosticBag diagnostics)
         {
-            Debug.Assert(interpolatedString.InterpolationData is not null);
+
+            var data = expression switch
+            {
+                BoundInterpolatedString { InterpolationData: { } d } => d,
+                BoundBinaryOperator { InterpolatedStringHandlerData: { } d } => d,
+                _ => throw ExceptionUtilities.UnexpectedValue(expression.Kind)
+            };
 
             // We need to check to see if any values could potentially escape outside the max depth via the handler type.
             // Consider the case where a ref-struct handler saves off the result of one call to AppendFormatted,
             // and then on a subsequent call it either assigns that saved value to another ref struct with a larger
             // escape, or does the opposite. In either case, we need to check.
 
-            CheckValEscape(interpolatedString.Syntax, interpolatedString.InterpolationData.GetValueOrDefault().Construction, escapeFrom, escapeTo, checkingReceiver: false, diagnostics);
+            CheckValEscape(expression.Syntax, data.Construction, escapeFrom, escapeTo, checkingReceiver: false, diagnostics);
 
-            foreach (var part in interpolatedString.Parts)
+            while (true)
             {
-                if (part is not BoundCall { Method: { Name: "AppendFormatted" } } call)
+                switch (expression)
                 {
-                    // Dynamic calls cannot have ref struct parameters, and AppendLiteral calls will always have literal
-                    // string arguments and do not require us to be concerned with escape
-                    continue;
-                }
+                    case BoundBinaryOperator binary:
+                        if (!checkParts((BoundInterpolatedString)binary.Right))
+                        {
+                            return false;
+                        }
 
-                // The interpolation component is always the first argument to the method, and it was not passed by name
-                // so there can be no reordering.
-                var argument = call.Arguments[0];
-                var success = CheckValEscape(argument.Syntax, argument, escapeFrom, escapeTo, checkingReceiver: false, diagnostics);
+                        expression = binary.Left;
+                        continue;
 
-                if (!success)
-                {
-                    return false;
+                    case BoundInterpolatedString interpolatedString:
+                        if (!checkParts(interpolatedString))
+                        {
+                            return false;
+                        }
+
+                        return true;
+
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(expression.Kind);
                 }
             }
 
-            return true;
+            bool checkParts(BoundInterpolatedString interpolatedString)
+            {
+                foreach (var part in interpolatedString.Parts)
+                {
+                    if (part is not BoundCall { Method: { Name: "AppendFormatted" } } call)
+                    {
+                        // Dynamic calls cannot have ref struct parameters, and AppendLiteral calls will always have literal
+                        // string arguments and do not require us to be concerned with escape
+                        continue;
+                    }
+
+                    // The interpolation component is always the first argument to the method, and it was not passed by name
+                    // so there can be no reordering.
+                    var argument = call.Arguments[0];
+                    var success = CheckValEscape(argument.Syntax, argument, escapeFrom, escapeTo, checkingReceiver: false, diagnostics);
+
+                    if (!success)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
         }
 
         internal enum AddressKind

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -152,10 +152,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (conversion.Kind == ConversionKind.InterpolatedStringHandler)
             {
-                var unconvertedSource = (BoundUnconvertedInterpolatedString)source;
                 return new BoundConversion(
                     syntax,
-                    BindUnconvertedInterpolatedStringToHandlerType(unconvertedSource, (NamedTypeSymbol)destination, diagnostics, isHandlerConversion: true),
+                    BindUnconvertedInterpolatedExpressionToHandlerType(source, (NamedTypeSymbol)destination, diagnostics),
                     conversion,
                     @checked: CheckOverflowAtRuntime,
                     explicitCastInCode: isCast && !wasCompilerGenerated,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3004,10 +3004,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (kind.IsInterpolatedStringHandler)
                 {
-                    Debug.Assert(argument is BoundUnconvertedInterpolatedString);
+                    Debug.Assert(argument is BoundUnconvertedInterpolatedString or BoundBinaryOperator { IsUnconvertedInterpolatedStringAddition: true });
                     TypeWithAnnotations parameterTypeWithAnnotations = GetCorrespondingParameterTypeWithAnnotations(ref result, parameters, arg);
                     reportUnsafeIfNeeded(methodResult, diagnostics, argument, parameterTypeWithAnnotations);
-                    arguments[arg] = BindInterpolatedStringHandlerInMemberCall((BoundUnconvertedInterpolatedString)argument, arguments, parameters, ref result, arg, receiverType, receiverRefKind, receiverEscapeScope, diagnostics);
+                    arguments[arg] = BindInterpolatedStringHandlerInMemberCall(argument, arguments, parameters, ref result, arg, receiverType, receiverRefKind, receiverEscapeScope, diagnostics);
                 }
                 // https://github.com/dotnet/roslyn/issues/37119 : should we create an (Identity) conversion when the kind is Identity but the types differ?
                 else if (!kind.IsIdentity)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -380,6 +380,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         result = BindUnconvertedInterpolatedStringToString(unconvertedInterpolatedString, diagnostics);
                     }
                     break;
+                case BoundBinaryOperator unconvertedBinaryOperator:
+                    {
+                        result = RebindSimpleBinaryOperatorAsConverted(unconvertedBinaryOperator, diagnostics);
+                    }
+                    break;
                 default:
                     result = expression;
                     break;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -159,9 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Case 2. Attempt to see if all parts are strings.
-            if (unconvertedInterpolatedString.Parts.Length <= 4 &&
-                unconvertedInterpolatedString.Parts.All(p => p is BoundLiteral
-                                                               or BoundStringInsert { Value: { Type: { SpecialType: SpecialType.System_String } }, Alignment: null, Format: null }))
+            if (unconvertedInterpolatedString.Parts.Length <= 4 && AllInterpolatedStringPartsAreStrings(unconvertedInterpolatedString.Parts))
             {
                 return constructWithData(BindInterpolatedStringParts(unconvertedInterpolatedString, diagnostics), data: null);
             }
@@ -206,6 +204,143 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        private static bool AllInterpolatedStringPartsAreStrings(ImmutableArray<BoundExpression> parts)
+            => parts.All(p => p is BoundLiteral or BoundStringInsert { Value: { Type: { SpecialType: SpecialType.System_String } }, Alignment: null, Format: null });
+
+        private bool TryBindUnconvertedBinaryOperatorToDefaultInterpolatedStringHandler(BoundBinaryOperator binaryOperator, BindingDiagnosticBag diagnostics, [NotNullWhen(true)] out BoundBinaryOperator? convertedBinaryOperator)
+        {
+            // Much like BindUnconvertedInterpolatedStringToString above, we only want to use DefaultInterpolatedStringHandler if it's worth it. We therefore
+            // check for cases 1 and 2: if they are present, we let normal string binary operator binding machinery handle it. Otherwise, we take care of it ourselves.
+            Debug.Assert(binaryOperator.IsUnconvertedInterpolatedStringAddition);
+            convertedBinaryOperator = null;
+
+            var interpolatedStringHandlerType = Compilation.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler);
+            if (interpolatedStringHandlerType.IsErrorType())
+            {
+                // Can't ever bind to the handler no matter what, so just let the default handling take care of it. Cases 4 and 5 are covered by this.
+                return false;
+            }
+
+            bool isConstant = true;
+            var stack = ArrayBuilder<BoundBinaryOperator>.GetInstance();
+            var partsArrayBuilder = ArrayBuilder<ImmutableArray<BoundExpression>>.GetInstance();
+            int partsCount = 0;
+
+            BoundBinaryOperator? current = binaryOperator;
+
+            while (current != null)
+            {
+                Debug.Assert(current.IsUnconvertedInterpolatedStringAddition);
+                stack.Push(current);
+                isConstant = isConstant && current.Right.ConstantValue is not null;
+                var rightInterpolatedString = (BoundUnconvertedInterpolatedString)current.Right;
+
+                if (rightInterpolatedString.Parts.ContainsAwaitExpression())
+                {
+                    // Exception to case 3. Delegate to standard binding.
+                    stack.Free();
+                    partsArrayBuilder.Free();
+                    return false;
+                }
+
+                partsCount += rightInterpolatedString.Parts.Length;
+                partsArrayBuilder.Add(rightInterpolatedString.Parts);
+
+                switch (current.Left)
+                {
+                    case BoundBinaryOperator leftOperator:
+                        current = leftOperator;
+                        continue;
+                    case BoundUnconvertedInterpolatedString interpolatedString:
+                        isConstant = isConstant && interpolatedString.ConstantValue is not null;
+
+                        if (interpolatedString.Parts.ContainsAwaitExpression())
+                        {
+                            // Exception to case 3. Delegate to standard binding.
+                            stack.Free();
+                            partsArrayBuilder.Free();
+                            return false;
+                        }
+
+                        partsCount += interpolatedString.Parts.Length;
+                        partsArrayBuilder.Add(interpolatedString.Parts);
+                        current = null;
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(current.Left.Kind);
+                }
+            }
+
+            Debug.Assert(partsArrayBuilder.Count == stack.Count + 1);
+            Debug.Assert(partsArrayBuilder.Count >= 2);
+
+            if (isConstant ||
+                (partsCount <= 4 && partsArrayBuilder.All(static parts => AllInterpolatedStringPartsAreStrings(parts))))
+            {
+                // This is case 1 and 2. Let the standard machinery handle it
+                stack.Free();
+                partsArrayBuilder.Free();
+                return false;
+            }
+
+
+            // Parts were added to the array from right to left, but lexical order is left to right.
+            partsArrayBuilder.ReverseContents();
+
+            // Case 3. Delegate to standard binding
+            var (appendCalls, data) = BindUnconvertedInterpolatedPartsToHandlerType(
+                binaryOperator.Syntax,
+                partsArrayBuilder.ToImmutableAndFree(),
+                interpolatedStringHandlerType,
+                diagnostics,
+                isHandlerConversion: false,
+                additionalConstructorArguments: default,
+                additionalConstructorRefKinds: default);
+
+            Debug.Assert(appendCalls.Length == stack.Count + 1);
+
+            // Now that the parts have been bound, reconstruct the binary operators.
+            var @string = GetSpecialType(SpecialType.System_String, diagnostics, binaryOperator.Syntax);
+            var signature = new BinaryOperatorSignature(BinaryOperatorKind.StringConcatenation, @string, @string, @string);
+
+            var bottomOperator = stack.Pop();
+            var result = createBinaryOperator(bottomOperator, createInterpolation(bottomOperator.Left, appendCalls[0]), rightIndex: 1);
+
+            for (int i = 2; i < appendCalls.Length; i++)
+            {
+                result = createBinaryOperator(stack.Pop(), result, rightIndex: i);
+            }
+
+            convertedBinaryOperator = result.Update(BoundBinaryOperator.UncommonData.WithInterpolatedStringHandlerData(data));
+            return true;
+
+            BoundBinaryOperator createBinaryOperator(BoundBinaryOperator original, BoundExpression left, int rightIndex)
+                => new BoundBinaryOperator(
+                    original.Syntax,
+                    BinaryOperatorKind.StringConcatenation,
+                    left,
+                    createInterpolation(original.Right, appendCalls[rightIndex]),
+                    original.ConstantValue,
+                    signature.Method,
+                    signature.ConstrainedToTypeOpt,
+                    LookupResultKind.Viable,
+                    originalUserDefinedOperatorsOpt: default,
+                    @string,
+                    original.HasErrors);
+
+            static BoundInterpolatedString createInterpolation(BoundExpression expression, ImmutableArray<BoundExpression> parts)
+            {
+                Debug.Assert(expression is BoundUnconvertedInterpolatedString);
+                return new BoundInterpolatedString(
+                    expression.Syntax,
+                    interpolationData: null,
+                    parts,
+                    expression.ConstantValue,
+                    expression.Type,
+                    expression.HasErrors);
+            }
+        }
+
         private BoundInterpolatedString BindUnconvertedInterpolatedStringToHandlerType(
             BoundUnconvertedInterpolatedString unconvertedInterpolatedString,
             NamedTypeSymbol interpolatedStringHandlerType,
@@ -214,18 +349,46 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> additionalConstructorArguments = default,
             ImmutableArray<RefKind> additionalConstructorRefKinds = default)
         {
+            var (appendCalls, interpolationData) = BindUnconvertedInterpolatedPartsToHandlerType(
+                unconvertedInterpolatedString.Syntax,
+                ImmutableArray.Create(unconvertedInterpolatedString.Parts),
+                interpolatedStringHandlerType, diagnostics,
+                isHandlerConversion,
+                additionalConstructorArguments,
+                additionalConstructorRefKinds);
+
+            Debug.Assert(appendCalls.Length == 1);
+
+            return new BoundInterpolatedString(
+                unconvertedInterpolatedString.Syntax,
+                interpolationData,
+                appendCalls[0],
+                unconvertedInterpolatedString.ConstantValue,
+                unconvertedInterpolatedString.Type,
+                unconvertedInterpolatedString.HasErrors);
+        }
+
+        private (ImmutableArray<ImmutableArray<BoundExpression>> AppendCalls, InterpolatedStringHandlerData Data) BindUnconvertedInterpolatedPartsToHandlerType(
+            SyntaxNode syntax,
+            ImmutableArray<ImmutableArray<BoundExpression>> partsArray,
+            NamedTypeSymbol interpolatedStringHandlerType,
+            BindingDiagnosticBag diagnostics,
+            bool isHandlerConversion,
+            ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> additionalConstructorArguments,
+            ImmutableArray<RefKind> additionalConstructorRefKinds)
+        {
             Debug.Assert(additionalConstructorArguments.IsDefault
                 ? additionalConstructorRefKinds.IsDefault
                 : additionalConstructorArguments.Length == additionalConstructorRefKinds.Length);
             additionalConstructorArguments = additionalConstructorArguments.NullToEmpty();
             additionalConstructorRefKinds = additionalConstructorRefKinds.NullToEmpty();
 
-            ReportUseSite(interpolatedStringHandlerType, diagnostics, unconvertedInterpolatedString.Syntax);
+            ReportUseSite(interpolatedStringHandlerType, diagnostics, syntax);
 
             // We satisfy the conditions for using an interpolated string builder. Bind all the builder calls unconditionally, so that if
             // there are errors we get better diagnostics than "could not convert to object."
-            var implicitBuilderReceiver = new BoundInterpolatedStringHandlerPlaceholder(unconvertedInterpolatedString.Syntax, interpolatedStringHandlerType) { WasCompilerGenerated = true };
-            var (appendCalls, usesBoolReturn, positionInfo, baseStringLength, numFormatHoles) = BindInterpolatedStringAppendCalls(unconvertedInterpolatedString, implicitBuilderReceiver, diagnostics);
+            var implicitBuilderReceiver = new BoundInterpolatedStringHandlerPlaceholder(syntax, interpolatedStringHandlerType) { WasCompilerGenerated = true };
+            var (appendCallsArray, usesBoolReturn, positionInfo, baseStringLength, numFormatHoles) = BindInterpolatedStringAppendCalls(partsArray, implicitBuilderReceiver, diagnostics);
 
             // Prior to C# 10, all types in an interpolated string expression needed to be convertible to `object`. After 10, some types
             // (such as Span<T>) that are not convertible to `object` are permissible as interpolated string components, provided there
@@ -235,46 +398,49 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool needToCheckConversionToObject = false;
             if (isHandlerConversion)
             {
-                CheckFeatureAvailability(unconvertedInterpolatedString.Syntax, MessageID.IDS_FeatureImprovedInterpolatedStrings, diagnostics);
+                CheckFeatureAvailability(syntax, MessageID.IDS_FeatureImprovedInterpolatedStrings, diagnostics);
             }
             else if (!Compilation.IsFeatureEnabled(MessageID.IDS_FeatureImprovedInterpolatedStrings) && diagnostics.AccumulatesDiagnostics)
             {
                 needToCheckConversionToObject = true;
             }
 
-            Debug.Assert(appendCalls.Length == unconvertedInterpolatedString.Parts.Length);
-            Debug.Assert(appendCalls.All(a => a is { HasErrors: true } or BoundCall { Arguments: { Length: > 0 } } or BoundDynamicInvocation));
+            Debug.Assert(appendCallsArray.Select(a => a.Length).SequenceEqual(partsArray.Select(a => a.Length)));
+            Debug.Assert(appendCallsArray.All(appendCalls => appendCalls.All(a => a is { HasErrors: true } or BoundCall { Arguments: { Length: > 0 } } or BoundDynamicInvocation)));
 
             if (needToCheckConversionToObject)
             {
-                TypeSymbol objectType = GetSpecialType(SpecialType.System_Object, diagnostics, unconvertedInterpolatedString.Syntax);
+                TypeSymbol objectType = GetSpecialType(SpecialType.System_Object, diagnostics, syntax);
                 BindingDiagnosticBag conversionDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false);
-                foreach (var currentPart in unconvertedInterpolatedString.Parts)
+                foreach (var parts in partsArray)
                 {
-                    if (currentPart is BoundStringInsert insert)
+                    foreach (var currentPart in parts)
                     {
-                        var value = insert.Value;
-                        bool reported = false;
-                        if (value.Type is not null)
+                        if (currentPart is BoundStringInsert insert)
                         {
-                            value = BindToNaturalType(value, conversionDiagnostics);
-                            if (conversionDiagnostics.HasAnyErrors())
+                            var value = insert.Value;
+                            bool reported = false;
+                            if (value.Type is not null)
                             {
-                                CheckFeatureAvailability(value.Syntax, MessageID.IDS_FeatureImprovedInterpolatedStrings, diagnostics);
-                                reported = true;
+                                value = BindToNaturalType(value, conversionDiagnostics);
+                                if (conversionDiagnostics.HasAnyErrors())
+                                {
+                                    CheckFeatureAvailability(value.Syntax, MessageID.IDS_FeatureImprovedInterpolatedStrings, diagnostics);
+                                    reported = true;
+                                }
                             }
-                        }
 
-                        if (!reported)
-                        {
-                            _ = GenerateConversionForAssignment(objectType, value, conversionDiagnostics);
-                            if (conversionDiagnostics.HasAnyErrors())
+                            if (!reported)
                             {
-                                CheckFeatureAvailability(value.Syntax, MessageID.IDS_FeatureImprovedInterpolatedStrings, diagnostics);
+                                _ = GenerateConversionForAssignment(objectType, value, conversionDiagnostics);
+                                if (conversionDiagnostics.HasAnyErrors())
+                                {
+                                    CheckFeatureAvailability(value.Syntax, MessageID.IDS_FeatureImprovedInterpolatedStrings, diagnostics);
+                                }
                             }
-                        }
 
-                        conversionDiagnostics.Clear();
+                            conversionDiagnostics.Clear();
+                        }
                     }
                 }
 
@@ -282,7 +448,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
 
-            var intType = GetSpecialType(SpecialType.System_Int32, diagnostics, unconvertedInterpolatedString.Syntax);
+            var intType = GetSpecialType(SpecialType.System_Int32, diagnostics, syntax);
             int constructorArgumentLength = 3 + additionalConstructorArguments.Length;
             var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(constructorArgumentLength);
 
@@ -293,15 +459,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Add the trailing out validity parameter for the first attempt.Note that we intentionally use `diagnostics` for resolving System.Boolean,
             // because we want to track that we're using the type no matter what.
-            var boolType = GetSpecialType(SpecialType.System_Boolean, diagnostics, unconvertedInterpolatedString.Syntax);
-            var trailingConstructorValidityPlaceholder = new BoundInterpolatedStringArgumentPlaceholder(unconvertedInterpolatedString.Syntax, BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter, valSafeToEscape: LocalScopeDepth, boolType);
+            var boolType = GetSpecialType(SpecialType.System_Boolean, diagnostics, syntax);
+            var trailingConstructorValidityPlaceholder = new BoundInterpolatedStringArgumentPlaceholder(syntax, BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter, valSafeToEscape: LocalScopeDepth, boolType);
             var outConstructorAdditionalArguments = additionalConstructorArguments.Add(trailingConstructorValidityPlaceholder);
             refKindsBuilder.Add(RefKind.Out);
-            populateArguments(unconvertedInterpolatedString.Syntax, outConstructorAdditionalArguments, baseStringLength, numFormatHoles, intType, argumentsBuilder);
+            populateArguments(syntax, outConstructorAdditionalArguments, baseStringLength, numFormatHoles, intType, argumentsBuilder);
 
             BoundExpression constructorCall;
             var outConstructorDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: diagnostics.AccumulatesDependencies);
-            var outConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, unconvertedInterpolatedString.Syntax, outConstructorDiagnostics);
+            var outConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, syntax, outConstructorDiagnostics);
             if (outConstructorCall is not BoundObjectCreationExpression { ResultKind: LookupResultKind.Viable })
             {
                 // MakeConstructorInvocation can call CoerceArguments on the builder if overload resolution succeeded ignoring accessibility, which
@@ -309,11 +475,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argumentsBuilder.Clear();
 
                 // Try again without an out parameter.
-                populateArguments(unconvertedInterpolatedString.Syntax, additionalConstructorArguments, baseStringLength, numFormatHoles, intType, argumentsBuilder);
+                populateArguments(syntax, additionalConstructorArguments, baseStringLength, numFormatHoles, intType, argumentsBuilder);
                 refKindsBuilder.RemoveLast();
 
                 var nonOutConstructorDiagnostics = BindingDiagnosticBag.GetInstance(template: outConstructorDiagnostics);
-                BoundExpression nonOutConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, unconvertedInterpolatedString.Syntax, nonOutConstructorDiagnostics);
+                BoundExpression nonOutConstructorCall = MakeConstructorInvocation(interpolatedStringHandlerType, argumentsBuilder, refKindsBuilder, syntax, nonOutConstructorDiagnostics);
 
                 if (nonOutConstructorCall is BoundObjectCreationExpression { ResultKind: LookupResultKind.Viable })
                 {
@@ -373,23 +539,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (constructorCall is BoundDynamicObjectCreationExpression)
             {
                 // An interpolated string handler construction cannot use dynamic. Manually construct an instance of '{0}'.
-                diagnostics.Add(ErrorCode.ERR_InterpolatedStringHandlerCreationCannotUseDynamic, unconvertedInterpolatedString.Syntax.Location, interpolatedStringHandlerType.Name);
+                diagnostics.Add(ErrorCode.ERR_InterpolatedStringHandlerCreationCannotUseDynamic, syntax.Location, interpolatedStringHandlerType.Name);
             }
 
-            return new BoundInterpolatedString(
-                unconvertedInterpolatedString.Syntax,
-                new InterpolatedStringHandlerData(
-                    interpolatedStringHandlerType,
-                    constructorCall,
-                    usesBoolReturn,
-                    LocalScopeDepth,
-                    additionalConstructorArguments.NullToEmpty(),
-                    positionInfo,
-                    implicitBuilderReceiver),
-                appendCalls,
-                unconvertedInterpolatedString.ConstantValue,
-                unconvertedInterpolatedString.Type,
-                unconvertedInterpolatedString.HasErrors);
+            var interpolationData = new InterpolatedStringHandlerData(
+                                interpolatedStringHandlerType,
+                                constructorCall,
+                                usesBoolReturn,
+                                LocalScopeDepth,
+                                additionalConstructorArguments.NullToEmpty(),
+                                positionInfo,
+                                implicitBuilderReceiver);
+
+            return (appendCallsArray, interpolationData);
 
             static void populateArguments(SyntaxNode syntax, ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> additionalConstructorArguments, int baseStringLength, int numFormatHoles, NamedTypeSymbol intType, ArrayBuilder<BoundExpression> argumentsBuilder)
             {
@@ -447,113 +609,124 @@ namespace Microsoft.CodeAnalysis.CSharp
             return partsBuilder?.ToImmutableAndFree() ?? unconvertedInterpolatedString.Parts;
         }
 
-        private (ImmutableArray<BoundExpression> AppendFormatCalls, bool UsesBoolReturn, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>, int BaseStringLength, int NumFormatHoles) BindInterpolatedStringAppendCalls(
-            BoundUnconvertedInterpolatedString source,
+        private (ImmutableArray<ImmutableArray<BoundExpression>> AppendFormatCalls, bool UsesBoolReturn, ImmutableArray<ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>>, int BaseStringLength, int NumFormatHoles) BindInterpolatedStringAppendCalls(
+            ImmutableArray<ImmutableArray<BoundExpression>> partsArray,
             BoundInterpolatedStringHandlerPlaceholder implicitBuilderReceiver,
             BindingDiagnosticBag diagnostics)
         {
-            if (source.Parts.IsEmpty)
+            if (partsArray.IsEmpty && partsArray.All(p => p.IsEmpty))
             {
-                return (ImmutableArray<BoundExpression>.Empty, false, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>.Empty, 0, 0);
+                return (ImmutableArray<ImmutableArray<BoundExpression>>.Empty, false, ImmutableArray<ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>>.Empty, 0, 0);
             }
 
             bool? builderPatternExpectsBool = null;
-            var builderAppendCalls = ArrayBuilder<BoundExpression>.GetInstance(source.Parts.Length);
-            var positionInfo = ArrayBuilder<(bool IsLiteral, bool HasAlignment, bool HasFormat)>.GetInstance(source.Parts.Length);
+            var firstPartsLength = partsArray[0].Length;
+            var builderAppendCallsArray = ArrayBuilder<ImmutableArray<BoundExpression>>.GetInstance(partsArray.Length);
+            var builderAppendCalls = ArrayBuilder<BoundExpression>.GetInstance(firstPartsLength);
+            var positionInfoArray = ArrayBuilder<ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>>.GetInstance(partsArray.Length);
+            var positionInfo = ArrayBuilder<(bool IsLiteral, bool HasAlignment, bool HasFormat)>.GetInstance(firstPartsLength);
             var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(3);
             var parameterNamesAndLocationsBuilder = ArrayBuilder<(string, Location)?>.GetInstance(3);
             int baseStringLength = 0;
             int numFormatHoles = 0;
 
-            foreach (var part in source.Parts)
+            foreach (var parts in partsArray)
             {
-                Debug.Assert(part is BoundLiteral or BoundStringInsert);
-                string methodName;
-                bool isLiteral;
-                bool hasAlignment;
-                bool hasFormat;
-
-                if (part is BoundStringInsert insert)
+                foreach (var part in parts)
                 {
-                    methodName = "AppendFormatted";
-                    argumentsBuilder.Add(insert.Value);
-                    parameterNamesAndLocationsBuilder.Add(null);
-                    isLiteral = false;
-                    hasAlignment = false;
-                    hasFormat = false;
+                    Debug.Assert(part is BoundLiteral or BoundStringInsert);
+                    string methodName;
+                    bool isLiteral;
+                    bool hasAlignment;
+                    bool hasFormat;
 
-                    if (insert.Alignment is not null)
+                    if (part is BoundStringInsert insert)
                     {
-                        hasAlignment = true;
-                        argumentsBuilder.Add(insert.Alignment);
-                        parameterNamesAndLocationsBuilder.Add(("alignment", insert.Alignment.Syntax.Location));
+                        methodName = "AppendFormatted";
+                        argumentsBuilder.Add(insert.Value);
+                        parameterNamesAndLocationsBuilder.Add(null);
+                        isLiteral = false;
+                        hasAlignment = false;
+                        hasFormat = false;
+
+                        if (insert.Alignment is not null)
+                        {
+                            hasAlignment = true;
+                            argumentsBuilder.Add(insert.Alignment);
+                            parameterNamesAndLocationsBuilder.Add(("alignment", insert.Alignment.Syntax.Location));
+                        }
+                        if (insert.Format is not null)
+                        {
+                            hasFormat = true;
+                            argumentsBuilder.Add(insert.Format);
+                            parameterNamesAndLocationsBuilder.Add(("format", insert.Format.Syntax.Location));
+                        }
+                        numFormatHoles++;
                     }
-                    if (insert.Format is not null)
+                    else
                     {
-                        hasFormat = true;
-                        argumentsBuilder.Add(insert.Format);
-                        parameterNamesAndLocationsBuilder.Add(("format", insert.Format.Syntax.Location));
+                        var boundLiteral = (BoundLiteral)part;
+                        Debug.Assert(boundLiteral.ConstantValue != null && boundLiteral.ConstantValue.IsString);
+                        var literalText = ConstantValueUtils.UnescapeInterpolatedStringLiteral(boundLiteral.ConstantValue.StringValue);
+                        methodName = "AppendLiteral";
+                        argumentsBuilder.Add(boundLiteral.Update(ConstantValue.Create(literalText), boundLiteral.Type));
+                        isLiteral = true;
+                        hasAlignment = false;
+                        hasFormat = false;
+                        baseStringLength += literalText.Length;
                     }
-                    numFormatHoles++;
-                }
-                else
-                {
-                    var boundLiteral = (BoundLiteral)part;
-                    Debug.Assert(boundLiteral.ConstantValue != null && boundLiteral.ConstantValue.IsString);
-                    var literalText = ConstantValueUtils.UnescapeInterpolatedStringLiteral(boundLiteral.ConstantValue.StringValue);
-                    methodName = "AppendLiteral";
-                    argumentsBuilder.Add(boundLiteral.Update(ConstantValue.Create(literalText), boundLiteral.Type));
-                    isLiteral = true;
-                    hasAlignment = false;
-                    hasFormat = false;
-                    baseStringLength += literalText.Length;
+
+                    var arguments = argumentsBuilder.ToImmutableAndClear();
+                    ImmutableArray<(string, Location)?> parameterNamesAndLocations;
+                    if (parameterNamesAndLocationsBuilder.Count > 1)
+                    {
+                        parameterNamesAndLocations = parameterNamesAndLocationsBuilder.ToImmutableAndClear();
+                    }
+                    else
+                    {
+                        Debug.Assert(parameterNamesAndLocationsBuilder.Count == 0 || parameterNamesAndLocationsBuilder[0] == null);
+                        parameterNamesAndLocations = default;
+                        parameterNamesAndLocationsBuilder.Clear();
+                    }
+
+                    var call = MakeInvocationExpression(part.Syntax, implicitBuilderReceiver, methodName, arguments, diagnostics, names: parameterNamesAndLocations, searchExtensionMethodsIfNecessary: false);
+                    builderAppendCalls.Add(call);
+                    positionInfo.Add((isLiteral, hasAlignment, hasFormat));
+
+                    Debug.Assert(call is BoundCall or BoundDynamicInvocation or { HasErrors: true });
+
+                    // We just assume that dynamic is going to do the right thing, and runtime will fail if it does not. If there are only dynamic calls, we assume that
+                    // void is returned.
+                    if (call is BoundCall { Method: { ReturnType: var returnType } method })
+                    {
+                        bool methodReturnsBool = returnType.SpecialType == SpecialType.System_Boolean;
+                        if (!methodReturnsBool && returnType.SpecialType != SpecialType.System_Void)
+                        {
+                            // Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.
+                            diagnostics.Add(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnMalformed, part.Syntax.Location, method);
+                        }
+                        else if (builderPatternExpectsBool == null)
+                        {
+                            builderPatternExpectsBool = methodReturnsBool;
+                        }
+                        else if (builderPatternExpectsBool != methodReturnsBool)
+                        {
+                            // Interpolated string handler method '{0}' has inconsistent return types. Expected to return '{1}'.
+                            var expected = builderPatternExpectsBool == true ? Compilation.GetSpecialType(SpecialType.System_Boolean) : Compilation.GetSpecialType(SpecialType.System_Void);
+                            diagnostics.Add(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnInconsistent, part.Syntax.Location, method, expected);
+                        }
+                    }
                 }
 
-                var arguments = argumentsBuilder.ToImmutableAndClear();
-                ImmutableArray<(string, Location)?> parameterNamesAndLocations;
-                if (parameterNamesAndLocationsBuilder.Count > 1)
-                {
-                    parameterNamesAndLocations = parameterNamesAndLocationsBuilder.ToImmutableAndClear();
-                }
-                else
-                {
-                    Debug.Assert(parameterNamesAndLocationsBuilder.Count == 0 || parameterNamesAndLocationsBuilder[0] == null);
-                    parameterNamesAndLocations = default;
-                    parameterNamesAndLocationsBuilder.Clear();
-                }
-
-                var call = MakeInvocationExpression(part.Syntax, implicitBuilderReceiver, methodName, arguments, diagnostics, names: parameterNamesAndLocations, searchExtensionMethodsIfNecessary: false);
-                builderAppendCalls.Add(call);
-                positionInfo.Add((isLiteral, hasAlignment, hasFormat));
-
-                Debug.Assert(call is BoundCall or BoundDynamicInvocation or { HasErrors: true });
-
-                // We just assume that dynamic is going to do the right thing, and runtime will fail if it does not. If there are only dynamic calls, we assume that
-                // void is returned.
-                if (call is BoundCall { Method: { ReturnType: var returnType } method })
-                {
-                    bool methodReturnsBool = returnType.SpecialType == SpecialType.System_Boolean;
-                    if (!methodReturnsBool && returnType.SpecialType != SpecialType.System_Void)
-                    {
-                        // Interpolated string handler method '{0}' is malformed. It does not return 'void' or 'bool'.
-                        diagnostics.Add(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnMalformed, part.Syntax.Location, method);
-                    }
-                    else if (builderPatternExpectsBool == null)
-                    {
-                        builderPatternExpectsBool = methodReturnsBool;
-                    }
-                    else if (builderPatternExpectsBool != methodReturnsBool)
-                    {
-                        // Interpolated string handler method '{0}' has inconsistent return types. Expected to return '{1}'.
-                        var expected = builderPatternExpectsBool == true ? Compilation.GetSpecialType(SpecialType.System_Boolean) : Compilation.GetSpecialType(SpecialType.System_Void);
-                        diagnostics.Add(ErrorCode.ERR_InterpolatedStringHandlerMethodReturnInconsistent, part.Syntax.Location, method, expected);
-                    }
-                }
+                builderAppendCallsArray.Add(builderAppendCalls.ToImmutableAndClear());
+                positionInfoArray.Add(positionInfo.ToImmutableAndClear());
             }
 
             argumentsBuilder.Free();
             parameterNamesAndLocationsBuilder.Free();
-            return (builderAppendCalls.ToImmutableAndFree(), builderPatternExpectsBool ?? false, positionInfo.ToImmutableAndFree(), baseStringLength, numFormatHoles);
+            builderAppendCalls.Free();
+            positionInfo.Free();
+            return (builderAppendCallsArray.ToImmutableAndFree(), builderPatternExpectsBool ?? false, positionInfoArray.ToImmutableAndFree(), baseStringLength, numFormatHoles);
         }
 
         private BoundExpression BindInterpolatedStringHandlerInMemberCall(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -214,6 +214,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(binaryOperator.IsUnconvertedInterpolatedStringAddition);
             convertedBinaryOperator = null;
 
+            if (InExpressionTree)
+            {
+                return false;
+            }
+
             var interpolatedStringHandlerType = Compilation.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler);
             if (interpolatedStringHandlerType.IsErrorType())
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -306,7 +306,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(appendCalls.Length == stack.Count + 1);
             var @string = GetSpecialType(SpecialType.System_String, diagnostics, rootSyntax);
-            var signature = new BinaryOperatorSignature(BinaryOperatorKind.StringConcatenation, @string, @string, @string);
 
             var bottomOperator = stack.Pop();
             var result = createBinaryOperator(bottomOperator, createInterpolation(bottomOperator.Left, appendCalls[0]), rightIndex: 1);
@@ -316,7 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 result = createBinaryOperator(stack.Pop(), result, rightIndex: i);
             }
 
-            return result.Update(BoundBinaryOperator.UncommonData.WithInterpolatedStringHandlerData(data));
+            return result.Update(BoundBinaryOperator.UncommonData.InterpolatedStringHandlerAddition(data));
 
             BoundBinaryOperator createBinaryOperator(BoundBinaryOperator original, BoundExpression left, int rightIndex)
                 => new BoundBinaryOperator(
@@ -325,8 +324,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     left,
                     createInterpolation(original.Right, appendCalls[rightIndex]),
                     original.ConstantValue,
-                    signature.Method,
-                    signature.ConstrainedToTypeOpt,
+                    methodOpt: null,
+                    constrainedToTypeOpt: null,
                     LookupResultKind.Viable,
                     originalUserDefinedOperatorsOpt: default,
                     @string,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BindTupleBinaryOperatorNestedInfo(node, kind, left, right, diagnostics);
             }
 
-            BoundExpression comparison = BindSimpleBinaryOperator(node, diagnostics, left, right);
+            BoundExpression comparison = BindSimpleBinaryOperator(node, diagnostics, left, right, leaveUnconvertedIfInterpolatedString: false);
             switch (comparison)
             {
                 case BoundLiteral _:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return conversion;
         }
 
-        protected override Conversion GetInterpolatedStringConversion(BoundUnconvertedInterpolatedString source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        protected override Conversion GetInterpolatedStringConversion(TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (destination is NamedTypeSymbol { IsInterpolatedStringHandlerType: true })
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected abstract ConversionsBase CreateInstance(int currentRecursionDepth);
 
-        protected abstract Conversion GetInterpolatedStringConversion(BoundUnconvertedInterpolatedString source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo);
+        protected abstract Conversion GetInterpolatedStringConversion(TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo);
 
         internal AssemblySymbol CorLibrary { get { return corLibrary; } }
 
@@ -931,7 +931,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case BoundKind.UnconvertedInterpolatedString:
-                    Conversion interpolatedStringConversion = GetInterpolatedStringConversion((BoundUnconvertedInterpolatedString)sourceExpression, destination, ref useSiteInfo);
+                case BoundKind.BinaryOperator when ((BoundBinaryOperator)sourceExpression).IsUnconvertedInterpolatedStringAddition:
+                    Conversion interpolatedStringConversion = GetInterpolatedStringConversion(destination, ref useSiteInfo);
                     if (interpolatedStringConversion.Exists)
                     {
                         return interpolatedStringConversion;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/TypeConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/TypeConversions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             throw ExceptionUtilities.Unreachable;
         }
 
-        protected override Conversion GetInterpolatedStringConversion(BoundUnconvertedInterpolatedString source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        protected override Conversion GetInterpolatedStringConversion(TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             // Conversions involving interpolated strings require a Binder.
             throw ExceptionUtilities.Unreachable;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2138,7 +2138,7 @@ outerDefault:
                         var c2 = m2.Result.ConversionForArg(i);
 
                         isInterpolatedStringHandlerConversion = c1.IsInterpolatedStringHandler && c2.IsInterpolatedStringHandler;
-                        Debug.Assert(!isInterpolatedStringHandlerConversion || arguments[i].Kind == BoundKind.UnconvertedInterpolatedString);
+                        Debug.Assert(!isInterpolatedStringHandlerConversion || arguments[i] is BoundUnconvertedInterpolatedString or BoundBinaryOperator { IsUnconvertedInterpolatedStringAddition: true });
                     }
 
                     if (p1.RefKind == RefKind.None && isAcceptableRefMismatch(p2.RefKind, isInterpolatedStringHandlerConversion))
@@ -2430,8 +2430,7 @@ outerDefault:
             // C1 is a better conversion than C2 if E is a non-constant interpolated string expression, C1
             // is an interpolated string handler conversion, and C2 is not an interpolated string
             // handler conversion
-            // https://github.com/dotnet/roslyn/issues/54584 Handle binary operators composed only of added interpolated strings
-            if (node is BoundUnconvertedInterpolatedString { ConstantValueOpt: null })
+            if (node is BoundUnconvertedInterpolatedString { ConstantValueOpt: null } or BoundBinaryOperator { IsUnconvertedInterpolatedStringAddition: true, ConstantValue: null })
             {
                 switch ((conv1.Kind, conv2.Kind))
                 {
@@ -3633,7 +3632,7 @@ outerDefault:
                     }
 
                     bool hasInterpolatedStringRefMismatch = false;
-                    if (argument.Kind == BoundKind.UnconvertedInterpolatedString
+                    if (argument is BoundUnconvertedInterpolatedString or BoundBinaryOperator { IsUnconvertedInterpolatedStringAddition: true }
                         && parameterRefKind == RefKind.Ref
                         && parameters.ParameterTypes[argumentPosition].Type is NamedTypeSymbol { IsInterpolatedStringHandlerType: true, IsValueType: true })
                     {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundBinaryOperator.UncommonData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundBinaryOperator.UncommonData.cs
@@ -59,6 +59,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 IsUnconvertedInterpolatedStringAddition = isUnconvertedInterpolatedStringAddition;
                 InterpolatedStringHandlerData = interpolatedStringHandlerData;
             }
+
+            public UncommonData WithUpdatedMethod(MethodSymbol? method)
+            {
+                if ((object?)method == Method)
+                {
+                    return this;
+                }
+
+                return new UncommonData(ConstantValue, method, ConstrainedToType, OriginalUserDefinedOperatorsOpt, IsUnconvertedInterpolatedStringAddition, InterpolatedStringHandlerData);
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundBinaryOperator.UncommonData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundBinaryOperator.UncommonData.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     isUnconvertedInterpolatedStringAddition: true,
                     interpolatedStringHandlerData: null);
 
-            public static UncommonData WithInterpolatedStringHandlerData(InterpolatedStringHandlerData data)
+            public static UncommonData InterpolatedStringHandlerAddition(InterpolatedStringHandlerData data)
                 => new UncommonData(
                     constantValue: null,
                     method: null,
@@ -52,6 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private UncommonData(ConstantValue? constantValue, MethodSymbol? method, TypeSymbol? constrainedToType, ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt, bool isUnconvertedInterpolatedStringAddition, InterpolatedStringHandlerData? interpolatedStringHandlerData)
             {
+                Debug.Assert(interpolatedStringHandlerData is null || !isUnconvertedInterpolatedStringAddition);
                 ConstantValue = constantValue;
                 Method = method;
                 ConstrainedToType = constrainedToType;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundBinaryOperator.UncommonData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundBinaryOperator.UncommonData.cs
@@ -11,11 +11,29 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         internal class UncommonData
         {
+            public static UncommonData UnconvertedInterpolatedStringAddition(ConstantValue? constantValue) =>
+                new UncommonData(
+                    constantValue,
+                    method: null,
+                    constrainedToType: null,
+                    originalUserDefinedOperatorsOpt: default,
+                    isUnconvertedInterpolatedStringAddition: true,
+                    interpolatedStringHandlerData: null);
+
+            public static UncommonData WithInterpolatedStringHandlerData(InterpolatedStringHandlerData data)
+                => new UncommonData(
+                    constantValue: null,
+                    method: null,
+                    constrainedToType: null,
+                    originalUserDefinedOperatorsOpt: default,
+                    isUnconvertedInterpolatedStringAddition: false,
+                    data);
+
             public static UncommonData? CreateIfNeeded(ConstantValue? constantValue, MethodSymbol? method, TypeSymbol? constrainedToType, ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt)
             {
                 if (constantValue != null || method is not null || constrainedToType is not null || !originalUserDefinedOperatorsOpt.IsDefault)
                 {
-                    return new UncommonData(constantValue, method, constrainedToType, originalUserDefinedOperatorsOpt);
+                    return new UncommonData(constantValue, method, constrainedToType, originalUserDefinedOperatorsOpt, isUnconvertedInterpolatedStringAddition: false, interpolatedStringHandlerData: null);
                 }
 
                 return null;
@@ -24,18 +42,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             public readonly ConstantValue? ConstantValue;
             public readonly MethodSymbol? Method;
             public readonly TypeSymbol? ConstrainedToType;
+            public readonly bool IsUnconvertedInterpolatedStringAddition;
+            public readonly InterpolatedStringHandlerData? InterpolatedStringHandlerData;
 
             // The set of method symbols from which this operator's method was chosen.
             // Only kept in the tree if the operator was an error and overload resolution
             // was unable to choose a best method.
             public readonly ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt;
 
-            private UncommonData(ConstantValue? constantValue, MethodSymbol? method, TypeSymbol? constrainedToType, ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt)
+            private UncommonData(ConstantValue? constantValue, MethodSymbol? method, TypeSymbol? constrainedToType, ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt, bool isUnconvertedInterpolatedStringAddition, InterpolatedStringHandlerData? interpolatedStringHandlerData)
             {
                 ConstantValue = constantValue;
                 Method = method;
                 ConstrainedToType = constrainedToType;
                 OriginalUserDefinedOperatorsOpt = originalUserDefinedOperatorsOpt;
+                IsUnconvertedInterpolatedStringAddition = isUnconvertedInterpolatedStringAddition;
+                InterpolatedStringHandlerData = interpolatedStringHandlerData;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -66,6 +66,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // syntactic context where it could be either a pointer or a span, and
                     // in that case it requires conversion to one or the other.
                     return this.Type is null;
+                case BoundKind.BinaryOperator:
+                    return ((BoundBinaryOperator)this).IsUnconvertedInterpolatedStringAddition;
 #if DEBUG
                 case BoundKind.Local when !WasConverted:
                 case BoundKind.Parameter when !WasConverted:
@@ -283,6 +285,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal MethodSymbol? Method => Data?.Method;
 
         internal TypeSymbol? ConstrainedToType => Data?.ConstrainedToType;
+
+        internal bool IsUnconvertedInterpolatedStringAddition => Data?.IsUnconvertedInterpolatedStringAddition ?? false;
+
+        internal InterpolatedStringHandlerData? InterpolatedStringHandlerData => Data?.InterpolatedStringHandlerData;
 
         internal ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt => Data?.OriginalUserDefinedOperatorsOpt ?? default(ImmutableArray<MethodSymbol>);
     }

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -417,6 +417,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             var uncommonData = UncommonData.CreateIfNeeded(constantValueOpt, methodOpt, constrainedToTypeOpt, OriginalUserDefinedOperatorsOpt);
             return Update(operatorKind, uncommonData, resultKind, left, right, type);
         }
+
+        public BoundBinaryOperator Update(UncommonData uncommonData)
+        {
+            return Update(OperatorKind, uncommonData, ResultKind, Left, Right, Type);
+        }
     }
 
     internal sealed partial class BoundUserDefinedConditionalLogicalOperator

--- a/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/InterpolatedStringHandlerData.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public readonly ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> ArgumentPlaceholders;
 
-        public readonly ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> PositionInfo;
+        public readonly ImmutableArray<ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>> PositionInfo;
 
         public bool HasTrailingHandlerValidityParameter => ArgumentPlaceholders.Length > 0 && ArgumentPlaceholders[^1].ArgumentIndex == BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter;
 
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool usesBoolReturns,
             uint scopeOfContainingExpression,
             ImmutableArray<BoundInterpolatedStringArgumentPlaceholder> placeholders,
-            ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> positionInfo,
+            ImmutableArray<ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>> positionInfo,
             BoundInterpolatedStringHandlerPlaceholder receiverPlaceholder)
         {
             Debug.Assert(construction is BoundObjectCreationExpression or BoundDynamicObjectCreationExpression or BoundBadExpression);

--- a/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 stack.Push(currentBinary);
                 currentBinary = currentBinary.Left as BoundBinaryOperatorBase;
             }
-            while (currentBinary is object);
+            while (currentBinary is not null);
 
             Debug.Assert(stack.Count > 0);
             var leftChild = (BoundExpression)Visit(stack.Peek().Left);
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     BoundBinaryOperator binary => binary.Update(
                         binary.OperatorKind,
-                        BoundBinaryOperator.UncommonData.CreateIfNeeded(binary.ConstantValue, GetUpdatedSymbol(binary, binary.Method), binary.ConstrainedToType, binary.OriginalUserDefinedOperatorsOpt),
+                        binary.Data?.WithUpdatedMethod(GetUpdatedSymbol(binary, binary.Method)),
                         binary.ResultKind,
                         leftChild,
                         right,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2253,6 +2253,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(!node.OperatorKind.IsUserDefined());
                 VisitBinaryLogicalOperatorChildren(node);
             }
+            else if (node.InterpolatedStringHandlerData is { } data)
+            {
+                VisitBinaryInterpolatedStringAddition(node);
+            }
             else
             {
                 VisitBinaryOperatorChildren(node);
@@ -2404,7 +2408,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 stack.Push(binary);
                 binary = binary.Left as BoundBinaryOperator;
             }
-            while (binary != null && !binary.OperatorKind.IsLogical());
+            while (binary != null && !binary.OperatorKind.IsLogical() && binary.InterpolatedStringHandlerData is null);
 
             VisitBinaryOperatorChildren(stack);
             stack.Free();
@@ -2509,7 +2513,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     return true;
                 }
-                // `a && b(out x) == true`
+                // `a && b(out x) == trueValue`
                 else if (IsConditionalState && binary.Right.ConstantValue is { IsBoolean: true } rightConstant)
                 {
                     var (stateWhenTrue, stateWhenFalse) = (StateWhenTrue.Clone(), StateWhenFalse.Clone());
@@ -2536,6 +2540,83 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return false;
             }
+        }
+
+        protected void VisitBinaryInterpolatedStringAddition(BoundBinaryOperator node)
+        {
+            Debug.Assert(node.InterpolatedStringHandlerData.HasValue);
+            var stack = ArrayBuilder<BoundInterpolatedString>.GetInstance();
+            var data = node.InterpolatedStringHandlerData.GetValueOrDefault();
+
+            while (PushBinaryOperatorInterpolatedStringChildren(node, stack) is { } next)
+            {
+                node = next;
+            }
+
+            Debug.Assert(stack.Count >= 2);
+
+            VisitRvalue(data.Construction);
+
+            bool visitedFirst = false;
+            bool hasTrailingHandlerValidityParameter = data.HasTrailingHandlerValidityParameter;
+            TLocalState shortCircuitState = State.Clone();
+
+            while (stack.TryPop(out var currentString))
+            {
+                visitedFirst |= VisitInterpolatedStringComponentOfBinaryOperator(currentString, data.UsesBoolReturns, firstPartIsConditional: visitedFirst || hasTrailingHandlerValidityParameter, ref shortCircuitState);
+            }
+
+            if (data.UsesBoolReturns || hasTrailingHandlerValidityParameter)
+            {
+                Join(ref State, ref shortCircuitState);
+            }
+        }
+
+        protected virtual BoundBinaryOperator? PushBinaryOperatorInterpolatedStringChildren(BoundBinaryOperator node, ArrayBuilder<BoundInterpolatedString> stack)
+        {
+            stack.Push((BoundInterpolatedString)node.Right);
+            switch (node.Left)
+            {
+                case BoundBinaryOperator next:
+                    return next;
+                case BoundInterpolatedString @string:
+                    stack.Push(@string);
+                    return null;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Left.Kind);
+            }
+        }
+
+        protected virtual bool VisitInterpolatedStringComponentOfBinaryOperator(BoundInterpolatedString node, bool usesBoolReturns, bool firstPartIsConditional, ref TLocalState shortCircuitState)
+        {
+            if (node.Parts.IsEmpty)
+            {
+                return false;
+            }
+
+            ReadOnlySpan<BoundExpression> parts;
+
+            if (firstPartIsConditional)
+            {
+                parts = node.Parts.AsSpan();
+            }
+            else
+            {
+                VisitRvalue(node.Parts[0]);
+                shortCircuitState = State.Clone();
+                parts = node.Parts.AsSpan()[1..];
+            }
+
+            foreach (var part in parts)
+            {
+                VisitRvalue(part);
+                if (usesBoolReturns)
+                {
+                    Join(ref shortCircuitState, ref State);
+                }
+            }
+
+            return true;
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -169,6 +169,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
             {
+                if (node.InterpolatedStringHandlerData is { } data)
+                {
+                    Visit(data.Construction);
+                }
+
                 VisitBinaryOperatorChildren(node);
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4024,9 +4024,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override bool VisitInterpolatedStringComponentOfBinaryOperator(BoundInterpolatedString node, bool usesBoolReturns, bool firstPartIsUnconditional, ref LocalState shortCircuitState)
+        protected override bool VisitInterpolatedStringHandlerParts(BoundInterpolatedStringBase node, bool usesBoolReturns, bool firstPartIsConditional, ref LocalState shortCircuitState)
         {
-            var result = base.VisitInterpolatedStringComponentOfBinaryOperator(node, usesBoolReturns, firstPartIsUnconditional, ref shortCircuitState);
+            var result = base.VisitInterpolatedStringHandlerParts(node, usesBoolReturns, firstPartIsConditional, ref shortCircuitState);
             SetNotNullResult(node);
             return result;
         }
@@ -9783,14 +9783,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        public override BoundNode? VisitInterpolatedString(BoundInterpolatedString node)
-        {
-            // https://github.com/dotnet/roslyn/issues/54583
-            // Better handle the constructor propogation
-            var result = base.VisitInterpolatedString(node);
-            SetResultType(node, TypeWithState.Create(node.Type, NullableFlowState.NotNull));
-            return result;
-        }
+        // https://github.com/dotnet/roslyn/issues/54583
+        // Better handle the constructor propogation
+        //public override BoundNode? VisitInterpolatedString(BoundInterpolatedString node)
+        //{
+        //}
 
         public override BoundNode? VisitUnconvertedInterpolatedString(BoundUnconvertedInterpolatedString node)
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4024,6 +4024,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        protected override bool VisitInterpolatedStringComponentOfBinaryOperator(BoundInterpolatedString node, bool usesBoolReturns, bool firstPartIsUnconditional, ref LocalState shortCircuitState)
+        {
+            var result = base.VisitInterpolatedStringComponentOfBinaryOperator(node, usesBoolReturns, firstPartIsUnconditional, ref shortCircuitState);
+            SetNotNullResult(node);
+            return result;
+        }
+
+        protected override BoundBinaryOperator? PushBinaryOperatorInterpolatedStringChildren(BoundBinaryOperator node, ArrayBuilder<BoundInterpolatedString> stack)
+        {
+            var result = base.PushBinaryOperatorInterpolatedStringChildren(node, stack);
+            SetNotNullResult(node);
+            return result;
+        }
+
         /// <summary>
         /// If we learn that the operand is non-null, we can infer that certain
         /// sub-expressions were also non-null.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -22,10 +22,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.InterpolatedStringHandler:
                     Debug.Assert(node.Type is NamedTypeSymbol { IsInterpolatedStringHandlerType: true });
 
-                    var interpolatedString = (BoundInterpolatedString)node.Operand;
-                    Debug.Assert(interpolatedString.InterpolationData is not null);
+                    var (data, parts) = node.Operand switch
+                    {
+                        BoundInterpolatedString { InterpolationData: { } d, Parts: { } p } => (d, p),
+                        BoundBinaryOperator { InterpolatedStringHandlerData: { } d } binary => (d, CollectBinaryOperatorInterpolatedStringParts(binary)),
+                        _ => throw ExceptionUtilities.UnexpectedValue(node.Operand.Kind)
+                    };
 
-                    (ArrayBuilder<BoundExpression> handlerPatternExpressions, BoundLocal handlerLocal) = RewriteToInterpolatedStringHandlerPattern(interpolatedString.InterpolationData.Value, interpolatedString.Parts, interpolatedString.Syntax);
+                    (ArrayBuilder<BoundExpression> handlerPatternExpressions, BoundLocal handlerLocal) = RewriteToInterpolatedStringHandlerPattern(data, parts, node.Operand.Syntax);
                     return _factory.Sequence(ImmutableArray.Create(handlerLocal.LocalSymbol), handlerPatternExpressions.ToImmutableAndFree(), handlerLocal);
                 case ConversionKind.SwitchExpression or ConversionKind.ConditionalExpression:
                     // Skip through target-typed conditionals and switches

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -22,7 +22,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.InterpolatedStringHandler:
                     Debug.Assert(node.Type is NamedTypeSymbol { IsInterpolatedStringHandlerType: true });
 
-                    (ArrayBuilder<BoundExpression> handlerPatternExpressions, BoundLocal handlerLocal) = RewriteToInterpolatedStringHandlerPattern((BoundInterpolatedString)node.Operand);
+                    var interpolatedString = (BoundInterpolatedString)node.Operand;
+                    Debug.Assert(interpolatedString.InterpolationData is not null);
+
+                    (ArrayBuilder<BoundExpression> handlerPatternExpressions, BoundLocal handlerLocal) = RewriteToInterpolatedStringHandlerPattern(interpolatedString.InterpolationData.Value, interpolatedString.Parts, interpolatedString.Syntax);
                     return _factory.Sequence(ImmutableArray.Create(handlerLocal.LocalSymbol), handlerPatternExpressions.ToImmutableAndFree(), handlerLocal);
                 case ConversionKind.SwitchExpression or ConversionKind.ConditionalExpression:
                     // Skip through target-typed conditionals and switches

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -334,9 +334,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var arg in arguments)
                 {
-                    if (arg is BoundConversion { Conversion: { Kind: ConversionKind.InterpolatedStringHandler }, ExplicitCastInCode: false, Operand: BoundInterpolatedString @string })
+                    if (arg is BoundConversion { Conversion: { Kind: ConversionKind.InterpolatedStringHandler }, ExplicitCastInCode: false, Operand: var operand })
                     {
-                        Debug.Assert(((BoundObjectCreationExpression)@string.InterpolationData!.Value.Construction).Arguments.All(
+                        var data = operand switch
+                        {
+                            BoundInterpolatedString { InterpolationData: { } d } => d,
+                            BoundBinaryOperator { InterpolatedStringHandlerData: { } d } => d,
+                            _ => throw ExceptionUtilities.UnexpectedValue(operand.Kind)
+                        };
+                        Debug.Assert(((BoundObjectCreationExpression)data.Construction).Arguments.All(
                             a => a is BoundInterpolatedStringArgumentPlaceholder { ArgumentIndex: BoundInterpolatedStringArgumentPlaceholder.TrailingConstructorValidityParameter }
                                       or not BoundInterpolatedStringArgumentPlaceholder));
                     }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -2018,12 +2018,14 @@ namespace Microsoft.CodeAnalysis.Operations
                 return builder.ToImmutableAndFree();
             }
 
-            ImmutableArray<IInterpolatedStringContentOperation> createHandlerInterpolatedStringContent(ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> positionInfo)
+            ImmutableArray<IInterpolatedStringContentOperation> createHandlerInterpolatedStringContent(ImmutableArray<ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>> positionInfoArray)
             {
                 // For interpolated string handlers, we want to deconstruct the `AppendLiteral`/`AppendFormatted` calls into
                 // their relevant components.
                 // https://github.com/dotnet/roslyn/issues/54505 we need to handle interpolated strings used as handler conversions.
 
+                Debug.Assert(positionInfoArray.Length == 1);
+                ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> positionInfo = positionInfoArray[0];
                 Debug.Assert(parts.Length == positionInfo.Length);
                 var builder = ArrayBuilder<IInterpolatedStringContentOperation>.GetInstance(parts.Length);
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -959,7 +959,7 @@ namespace Microsoft.CodeAnalysis.Operations
             {
                 // https://github.com/dotnet/roslyn/issues/54505 Support interpolation handlers in conversions
                 Debug.Assert(!forceOperandImplicitLiteral);
-                Debug.Assert(boundOperand is BoundInterpolatedString);
+                Debug.Assert(boundOperand is BoundInterpolatedString { InterpolationData: not null } or BoundBinaryOperator { InterpolatedStringHandlerData: not null });
                 var interpolatedString = Create(boundOperand);
                 return new NoneOperation(ImmutableArray.Create(interpolatedString), _semanticModel, boundConversion.Syntax, boundConversion.GetPublicTypeSymbol(), boundConversion.ConstantValue, isImplicit);
             }
@@ -1301,6 +1301,7 @@ namespace Microsoft.CodeAnalysis.Operations
             // To solve this, we use a manual stack for the left side.
             var stack = ArrayBuilder<BoundBinaryOperatorBase>.GetInstance();
             BoundBinaryOperatorBase? currentBinary = boundBinaryOperatorBase;
+            InterpolatedStringHandlerData? interpolatedData = (boundBinaryOperatorBase as BoundBinaryOperator)?.InterpolatedStringHandlerData;
 
             do
             {
@@ -1308,13 +1309,16 @@ namespace Microsoft.CodeAnalysis.Operations
                 currentBinary = currentBinary.Left as BoundBinaryOperatorBase;
             } while (currentBinary is not null);
 
+            Debug.Assert(interpolatedData == null || interpolatedData.GetValueOrDefault().PositionInfo.Length == stack.Count + 1);
+
             Debug.Assert(stack.Count > 0);
             IOperation? left = null;
+            int positionInfoIndex = 0;
 
             while (stack.TryPop(out currentBinary))
             {
-                left = left ?? Create(currentBinary.Left);
-                IOperation right = Create(currentBinary.Right);
+                left ??= visitOperand(currentBinary.Left);
+                IOperation right = visitOperand(currentBinary.Right);
                 left = currentBinary switch
                 {
                     BoundBinaryOperator binaryOp => createBoundBinaryOperatorOperation(binaryOp, left, right),
@@ -1326,6 +1330,11 @@ namespace Microsoft.CodeAnalysis.Operations
             Debug.Assert(left is not null && stack.Count == 0);
             stack.Free();
             return left;
+
+            IOperation visitOperand(BoundExpression operand)
+                => interpolatedData is { } data
+                    ? CreateBoundInterpolatedStringExpressionOperation((BoundInterpolatedString)operand, data.PositionInfo[positionInfoIndex++])
+                    : Create(operand);
 
             IBinaryOperation createBoundBinaryOperatorOperation(BoundBinaryOperator boundBinaryOperator, IOperation left, IOperation right)
             {
@@ -1986,9 +1995,10 @@ namespace Microsoft.CodeAnalysis.Operations
             return new TupleOperation(elements, naturalType.GetPublicSymbol(), _semanticModel, syntax, type, isImplicit);
         }
 
-        private IInterpolatedStringOperation CreateBoundInterpolatedStringExpressionOperation(BoundInterpolatedString boundInterpolatedString)
+        private IInterpolatedStringOperation CreateBoundInterpolatedStringExpressionOperation(BoundInterpolatedString boundInterpolatedString, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>? positionInfo = null)
         {
-            ImmutableArray<IInterpolatedStringContentOperation> parts = CreateBoundInterpolatedStringContentOperation(boundInterpolatedString.Parts, boundInterpolatedString.InterpolationData);
+            Debug.Assert(positionInfo == null || boundInterpolatedString.InterpolationData == null);
+            ImmutableArray<IInterpolatedStringContentOperation> parts = CreateBoundInterpolatedStringContentOperation(boundInterpolatedString.Parts, positionInfo ?? boundInterpolatedString.InterpolationData?.PositionInfo[0]);
             SyntaxNode syntax = boundInterpolatedString.Syntax;
             ITypeSymbol? type = boundInterpolatedString.GetPublicTypeSymbol();
             ConstantValue? constantValue = boundInterpolatedString.ConstantValue;
@@ -1996,9 +2006,9 @@ namespace Microsoft.CodeAnalysis.Operations
             return new InterpolatedStringOperation(parts, _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
-        internal ImmutableArray<IInterpolatedStringContentOperation> CreateBoundInterpolatedStringContentOperation(ImmutableArray<BoundExpression> parts, InterpolatedStringHandlerData? data)
+        internal ImmutableArray<IInterpolatedStringContentOperation> CreateBoundInterpolatedStringContentOperation(ImmutableArray<BoundExpression> parts, ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>? positionInfo)
         {
-            return data is { PositionInfo: var positionInfo } ? createHandlerInterpolatedStringContent(positionInfo) : createNonHandlerInterpolatedStringContent();
+            return positionInfo is { } info ? createHandlerInterpolatedStringContent(info) : createNonHandlerInterpolatedStringContent();
 
             ImmutableArray<IInterpolatedStringContentOperation> createNonHandlerInterpolatedStringContent()
             {
@@ -2018,14 +2028,12 @@ namespace Microsoft.CodeAnalysis.Operations
                 return builder.ToImmutableAndFree();
             }
 
-            ImmutableArray<IInterpolatedStringContentOperation> createHandlerInterpolatedStringContent(ImmutableArray<ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)>> positionInfoArray)
+            ImmutableArray<IInterpolatedStringContentOperation> createHandlerInterpolatedStringContent(ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> positionInfo)
             {
                 // For interpolated string handlers, we want to deconstruct the `AppendLiteral`/`AppendFormatted` calls into
                 // their relevant components.
                 // https://github.com/dotnet/roslyn/issues/54505 we need to handle interpolated strings used as handler conversions.
 
-                Debug.Assert(positionInfoArray.Length == 1);
-                ImmutableArray<(bool IsLiteral, bool HasAlignment, bool HasFormat)> positionInfo = positionInfoArray[0];
                 Debug.Assert(parts.Length == positionInfo.Length);
                 var builder = ArrayBuilder<IInterpolatedStringContentOperation>.GetInstance(parts.Length);
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1307,7 +1307,7 @@ namespace Microsoft.CodeAnalysis.Operations
             {
                 stack.Push(currentBinary);
                 currentBinary = currentBinary.Left as BoundBinaryOperatorBase;
-            } while (currentBinary is not null);
+            } while (currentBinary is not null and not BoundBinaryOperator { InterpolatedStringHandlerData: not null });
 
             Debug.Assert(interpolatedData == null || interpolatedData.GetValueOrDefault().PositionInfo.Length == stack.Count + 1);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -12149,6 +12149,30 @@ value:3
         }
 
         [Fact]
+        public void InterpolatedStringsAddedUnderObjectAddition_DefiniteAssignment()
+        {
+            var code = @"
+object o1;
+object o2;
+object o3;
+_ = $""{o1 = null}"" + $""{o2 = null}"" + $""{o3 = null}"" + 1;
+o1.ToString();
+o2.ToString();
+o3.ToString();
+";
+
+            var comp = CreateCompilation(new[] { code, GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: true) });
+            comp.VerifyDiagnostics(
+                // (7,1): error CS0165: Use of unassigned local variable 'o2'
+                // o2.ToString();
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "o2").WithArguments("o2").WithLocation(7, 1),
+                // (8,1): error CS0165: Use of unassigned local variable 'o3'
+                // o3.ToString();
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "o3").WithArguments("o3").WithLocation(8, 1)
+            );
+        }
+
+        [Fact]
         public void ParenthesizedAdditiveExpression_01()
         {
             var code = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -10963,6 +10963,74 @@ Expression e = Func<string, string> () => (string o) => $""{o.Length}"";";
 ");
         }
 
+        [Fact, WorkItem(55114, "https://github.com/dotnet/roslyn/issues/55114")]
+        public void AsStringInExpressionTrees_05()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+Expression<Func<string, string>> e = o => $""{o.Length}"" + $""literal"";";
+
+            var comp = CreateCompilation(new[] { code, GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false) });
+            var verifier = CompileAndVerify(comp);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size      167 (0xa7)
+  .maxstack  7
+  .locals init (System.Linq.Expressions.ParameterExpression V_0)
+  IL_0000:  ldtoken    ""string""
+  IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_000a:  ldstr      ""o""
+  IL_000f:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0014:  stloc.0
+  IL_0015:  ldnull
+  IL_0016:  ldtoken    ""string string.Format(string, object)""
+  IL_001b:  call       ""System.Reflection.MethodBase System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle)""
+  IL_0020:  castclass  ""System.Reflection.MethodInfo""
+  IL_0025:  ldc.i4.2
+  IL_0026:  newarr     ""System.Linq.Expressions.Expression""
+  IL_002b:  dup
+  IL_002c:  ldc.i4.0
+  IL_002d:  ldstr      ""{0}""
+  IL_0032:  ldtoken    ""string""
+  IL_0037:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_003c:  call       ""System.Linq.Expressions.ConstantExpression System.Linq.Expressions.Expression.Constant(object, System.Type)""
+  IL_0041:  stelem.ref
+  IL_0042:  dup
+  IL_0043:  ldc.i4.1
+  IL_0044:  ldloc.0
+  IL_0045:  ldtoken    ""int string.Length.get""
+  IL_004a:  call       ""System.Reflection.MethodBase System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle)""
+  IL_004f:  castclass  ""System.Reflection.MethodInfo""
+  IL_0054:  call       ""System.Linq.Expressions.MemberExpression System.Linq.Expressions.Expression.Property(System.Linq.Expressions.Expression, System.Reflection.MethodInfo)""
+  IL_0059:  ldtoken    ""object""
+  IL_005e:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0063:  call       ""System.Linq.Expressions.UnaryExpression System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type)""
+  IL_0068:  stelem.ref
+  IL_0069:  call       ""System.Linq.Expressions.MethodCallExpression System.Linq.Expressions.Expression.Call(System.Linq.Expressions.Expression, System.Reflection.MethodInfo, params System.Linq.Expressions.Expression[])""
+  IL_006e:  ldstr      ""literal""
+  IL_0073:  ldtoken    ""string""
+  IL_0078:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_007d:  call       ""System.Linq.Expressions.ConstantExpression System.Linq.Expressions.Expression.Constant(object, System.Type)""
+  IL_0082:  ldtoken    ""string string.Concat(string, string)""
+  IL_0087:  call       ""System.Reflection.MethodBase System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle)""
+  IL_008c:  castclass  ""System.Reflection.MethodInfo""
+  IL_0091:  call       ""System.Linq.Expressions.BinaryExpression System.Linq.Expressions.Expression.Add(System.Linq.Expressions.Expression, System.Linq.Expressions.Expression, System.Reflection.MethodInfo)""
+  IL_0096:  ldc.i4.1
+  IL_0097:  newarr     ""System.Linq.Expressions.ParameterExpression""
+  IL_009c:  dup
+  IL_009d:  ldc.i4.0
+  IL_009e:  ldloc.0
+  IL_009f:  stelem.ref
+  IL_00a0:  call       ""System.Linq.Expressions.Expression<System.Func<string, string>> System.Linq.Expressions.Expression.Lambda<System.Func<string, string>>(System.Linq.Expressions.Expression, params System.Linq.Expressions.ParameterExpression[])""
+  IL_00a5:  pop
+  IL_00a6:  ret
+}
+");
+        }
+
         [Theory]
         [CombinatorialData]
         public void CustomHandlerUsedAsArgumentToCustomHandler(bool useBoolReturns, bool validityParameter, [CombinatorialValues(@"$""""", @"$"""" + $""""")] string expression)


### PR DESCRIPTION
This adds support for treating binary addition of interpolated strings as if they were a single string, for the purposes of conversions to custom handler types and lowering. I implemented this by delaying binding of binary additions composed entirely of interpolated strings until use, and adjusting all the points that currently expect a string to instead expect either an interpolated string or a binary addition of interpolated strings. @dotnet/roslyn-compiler for review: I'd suggest reviewing commit-by-commit. Commit 1 implements the basic changes just for interpolated strings used as strings, and the second commit adds support for conversions. Closes https://github.com/dotnet/roslyn/issues/54584.

Test plan: https://github.com/dotnet/roslyn/issues/51499