### PR TITLE
Fix faulty cast in state machine rewriter

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -465,11 +465,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool needsSacrificialEvaluation = false;
             var hoistedFields = ArrayBuilder<StateMachineFieldSymbol>.GetInstance();
 
-            AwaitExpressionSyntax awaitSyntaxOpt;
+            SyntaxNode awaitSyntaxOpt;
             int syntaxOffset;
             if (F.Compilation.Options.OptimizationLevel == OptimizationLevel.Debug)
             {
-                awaitSyntaxOpt = (AwaitExpressionSyntax)local.GetDeclaratorSyntax();
+                awaitSyntaxOpt = local.GetDeclaratorSyntax();
+                Debug.Assert(awaitSyntaxOpt.IsKind(SyntaxKind.AwaitExpression) || awaitSyntaxOpt.IsKind(SyntaxKind.SwitchExpression));
                 syntaxOffset = OriginalMethod.CalculateLocalSyntaxOffset(LambdaUtilities.GetDeclaratorPosition(awaitSyntaxOpt), awaitSyntaxOpt.SyntaxTree);
             }
             else
@@ -505,7 +506,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression HoistExpression(
             BoundExpression expr,
-            AwaitExpressionSyntax awaitSyntaxOpt,
+            SyntaxNode awaitSyntaxOpt,
             int syntaxOffset,
             RefKind refKind,
             ArrayBuilder<BoundExpression> sideEffects,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -3271,5 +3271,20 @@ static class Ex
             compilation.VerifyEmitDiagnostics(
                 );
         }
+
+        [Fact, WorkItem(51930, "https://github.com/dotnet/roslyn/issues/51930")]
+        public void AssignSwitchToRefReturningMethod()
+        {
+            var source = @"
+GetRef() = 1 switch { _ => await System.Threading.Tasks.Task.FromResult(1) };
+ref int GetRef() => throw null;";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyEmitDiagnostics(
+                // (2,1): error CS8178: 'await' cannot be used in an expression containing a call to '<Program>$.<<Main>$>g__GetRef|0_0()' because it returns by reference
+                // GetRef() = 1 switch { _ => await System.Threading.Tasks.Task.FromResult(1) };
+                Diagnostic(ErrorCode.ERR_RefReturningCallAndAwait, "GetRef()").WithArguments("<Program>$.<<Main>$>g__GetRef|0_0()").WithLocation(2, 1)
+            );
+        }
     }
 }


### PR DESCRIPTION
HoistRefInitialization assumed that the declarator syntax for locals would always be an await expression, but this is not true for switch expressions. CalculateLocalSyntaxOffset already correctly handles switch expressions, so we just needed to update this call site. I also inspected any other calls to CalculateLocalSyntaxOffset to make sure that nothing else was making such an assumption, but I didn't see any that are concerning.

Fixes https://github.com/dotnet/roslyn/issues/51930.