### PR TITLE
Revert "Adjust test baseline for `CSharpAddMissingUsingsOnPaste.Verif…yDisabledWithNull`"

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpAddMissingUsingsOnPaste.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpAddMissingUsingsOnPaste.cs
@@ -85,7 +85,6 @@ class Program
 
             VisualStudio.Editor.Verify.TextContains(@"
 using System;
-using System.Threading.Tasks;
 
 class Program
 {


### PR DESCRIPTION
The original test baseline was intentional and correct. This is an integration test specifically that Add Imports on Paste is not enabled, and the modified baseline had the opposite result.

This reverts commit a0e35ea51ebe287704c3973d20643629a94139fb.