### PR TITLE
Introduce Parameter: Do not show code action if highlighted expression's parent is member access expression

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceParameter/IntroduceParameterTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceParameter/IntroduceParameterTests.cs
@@ -1820,5 +1820,39 @@ class TestClass
 
             await TestInRegularAndScriptAsync(code, expected, index: 0);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceParameter)]
+        public async Task TestClassObject()
+        {
+            var code =
+@"
+class F
+{
+    public int x;
+    public int y;
+
+    public F(int x, int y)
+    {
+        this.x = x;
+        this.y = y;
+    }
+}
+
+class TestClass
+{
+    int N(F f)
+    {
+        return f.[|x|];
+    }
+
+    void M()
+    {
+        N(new F(1, 2));
+    }
+}
+";
+
+            await TestMissingInRegularAndScriptAsync(code);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceParameter/IntroduceParameterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceParameter/IntroduceParameterTests.vb
@@ -943,6 +943,28 @@ End Class"
 
             Await TestMissingInRegularAndScriptAsync(source)
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceParameter)>
+        Public Async Function TestClassObject() As Task
+            Dim source =
+"Class F
+    Public x As Integer
+    Public y As Integer
+
+    Public Sub F(x As Integer, y As Integer)
+        Me.x = x
+        Me.y = y
+    End Sub
+End Class
+
+Class TestClass
+    Public Function N(f As F)
+        Return f.[|x|]
+    End Function
+End Class"
+
+            Await TestMissingInRegularAndScriptAsync(source)
+        End Function
     End Class
 End Namespace
 

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceParameterService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceParameterService.cs
@@ -76,6 +76,13 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 return;
             }
 
+            // Need to special case for expressions whose direct parent is a MemberAccessExpression since they will
+            // never introduce a parameter that makes sense in that case.
+            if (syntaxFacts.IsNameOfAnyMemberAccessExpression(expression))
+            {
+                return;
+            }
+
             var generator = SyntaxGenerator.GetGenerator(document);
             var containingMethod = expression.FirstAncestorOrSelf<SyntaxNode>(node => generator.GetParameterListNode(node) is not null);
 


### PR DESCRIPTION
Fixes: #54878 

 