### PR TITLE
Change default level to warning to avoid creating 100gb sized log files

### DIFF
--- a/src/Features/LanguageServer/Protocol/ILspLoggerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/ILspLoggerFactory.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer;
+using StreamJsonRpc;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
+{
+    internal interface ILspLoggerFactory
+    {
+        Task<ILspLogger> CreateLoggerAsync(string serverTypeName, string? clientName, JsonRpc jsonRpc, CancellationToken cancellationToken);
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractInProcLanguageClient.cs
@@ -4,9 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -14,31 +12,20 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.LogHub;
-using Microsoft.VisualStudio.RpcContracts.Logging;
-using Microsoft.VisualStudio.Shell.ServiceBroker;
 using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
 using Roslyn.Utilities;
 using StreamJsonRpc;
-using VSShell = Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
 {
     internal abstract partial class AbstractInProcLanguageClient : ILanguageClient, ILanguageServerFactory, ICapabilitiesProvider
     {
-        /// <summary>
-        /// A unique, always increasing, ID we use to identify this server in our loghub logs.  Needed so that if our
-        /// server is restarted that we can have a new logstream for the new server.
-        /// </summary>
-        private static int s_logHubSessionId;
-
         private readonly string? _diagnosticsClientName;
-        private readonly VSShell.IAsyncServiceProvider _asyncServiceProvider;
         private readonly IThreadingContext _threadingContext;
+        private readonly ILspLoggerFactory _lspLoggerFactory;
 
         /// <summary>
         /// Legacy support for LSP push diagnostics.
@@ -92,7 +79,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             IDiagnosticService? diagnosticService,
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
-            VSShell.IAsyncServiceProvider asyncServiceProvider,
+            ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext,
             string? diagnosticsClientName)
         {
@@ -102,7 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             _listenerProvider = listenerProvider;
             _lspWorkspaceRegistrationService = lspWorkspaceRegistrationService;
             _diagnosticsClientName = diagnosticsClientName;
-            _asyncServiceProvider = asyncServiceProvider;
+            _lspLoggerFactory = lspLoggerFactory;
             _threadingContext = threadingContext;
         }
 
@@ -147,7 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                 serverStream,
                 serverStream,
                 _lspWorkspaceRegistrationService,
-                _asyncServiceProvider,
+                _lspLoggerFactory,
                 _diagnosticsClientName,
                 cancellationToken).ConfigureAwait(false);
 
@@ -188,7 +175,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             Stream inputStream,
             Stream outputStream,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
-            VSShell.IAsyncServiceProvider? asyncServiceProvider,
+            ILspLoggerFactory lspLoggerFactory,
             string? clientName,
             CancellationToken cancellationToken)
         {
@@ -202,43 +189,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
 
             var serverTypeName = languageClient.GetType().Name;
 
-            var logger = await CreateLoggerAsync(asyncServiceProvider, serverTypeName, clientName, jsonRpc, cancellationToken).ConfigureAwait(false);
+            var logger = await lspLoggerFactory.CreateLoggerAsync(serverTypeName, clientName, jsonRpc, cancellationToken).ConfigureAwait(false);
 
             var server = languageClient.Create(
                 jsonRpc,
                 languageClient,
                 lspWorkspaceRegistrationService,
-                logger ?? NoOpLspLogger.Instance);
+                logger);
 
             jsonRpc.StartListening();
             return server;
-        }
-
-        private static async Task<LogHubLspLogger?> CreateLoggerAsync(
-            VSShell.IAsyncServiceProvider? asyncServiceProvider,
-            string serverTypeName,
-            string? clientName,
-            JsonRpc jsonRpc,
-            CancellationToken cancellationToken)
-        {
-            if (asyncServiceProvider == null)
-                return null;
-
-            var logName = $"Roslyn.{serverTypeName}.{clientName ?? "Default"}.{Interlocked.Increment(ref s_logHubSessionId)}";
-            var logId = new LogId(logName, new ServiceMoniker(typeof(LanguageServerTarget).FullName));
-
-            var serviceContainer = await VSShell.ServiceExtensions.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>(asyncServiceProvider).ConfigureAwait(false);
-            var service = serviceContainer.GetFullAccessServiceBroker();
-
-            var configuration = await TraceConfiguration.CreateTraceConfigurationInstanceAsync(service, cancellationToken).ConfigureAwait(false);
-            var logOptions = new RpcContracts.Logging.LoggerOptions(new LoggingLevelSettings(SourceLevels.ActivityTracing | SourceLevels.Information));
-            var traceSource = await configuration.RegisterLogSourceAsync(logId, logOptions, cancellationToken).ConfigureAwait(false);
-
-            // Associate this trace source with the jsonrpc conduit.  This ensures that we can associate logs we report
-            // with our callers and the operations they are performing.
-            jsonRpc.ActivityTracingStrategy = new CorrelationManagerTracingStrategy { TraceSource = traceSource };
-
-            return new LogHubLspLogger(configuration, traceSource);
         }
 
         public ILanguageServerTarget Create(

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
@@ -13,9 +13,7 @@ using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Utilities;
-using VSShell = Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
 {
@@ -41,9 +39,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
             DefaultCapabilitiesProvider defaultCapabilitiesProvider,
-            [Import(typeof(SAsyncServiceProvider))] VSShell.IAsyncServiceProvider asyncServiceProvider,
+            ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
-            : base(csharpVBRequestDispatcherFactory, workspace, diagnosticService: null, listenerProvider, lspWorkspaceRegistrationService, asyncServiceProvider, threadingContext, diagnosticsClientName: null)
+            : base(csharpVBRequestDispatcherFactory, workspace, diagnosticService: null, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
         {
             _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
         }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/LiveShareInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/LiveShareInProcLanguageClient.cs
@@ -13,9 +13,7 @@ using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Utilities;
-using VSShell = Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
 {
@@ -38,9 +36,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
             DefaultCapabilitiesProvider defaultCapabilitiesProvider,
-            [Import(typeof(SAsyncServiceProvider))] VSShell.IAsyncServiceProvider asyncServiceProvider,
+            ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
-            : base(csharpVBRequestDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, asyncServiceProvider, threadingContext, diagnosticsClientName: null)
+            : base(csharpVBRequestDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
         {
             _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
         }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/LogHubLspLogger.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/LogHubLspLogger.cs
@@ -10,48 +10,45 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
 {
-    internal abstract partial class AbstractInProcLanguageClient
+    internal class LogHubLspLogger : ILspLogger
     {
-        private class LogHubLspLogger : ILspLogger
+        private readonly TraceConfiguration _configuration;
+        private readonly TraceSource _traceSource;
+        private bool _disposed;
+
+        public LogHubLspLogger(TraceConfiguration configuration, TraceSource traceSource)
         {
-            private readonly TraceConfiguration _configuration;
-            private readonly TraceSource _traceSource;
-            private bool _disposed;
-
-            public LogHubLspLogger(TraceConfiguration configuration, TraceSource traceSource)
-            {
-                _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-                _traceSource = traceSource ?? throw new ArgumentNullException(nameof(traceSource));
-            }
-
-            public void Dispose()
-            {
-                if (_disposed)
-                {
-                    Contract.Fail($"{GetType().FullName} was double disposed");
-                    return;
-                }
-
-                _disposed = true;
-                _traceSource.Flush();
-                _traceSource.Close();
-                _configuration.Dispose();
-            }
-
-            public void TraceInformation(string message)
-                => _traceSource.TraceInformation(message);
-
-            public void TraceWarning(string message)
-                => _traceSource.TraceEvent(TraceEventType.Warning, id: 0, message);
-
-            public void TraceException(Exception exception)
-                => _traceSource.TraceEvent(TraceEventType.Error, id: 0, "Exception: {0}", exception);
-
-            public void TraceStart(string message)
-                => _traceSource.TraceEvent(TraceEventType.Start, id: 0, message);
-
-            public void TraceStop(string message)
-                => _traceSource.TraceEvent(TraceEventType.Stop, id: 0, message);
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _traceSource = traceSource ?? throw new ArgumentNullException(nameof(traceSource));
         }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                Contract.Fail($"{GetType().FullName} was double disposed");
+                return;
+            }
+
+            _disposed = true;
+            _traceSource.Flush();
+            _traceSource.Close();
+            _configuration.Dispose();
+        }
+
+        public void TraceInformation(string message)
+            => _traceSource.TraceInformation(message);
+
+        public void TraceWarning(string message)
+            => _traceSource.TraceEvent(TraceEventType.Warning, id: 0, message);
+
+        public void TraceException(Exception exception)
+            => _traceSource.TraceEvent(TraceEventType.Error, id: 0, "Exception: {0}", exception);
+
+        public void TraceStart(string message)
+            => _traceSource.TraceEvent(TraceEventType.Start, id: 0, message);
+
+        public void TraceStop(string message)
+            => _traceSource.TraceEvent(TraceEventType.Stop, id: 0, message);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorInProcLanguageClient.cs
@@ -14,9 +14,7 @@ using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Utilities;
-using VSShell = Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Lsp
 {
@@ -59,8 +57,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Lsp
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
             DefaultCapabilitiesProvider defaultCapabilitiesProvider,
             IThreadingContext threadingContext,
-            [Import(typeof(SAsyncServiceProvider))] VSShell.IAsyncServiceProvider asyncServiceProvider)
-            : base(csharpVBRequestDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, asyncServiceProvider, threadingContext, ClientName)
+            ILspLoggerFactory lspLoggerFactory)
+            : base(csharpVBRequestDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, ClientName)
         {
             _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
         }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioLogHubLoggerFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioLogHubLoggerFactory.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.LogHub;
+using Microsoft.VisualStudio.RpcContracts.Logging;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Microsoft.VisualStudio.Threading;
+using StreamJsonRpc;
+using VSShell = Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
+{
+    [Export(typeof(ILspLoggerFactory))]
+    internal class VisualStudioLogHubLoggerFactory : ILspLoggerFactory
+    {
+        /// <summary>
+        /// Command line flag name for the /log parameter when launching devenv.
+        /// </summary>
+        private const string LogCommandLineFlag = "log";
+
+        /// <summary>
+        /// A unique, always increasing, ID we use to identify this server in our loghub logs.  Needed so that if our
+        /// server is restarted that we can have a new logstream for the new server.
+        /// </summary>
+        private static int s_logHubSessionId;
+
+        private readonly VSShell.IAsyncServiceProvider _asyncServiceProvider;
+        private readonly IThreadingContext _threadingContext;
+
+        private readonly AsyncLazy<bool> _wasVSStartedWithLogParameterLazy;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public VisualStudioLogHubLoggerFactory(
+            [Import(typeof(SAsyncServiceProvider))] VSShell.IAsyncServiceProvider asyncServiceProvider,
+            IThreadingContext threadingContext)
+        {
+            _asyncServiceProvider = asyncServiceProvider;
+            _threadingContext = threadingContext;
+
+            _wasVSStartedWithLogParameterLazy = new AsyncLazy<bool>(WasVSStartedWithLogParameterAsync, _threadingContext.JoinableTaskFactory);
+        }
+
+        public async Task<ILspLogger> CreateLoggerAsync(string serverTypeName, string? clientName, JsonRpc jsonRpc, CancellationToken cancellationToken)
+        {
+            var logName = $"Roslyn.{serverTypeName}.{clientName ?? "Default"}.{Interlocked.Increment(ref s_logHubSessionId)}";
+            var logId = new LogId(logName, new ServiceMoniker(typeof(LanguageServerTarget).FullName));
+
+            var serviceContainer = await VSShell.ServiceExtensions.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>(_asyncServiceProvider).ConfigureAwait(false);
+            var service = serviceContainer.GetFullAccessServiceBroker();
+
+            var configuration = await TraceConfiguration.CreateTraceConfigurationInstanceAsync(service, cancellationToken).ConfigureAwait(false);
+
+            // Register the default log level as warning to avoid creating log files in the hundreds of GB.
+            // This level can be overriden by setting the environment variable 'LogLevel' to the desired source level.
+            // See https://dev.azure.com/devdiv/DevDiv/_git/VS?path=%2Fsrc%2FPlatform%2FUtilities%2FImpl%2FLogHub%2FLocalTraceHub.cs&version=GBmain&line=142&lineEnd=143&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
+            // This should be switched back to SourceLevels.Information once Loghub adds support for recyclying logs while VS is open.
+            // See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1359778/
+            var loggingLevel = SourceLevels.ActivityTracing | SourceLevels.Warning;
+
+            // If VS was explicitly started with /log, then record all information logs as well.
+            // This is extremely useful for development so that F5 deployment automatically logs everything.
+            var wasVSStartedWithLogParameter = await _wasVSStartedWithLogParameterLazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            if (wasVSStartedWithLogParameter)
+            {
+                loggingLevel |= SourceLevels.Information;
+            }
+
+            var logOptions = new RpcContracts.Logging.LoggerOptions(new LoggingLevelSettings(loggingLevel));
+            var traceSource = await configuration.RegisterLogSourceAsync(logId, logOptions, cancellationToken).ConfigureAwait(false);
+
+            // Associate this trace source with the jsonrpc conduit.  This ensures that we can associate logs we report
+            // with our callers and the operations they are performing.
+            jsonRpc.ActivityTracingStrategy = new CorrelationManagerTracingStrategy { TraceSource = traceSource };
+
+            return new LogHubLspLogger(configuration, traceSource);
+        }
+
+        private async Task<bool> WasVSStartedWithLogParameterAsync()
+        {
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var appCommandLiveService = await _asyncServiceProvider.GetServiceAsync(typeof(SVsAppCommandLine)).ConfigureAwait(true);
+            if (appCommandLiveService is IVsAppCommandLine commandLine)
+            {
+                return ErrorHandler.Succeeded(commandLine.GetOption(LogCommandLineFlag, out var present, out _)) && present == 1;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
@@ -16,9 +16,7 @@ using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient;
 using Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Utilities;
-using VSShell = Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Xaml
 {
@@ -38,9 +36,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             IDiagnosticService diagnosticService,
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
-            [Import(typeof(SAsyncServiceProvider))] VSShell.IAsyncServiceProvider asyncServiceProvider,
+            ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
-            : base(xamlDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, asyncServiceProvider, threadingContext, diagnosticsClientName: null)
+            : base(xamlDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
         {
         }
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClientDisableUX.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClientDisableUX.cs
@@ -16,9 +16,7 @@ using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient;
 using Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Utilities;
-using VSShell = Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Xaml
 {
@@ -40,9 +38,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             IDiagnosticService diagnosticService,
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
-            [Import(typeof(SAsyncServiceProvider))] VSShell.IAsyncServiceProvider asyncServiceProvider,
+            ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
-            : base(xamlDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, asyncServiceProvider, threadingContext, diagnosticsClientName: null)
+            : base(xamlDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
         {
         }
 


### PR DESCRIPTION
The real fix is on the LSP client side to recycle live logs (while VS is open).
That is tracked here for next sprint - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1359778/ (I would consider this a blocker for fully enabling lsp pull diagnostics)

However to avoid destroying my VS if I leave it on with pull diagnostics for a couple hours, I'm changing the default logging level.

I also abstracted out the loghub log creation code into a mef service as part 1 of https://github.com/dotnet/roslyn/issues/55060 (vs lsp client will be re-used in VSMac, so we need to move the AbstractInProcLanguageClient code down to editor features)