### PR TITLE
EnC: Include added types in changed types of emit result

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             var manifestResources = SpecializedCollections.EmptyEnumerable<ResourceDescription>();
 
             var updatedMethods = ArrayBuilder<MethodDefinitionHandle>.GetInstance();
-            var updatedTypes = ArrayBuilder<TypeDefinitionHandle>.GetInstance();
+            var changedTypes = ArrayBuilder<TypeDefinitionHandle>.GetInstance();
 
             PEDeltaAssemblyBuilder moduleBeingBuilt;
             try
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             {
                 // TODO: https://github.com/dotnet/roslyn/issues/9004
                 diagnostics.Add(ErrorCode.ERR_ModuleEmitFailure, NoLocation.Singleton, compilation.AssemblyName, e.Message);
-                return new EmitDifferenceResult(success: false, diagnostics: diagnostics.ToReadOnlyAndFree(), baseline: null, updatedMethods: updatedMethods.ToImmutableAndFree(), updatedTypes: updatedTypes.ToImmutableAndFree());
+                return new EmitDifferenceResult(success: false, diagnostics: diagnostics.ToReadOnlyAndFree(), baseline: null, updatedMethods: updatedMethods.ToImmutableAndFree(), changedTypes: changedTypes.ToImmutableAndFree());
             }
 
             if (testData != null)
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     ilStream,
                     pdbStream,
                     updatedMethods,
-                    updatedTypes,
+                    changedTypes,
                     diagnostics,
                     testData?.SymWriterFactory,
                     emitOptions.PdbFilePath,
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 diagnostics: diagnostics.ToReadOnlyAndFree(),
                 baseline: newBaseline,
                 updatedMethods: updatedMethods.ToImmutableAndFree(),
-                updatedTypes: updatedTypes.ToImmutableAndFree());
+                changedTypes: changedTypes.ToImmutableAndFree());
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
@@ -187,6 +187,31 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             AssertEx.Equal(expectedNames, actualNames);
         }
 
+        public static void CheckNames(IList<MetadataReader> readers, ImmutableArray<TypeDefinitionHandle> typeHandles, params string[] expectedNames)
+            => CheckNames(readers, typeHandles, (reader, handle) => reader.GetTypeDefinition((TypeDefinitionHandle)handle).Name, handle => handle, expectedNames);
+
+        public static void CheckNames(IList<MetadataReader> readers, ImmutableArray<MethodDefinitionHandle> methodHandles, params string[] expectedNames)
+            => CheckNames(readers, methodHandles, (reader, handle) => reader.GetMethodDefinition((MethodDefinitionHandle)handle).Name, handle => handle, expectedNames);
+
+        private static void CheckNames<THandle>(
+            IList<MetadataReader> readers,
+            ImmutableArray<THandle> entityHandles,
+            Func<MetadataReader, Handle, StringHandle> getName,
+            Func<THandle, Handle> toHandle,
+            string[] expectedNames)
+        {
+            var aggregator = new MetadataAggregator(readers[0], readers.Skip(1).ToArray());
+
+            AssertEx.Equal(expectedNames, entityHandles.Select(handle =>
+            {
+                var genEntityHandle = aggregator.GetGenerationHandle(toHandle(handle), out int typeGeneration);
+                var nameHandle = getName(readers[typeGeneration], genEntityHandle);
+
+                var genNameHandle = (StringHandle)aggregator.GetGenerationHandle(nameHandle, out int nameGeneration);
+                return readers[nameGeneration].GetString(genNameHandle);
+            }));
+        }
+
         internal static string EncLogRowToString(EditAndContinueLogEntry row)
         {
             TableIndex tableIndex;

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -2088,6 +2088,7 @@ class C
             var readers = new[] { reader0, reader1 };
 
             CheckNames(readers, reader1.GetTypeDefNames(), "C#1");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C#1");
 
             CheckEncLogDefinitions(reader1,
                 Row(3, TableIndex.TypeDef, EditAndContinueOperation.Default),
@@ -2119,6 +2120,7 @@ class C
             readers = new[] { reader0, reader1, reader2 };
 
             CheckNames(readers, reader2.GetTypeDefNames(), "C#2");
+            CheckNames(readers, diff2.EmitResult.ChangedTypes, "C#2");
 
             CheckEncLogDefinitions(reader2,
                 Row(4, TableIndex.TypeDef, EditAndContinueOperation.Default),
@@ -2151,6 +2153,7 @@ class C
             readers = new[] { reader0, reader1, reader2, reader3 };
 
             CheckNames(readers, reader3.GetTypeDefNames(), "C#2");
+            CheckNames(readers, diff3.EmitResult.ChangedTypes, "C#2");
 
             CheckEncLogDefinitions(reader3,
                 Row(4, TableIndex.TypeDef, EditAndContinueOperation.Default),

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -970,8 +970,64 @@ class D
                 Handle(4, TableIndex.AssemblyRef));
         }
 
+        [WorkItem(962219, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/962219")]
         [Fact]
-        public void AddMethod_WithAttributes()
+        public void PartialMethod()
+        {
+            var source =
+@"partial class C
+{
+    static partial void M1();
+    static partial void M2();
+    static partial void M3();
+    static partial void M1() { }
+    static partial void M2() { }
+}";
+            var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
+            var compilation1 = compilation0.WithSource(source);
+
+            var bytes0 = compilation0.EmitToArray();
+            using var md0 = ModuleMetadata.CreateFromImage(bytes0);
+            var reader0 = md0.MetadataReader;
+
+            CheckNames(reader0, reader0.GetMethodDefNames(), "M1", "M2", ".ctor");
+
+            var method0 = compilation0.GetMember<MethodSymbol>("C.M2").PartialImplementationPart;
+            var method1 = compilation1.GetMember<MethodSymbol>("C.M2").PartialImplementationPart;
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(
+                md0,
+                EmptyLocalsProvider);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, method0, method1)));
+
+            var methods = diff1.TestData.GetMethodsByName();
+            Assert.Equal(1, methods.Count);
+            Assert.True(methods.ContainsKey("C.M2()"));
+
+            using var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+            var readers = new[] { reader0, reader1 };
+
+            EncValidation.VerifyModuleMvid(1, reader0, reader1);
+
+            CheckNames(readers, reader1.GetMethodDefNames(), "M2");
+
+            CheckEncLog(reader1,
+                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
+                Row(6, TableIndex.TypeRef, EditAndContinueOperation.Default),
+                Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default));
+
+            CheckEncMap(reader1,
+                Handle(6, TableIndex.TypeRef),
+                Handle(2, TableIndex.MethodDef),
+                Handle(2, TableIndex.AssemblyRef));
+        }
+
+        [Fact]
+        public void Method_WithAttributes_Add()
         {
             var source0 =
 @"class C
@@ -1045,150 +1101,87 @@ class D
                 Handle(2, TableIndex.AssemblyRef));
         }
 
-        [WorkItem(962219, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/962219")]
-        [Fact]
-        public void PartialMethod()
-        {
-            var source =
-@"partial class C
-{
-    static partial void M1();
-    static partial void M2();
-    static partial void M3();
-    static partial void M1() { }
-    static partial void M2() { }
-}";
-            var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
-            var compilation1 = compilation0.WithSource(source);
-
-            var bytes0 = compilation0.EmitToArray();
-            using var md0 = ModuleMetadata.CreateFromImage(bytes0);
-            var reader0 = md0.MetadataReader;
-
-            CheckNames(reader0, reader0.GetMethodDefNames(), "M1", "M2", ".ctor");
-
-            var method0 = compilation0.GetMember<MethodSymbol>("C.M2").PartialImplementationPart;
-            var method1 = compilation1.GetMember<MethodSymbol>("C.M2").PartialImplementationPart;
-
-            var generation0 = EmitBaseline.CreateInitialBaseline(
-                md0,
-                EmptyLocalsProvider);
-
-            var diff1 = compilation1.EmitDifference(
-                generation0,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, method0, method1)));
-
-            var methods = diff1.TestData.GetMethodsByName();
-            Assert.Equal(1, methods.Count);
-            Assert.True(methods.ContainsKey("C.M2()"));
-
-            using var md1 = diff1.GetMetadata();
-            var reader1 = md1.Reader;
-            var readers = new[] { reader0, reader1 };
-
-            EncValidation.VerifyModuleMvid(1, reader0, reader1);
-
-            CheckNames(readers, reader1.GetMethodDefNames(), "M2");
-
-            CheckEncLog(reader1,
-                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(6, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default));
-
-            CheckEncMap(reader1,
-                Handle(6, TableIndex.TypeRef),
-                Handle(2, TableIndex.MethodDef),
-                Handle(2, TableIndex.AssemblyRef));
-        }
-
         /// <summary>
         /// Add a method that requires entries in the ParameterDefs table.
         /// Specifically, normal parameters or return types with attributes.
         /// Add the method in the first edit, then modify the method in the second.
         /// </summary>
         [Fact]
