### PR TITLE
Support EditorBrowsable in Fully-Qualify

### DIFF
--- a/src/EditorFeatures/CSharpTest/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/FullyQualify/FullyQualifyTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.FullyQualify;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
@@ -1495,6 +1496,156 @@ class Class
             await TestInRegularAndScriptAsync(
 @"using M = [|Math|]",
 @"using M = System.Math");
+        }
+
+        [Fact]
+        [WorkItem(54544, "https://github.com/dotnet/roslyn/issues/54544")]
+        public async Task TestAddUsingsEditorBrowsableNeverSameProject()
+        {
+            const string InitialWorkspace = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""lib"" CommonReferences=""true"">
+        <Document FilePath=""lib.cs"">
+using System.ComponentModel;
+namespace ProjectLib
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class Project
+    {
+    }
+}
+        </Document>
+        <Document FilePath=""Program.cs"">
+class Program
+{
+    static void Main(string[] args)
+    {
+        Project p = new [|Project()|];
+    }
+}
+</Document>
+    </Project>
+</Workspace>";
+
+            const string ExpectedDocumentText = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Project p = new [|ProjectLib.Project()|];
+    }
+}
+";
+
+            await TestInRegularAndScript1Async(InitialWorkspace, ExpectedDocumentText);
+        }
+
+        [Fact]
+        [WorkItem(54544, "https://github.com/dotnet/roslyn/issues/54544")]
+        public async Task TestAddUsingsEditorBrowsableNeverDifferentProject()
+        {
+            const string InitialWorkspace = @"
+<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""lib"" CommonReferences=""true"">
+        <Document FilePath=""lib.vb"">
+imports System.ComponentModel
+namespace ProjectLib
+    &lt;EditorBrowsable(EditorBrowsableState.Never)&gt;
+    public class Project
+    end class
+end namespace
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Console"" CommonReferences=""true"">
+        <ProjectReference>lib</ProjectReference>
+        <Document FilePath=""Program.cs"">
+class Program
+{
+    static void Main(string[] args)
+    {
+        [|Project|] p = new Project();
+    }
+}
+</Document>
+    </Project>
+</Workspace>";
+            await TestMissingAsync(InitialWorkspace);
+        }
+
+        [Fact]
+        [WorkItem(54544, "https://github.com/dotnet/roslyn/issues/54544")]
+        public async Task TestAddUsingsEditorBrowsableAdvancedDifferentProjectOptionOn()
+        {
+            const string InitialWorkspace = @"
+<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""lib"" CommonReferences=""true"">
+        <Document FilePath=""lib.vb"">
+imports System.ComponentModel
+namespace ProjectLib
+    &lt;EditorBrowsable(EditorBrowsableState.Advanced)&gt;
+    public class Project
+    end class
+end namespace
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Console"" CommonReferences=""true"">
+        <ProjectReference>lib</ProjectReference>
+        <Document FilePath=""Program.cs"">
+class Program
+{
+    static void Main(string[] args)
+    {
+        [|Project|] p = new Project();
+    }
+}
+</Document>
+    </Project>
+</Workspace>";
+
+            const string ExpectedDocumentText = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        ProjectLib.Project p = new Project();
+    }
+}
+";
+            await TestInRegularAndScript1Async(InitialWorkspace, ExpectedDocumentText);
+        }
+
+        [Fact]
+        [WorkItem(54544, "https://github.com/dotnet/roslyn/issues/54544")]
+        public async Task TestAddUsingsEditorBrowsableAdvancedDifferentProjectOptionOff()
+        {
+            const string InitialWorkspace = @"
+<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""lib"" CommonReferences=""true"">
+        <Document FilePath=""lib.vb"">
+imports System.ComponentModel
+namespace ProjectLib
+    &lt;EditorBrowsable(EditorBrowsableState.Advanced)&gt;
+    public class Project
+    end class
+end namespace
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Console"" CommonReferences=""true"">
+        <ProjectReference>lib</ProjectReference>
+        <Document FilePath=""Program.cs"">
+class Program
+{
+    static void Main(string[] args)
+    {
+        [|Project|] p = new Project();
+    }
+}
+</Document>
+    </Project>
+</Workspace>";
+
+            await TestMissingAsync(InitialWorkspace, new TestParameters(
+                options: Option(CompletionOptions.HideAdvancedMembers, true)));
         }
     }
 }

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -9,11 +9,14 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.Shared.Utilities.EditorBrowsableHelpers;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
 {
@@ -62,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
 
                 var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-                var matchingTypes = await GetMatchingTypesAsync(project, semanticModel, node, cancellationToken).ConfigureAwait(false);
+                var matchingTypes = await GetMatchingTypesAsync(document, semanticModel, node, cancellationToken).ConfigureAwait(false);
                 var matchingNamespaces = await GetMatchingNamespacesAsync(project, semanticModel, node, cancellationToken).ConfigureAwait(false);
 
                 if (matchingTypes.IsEmpty && matchingNamespaces.IsEmpty)
@@ -144,10 +147,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
         }
 
         private async Task<ImmutableArray<SymbolResult>> GetMatchingTypesAsync(
-            Project project, SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
+            Document document, SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            var project = document.Project;
             var syntaxFacts = project.LanguageServices.GetRequiredService<ISyntaxFactsService>();
 
             syntaxFacts.GetNameAndArityOfSimpleName(node, out var name, out var arity);
@@ -167,9 +171,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
                 symbols = symbols.Concat(attributeSymbols);
             }
 
+            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var hideAdvancedMembers = options.GetOption(CompletionOptions.HideAdvancedMembers);
+            var editorBrowserInfo = new EditorBrowsableInfo(semanticModel.Compilation);
+
             var validSymbols = symbols
                 .OfType<INamedTypeSymbol>()
-                .Where(s => IsValidNamedTypeSearchResult(semanticModel, arity, inAttributeContext, looksGeneric, s))
+                .Where(s => IsValidNamedTypeSearchResult(semanticModel, arity, inAttributeContext, looksGeneric, s) &&
+                            s.IsEditorBrowsable(hideAdvancedMembers, semanticModel.Compilation, editorBrowserInfo))
                 .ToImmutableArray();
 
             // Check what the current node binds to.  If it binds to any symbols, but with


### PR DESCRIPTION
Fixes  https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1360402

This is a port from teh same fix in main-vs-deps: https://github.com/dotnet/roslyn/pull/53427
Partner team would like this in 16.11