### PR TITLE
Fix nav-to out of date message.

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToSearcherTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToSearcherTests.cs
@@ -54,8 +54,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             return searchServiceCallback.ReturnsAsync(isFullyLoaded ? NavigateToSearchLocation.Latest : NavigateToSearchLocation.Cache);
         }
 
-        private static ValueTask<(bool projectSystem, bool remoteHost)> IsFullyLoadedAsync(bool projectSystem, bool remoteHost)
-            => new((projectSystem, remoteHost));
+        private static ValueTask<bool> IsFullyLoadedAsync(bool projectSystem, bool remoteHost)
+            => new(projectSystem && remoteHost);
 
         [Fact]
         public async Task NotFullyLoadedOnlyMakesOneSearchProjectCallIfValueReturned()
@@ -121,8 +121,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             callbackMock.Setup(c => c.AddItemAsync(It.IsAny<Project>(), result, It.IsAny<CancellationToken>()))
                         .Returns(Task.CompletedTask);
 
-            // Because we did a full search, the accuracy is dependent on it the project system was fully loaded or not.
-            callbackMock.Setup(c => c.Done(projectSystemFullyLoaded));
+            // Because the remote host wasn't fully loaded, we still notify that our results may be incomplete.
+            callbackMock.Setup(c => c.Done(false));
 
             var searcher = NavigateToSearcher.Create(
                 workspace.CurrentSolution,
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
 
         [Theory]
         [CombinatorialData]
-        public async Task NotFullyLoadedStillReportsAsFullyCompletedIfSecondCallReturnsNothing(bool projectIsFullyLoaded)
+        public async Task NotFullyLoadedStillReportsAsNotCompleteIfRemoteHostIsStillHydrating(bool projectIsFullyLoaded)
         {
             using var workspace = TestWorkspace.CreateCSharp("");
 
@@ -161,8 +161,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
             var callbackMock = new Mock<INavigateToSearchCallback>(MockBehavior.Strict);
             callbackMock.Setup(c => c.ReportProgress(It.IsAny<int>(), It.IsAny<int>()));
 
-            // Because we did a full search, the accuracy is dependent on it the project system was fully loaded or not.
-            callbackMock.Setup(c => c.Done(projectIsFullyLoaded));
+            // Because the remote host wasn't fully loaded, we still notify that our results may be incomplete.
+            callbackMock.Setup(c => c.Done(false));
 
             var searcher = NavigateToSearcher.Create(
                 workspace.CurrentSolution,

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearcherHost.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         /// <summary>
         /// Returns the fully loaded state for both the project system and the remote host.
         /// </summary>
-        ValueTask<(bool projectSystem, bool remoteHost)> IsFullyLoadedAsync(CancellationToken cancellationToken);
+        ValueTask<bool> IsFullyLoadedAsync(CancellationToken cancellationToken);
     }
 
     internal class DefaultNavigateToSearchHost : INavigateToSearcherHost
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         public INavigateToSearchService? GetNavigateToSearchService(Project project)
             => project.GetLanguageService<INavigateToSearchService>();
 
-        public async ValueTask<(bool projectSystem, bool remoteHost)> IsFullyLoadedAsync(CancellationToken cancellationToken)
+        public async ValueTask<bool> IsFullyLoadedAsync(CancellationToken cancellationToken)
         {
             var service = _solution.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
 
@@ -63,10 +63,10 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             // return cached data from languages that support that.
             var isProjectSystemFullyLoaded = await service.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
             if (!isProjectSystemFullyLoaded)
-                return (false, false);
+                return false;
 
             var isRemoteHostFullyLoaded = GetRemoteHostHydrateTask().IsCompleted;
-            return (isProjectSystemFullyLoaded, isRemoteHostFullyLoaded);
+            return isRemoteHostFullyLoaded;
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -86,14 +86,18 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
         internal async Task SearchAsync(CancellationToken cancellationToken)
         {
-            var searchWasComplete = true;
+            var isFullyLoaded = true;
 
             try
             {
                 using var navigateToSearch = Logger.LogBlock(FunctionId.NavigateTo_Search, KeyValueLogMessage.Create(LogType.UserAction), cancellationToken);
                 using var asyncToken = _asyncListener.BeginAsyncOperation(GetType() + ".Search");
 
-                searchWasComplete = await SearchAllProjectsAsync(cancellationToken).ConfigureAwait(false);
+                // We consider ourselves fully loaded when both the project system has completed loaded us, and we've
+                // totally hydrated the oop side.  Until that happens, we'll attempt to return cached data from languages
+                // that support that.
+                isFullyLoaded = await _host.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
+                await SearchAllProjectsAsync(isFullyLoaded, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -102,46 +106,31 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             {
                 // providing this extra information will make UI to show indication to users
                 // that result might not contain full data
-                _callback.Done(searchWasComplete);
+                _callback.Done(isFullyLoaded);
             }
         }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if all searches were performed against the latest data and represent the
-        /// complete set of results. Or <see langword="false"/> if any searches were performed against cached data and
-        /// could be incomplete or inaccurate.
-        /// </summary>
-        private async Task<bool> SearchAllProjectsAsync(CancellationToken cancellationToken)
+        private async Task SearchAllProjectsAsync(bool isFullyLoaded, CancellationToken cancellationToken)
         {
-            // We consider ourselves fully loaded when both the project system has completed loaded us, and we've
-            // totally hydrated the oop side.  Until that happens, we'll attempt to return cached data from languages
-            // that support that.
-            var (projectSystemIsFullyLoaded, remoteHostIsFullyLoaded) = await _host.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false);
-
-            var isFullyLoaded = projectSystemIsFullyLoaded && remoteHostIsFullyLoaded;
             var orderedProjects = GetOrderedProjectsToProcess();
             var (itemsReported, projectResults) = await ProcessProjectsAsync(orderedProjects, isFullyLoaded, cancellationToken).ConfigureAwait(false);
 
             // If we're fully loaded then we're done at this point.  All the searches would have been against the latest
             // computed data and we don't need to do anything else.
             if (isFullyLoaded)
-                return true;
+                return;
 
             // We weren't fully loaded *but* we reported some items to the user, then consider that good enough for now.
             // The user will have some results they can use, and (in the case that we actually examined the cache for
             // data) we will tell the user that the results may be incomplete/inaccurate and they should try again soon.
             if (itemsReported > 0)
-                return projectResults.All(t => t.location == NavigateToSearchLocation.Latest);
+                return;
 
             // We didn't have any items reported *and* we weren't fully loaded.  If it turns out that some of our
             // projects were using cached data then we can try searching them again, but this tell them to use the
             // latest data.  The ensures the user at least gets some result instead of nothing.
             var projectsUsingCache = projectResults.SelectAsArray(t => t.location == NavigateToSearchLocation.Cache, t => t.project);
             await ProcessProjectsAsync(ImmutableArray.Create(projectsUsingCache), isFullyLoaded: true, cancellationToken).ConfigureAwait(false);
-
-            // We attempted a full oop sync and an uncached search.  However, we still may need to tell the user that
-            // things are incomplete if the project system hadn't fully loaded.
-            return projectSystemIsFullyLoaded;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/55201

It was possible for us to think the project was fully loaded, but only have sync'ed the partial solution prior to that, leading to incomplete results.  This would cause us to not report that results were incomplete (since we thought we were fully sync'ed).  Now we ensure that unless we have the full sync complete that we always report potential stale results.