### PR TITLE
Extract local function: Variable shadowing prior CSharp 8

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -4851,5 +4851,36 @@ class C
     }
 }", codeActionIndex: 1);
         }
+
+        [WorkItem(55031, "https://github.com/dotnet/roslyn/issues/55031")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]
+        public async Task ExtractLocalFunctionVariableNameShadowing_PriorCSharp8()
+        {
+            var code = @"
+class C
+{
+    static void Main(string[] args)
+    {
+        var f = ""{0}"";
+        [|string.Format(f, """");|]
+    }
+}";
+            var expected = @"
+class C
+{
+    static void Main(string[] args)
+    {
+        var f = ""{0}"";
+        {|Rename:NewMethod|}(f);
+
+        void NewMethod(string f)
+        {
+            string.Format(f, """");
+        }
+    }
+}";
+
+            await TestInRegularAndScript1Async(code, expected, CodeActionIndex, new TestParameters(parseOptions: new CSharpParseOptions(languageVersion: LanguageVersion.CSharp7_3)));
+        }
     }
 }


### PR DESCRIPTION
Fix #55031

C# 8 allows shadowing of variables by local function parameters. The *Extract local function* refactoring takes this for granted. The following code is causing CS0136 (A local variable named 'var' cannot be declared in this scope because it would give a different meaning to 'var', which is already used in a 'parent or current/child' scope to denote something else) in C# 7.3 and older:

**Before**

```CS
        static void Main(string[] args)
        {
            var f = "{0}";
            string.Format(f, ""); // Extract local function
        }
```

**After**

```CS
        static void Main(string[] args)
        {
            var f = "{0}";
            NewMethod(f);

            void NewMethod(string f) // Valid in C#8 but causes CS0136 in C#7.3.
            {
                string.Format(f, "");
            }
        }
```