### PR TITLE
More generic attributes tests

### DIFF
--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -41,7 +41,7 @@ This document provides guidance for thinking about language interactions and tes
 - properties (including get/set/init accessors)
 - events (including add/remove accessors)
 - Parameter modifiers (ref, out, in, params)
-- Attributes (including security attribute)
+- Attributes (including generic attributes and security attributes)
 - Generics (type arguments, variance, constraints including `class`, `struct`, `new()`, `unmanaged`, `notnull`, types and interfaces with nullability)
 - Default and constant values
 - Partial classes

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -10441,7 +10441,6 @@ public class Attr<T> : Attribute { }
         {
             var source = @"
 using System;
-using System.Reflection;
 
 class Attr<T> : Attribute { }
 class Attr2<T> : Attribute { }
@@ -10456,11 +10455,8 @@ class Program
     {
         try
         {
-            var attrs = CustomAttributeData.GetCustomAttributes(typeof(Holder), typeof(Attr<>));
-            foreach (var attr in attrs)
-            {
-                Console.Write(attr);
-            }
+            var attr = Attribute.GetCustomAttribute(typeof(Holder), typeof(Attr<>));
+            Console.Write(attr?.ToString() ?? ""not found"");
         }
         catch (Exception e)
         {
@@ -10469,7 +10465,7 @@ class Program
     }
 }
 ";
-            var verifier = CompileAndVerify(source, expectedOutput: "Attr[System.String]");
+            var verifier = CompileAndVerify(source, expectedOutput: "not found");
             verifier.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -10473,6 +10473,28 @@ class Program
             verifier.VerifyDiagnostics();
         }
 
+        [Fact]
+        public void GenericAttributeNested()
+        {
+            var source = @"
+using System;
+
+class Attr<T> : Attribute { }
+
+[Attr<Attr<string>>]
+class C { }
+";
+            var verifier = CompileAndVerify(source, symbolValidator: verify, sourceSymbolValidator: verify);
+            verifier.VerifyDiagnostics();
+
+            void verify(ModuleSymbol module)
+            {
+                var c = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+                var attrs = c.GetAttributes();
+                Assert.Equal(new[] { "Attr<Attr<System.String>>" }, GetAttributeStrings(attrs));
+            }
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -10291,7 +10291,7 @@ class Outer<T2>
                 Diagnostic(ErrorCode.ERR_BadAttributeArgument, "default(T2)").WithLocation(10, 22));
         }
 
-        [Fact, WorkItem(55190, "https://github.com/dotnet/roslyn/issues/55190")]
+        [ConditionalFact(typeof(CoreClrOnly)), WorkItem(55190, "https://github.com/dotnet/roslyn/issues/55190")]
         public void GenericAttributeParameter_01()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -10101,8 +10101,7 @@ class C1
 }
 ";
             var comp = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp);
-            var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetCoreApp);
-            verifier.VerifyDiagnostics();
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
@@ -2109,7 +2109,7 @@ class Program
         }
 
         [Fact]
-        public void GenericAttribute_LookupSymbols()
+        public void GenericAttribute_LookupSymbols_01()
         {
             var source = @"
 using System;
@@ -2126,6 +2126,21 @@ class C { }";
             var node = tree.GetRoot().DescendantNodes().OfType<AttributeSyntax>().Single();
             var symbol = model.GetSymbolInfo(node);
             Assert.Equal("Attr1<System.String>..ctor(System.String t)", symbol.Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void GenericAttribute_LookupSymbols_02()
+        {
+            var source = @"
+using System;
+class Attr1<T> : Attribute { public Attr1(T t) { } }
+
+[Attr1</*<bind>*/string/*</bind>*/>]
+class C { }";
+
+            var names = GetLookupNames(source);
+            Assert.Contains("C", names);
+            Assert.Contains("Attr1", names);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
@@ -2108,6 +2108,22 @@ class Program
             Assert.NotNull(symbolInfo.Symbol);
         }
 
+        // TODO: it's not clear that this test is meaningful.
+        [Fact]
+        public void GenericAttribute_LookupSymbols()
+        {
+            var source = @"
+using System;
+class Attr1<T> : Attribute { public Attr1(T t) { } }
+
+[/*<bind>*/Attr1<string>/*</bind>*/]
+class C { }";
+
+            var symbols = GetLookupSymbols(source);
+            Assert.Contains(@"Attr1<T>", symbols.ListToSortedString());
+        }
+
+
         #endregion
     }
 }


### PR DESCRIPTION
Related to test plan #36285
Related to #55190

This adds coverage for everything considered blocking. Note that there is an issue when an attribute constructor parameter is of a type parameter type in its original definition, even when the parameter is a closed type in its usage. Currently I think this might be a runtime bug but we will have to dig in more closely to be sure.