### PR TITLE
Turn off LSP TextEdit completion feature flag by default

### DIFF
--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -21,7 +21,7 @@
 
 [$RootKey$\FeatureFlags\Roslyn\LSP\Completion]
 "Description"="Enables the LSP-powered C#/VB completion experience to operate with prototype behavior. Note this currently will not affect local C#/VB scenarios except for C# in Razor."
-"Value"=dword:00000001
+"Value"=dword:00000000
 "Title"="C#/VB LSP completion experience"
 "PreviewPaneChannels"="IntPreview,int.main"
 


### PR DESCRIPTION
I thought by turning the feature flag on only for internal users, then external users wouldn't be affected. It turns out I was wrong and if the feature flag doesn't exist, the default value is used (which in this case is on). Thanks to Taylor for the catch!
This change turns off the flag by default for everyone.