### PR TITLE
Make sure buffers are returned to the pool

### DIFF
--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Differencing
 {
@@ -117,6 +118,7 @@ namespace Microsoft.CodeAnalysis.Differencing
         protected struct VStack
         {
             private readonly ObjectPool<VBuffer> _bufferPool;
+            private readonly VBuffer _firstBuffer;
 
             private VBuffer _currentBuffer;
             private int _depth;
@@ -124,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Differencing
             public VStack(ObjectPool<VBuffer> bufferPool)
             {
                 _bufferPool = bufferPool;
-                _currentBuffer = bufferPool.Allocate();
+                _currentBuffer = _firstBuffer = bufferPool.Allocate();
                 _depth = 0;
             }
 
@@ -162,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Differencing
                     yield return (buffer.GetVArray(depth), depth);
                 }
 
-                _bufferPool.Free(_currentBuffer);
+                _bufferPool.Free(_firstBuffer);
                 _currentBuffer = null;
             }
         }
@@ -274,6 +276,12 @@ namespace Microsoft.CodeAnalysis.Differencing
 
                 x = xStart;
                 y = yStart;
+            }
+
+            // make sure we finish the enumeration as it returns the allocated buffers to the pool
+            if (varrays.MoveNext())
+            {
+                throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
@@ -279,9 +279,8 @@ namespace Microsoft.CodeAnalysis.Differencing
             }
 
             // make sure we finish the enumeration as it returns the allocated buffers to the pool
-            if (varrays.MoveNext())
+            while (varrays.MoveNext())
             {
-                throw ExceptionUtilities.Unreachable;
             }
         }
 


### PR DESCRIPTION
Reduces total memory allocations of EnC diffing.

Fixes https://github.com/dotnet/roslyn/issues/55076
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1338956