-        public void AddThenModifyMethod()
+        public void Method_WithParameterAttributes_AddThenUpdate()
         {
             var source0 =
 @"class A : System.Attribute { }
 class C
 {
-    static void Main() { F1(null); }
-    static object F1(string s1) { return s1; }
 }";
             var source1 =
 @"class A : System.Attribute { }
 class C
 {
-    static void Main() { F2(); }
-    [return:A]static object F2(string s2 = ""2"") { return s2; }
+    [return:A]static object F(int arg = 1) => arg;
 }";
             var source2 =
 @"class A : System.Attribute { }
 class C
 {
-    static void Main() { F2(); }
-    [return:A]static object F2(string s2 = ""2"") { return null; }
+    [return:A]static object F(int arg = 1) => null;
 }";
-            var compilation0 = CreateCompilation(source0, options: TestOptions.DebugExe);
+            var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
             var compilation2 = compilation0.WithSource(source2);
 
-            // Verify full metadata contains expected rows.
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+
             var bytes0 = compilation0.EmitToArray();
             using var md0 = ModuleMetadata.CreateFromImage(bytes0);
             var reader0 = md0.MetadataReader;
 
             CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "A", "C");
-            CheckNames(reader0, reader0.GetMethodDefNames(), ".ctor", "Main", "F1", ".ctor");
-            CheckNames(reader0, reader0.GetParameterDefNames(), "s1");
+            CheckNames(reader0, reader0.GetMethodDefNames(), ".ctor", ".ctor");
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, EmptyLocalsProvider);
 
-            var method1 = compilation1.GetMember<MethodSymbol>("C.F2");
+            // gen 1
+
             var diff1 = compilation1.EmitDifference(
                 generation0,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Insert, null, method1)));
+                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Insert, null, f1)));
 
-            // Verify delta metadata contains expected rows.
             using var md1 = diff1.GetMetadata();
             var reader1 = md1.Reader;
             var readers = new List<MetadataReader> { reader0, reader1 };
             EncValidation.VerifyModuleMvid(1, reader0, reader1);
 
             CheckNames(readers, reader1.GetTypeDefNames());
-            CheckNames(readers, reader1.GetMethodDefNames(), "F2");
-            CheckNames(readers, reader1.GetParameterDefNames(), "", "s2");
+            CheckNames(readers, reader1.GetMethodDefNames(), "F");
+            CheckNames(readers, reader1.GetParameterDefNames(), "", "arg");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
+            CheckNames(readers, diff1.EmitResult.UpdatedMethods);
 
-            CheckEncLog(reader1,
-                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(7, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+            CheckEncLogDefinitions(reader1,
                 Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(5, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(1, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
                 Row(2, TableIndex.Param, EditAndContinueOperation.Default),
-                Row(5, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
-                Row(3, TableIndex.Param, EditAndContinueOperation.Default),
                 Row(1, TableIndex.Constant, EditAndContinueOperation.Default),
                 Row(4, TableIndex.CustomAttribute, EditAndContinueOperation.Default));
 
-            CheckEncMap(reader1,
-                Handle(7, TableIndex.TypeRef),
-                Handle(5, TableIndex.MethodDef),
+            CheckEncMapDefinitions(reader1,
+                Handle(3, TableIndex.MethodDef),
+                Handle(1, TableIndex.Param),
                 Handle(2, TableIndex.Param),
-                Handle(3, TableIndex.Param),
                 Handle(1, TableIndex.Constant),
-                Handle(4, TableIndex.CustomAttribute),
-                Handle(2, TableIndex.StandAloneSig),
-                Handle(2, TableIndex.AssemblyRef));
+                Handle(4, TableIndex.CustomAttribute));
 
-            var method2 = compilation2.GetMember<MethodSymbol>("C.F2");
+            // gen 2
+
             var diff2 = compilation2.EmitDifference(
                 diff1.NextGeneration,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, method1, method2)));
+                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, f1, f2)));
 
-            // Verify delta metadata contains expected rows.
             using var md2 = diff2.GetMetadata();
             var reader2 = md2.Reader;
             readers.Add(reader2);
@@ -1196,24 +1189,20 @@ class C
             EncValidation.VerifyModuleMvid(2, reader1, reader2);
 
             CheckNames(readers, reader2.GetTypeDefNames());
-            CheckNames(readers, reader2.GetMethodDefNames(), "F2");
+            CheckNames(readers, reader2.GetMethodDefNames(), "F");
             CheckNames(readers, reader2.GetParameterDefNames());
+            CheckNames(readers, diff2.EmitResult.ChangedTypes, "C");
+            CheckNames(readers, diff2.EmitResult.UpdatedMethods, "F");
 
-            CheckEncLog(reader2,
-                Row(3, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(8, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default)); // C.F2
+            CheckEncLogDefinitions(reader2,
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.Default)); // C.F
 
-            CheckEncMap(reader2,
-                Handle(8, TableIndex.TypeRef),
-                Handle(5, TableIndex.MethodDef),
-                Handle(3, TableIndex.StandAloneSig),
-                Handle(3, TableIndex.AssemblyRef));
+            CheckEncMapDefinitions(reader2,
+                Handle(3, TableIndex.MethodDef));
         }
 
         [Fact]
-        public void AddThenModifyMethod_EmbeddedAttributes()
+        public void Method_WithEmbeddedAttributes_AndThenUpdate()
         {
             var source0 =
 @"
@@ -1509,7 +1498,7 @@ namespace N
         }
 
         [Fact]
-        public void AddField()
+        public void Field_Add()
         {
             var source0 =
 @"class C
@@ -1549,9 +1538,7 @@ namespace N
             var reader1 = md1.Reader;
             var readers = new[] { reader0, reader1 };
 
-            diff1.VerifyUpdatedTypes("0x02000002");
-
-            CheckNames(readers, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "C");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
 
             CheckNames(readers, reader1.GetTypeDefNames());
             CheckNames(readers, reader1.GetFieldDefNames(), "G");
@@ -1574,7 +1561,7 @@ namespace N
         }
 
         [Fact]
-        public void ModifyProperty()
+        public void Property_Accessor_Update()
         {
             var source0 =
 @"class C
@@ -1631,57 +1618,47 @@ namespace N
         }
 
         [Fact]
-        public void AddProperty()
+        public void Property_Add()
         {
-            var source0 =
-@"class A
+            var source0 = @"
+class C
 {
-    object P { get; set; }
 }
-class B
-{
-}";
-            var source1 =
-@"class A
-{
-    object P { get; set; }
-}
-class B
+";
+            var source1 = @"
+class C
 {
     object R { get { return null; } }
-}";
-            var source2 =
-@"class A
+}
+";
+            var source2 = @"
+class C
 {
-    object P { get; set; }
+    object R { get { return null; } }
     object Q { get; set; }
 }
-class B
-{
-    object R { get { return null; } }
-    object S { set { } }
-}";
+";
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
             var compilation2 = compilation0.WithSource(source2);
 
-            // Verify full metadata contains expected rows.
+            var r1 = compilation1.GetMember<PropertySymbol>("C.R");
+            var q2 = compilation2.GetMember<PropertySymbol>("C.Q");
+
             var bytes0 = compilation0.EmitToArray();
             using var md0 = ModuleMetadata.CreateFromImage(bytes0);
             var reader0 = md0.MetadataReader;
 
-            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "A", "B");
-            CheckNames(reader0, reader0.GetFieldDefNames(), "<P>k__BackingField");
-            CheckNames(reader0, reader0.GetPropertyDefNames(), "P");
-            CheckNames(reader0, reader0.GetMethodDefNames(), "get_P", "set_P", ".ctor", ".ctor");
+            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C");
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, EmptyLocalsProvider);
 
+            // gen 1
+
             var diff1 = compilation1.EmitDifference(
                 generation0,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetMember<PropertySymbol>("B.R"))));
+                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Insert, null, r1)));
 
-            // Verify delta metadata contains expected rows.
             using var md1 = diff1.GetMetadata();
             var reader1 = md1.Reader;
             var readers = new List<MetadataReader> { reader0, reader1 };
@@ -1690,191 +1667,191 @@ class B
             CheckNames(readers, reader1.GetFieldDefNames());
             CheckNames(readers, reader1.GetPropertyDefNames(), "R");
             CheckNames(readers, reader1.GetMethodDefNames(), "get_R");
+            CheckNames(readers, diff1.EmitResult.UpdatedMethods);
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
 
-            CheckEncLog(reader1,
-                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(9, TableIndex.TypeRef, EditAndContinueOperation.Default),
+            CheckEncLogDefinitions(reader1,
                 Row(1, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(2, TableIndex.PropertyMap, EditAndContinueOperation.Default),
-                Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(2, TableIndex.PropertyMap, EditAndContinueOperation.AddProperty),
-                Row(2, TableIndex.Property, EditAndContinueOperation.Default),
-                Row(3, TableIndex.MethodSemantics, EditAndContinueOperation.Default));
+                Row(1, TableIndex.PropertyMap, EditAndContinueOperation.Default),
+                Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(1, TableIndex.PropertyMap, EditAndContinueOperation.AddProperty),
+                Row(1, TableIndex.Property, EditAndContinueOperation.Default),
+                Row(1, TableIndex.MethodSemantics, EditAndContinueOperation.Default));
 
-            CheckEncMap(reader1,
-                Handle(9, TableIndex.TypeRef),
-                Handle(5, TableIndex.MethodDef),
+            CheckEncMapDefinitions(reader1,
+                Handle(2, TableIndex.MethodDef),
                 Handle(1, TableIndex.StandAloneSig),
-                Handle(2, TableIndex.PropertyMap),
-                Handle(2, TableIndex.Property),
-                Handle(3, TableIndex.MethodSemantics),
-                Handle(2, TableIndex.AssemblyRef));
+                Handle(1, TableIndex.PropertyMap),
+                Handle(1, TableIndex.Property),
+                Handle(1, TableIndex.MethodSemantics));
+
+            // gen 2
 
             var diff2 = compilation2.EmitDifference(
                 diff1.NextGeneration,
                 ImmutableArray.Create(
-                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation2.GetMember<PropertySymbol>("A.Q")),
-                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation2.GetMember<PropertySymbol>("B.S"))));
+                    SemanticEdit.Create(SemanticEditKind.Insert, null, q2)));
 
