### PR TITLE
Skip BuildWithCommandLine test

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
@@ -50,7 +50,7 @@ class Program
             // TODO: Validate build works as expected
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Build)]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/18204"), Trait(Traits.Feature, Traits.Features.Build)]
         public void BuildWithCommandLine()
         {
             VisualStudio.SolutionExplorer.SaveAll();


### PR DESCRIPTION
There's an issue causing this test to fail semi-consistently, tracked by https://github.com/dotnet/roslyn/issues/18204. Skipping for now to improve merge flow.