### PR TITLE
Fix regression in recursive patterns

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -536,6 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         Debug.Assert(recursive.HasAnyErrors);
                         tests.Add(new Tests.One(new BoundDagTypeTest(recursive.Syntax, ErrorType(), input, hasErrors: true)));
+                        continue;
                     }
                     tests.Add(MakeTestsAndBindings(currentInput, pattern, bindings));
                 }

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -536,9 +536,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         Debug.Assert(recursive.HasAnyErrors);
                         tests.Add(new Tests.One(new BoundDagTypeTest(recursive.Syntax, ErrorType(), input, hasErrors: true)));
-                        continue;
                     }
-                    tests.Add(MakeTestsAndBindings(currentInput, pattern, bindings));
+                    else
+                    {
+                        tests.Add(MakeTestsAndBindings(currentInput, pattern, bindings));
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests5.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests5.cs
@@ -1832,6 +1832,34 @@ class C
                 );
         }
 
+        [Fact, WorkItem(55184, "https://github.com/dotnet/roslyn/issues/55184")]
+        public void Repro55184()
+        {
+            var source = @"
+var x = """";
+
+_ = x is { Error: { Length: > 0 } };
+_ = x is { Error.Length: > 0 };
+_ = x is { Length: { Error: > 0 } };
+_ = x is { Length.Error: > 0 };
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,12): error CS0117: 'string' does not contain a definition for 'Error'
+                // _ = x is { Error: { Length: > 0 } };
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "Error").WithArguments("string", "Error").WithLocation(4, 12),
+                // (5,12): error CS0117: 'string' does not contain a definition for 'Error'
+                // _ = x is { Error.Length: > 0 };
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "Error").WithArguments("string", "Error").WithLocation(5, 12),
+                // (6,22): error CS0117: 'int' does not contain a definition for 'Error'
+                // _ = x is { Length: { Error: > 0 } };
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "Error").WithArguments("int", "Error").WithLocation(6, 22),
+                // (7,19): error CS0117: 'int' does not contain a definition for 'Error'
+                // _ = x is { Length.Error: > 0 };
+                Diagnostic(ErrorCode.ERR_NoSuchMember, "Error").WithArguments("int", "Error").WithLocation(7, 19)
+                );
+        }
+
         public class FlowAnalysisTests : FlowTestBase
         {
             [Fact]


### PR DESCRIPTION
Looking back at the change in `MakeTestsAndBindingsForRecursivePattern` for the [extended property patterns](https://github.com/dotnet/roslyn/pull/53946), I see that the behavior in error case changed a bit. It used to bail, avoiding continuing to `MakeTestsAndBindings`. This PR restores that behavior.

Although we do have some tests for error cases (such as `ExtendedPropertyPatterns_BadMemberAccess`) they happen to use patterns that are compatible with the original input type, so didn't hit this crash.

Fixes https://github.com/dotnet/roslyn/issues/55184