### PR TITLE
Correctly set IsRetargetable for source assemblies

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2103,7 +2103,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 VersionHelper.GenerateVersionFromPatternAndCurrentTime(_compilation.Options.CurrentLocalTime, AssemblyVersionAttributeSetting),
                 this.AssemblyCultureAttributeSetting,
                 StrongNameKeys.PublicKey,
-                hasPublicKey: !StrongNameKeys.PublicKey.IsDefault);
+                hasPublicKey: !StrongNameKeys.PublicKey.IsDefault,
+                isRetargetable: (AssemblyFlags & AssemblyFlags.Retargetable) == AssemblyFlags.Retargetable);
         }
 
         //This maps from assembly name to a set of public keys. It uses concurrent dictionaries because it is built,

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AssemblyAndNamespaceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AssemblyAndNamespaceTests.cs
@@ -676,5 +676,17 @@ int x; // 1
                 // int x; // 1
                 Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "x").WithLocation(3, 5));
         }
+
+        [Fact, WorkItem(54836, "https://github.com/dotnet/roslyn/issues/54836")]
+        public void AssemblyRetargetableAttributeIsRespected()
+        {
+            var code = @"
+using System.Reflection;
+[assembly: AssemblyFlags(AssemblyNameFlags.Retargetable)]";
+
+            var comp = CreateCompilation(code);
+            Assert.True(comp.Assembly.Identity.IsRetargetable);
+            comp.VerifyEmitDiagnostics();
+        }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
@@ -222,10 +222,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentException>(() => new AssemblyIdentity(null));
 
             Assert.Throws<ArgumentException>(
-                () => new AssemblyIdentity("Goo", new Version(1, 0, 0, 0), "", ImmutableArray<byte>.Empty, hasPublicKey: true, isRetargetable: false));
+                () => new AssemblyIdentity("Goo", new Version(1, 0, 0, 0), "", ImmutableArray<byte>.Empty, hasPublicKey: true, isRetargetable: false, contentType: AssemblyContentType.Default));
 
             Assert.Throws<ArgumentException>(
-                () => new AssemblyIdentity("Goo", new Version(1, 0, 0, 0), "", new byte[] { 1, 2, 3 }.AsImmutableOrNull(), hasPublicKey: false, isRetargetable: false));
+                () => new AssemblyIdentity("Goo", new Version(1, 0, 0, 0), "", new byte[] { 1, 2, 3 }.AsImmutableOrNull(), hasPublicKey: false, isRetargetable: false, contentType: AssemblyContentType.Default));
 
             foreach (var v in new Version[]
             {

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentity.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentity.cs
@@ -158,7 +158,8 @@ namespace Microsoft.CodeAnalysis
             Version version,
             string? cultureName,
             ImmutableArray<byte> publicKeyOrToken,
-            bool hasPublicKey)
+            bool hasPublicKey,
+            bool isRetargetable)
         {
             Debug.Assert(name != null);
             Debug.Assert(IsValid(version));
@@ -168,7 +169,7 @@ namespace Microsoft.CodeAnalysis
             _name = name;
             _version = version ?? NullVersion;
             _cultureName = NormalizeCultureName(cultureName);
-            _isRetargetable = false;
+            _isRetargetable = isRetargetable;
             _contentType = AssemblyContentType.Default;
             InitializeKey(publicKeyOrToken, hasPublicKey, out _publicKey, out _lazyPublicKeyToken);
         }

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1705,7 +1705,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                         VersionHelper.GenerateVersionFromPatternAndCurrentTime(_compilation.Options.CurrentLocalTime, AssemblyVersionAttributeSetting),
                                         Me.AssemblyCultureAttributeSetting,
                                         StrongNameKeys.PublicKey,
-                                        hasPublicKey:=Not StrongNameKeys.PublicKey.IsDefault)
+                                        hasPublicKey:=Not StrongNameKeys.PublicKey.IsDefault,
+                                        isRetargetable:=(AssemblyFlags And AssemblyFlags.Retargetable) = AssemblyFlags.Retargetable)
 
         End Function
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AssemblyAndNamespaceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AssemblyAndNamespaceTests.vb
@@ -573,6 +573,18 @@ BC30560: 'Task' is ambiguous in the namespace 'System.Threading.Tasks'.
                 </expected>)
         End Sub
 
+        <Fact, WorkItem(54836, "https://github.com/dotnet/roslyn/issues/54836")>
+        Public Sub RetargetableAttributeIsRespectedInSource()
+            Dim code = <![CDATA[
+Imports System.Reflection
+<Assembly: AssemblyFlags(AssemblyNameFlags.Retargetable)>
+]]>
+
+            Dim comp = CreateCompilation(code.Value)
+            Assert.True(comp.Assembly.Identity.IsRetargetable)
+            AssertTheseEmitDiagnostics(comp)
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Source assemblies weren't checking assembly flags and setting IsRetargetable, despite having already decoded all well-known attributes to find the other bits of the assembly identity. We now check and correctly set the IsRetargetable bit. Fixes https://github.com/dotnet/roslyn/issues/54836.
