### PR TITLE
React to changes in .net6p7 to how source generated file paths are created

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/CompileTimeSolutionProviderTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/CompileTimeSolutionProviderTests.cs
@@ -24,8 +24,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
     [UseExportProvider]
     public class CompileTimeSolutionProviderTests
     {
-        [Fact]
-        public async Task TryGetCompileTimeDocumentAsync()
+        [Theory]
+        [CombinatorialData]
+        public async Task TryGetCompileTimeDocumentAsync([CombinatorialValues(@"_a_X_razor.cs", @"a_X_razor.g.cs")] string generatedHintName)
         {
             var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features);
             var projectId = ProjectId.CreateNewId();
@@ -33,7 +34,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             var projectFilePath = Path.Combine(TempRoot.Root, "a.csproj");
             var additionalFilePath = Path.Combine(TempRoot.Root, "a", "X.razor");
             var designTimeFilePath = Path.Combine(TempRoot.Root, "a", "X.razor.g.cs");
-            var generatedHintName = @"_a_X_razor.cs";
 
             var generator = new TestSourceGenerator() { ExecuteImpl = context => context.AddSource(generatedHintName, "") };
             var sourceGeneratedPathPrefix = Path.Combine(typeof(TestSourceGenerator).Assembly.GetName().Name, typeof(TestSourceGenerator).FullName);


### PR DESCRIPTION
there were a couple changes to file paths for source generated docs in net6p7 causing enc diagnostics in razor to fail.  This must go into VS p3 since net6p7 will soon be added to VS p3.

Prior to net6p7 we looked for file paths like: "Microsoft.NET.Sdk.Razor.SourceGenerators\\Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator\\_Pages_Counter_razor.cs"

In net6p7, this changed to: "Microsoft.NET.Sdk.Razor.SourceGenerators\\Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator\\Pages_Counter_razor.g.cs"
Note the .g.cs and the missing underscore at the begining of the name