-            // Verify delta metadata contains expected rows.
             using var md2 = diff2.GetMetadata();
             var reader2 = md2.Reader;
             readers.Add(reader2);
 
             CheckNames(readers, reader2.GetTypeDefNames());
             CheckNames(readers, reader2.GetFieldDefNames(), "<Q>k__BackingField");
-            CheckNames(readers, reader2.GetPropertyDefNames(), "Q", "S");
-            CheckNames(readers, reader2.GetMethodDefNames(), "get_Q", "set_Q", "set_S");
+            CheckNames(readers, reader2.GetPropertyDefNames(), "Q");
+            CheckNames(readers, reader2.GetMethodDefNames(), "get_Q", "set_Q");
+            CheckNames(readers, diff1.EmitResult.UpdatedMethods);
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
 
-            CheckEncLog(reader2,
-                Row(3, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(7, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(8, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(10, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(11, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(12, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(13, TableIndex.TypeRef, EditAndContinueOperation.Default),
+            CheckEncLogDefinitions(reader2,
                 Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddField),
-                Row(2, TableIndex.Field, EditAndContinueOperation.Default),
+                Row(1, TableIndex.Field, EditAndContinueOperation.Default),
                 Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(7, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(8, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(1, TableIndex.PropertyMap, EditAndContinueOperation.AddProperty),
-                Row(3, TableIndex.Property, EditAndContinueOperation.Default),
-                Row(2, TableIndex.PropertyMap, EditAndContinueOperation.AddProperty),
-                Row(4, TableIndex.Property, EditAndContinueOperation.Default),
-                Row(7, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
-                Row(2, TableIndex.Param, EditAndContinueOperation.Default),
-                Row(8, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
-                Row(3, TableIndex.Param, EditAndContinueOperation.Default),
-                Row(8, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(9, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(10, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(11, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(4, TableIndex.MethodSemantics, EditAndContinueOperation.Default),
-                Row(5, TableIndex.MethodSemantics, EditAndContinueOperation.Default),
-                Row(6, TableIndex.MethodSemantics, EditAndContinueOperation.Default));
+                Row(2, TableIndex.Property, EditAndContinueOperation.Default),
+                Row(4, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(1, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(4, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(5, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(6, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(7, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(2, TableIndex.MethodSemantics, EditAndContinueOperation.Default),
+                Row(3, TableIndex.MethodSemantics, EditAndContinueOperation.Default));
 
-            CheckEncMap(reader2,
-                Handle(10, TableIndex.TypeRef),
-                Handle(11, TableIndex.TypeRef),
-                Handle(12, TableIndex.TypeRef),
-                Handle(13, TableIndex.TypeRef),
-                Handle(2, TableIndex.Field),
-                Handle(6, TableIndex.MethodDef),
-                Handle(7, TableIndex.MethodDef),
-                Handle(8, TableIndex.MethodDef),
-                Handle(2, TableIndex.Param),
-                Handle(3, TableIndex.Param),
-                Handle(7, TableIndex.MemberRef),
-                Handle(8, TableIndex.MemberRef),
-                Handle(8, TableIndex.CustomAttribute),
-                Handle(9, TableIndex.CustomAttribute),
-                Handle(10, TableIndex.CustomAttribute),
-                Handle(11, TableIndex.CustomAttribute),
-                Handle(3, TableIndex.Property),
-                Handle(4, TableIndex.Property),
-                Handle(4, TableIndex.MethodSemantics),
-                Handle(5, TableIndex.MethodSemantics),
-                Handle(6, TableIndex.MethodSemantics),
-                Handle(3, TableIndex.AssemblyRef));
+            CheckEncMapDefinitions(reader2,
+                Handle(1, TableIndex.Field),
+                Handle(3, TableIndex.MethodDef),
+                Handle(4, TableIndex.MethodDef),
+                Handle(1, TableIndex.Param),
+                Handle(4, TableIndex.CustomAttribute),
+                Handle(5, TableIndex.CustomAttribute),
+                Handle(6, TableIndex.CustomAttribute),
+                Handle(7, TableIndex.CustomAttribute),
+                Handle(2, TableIndex.Property),
+                Handle(2, TableIndex.MethodSemantics),
+                Handle(3, TableIndex.MethodSemantics));
         }
 
         [Fact]
-        public void AddEvent()
+        public void Event_Add()
         {
-            var source0 =
-@"delegate void D();
-class A
-{
-    event D E;
-}
-class B
+            var source0 = @"
+class C
 {
 }";
-            var source1 =
-@"delegate void D();
-class A
+            var source1 = @"
+class C
 {
-    event D E;
-}
-class B
-{
-    event D F;
+    event System.Action E;
 }";
-            var source2 =
-@"delegate void D();
-class A
+            var source2 = @"
+class C
 {
-    event D E;
-    event D G;
-}
-class B
-{
-    event D F;
-    event D H;
+    event System.Action E;
+    event System.Action G;
 }";
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll);
             var compilation1 = compilation0.WithSource(source1);
             var compilation2 = compilation0.WithSource(source2);
 
-            // Verify full metadata contains expected rows.
+            var e1 = compilation1.GetMember<EventSymbol>("C.E");
+            var g2 = compilation2.GetMember<EventSymbol>("C.G");
+
             var bytes0 = compilation0.EmitToArray();
             using var md0 = ModuleMetadata.CreateFromImage(bytes0);
             var reader0 = md0.MetadataReader;
-
-            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "D", "A", "B");
-            CheckNames(reader0, reader0.GetFieldDefNames(), "E");
-            CheckNames(reader0, reader0.GetEventDefNames(), "E");
-            CheckNames(reader0, reader0.GetMethodDefNames(), ".ctor", "Invoke", "BeginInvoke", "EndInvoke", "add_E", "remove_E", ".ctor", ".ctor");
-
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, EmptyLocalsProvider);
+
+            // gen 1
 
             var diff1 = compilation1.EmitDifference(
                 generation0,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetMember<EventSymbol>("B.F"))));
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Insert, null, e1)));
 
-            // Verify delta metadata contains expected rows.
             using var md1 = diff1.GetMetadata();
             var reader1 = md1.Reader;
             var readers = new List<MetadataReader> { reader0, reader1 };
 
             CheckNames(readers, reader1.GetTypeDefNames());
-            CheckNames(readers, reader1.GetFieldDefNames(), "F");
-            CheckNames(readers, reader1.GetMethodDefNames(), "add_F", "remove_F");
+            CheckNames(readers, reader1.GetFieldDefNames(), "E");
+            CheckNames(readers, reader1.GetMethodDefNames(), "add_E", "remove_E");
+            CheckNames(readers, diff1.EmitResult.UpdatedMethods);
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
 
-            CheckEncLog(reader1,
-                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(10, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(11, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(12, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(13, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(14, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(2, TableIndex.MethodSpec, EditAndContinueOperation.Default),
-                Row(14, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(15, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(16, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(17, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(18, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(19, TableIndex.TypeRef, EditAndContinueOperation.Default),
+            CheckEncLogDefinitions(reader1,
+                Row(1, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(1, TableIndex.EventMap, EditAndContinueOperation.Default),
+                Row(1, TableIndex.EventMap, EditAndContinueOperation.AddEvent),
+                Row(1, TableIndex.Event, EditAndContinueOperation.Default),
+                Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddField),
+                Row(1, TableIndex.Field, EditAndContinueOperation.Default),
+                Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(2, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(1, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(2, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(4, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(5, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(6, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(7, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(1, TableIndex.MethodSemantics, EditAndContinueOperation.Default),
+                Row(2, TableIndex.MethodSemantics, EditAndContinueOperation.Default));
+
+            CheckEncMapDefinitions(reader1,
+                Handle(1, TableIndex.Field),
+                Handle(2, TableIndex.MethodDef),
+                Handle(3, TableIndex.MethodDef),
+                Handle(1, TableIndex.Param),
+                Handle(2, TableIndex.Param),
+                Handle(4, TableIndex.CustomAttribute),
+                Handle(5, TableIndex.CustomAttribute),
+                Handle(6, TableIndex.CustomAttribute),
+                Handle(7, TableIndex.CustomAttribute),
+                Handle(1, TableIndex.StandAloneSig),
+                Handle(1, TableIndex.EventMap),
+                Handle(1, TableIndex.Event),
+                Handle(1, TableIndex.MethodSemantics),
+                Handle(2, TableIndex.MethodSemantics));
+
+            // gen 2
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Insert, null, g2)));
+
+            using var md2 = diff2.GetMetadata();
+            var reader2 = md2.Reader;
+
+            readers.Add(reader2);
+            CheckNames(readers, reader2.GetTypeDefNames());
+            CheckNames(readers, reader2.GetFieldDefNames(), "G");
+            CheckNames(readers, reader2.GetMethodDefNames(), "add_G", "remove_G");
+            CheckNames(readers, diff1.EmitResult.UpdatedMethods);
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
+
+            CheckEncLogDefinitions(reader2,
                 Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(2, TableIndex.EventMap, EditAndContinueOperation.Default),
-                Row(2, TableIndex.EventMap, EditAndContinueOperation.AddEvent),
+                Row(1, TableIndex.EventMap, EditAndContinueOperation.AddEvent),
                 Row(2, TableIndex.Event, EditAndContinueOperation.Default),
-                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddField),
+                Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddField),
                 Row(2, TableIndex.Field, EditAndContinueOperation.Default),
-                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(9, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(9, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
-                Row(8, TableIndex.Param, EditAndContinueOperation.Default),
-                Row(10, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
-                Row(9, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(5, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(4, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(3, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(5, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
+                Row(4, TableIndex.Param, EditAndContinueOperation.Default),
                 Row(8, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
                 Row(9, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
                 Row(10, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
@@ -1882,141 +1859,20 @@ class B
                 Row(3, TableIndex.MethodSemantics, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodSemantics, EditAndContinueOperation.Default));
 
-            CheckEncMap(reader1,
-                Handle(14, TableIndex.TypeRef),
-                Handle(15, TableIndex.TypeRef),
-                Handle(16, TableIndex.TypeRef),
-                Handle(17, TableIndex.TypeRef),
-                Handle(18, TableIndex.TypeRef),
-                Handle(19, TableIndex.TypeRef),
+            CheckEncMapDefinitions(reader2,
                 Handle(2, TableIndex.Field),
-                Handle(9, TableIndex.MethodDef),
-                Handle(10, TableIndex.MethodDef),
-                Handle(8, TableIndex.Param),
-                Handle(9, TableIndex.Param),
-                Handle(10, TableIndex.MemberRef),
-                Handle(11, TableIndex.MemberRef),
-                Handle(12, TableIndex.MemberRef),
-                Handle(13, TableIndex.MemberRef),
-                Handle(14, TableIndex.MemberRef),
+                Handle(4, TableIndex.MethodDef),
+                Handle(5, TableIndex.MethodDef),
+                Handle(3, TableIndex.Param),
+                Handle(4, TableIndex.Param),
                 Handle(8, TableIndex.CustomAttribute),
                 Handle(9, TableIndex.CustomAttribute),
                 Handle(10, TableIndex.CustomAttribute),
                 Handle(11, TableIndex.CustomAttribute),
                 Handle(2, TableIndex.StandAloneSig),
-                Handle(2, TableIndex.EventMap),
                 Handle(2, TableIndex.Event),
                 Handle(3, TableIndex.MethodSemantics),
-                Handle(4, TableIndex.MethodSemantics),
-                Handle(2, TableIndex.AssemblyRef),
-                Handle(2, TableIndex.MethodSpec));
-
-            var diff2 = compilation2.EmitDifference(
-                diff1.NextGeneration,
-                ImmutableArray.Create(
-                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation2.GetMember<EventSymbol>("A.G")),
-                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation2.GetMember<EventSymbol>("B.H"))));
-
-            // Verify delta metadata contains expected rows.
-            using var md2 = diff2.GetMetadata();
-            var reader2 = md2.Reader;
-
-            readers.Add(reader2);
-            CheckNames(readers, reader2.GetTypeDefNames());
-            CheckNames(readers, reader2.GetFieldDefNames(), "G", "H");
-            CheckNames(readers, reader2.GetMethodDefNames(), "add_G", "remove_G", "add_H", "remove_H");
-
-            CheckEncLog(reader2,
-                Row(3, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(15, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(16, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(17, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(18, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(19, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(3, TableIndex.MethodSpec, EditAndContinueOperation.Default),
-                Row(20, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(21, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(22, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(23, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(24, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(25, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(1, TableIndex.EventMap, EditAndContinueOperation.AddEvent),
-                Row(3, TableIndex.Event, EditAndContinueOperation.Default),
-                Row(2, TableIndex.EventMap, EditAndContinueOperation.AddEvent),
-                Row(4, TableIndex.Event, EditAndContinueOperation.Default),
-                Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddField),
-                Row(3, TableIndex.Field, EditAndContinueOperation.Default),
-                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddField),
-                Row(4, TableIndex.Field, EditAndContinueOperation.Default),
-                Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(11, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(3, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(12, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(13, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
-                Row(14, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(11, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
-                Row(10, TableIndex.Param, EditAndContinueOperation.Default),
-                Row(12, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
-                Row(11, TableIndex.Param, EditAndContinueOperation.Default),
-                Row(13, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
-                Row(12, TableIndex.Param, EditAndContinueOperation.Default),
-                Row(14, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
-                Row(13, TableIndex.Param, EditAndContinueOperation.Default),
-                Row(12, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(13, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(14, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(15, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(16, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(17, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(18, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(19, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(5, TableIndex.MethodSemantics, EditAndContinueOperation.Default),
-                Row(6, TableIndex.MethodSemantics, EditAndContinueOperation.Default),
-                Row(7, TableIndex.MethodSemantics, EditAndContinueOperation.Default),
-                Row(8, TableIndex.MethodSemantics, EditAndContinueOperation.Default));
-
-            CheckEncMap(reader2,
-                Handle(20, TableIndex.TypeRef),
-                Handle(21, TableIndex.TypeRef),
-                Handle(22, TableIndex.TypeRef),
-                Handle(23, TableIndex.TypeRef),
-                Handle(24, TableIndex.TypeRef),
-                Handle(25, TableIndex.TypeRef),
-                Handle(3, TableIndex.Field),
-                Handle(4, TableIndex.Field),
-                Handle(11, TableIndex.MethodDef),
-                Handle(12, TableIndex.MethodDef),
-                Handle(13, TableIndex.MethodDef),
-                Handle(14, TableIndex.MethodDef),
-                Handle(10, TableIndex.Param),
-                Handle(11, TableIndex.Param),
-                Handle(12, TableIndex.Param),
-                Handle(13, TableIndex.Param),
-                Handle(15, TableIndex.MemberRef),
-                Handle(16, TableIndex.MemberRef),
-                Handle(17, TableIndex.MemberRef),
-                Handle(18, TableIndex.MemberRef),
-                Handle(19, TableIndex.MemberRef),
-                Handle(12, TableIndex.CustomAttribute),
-                Handle(13, TableIndex.CustomAttribute),
-                Handle(14, TableIndex.CustomAttribute),
-                Handle(15, TableIndex.CustomAttribute),
-                Handle(16, TableIndex.CustomAttribute),
-                Handle(17, TableIndex.CustomAttribute),
-                Handle(18, TableIndex.CustomAttribute),
-                Handle(19, TableIndex.CustomAttribute),
-                Handle(3, TableIndex.StandAloneSig),
-                Handle(3, TableIndex.Event),
-                Handle(4, TableIndex.Event),
-                Handle(5, TableIndex.MethodSemantics),
-                Handle(6, TableIndex.MethodSemantics),
-                Handle(7, TableIndex.MethodSemantics),
-                Handle(8, TableIndex.MethodSemantics),
-                Handle(3, TableIndex.AssemblyRef),
-                Handle(3, TableIndex.MethodSpec));
+                Handle(4, TableIndex.MethodSemantics));
         }
 
         [WorkItem(1175704, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1175704")]
@@ -2368,6 +2224,9 @@ class C
 
             CheckNames(readers, reader1.GetTypeDefNames(), "C", "D");
             CheckNames(readers, reader1.GetMethodDefNames(), "F", "G", ".ctor", ".ctor");
+            CheckNames(readers, diff1.EmitResult.UpdatedMethods, "F");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "A", "C", "D");
+
             Assert.Equal(2, reader1.GetTableRowCount(TableIndex.NestedClass));
 
             CheckEncLog(reader1,
@@ -2526,9 +2385,7 @@ class C
             var reader1 = md1.Reader;
             var readers = new[] { reader0, reader1 };
 
-            diff1.VerifyUpdatedTypes("0x02000002", "0x02000003");
-
-            CheckNames(readers, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "A", "B`1");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "A", "B`1", "C`1");
 
             CheckNames(readers, reader1.GetTypeDefNames(), "C`1");
             Assert.Equal(1, reader1.GetTableRowCount(TableIndex.NestedClass));
@@ -2961,9 +2818,7 @@ interface I
             var reader1 = md1.Reader;
             var readers = new[] { reader0, reader1 };
 
-            diff1.VerifyUpdatedTypes("0x02000002");
-
-            CheckNames(readers, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "I");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "I", "J");
 
             CheckNames(readers, reader1.GetTypeDefNames(), "J");
             CheckNames(readers, reader1.GetFieldDefNames(), "X", "Y");
@@ -2990,9 +2845,7 @@ interface I
             var reader2 = md2.Reader;
             readers = new[] { reader0, reader1, reader2 };
 
-            diff2.VerifyUpdatedTypes("0x02000002");
-
-            CheckNames(readers, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "I");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "I", "J");
 
             CheckNames(readers, reader2.GetTypeDefNames());
             CheckNames(readers, reader2.GetFieldDefNames(), "X");
@@ -3130,27 +2983,12 @@ delegate void D();
             var reader1 = md1.Reader;
             var readers = new[] { reader0, reader1 };
 
-            diff1.VerifyUpdatedTypes("0x02000004");
-
-            CheckNames(readers, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "C");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
 
             CheckNames(readers, reader1.GetTypeDefNames());
             CheckNames(readers, reader1.GetMethodDefNames(), "M2", "get_P2", "add_E2", "remove_E2");
 
-            CheckEncLog(reader1,
-                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(11, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(12, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(13, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(14, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(15, TableIndex.MemberRef, EditAndContinueOperation.Default),
-                Row(2, TableIndex.MethodSpec, EditAndContinueOperation.Default),
-                Row(15, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(16, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(17, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(18, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(19, TableIndex.TypeRef, EditAndContinueOperation.Default),
-                Row(20, TableIndex.TypeRef, EditAndContinueOperation.Default),
+            CheckEncLogDefinitions(reader1,
                 Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(4, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(1, TableIndex.EventMap, EditAndContinueOperation.AddEvent),
@@ -3187,13 +3025,7 @@ delegate void D();
                 Row(6, TableIndex.MethodSemantics, EditAndContinueOperation.Default),
                 Row(2, TableIndex.GenericParam, EditAndContinueOperation.Default));
 
-            CheckEncMap(reader1,
-                Handle(15, TableIndex.TypeRef),
-                Handle(16, TableIndex.TypeRef),
-                Handle(17, TableIndex.TypeRef),
-                Handle(18, TableIndex.TypeRef),
-                Handle(19, TableIndex.TypeRef),
-                Handle(20, TableIndex.TypeRef),
+            CheckEncMapDefinitions(reader1,
                 Handle(3, TableIndex.Field),
                 Handle(4, TableIndex.Field),
                 Handle(12, TableIndex.MethodDef),
@@ -3202,11 +3034,6 @@ delegate void D();
                 Handle(15, TableIndex.MethodDef),
                 Handle(8, TableIndex.Param),
                 Handle(9, TableIndex.Param),
-                Handle(11, TableIndex.MemberRef),
-                Handle(12, TableIndex.MemberRef),
-                Handle(13, TableIndex.MemberRef),
-                Handle(14, TableIndex.MemberRef),
-                Handle(15, TableIndex.MemberRef),
                 Handle(7, TableIndex.CustomAttribute),
                 Handle(13, TableIndex.CustomAttribute),
                 Handle(14, TableIndex.CustomAttribute),
@@ -3223,9 +3050,7 @@ delegate void D();
                 Handle(4, TableIndex.MethodSemantics),
                 Handle(5, TableIndex.MethodSemantics),
                 Handle(6, TableIndex.MethodSemantics),
-                Handle(2, TableIndex.AssemblyRef),
-                Handle(2, TableIndex.GenericParam),
-                Handle(2, TableIndex.MethodSpec));
+                Handle(2, TableIndex.GenericParam));
 
             CheckAttributes(reader1,
                 new CustomAttributeRow(Handle(1, TableIndex.GenericParam), Handle(1, TableIndex.MethodDef)),
@@ -3280,9 +3105,7 @@ class C
             using var md1 = diff1.GetMetadata();
             var readers = new[] { reader0, md1.Reader };
 
-            diff1.VerifyUpdatedTypes("0x02000002");
-
-            CheckNames(readers, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "C");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
 
             CheckNames(readers, md1.Reader.GetTypeDefNames());
             CheckNames(readers, md1.Reader.GetMethodDefNames(), "M");
@@ -3355,9 +3178,7 @@ class C
             var reader1 = md1.Reader;
             var readers = new[] { reader0, reader1 };
 
-            diff1.VerifyUpdatedTypes("0x02000003");
-
-            CheckNames(readers, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "C");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
 
             CheckNames(readers, reader1.GetTypeDefNames());
             CheckNames(readers, reader1.GetEventDefNames());
@@ -3403,10 +3224,9 @@ class C
 
             var md1 = diff1.GetMetadata();
             var reader1 = md1.Reader;
+            var readers = new[] { reader0, reader1 };
 
-            diff1.VerifyUpdatedTypes("0x02000002");
-
-            CheckNames(reader0, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "C");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
 
             CheckEncLog(reader1,
                 Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
@@ -3498,34 +3318,29 @@ class C
             var bytes0 = compilation0.EmitToArray();
             var generation0 = EmitBaseline.CreateInitialBaseline(ModuleMetadata.CreateFromImage(bytes0), EmptyLocalsProvider);
             using var md0 = ModuleMetadata.CreateFromImage(bytes0);
+            var reader0 = md0.MetadataReader;
 
             var diff1 = compilation1.EmitDifference(
                 generation0,
                 ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetMember<MethodSymbol>("C.puts"))));
 
-            diff1.VerifyUpdatedTypes("0x02000002");
-
-            var reader0 = md0.MetadataReader;
-            CheckNames(reader0, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "C");
-
             using var md1 = diff1.GetMetadata();
             var reader1 = md1.Reader;
-            CheckEncLog(reader1,
-                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(2, TableIndex.ModuleRef, EditAndContinueOperation.Default),
-                Row(6, TableIndex.TypeRef, EditAndContinueOperation.Default),
+            var readers = new[] { reader0, reader1 };
+
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C");
+
+            CheckEncLogDefinitions(reader1,
                 Row(2, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
                 Row(3, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(3, TableIndex.MethodDef, EditAndContinueOperation.AddParameter),
                 Row(1, TableIndex.Param, EditAndContinueOperation.Default),
                 Row(2, TableIndex.ImplMap, EditAndContinueOperation.Default));
-            CheckEncMap(reader1,
-                Handle(6, TableIndex.TypeRef),
+
+            CheckEncMapDefinitions(reader1,
                 Handle(3, TableIndex.MethodDef),
                 Handle(1, TableIndex.Param),
-                Handle(2, TableIndex.ModuleRef),
-                Handle(2, TableIndex.ImplMap),
-                Handle(2, TableIndex.AssemblyRef));
+                Handle(2, TableIndex.ImplMap));
         }
 
         /// <summary>
@@ -10316,17 +10131,19 @@ public class C : Base
 ");
 
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
-
+            var reader0 = md0.MetadataReader;
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
             var diff1 = compilation1.EmitDifference(
                 generation0,
                 ImmutableArray.Create(
                     SemanticEdit.Create(SemanticEditKind.Update, ctor0, ctor1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
 
-            diff1.VerifyUpdatedTypes("0x02000002", "0x02000004");
+            using var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+            var readers = new[] { reader0, reader1 };
 
-            var reader0 = md0.MetadataReader;
-            CheckNames(reader0, reader0.GetUpdatedTypeDefNames(diff1.EmitResult), "C", "<>c__DisplayClass0_0");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C", "<>c__DisplayClass0_0");
 
             diff1.VerifySynthesizedMembers(
                 "C: {<>c__DisplayClass0_0}",
@@ -10371,9 +10188,11 @@ public class C : Base
                 ImmutableArray.Create(
                     SemanticEdit.Create(SemanticEditKind.Update, ctor1, ctor2, GetSyntaxMapFromMarkers(source1, source0), preserveLocalVariables: true)));
 
-            diff2.VerifyUpdatedTypes("0x02000002", "0x02000004");
+            using var md2 = diff2.GetMetadata();
+            var reader2 = md2.Reader;
+            readers = new[] { reader0, reader1, reader2 };
 
-            CheckNames(reader0, reader0.GetUpdatedTypeDefNames(diff2.EmitResult), "C", "<>c__DisplayClass0_0");
+            CheckNames(readers, diff2.EmitResult.ChangedTypes, "C", "<>c__DisplayClass0_0");
 
             diff2.VerifySynthesizedMembers(
                 "C: {<>c__DisplayClass0_0}",

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -3132,7 +3132,7 @@ namespace Microsoft.CodeAnalysis
                         out MetadataSizes metadataSizes);
 
                     writer.GetUpdatedMethodTokens(updatedMethods);
-                    writer.GetChangedTypeTokens(context, changedTypes);
+                    writer.GetChangedTypeTokens(changedTypes);
 
                     nativePdbWriter?.WriteTo(pdbStream);
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -3096,7 +3096,7 @@ namespace Microsoft.CodeAnalysis
             Stream ilStream,
             Stream pdbStream,
             ArrayBuilder<MethodDefinitionHandle> updatedMethods,
-            ArrayBuilder<TypeDefinitionHandle> updatedTypes,
+            ArrayBuilder<TypeDefinitionHandle> changedTypes,
             DiagnosticBag diagnostics,
             Func<ISymWriterMetadataProvider, SymUnmanagedWriter>? testSymWriterFactory,
             string? pdbFilePath,
@@ -3132,8 +3132,7 @@ namespace Microsoft.CodeAnalysis
                         out MetadataSizes metadataSizes);
 
                     writer.GetUpdatedMethodTokens(updatedMethods);
-
-                    writer.GetUpdatedTypeTokens(updatedTypes);
+                    writer.GetChangedTypeTokens(context, changedTypes);
 
                     nativePdbWriter?.WriteTo(pdbStream);
 

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.Emit
         /// <summary>
         /// Return tokens for all updated or added types.
         /// </summary>
-        public void GetChangedTypeTokens(EmitContext context, ArrayBuilder<TypeDefinitionHandle> types)
+        public void GetChangedTypeTokens(ArrayBuilder<TypeDefinitionHandle> types)
         {
             foreach (var def in _changedTypeDefs)
             {

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -25,7 +25,11 @@ namespace Microsoft.CodeAnalysis.Emit
         private readonly DefinitionMap _definitionMap;
         private readonly SymbolChanges _changes;
 
-        private readonly List<ITypeDefinition> _updatedTypeDefs;
+        /// <summary>
+        /// Type definitions containing any changes (includes added types).
+        /// </summary>
+        private readonly List<ITypeDefinition> _changedTypeDefs;
+
         private readonly DefinitionIndex<ITypeDefinition> _typeDefs;
         private readonly DefinitionIndex<IEventDefinition> _eventDefs;
         private readonly DefinitionIndex<IFieldDefinition> _fieldDefs;
@@ -89,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
             var sizes = previousGeneration.TableSizes;
 
-            _updatedTypeDefs = new List<ITypeDefinition>();
+            _changedTypeDefs = new List<ITypeDefinition>();
             _typeDefs = new DefinitionIndex<ITypeDefinition>(this.TryGetExistingTypeDefIndex, sizes[(int)TableIndex.TypeDef]);
             _eventDefs = new DefinitionIndex<IEventDefinition>(this.TryGetExistingEventDefIndex, sizes[(int)TableIndex.Event]);
             _fieldDefs = new DefinitionIndex<IFieldDefinition>(this.TryGetExistingFieldDefIndex, sizes[(int)TableIndex.Field]);
@@ -253,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Emit
         }
 
         /// <summary>
-        /// Return tokens for all modified debuggable methods.
+        /// Return tokens for all updated debuggable methods.
         /// </summary>
         public void GetUpdatedMethodTokens(ArrayBuilder<MethodDefinitionHandle> methods)
         {
@@ -262,19 +266,19 @@ namespace Microsoft.CodeAnalysis.Emit
                 // The debugger tries to remap all modified methods, which requires presence of sequence points.
                 if (!_methodDefs.IsAddedNotChanged(def) && def.GetBody(Context)?.SequencePoints.Length > 0)
                 {
-                    methods.Add(MetadataTokens.MethodDefinitionHandle(_methodDefs[def]));
+                    methods.Add(MetadataTokens.MethodDefinitionHandle(_methodDefs.GetRowId(def)));
                 }
             }
         }
 
         /// <summary>
-        /// Return tokens for all modified debuggable types.
+        /// Return tokens for all updated or added types.
         /// </summary>
-        public void GetUpdatedTypeTokens(ArrayBuilder<TypeDefinitionHandle> types)
+        public void GetChangedTypeTokens(EmitContext context, ArrayBuilder<TypeDefinitionHandle> types)
         {
-            foreach (var def in _updatedTypeDefs)
+            foreach (var def in _changedTypeDefs)
             {
-                types.Add(MetadataTokens.TypeDefinitionHandle(_typeDefs[def]));
+                types.Add(MetadataTokens.TypeDefinitionHandle(_typeDefs.GetRowId(def)));
             }
         }
 
@@ -295,7 +299,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         protected override EventDefinitionHandle GetEventDefinitionHandle(IEventDefinition def)
         {
-            return MetadataTokens.EventDefinitionHandle(_eventDefs[def]);
+            return MetadataTokens.EventDefinitionHandle(_eventDefs.GetRowId(def));
         }
 
         protected override IReadOnlyList<IEventDefinition> GetEventDefs()
@@ -305,7 +309,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
         protected override FieldDefinitionHandle GetFieldDefinitionHandle(IFieldDefinition def)
         {
-            return MetadataTokens.FieldDefinitionHandle(_fieldDefs[def]);
+            return MetadataTokens.FieldDefinitionHandle(_fieldDefs.GetRowId(def));
         }
 
         protected override IReadOnlyList<IFieldDefinition> GetFieldDefs()
@@ -316,19 +320,19 @@ namespace Microsoft.CodeAnalysis.Emit
         protected override bool TryGetTypeDefinitionHandle(ITypeDefinition def, out TypeDefinitionHandle handle)
         {
             int index;
-            bool result = _typeDefs.TryGetValue(def, out index);
+            bool result = _typeDefs.TryGetRowId(def, out index);
             handle = MetadataTokens.TypeDefinitionHandle(index);
             return result;
         }
 
         protected override TypeDefinitionHandle GetTypeDefinitionHandle(ITypeDefinition def)
         {
-            return MetadataTokens.TypeDefinitionHandle(_typeDefs[def]);
+            return MetadataTokens.TypeDefinitionHandle(_typeDefs.GetRowId(def));
         }
 
         protected override ITypeDefinition GetTypeDef(TypeDefinitionHandle handle)
         {
-            return _typeDefs[MetadataTokens.GetRowNumber(handle)];
+            return _typeDefs.GetDefinition(MetadataTokens.GetRowNumber(handle));
         }
 
         protected override IReadOnlyList<ITypeDefinition> GetTypeDefs()
@@ -339,28 +343,28 @@ namespace Microsoft.CodeAnalysis.Emit
         protected override bool TryGetMethodDefinitionHandle(IMethodDefinition def, out MethodDefinitionHandle handle)
         {
             int index;
-            bool result = _methodDefs.TryGetValue(def, out index);
+            bool result = _methodDefs.TryGetRowId(def, out index);
             handle = MetadataTokens.MethodDefinitionHandle(index);
             return result;
         }
 
         protected override MethodDefinitionHandle GetMethodDefinitionHandle(IMethodDefinition def)
-            => MetadataTokens.MethodDefinitionHandle(_methodDefs[def]);
+            => MetadataTokens.MethodDefinitionHandle(_methodDefs.GetRowId(def));
 
         protected override IMethodDefinition GetMethodDef(MethodDefinitionHandle index)
-            => _methodDefs[MetadataTokens.GetRowNumber(index)];
+            => _methodDefs.GetDefinition(MetadataTokens.GetRowNumber(index));
 
         protected override IReadOnlyList<IMethodDefinition> GetMethodDefs()
             => _methodDefs.GetRows();
 
         protected override PropertyDefinitionHandle GetPropertyDefIndex(IPropertyDefinition def)
-            => MetadataTokens.PropertyDefinitionHandle(_propertyDefs[def]);
+            => MetadataTokens.PropertyDefinitionHandle(_propertyDefs.GetRowId(def));
 
         protected override IReadOnlyList<IPropertyDefinition> GetPropertyDefs()
             => _propertyDefs.GetRows();
 
         protected override ParameterHandle GetParameterHandle(IParameterDefinition def)
-            => MetadataTokens.ParameterHandle(_parameterDefs[def]);
+            => MetadataTokens.ParameterHandle(_parameterDefs.GetRowId(def));
 
         protected override IReadOnlyList<IParameterDefinition> GetParameterDefs()
             => _parameterDefs.GetRows();
@@ -482,6 +486,8 @@ namespace Microsoft.CodeAnalysis.Emit
             {
                 case SymbolChange.Added:
                     _typeDefs.Add(typeDef);
+                    _changedTypeDefs.Add(typeDef);
+
                     var typeParameters = this.GetConsolidatedTypeParameters(typeDef);
                     if (typeParameters != null)
                     {
@@ -490,11 +496,12 @@ namespace Microsoft.CodeAnalysis.Emit
                             _genericParameters.Add(typeParameter);
                         }
                     }
+
                     break;
 
                 case SymbolChange.Updated:
                     _typeDefs.AddUpdated(typeDef);
-                    _updatedTypeDefs.Add(typeDef);
+                    _changedTypeDefs.Add(typeDef);
                     break;
 
                 case SymbolChange.ContainsChanges:
@@ -502,7 +509,7 @@ namespace Microsoft.CodeAnalysis.Emit
                     // We keep this list separately because we don't want to output duplicate typedef entries in the EnC log,
                     // which uses _typeDefs, but it's simpler to let the members output those rows for the updated typedefs
                     // with the right update type.
-                    _updatedTypeDefs.Add(typeDef);
+                    _changedTypeDefs.Add(typeDef);
                     break;
 
                 case SymbolChange.None:
@@ -514,13 +521,13 @@ namespace Microsoft.CodeAnalysis.Emit
             }
 
             int typeIndex;
-            var ok = _typeDefs.TryGetValue(typeDef, out typeIndex);
+            var ok = _typeDefs.TryGetRowId(typeDef, out typeIndex);
             Debug.Assert(ok);
 
             foreach (var eventDef in typeDef.GetEvents(this.Context))
             {
                 int eventMapIndex;
-                if (!_eventMap.TryGetValue(typeIndex, out eventMapIndex))
+                if (!_eventMap.TryGetRowId(typeIndex, out eventMapIndex))
                 {
                     _eventMap.Add(typeIndex);
                 }
@@ -556,7 +563,7 @@ namespace Microsoft.CodeAnalysis.Emit
             foreach (var propertyDef in typeDef.GetProperties(this.Context))
             {
                 int propertyMapIndex;
-                if (!_propertyMap.TryGetValue(typeIndex, out propertyMapIndex))
+                if (!_propertyMap.TryGetRowId(typeIndex, out propertyMapIndex))
                 {
                     _propertyMap.Add(typeIndex);
                 }
@@ -573,14 +580,14 @@ namespace Microsoft.CodeAnalysis.Emit
                 RoslynDebug.AssertNotNull(methodDef);
 
                 int methodDefIndex;
-                ok = _methodDefs.TryGetValue(methodDef, out methodDefIndex);
+                ok = _methodDefs.TryGetRowId(methodDef, out methodDefIndex);
                 Debug.Assert(ok);
 
                 // If there are N existing MethodImpl entries for this MethodDef,
                 // those will be index:1, ..., index:N, so it's sufficient to check for index:1.
                 int methodImplIndex;
                 var key = new MethodImplKey(methodDefIndex, index: 1);
-                if (!_methodImpls.TryGetValue(key, out methodImplIndex))
+                if (!_methodImpls.TryGetRowId(key, out methodImplIndex))
                 {
                     implementingMethods.Add(methodDefIndex);
                     this.methodImplList.Add(methodImpl);
@@ -595,7 +602,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 {
                     int methodImplIndex;
                     var key = new MethodImplKey(methodDefIndex, index);
-                    if (!_methodImpls.TryGetValue(key, out methodImplIndex))
+                    if (!_methodImpls.TryGetRowId(key, out methodImplIndex))
                     {
                         _methodImpls.Add(key);
                         break;
@@ -794,11 +801,11 @@ namespace Microsoft.CodeAnalysis.Emit
             {
                 if (index.IsAddedNotChanged(member))
                 {
-                    int typeIndex = _typeDefs[member.ContainingTypeDefinition];
+                    int typeIndex = _typeDefs.GetRowId(member.ContainingTypeDefinition);
                     Debug.Assert(typeIndex > 0);
 
                     int mapRowId;
-                    var ok = map.TryGetValue(typeIndex, out mapRowId);
+                    var ok = map.TryGetRowId(typeIndex, out mapRowId);
                     Debug.Assert(ok);
 
                     metadata.AddEncLogEntry(
@@ -807,7 +814,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 }
 
                 metadata.AddEncLogEntry(
-                    entity: MetadataTokens.Handle(table, index[member]),
+                    entity: MetadataTokens.Handle(table, index.GetRowId(member)),
                     code: EditAndContinueOperation.Default);
             }
         }
@@ -823,12 +830,12 @@ namespace Microsoft.CodeAnalysis.Emit
                 if (index.IsAddedNotChanged(member))
                 {
                     metadata.AddEncLogEntry(
-                        entity: MetadataTokens.TypeDefinitionHandle(_typeDefs[(INamedTypeDefinition)member.ContainingTypeDefinition]),
+                        entity: MetadataTokens.TypeDefinitionHandle(_typeDefs.GetRowId(member.ContainingTypeDefinition)),
                         code: addCode);
                 }
 
                 metadata.AddEncLogEntry(
-                    entity: MetadataTokens.Handle(tableIndex, index[member]),
+                    entity: MetadataTokens.Handle(tableIndex, index.GetRowId(member)),
                     code: EditAndContinueOperation.Default);
             }
         }
@@ -841,7 +848,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 var methodDef = _parameterDefList[i].Key;
 
                 metadata.AddEncLogEntry(
-                    entity: MetadataTokens.MethodDefinitionHandle(_methodDefs[methodDef]),
+                    entity: MetadataTokens.MethodDefinitionHandle(_methodDefs.GetRowId(methodDef)),
                     code: EditAndContinueOperation.AddParameter);
 
                 metadata.AddEncLogEntry(
@@ -968,7 +975,7 @@ namespace Microsoft.CodeAnalysis.Emit
             foreach (var member in index.GetRows())
             {
                 metadata.AddEncLogEntry(
-                    entity: MetadataTokens.Handle(tableIndex, index[member]),
+                    entity: MetadataTokens.Handle(tableIndex, index.GetRowId(member)),
                     code: EditAndContinueOperation.Default);
             }
         }
@@ -1137,7 +1144,7 @@ namespace Microsoft.CodeAnalysis.Emit
         {
             foreach (var member in index.GetRows())
             {
-                tokens.Add(MetadataTokens.Handle(tableIndex, index[member]));
+                tokens.Add(MetadataTokens.Handle(tableIndex, index.GetRowId(member)));
             }
         }
 
@@ -1155,7 +1162,7 @@ namespace Microsoft.CodeAnalysis.Emit
             {
                 metadata.AddEventMap(
                     declaringType: MetadataTokens.TypeDefinitionHandle(typeId),
-                    eventList: MetadataTokens.EventDefinitionHandle(_eventMap[typeId]));
+                    eventList: MetadataTokens.EventDefinitionHandle(_eventMap.GetRowId(typeId)));
             }
         }
 
@@ -1165,7 +1172,7 @@ namespace Microsoft.CodeAnalysis.Emit
             {
                 metadata.AddPropertyMap(
                     declaringType: MetadataTokens.TypeDefinitionHandle(typeId),
-                    propertyList: MetadataTokens.PropertyDefinitionHandle(_propertyMap[typeId]));
+                    propertyList: MetadataTokens.PropertyDefinitionHandle(_propertyMap.GetRowId(typeId)));
             }
         }
 
@@ -1184,21 +1191,17 @@ namespace Microsoft.CodeAnalysis.Emit
                 _firstRowId = lastRowId + 1;
             }
 
-            public abstract bool TryGetValue(T item, out int index);
+            public abstract bool TryGetRowId(T item, out int rowId);
 
-            public int this[T item]
+            public int GetRowId(T item)
             {
-                get
-                {
-                    int token;
-                    this.TryGetValue(item, out token);
+                TryGetRowId(item, out int rowId);
 
-                    // Fails if we are attempting to make a change that should have been reported as rude,
-                    // e.g. the corresponding definitions type don't match, etc.
-                    Debug.Assert(token > 0);
+                // Fails if we are attempting to make a change that should have been reported as rude,
+                // e.g. the corresponding definitions type don't match, etc.
+                Debug.Assert(rowId > 0);
 
-                    return token;
-                }
+                return rowId;
             }
 
             // A method rather than a property since it freezes the table.
@@ -1273,7 +1276,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 _map = new Dictionary<int, T>();
             }
 
-            public override bool TryGetValue(T item, out int index)
+            public override bool TryGetRowId(T item, out int index)
             {
                 if (this.added.TryGetValue(item, out index))
                 {
@@ -1283,22 +1286,17 @@ namespace Microsoft.CodeAnalysis.Emit
                 if (_tryGetExistingIndex(item, out index))
                 {
 #if DEBUG
-                    T? other;
-                    Debug.Assert(!_map.TryGetValue(index, out other) || ((object)other == (object)item));
+                    Debug.Assert(!_map.TryGetValue(index, out var other) || ((object)other == (object)item));
 #endif
                     _map[index] = item;
                     return true;
                 }
+
                 return false;
             }
 
-            public T this[int rowId]
-            {
-                get
-                {
-                    return _map[rowId];
-                }
-            }
+            public T GetDefinition(int rowId)
+                => _map[rowId];
 
             public void Add(T item)
             {
@@ -1321,19 +1319,10 @@ namespace Microsoft.CodeAnalysis.Emit
             }
 
             public bool IsAddedNotChanged(T item)
-            {
-                return this.added.ContainsKey(item);
-            }
+                => added.ContainsKey(item);
 
             protected override void OnFrozen()
-            {
-                this.rows.Sort(this.CompareRows);
-            }
-
-            private int CompareRows(T x, T y)
-            {
-                return this[x] - this[y];
-            }
+                => rows.Sort((x, y) => GetRowId(x).CompareTo(GetRowId(y)));
         }
 
         private bool TryGetExistingTypeDefIndex(ITypeDefinition item, out int index)
@@ -1486,7 +1475,7 @@ namespace Microsoft.CodeAnalysis.Emit
             {
             }
 
-            public override bool TryGetValue(IParameterDefinition item, out int index)
+            public override bool TryGetRowId(IParameterDefinition item, out int index)
             {
                 return this.added.TryGetValue(item, out index);
             }
@@ -1508,7 +1497,7 @@ namespace Microsoft.CodeAnalysis.Emit
             {
             }
 
-            public override bool TryGetValue(IGenericParameter item, out int index)
+            public override bool TryGetRowId(IGenericParameter item, out int index)
             {
                 return this.added.TryGetValue(item, out index);
             }
@@ -1535,7 +1524,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 _tryGetExistingIndex = tryGetExistingIndex;
             }
 
-            public override bool TryGetValue(int item, out int index)
+            public override bool TryGetRowId(int item, out int index)
             {
                 if (this.added.TryGetValue(item, out index))
                 {
@@ -1571,7 +1560,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 _writer = writer;
             }
 
-            public override bool TryGetValue(MethodImplKey item, out int index)
+            public override bool TryGetRowId(MethodImplKey item, out int index)
             {
                 if (this.added.TryGetValue(item, out index))
                 {

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitDifferenceResult.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitDifferenceResult.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Emit
         public ImmutableArray<MethodDefinitionHandle> UpdatedMethods { get; }
 
         /// <summary>
-        /// Hnadles of types that were changed (updated or inserted) in this delta.
+        /// Handles of types that were changed (updated or inserted) in this delta.
         /// </summary>
         public ImmutableArray<TypeDefinitionHandle> ChangedTypes { get; }
 

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitDifferenceResult.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitDifferenceResult.cs
@@ -11,16 +11,22 @@ namespace Microsoft.CodeAnalysis.Emit
     {
         public EmitBaseline? Baseline { get; }
 
+        /// <summary>
+        /// Handles of methods with sequence points that have been updated in this delta.
+        /// </summary>
         public ImmutableArray<MethodDefinitionHandle> UpdatedMethods { get; }
 
-        public ImmutableArray<TypeDefinitionHandle> UpdatedTypes { get; }
+        /// <summary>
+        /// Hnadles of types that were changed (updated or inserted) in this delta.
+        /// </summary>
+        public ImmutableArray<TypeDefinitionHandle> ChangedTypes { get; }
 
-        internal EmitDifferenceResult(bool success, ImmutableArray<Diagnostic> diagnostics, EmitBaseline? baseline, ImmutableArray<MethodDefinitionHandle> updatedMethods, ImmutableArray<TypeDefinitionHandle> updatedTypes)
+        internal EmitDifferenceResult(bool success, ImmutableArray<Diagnostic> diagnostics, EmitBaseline? baseline, ImmutableArray<MethodDefinitionHandle> updatedMethods, ImmutableArray<TypeDefinitionHandle> changedTypes)
             : base(success, diagnostics)
         {
             Baseline = baseline;
             UpdatedMethods = updatedMethods;
-            UpdatedTypes = updatedTypes;
+            ChangedTypes = changedTypes;
         }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -2,8 +2,8 @@
 abstract Microsoft.CodeAnalysis.SyntaxTree.GetLineMappings(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.LineMapping>!
 const Microsoft.CodeAnalysis.WellKnownMemberNames.PrintMembersMethodName = "PrintMembers" -> string!
 Microsoft.CodeAnalysis.Compilation.EmitDifference(Microsoft.CodeAnalysis.Emit.EmitBaseline! baseline, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Emit.SemanticEdit>! edits, System.Func<Microsoft.CodeAnalysis.ISymbol!, bool>! isAddedSymbol, System.IO.Stream! metadataStream, System.IO.Stream! ilStream, System.IO.Stream! pdbStream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.Emit.EmitDifferenceResult!
+Microsoft.CodeAnalysis.Emit.EmitDifferenceResult.ChangedTypes.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.TypeDefinitionHandle>
 Microsoft.CodeAnalysis.Emit.EmitDifferenceResult.UpdatedMethods.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle>
-Microsoft.CodeAnalysis.Emit.EmitDifferenceResult.UpdatedTypes.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.TypeDefinitionHandle>
 Microsoft.CodeAnalysis.Emit.SemanticEditKind.Replace = 4 -> Microsoft.CodeAnalysis.Emit.SemanticEditKind
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string! firstLanguage, params string![]! additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string![]!

--- a/src/Compilers/Test/Core/Compilation/CompilationDifference.cs
+++ b/src/Compilers/Test/Core/Compilation/CompilationDifference.cs
@@ -149,12 +149,5 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 expectedMethodTokens,
                 EmitResult.UpdatedMethods.Select(methodHandle => $"0x{MetadataTokens.GetToken(methodHandle):X8}"));
         }
-
-        public void VerifyUpdatedTypes(params string[] expectedTypeTokens)
-        {
-            AssertEx.Equal(
-                expectedTypeTokens,
-                EmitResult.UpdatedTypes.Select(typeHandle => $"0x{MetadataTokens.GetToken(typeHandle):X8}"));
-        }
     }
 }

--- a/src/Compilers/Test/Core/Metadata/MetadataReaderUtils.cs
+++ b/src/Compilers/Test/Core/Metadata/MetadataReaderUtils.cs
@@ -109,11 +109,6 @@ namespace Roslyn.Test.Utilities
             return reader.GetGuid(reader.GetModuleDefinition().Mvid);
         }
 
-        public static StringHandle[] GetUpdatedTypeDefNames(this MetadataReader reader, EmitDifferenceResult emitResult)
-        {
-            return emitResult.UpdatedTypes.Select(handle => reader.GetTypeDefinition(handle).Name).ToArray();
-        }
-
         public static StringHandle[] GetAssemblyRefNames(this MetadataReader reader)
         {
             return reader.AssemblyReferences.Select(handle => reader.GetAssemblyReference(handle).Name).ToArray();

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Catch e As NotSupportedException
                 ' TODO: https://github.com/dotnet/roslyn/issues/9004
                 diagnostics.Add(ERRID.ERR_ModuleEmitFailure, NoLocation.Singleton, compilation.AssemblyName, e.Message)
-                Return New EmitDifferenceResult(success:=False, diagnostics:=diagnostics.ToReadOnlyAndFree(), baseline:=Nothing, updatedMethods:=updatedMethods.ToImmutableAndFree(), updatedTypes:=updatedTypes.ToImmutableAndFree())
+                Return New EmitDifferenceResult(success:=False, diagnostics:=diagnostics.ToReadOnlyAndFree(), baseline:=Nothing, updatedMethods:=updatedMethods.ToImmutableAndFree(), changedTypes:=updatedTypes.ToImmutableAndFree())
             End Try
 
             If testData IsNot Nothing Then
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 diagnostics:=diagnostics.ToReadOnlyAndFree(),
                 baseline:=newBaseline,
                 updatedMethods:=updatedMethods.ToImmutableAndFree(),
-                updatedTypes:=updatedTypes.ToImmutableAndFree())
+                changedTypes:=updatedTypes.ToImmutableAndFree())
         End Function
 
         Friend Function MapToCompilation(

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
@@ -34,9 +34,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Dim serializationProperties = compilation.ConstructModuleSerializationProperties(emitOpts, runtimeMDVersion, baseline.ModuleVersionId)
             Dim manifestResources = SpecializedCollections.EmptyEnumerable(Of ResourceDescription)()
 
-            Dim updatedMethods = ArrayBuilder(Of MethodDefinitionHandle).GetInstance()
-            Dim updatedTypes = ArrayBuilder(Of TypeDefinitionHandle).GetInstance()
-
             Dim moduleBeingBuilt As PEDeltaAssemblyBuilder
             Try
                 moduleBeingBuilt = New PEDeltaAssemblyBuilder(
@@ -51,7 +48,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Catch e As NotSupportedException
                 ' TODO: https://github.com/dotnet/roslyn/issues/9004
                 diagnostics.Add(ERRID.ERR_ModuleEmitFailure, NoLocation.Singleton, compilation.AssemblyName, e.Message)
-                Return New EmitDifferenceResult(success:=False, diagnostics:=diagnostics.ToReadOnlyAndFree(), baseline:=Nothing, updatedMethods:=updatedMethods.ToImmutableAndFree(), changedTypes:=updatedTypes.ToImmutableAndFree())
+                Return New EmitDifferenceResult(
+                    success:=False,
+                    diagnostics:=diagnostics.ToReadOnlyAndFree(),
+                    baseline:=Nothing,
+                    updatedMethods:=ImmutableArray(Of MethodDefinitionHandle).Empty,
+                    changedTypes:=ImmutableArray(Of TypeDefinitionHandle).Empty)
             End Try
 
             If testData IsNot Nothing Then
@@ -63,6 +65,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Dim changes = moduleBeingBuilt.EncSymbolChanges
 
             Dim newBaseline As EmitBaseline = Nothing
+            Dim updatedMethods = ArrayBuilder(Of MethodDefinitionHandle).GetInstance()
+            Dim changedTypes = ArrayBuilder(Of TypeDefinitionHandle).GetInstance()
 
             If compilation.Compile(moduleBeingBuilt,
                                    emittingPdb:=True,
@@ -84,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                     ilStream,
                     pdbStream,
                     updatedMethods,
-                    updatedTypes,
+                    changedTypes,
                     diagnostics,
                     testData?.SymWriterFactory,
                     emitOpts.PdbFilePath,
@@ -96,7 +100,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 diagnostics:=diagnostics.ToReadOnlyAndFree(),
                 baseline:=newBaseline,
                 updatedMethods:=updatedMethods.ToImmutableAndFree(),
-                changedTypes:=updatedTypes.ToImmutableAndFree())
+                changedTypes:=changedTypes.ToImmutableAndFree())
         End Function
 
         Friend Function MapToCompilation(

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -760,7 +760,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         Contract.ThrowIfNull(emitResult.Baseline);
 
                         var updatedMethodTokens = emitResult.UpdatedMethods.SelectAsArray(h => MetadataTokens.GetToken(h));
-                        var updatedTypeTokens = emitResult.ChangedTypes.SelectAsArray(h => MetadataTokens.GetToken(h));
+                        var changedTypeTokens = emitResult.ChangedTypes.SelectAsArray(h => MetadataTokens.GetToken(h));
 
                         // Determine all active statements whose span changed and exception region span deltas.
                         GetActiveStatementAndExceptionRegionSpans(
@@ -780,7 +780,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             pdbStream.ToImmutableArray(),
                             projectChanges.LineChanges,
                             updatedMethodTokens,
-                            updatedTypeTokens,
+                            changedTypeTokens,
                             activeStatementsInUpdatedMethods,
                             exceptionRegionUpdates));
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -760,7 +760,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         Contract.ThrowIfNull(emitResult.Baseline);
 
                         var updatedMethodTokens = emitResult.UpdatedMethods.SelectAsArray(h => MetadataTokens.GetToken(h));
-                        var updatedTypeTokens = emitResult.UpdatedTypes.SelectAsArray(h => MetadataTokens.GetToken(h));
+                        var updatedTypeTokens = emitResult.ChangedTypes.SelectAsArray(h => MetadataTokens.GetToken(h));
 
                         // Determine all active statements whose span changed and exception region span deltas.
                         GetActiveStatementAndExceptionRegionSpans(


### PR DESCRIPTION
The types are reported to the application via runtime event. The application needs to know about added types, not just updated ones.

\+ Simplify some EnC tests.