### PR TITLE
Switch back integration queue name to default

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCorePublic-Pool
-    queue: BuildPool.Windows.Amd64.VS2022.Pre.Open
+    queue: $(queueName)
   strategy:
     maxParallel: 4
     matrix:


### PR DESCRIPTION
Now that https://github.com/dotnet/roslyn/issues/54830 has been merged in, we can change the integration pipeline back to using `queueName`. I changed the [integration pipeline](https://dev.azure.com/dnceng/public/_build?definitionId=245) to use `BuildPool.Windows.Amd64.VS2022.Pre.Open` by default instead of the 2019 version.