### PR TITLE
Inline Hints Perf

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
@@ -159,7 +159,6 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                 Margin = new Thickness(left, top: 0, right, bottom: 0),
             };
 
-            border.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
             // gets pixel distance of baseline to top of the font height
             var dockPanelHeight = format.Typeface.FontFamily.Baseline * format.FontRenderingEmSize;
 

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
@@ -114,14 +114,12 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             // Constructs the hint block which gets assigned parameter name and fontstyles according to the options
             // page. Calculates a inline tag that will be 3/4s the size of a normal line. This shrink size tends to work
             // well with VS at any zoom level or font size.
-
             var block = new TextBlock
             {
                 FontFamily = format.Typeface.FontFamily,
                 FontSize = 0.75 * format.FontRenderingEmSize,
                 FontStyle = FontStyles.Normal,
                 Foreground = format.ForegroundBrush,
-
                 // Adds a little bit of padding to the left of the text relative to the border to make the text seem
                 // more balanced in the border
                 Padding = new Thickness(left: 2, top: 0, right: 2, bottom: 0)
@@ -143,8 +141,9 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                 block.Inlines.Add(run);
             }
 
-            // Encapsulates the textblock within a border. Gets foreground/background colors from the options menu.
+            block.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
 
+            // Encapsulates the textblock within a border. Gets foreground/background colors from the options menu.
             // If the tag is started or followed by a space, we trim that off but represent the space as buffer on hte
             // left or right side.
             var left = leftPadding * 5;
@@ -161,7 +160,6 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
 
             // gets pixel distance of baseline to top of the font height
             var dockPanelHeight = format.Typeface.FontFamily.Baseline * format.FontRenderingEmSize;
-
             var dockPanel = new DockPanel
             {
                 Height = dockPanelHeight,

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
         /// <summary>
         /// stores the parameter hint tags in a global location 
         /// </summary>
-        private readonly List<(IMappingTagSpan<InlineHintDataTag> mappingTagSpan, ITagSpan<IntraTextAdornmentTag>? tagSpan)> _cache;
+        private readonly List<(IMappingTagSpan<InlineHintDataTag> mappingTagSpan, ITagSpan<IntraTextAdornmentTag>? tagSpan)> _cache = new();
 
         /// <summary>
         /// Stores the snapshot associated with the cached tags in <see cref="_cache" /> 
@@ -58,8 +58,6 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             ITextBuffer buffer,
             ITagAggregator<InlineHintDataTag> tagAggregator)
         {
-            _cache = new List<(IMappingTagSpan<InlineHintDataTag>, ITagSpan<IntraTextAdornmentTag>?)>();
-
             _threadAffinitizedObject = new ForegroundThreadAffinitizedObject(taggerProvider.ThreadingContext);
             _taggerProvider = taggerProvider;
 
@@ -129,7 +127,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                     var dataTagSpans = tag.Span.GetSpans(snapshot);
                     if (dataTagSpans.Count == 1)
                     {
-                        _cache.Add((tag, null));
+                        _cache.Add((tag, tagSpan: null));
                     }
                 }
             }

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Formatting;
 using Microsoft.VisualStudio.Text.Tagging;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace Microsoft.CodeAnalysis.Editor.InlineHints
 {
@@ -28,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
         /// <summary>
         /// stores the parameter hint tags in a global location 
         /// </summary>
-        private readonly List<ITagSpan<IntraTextAdornmentTag>> _cache;
+        private readonly List<(IMappingTagSpan<InlineHintDataTag> mappingTagSpan, ITagSpan<IntraTextAdornmentTag>? tagSpan)> _cache;
 
         /// <summary>
         /// Stores the snapshot associated with the cached tags in <see cref="_cache" /> 
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             ITextBuffer buffer,
             ITagAggregator<InlineHintDataTag> tagAggregator)
         {
-            _cache = new List<ITagSpan<IntraTextAdornmentTag>>();
+            _cache = new List<(IMappingTagSpan<InlineHintDataTag>, ITagSpan<IntraTextAdornmentTag>?)>();
 
             _threadAffinitizedObject = new ForegroundThreadAffinitizedObject(taggerProvider.ThreadingContext);
             _taggerProvider = taggerProvider;
@@ -116,9 +117,6 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                 _cache.Clear();
                 _cacheSnapshot = snapshot;
 
-                var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
-                var classify = document?.Project.Solution.Workspace.Options.GetOption(InlineHintsOptions.ColorHints, document?.Project.Language) ?? false;
-
                 // Calling into the InlineParameterNameHintsDataTaggerProvider which only responds with the current
                 // active view and disregards and requests for tags not in that view
                 var fullSpan = new SnapshotSpan(snapshot, 0, snapshot.Length);
@@ -131,21 +129,29 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                     var dataTagSpans = tag.Span.GetSpans(snapshot);
                     if (dataTagSpans.Count == 1)
                     {
-                        var dataTagSpan = dataTagSpans[0];
-                        var parameterHintUITag = InlineHintsTag.Create(
-                            tag.Tag.Hint, Format, _textView, dataTagSpan, _taggerProvider, _formatMap, classify);
-
-                        _cache.Add(new TagSpan<IntraTextAdornmentTag>(dataTagSpan, parameterHintUITag));
+                        _cache.Add((tag, null));
                     }
                 }
             }
 
+            var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
+            var classify = document?.Project.Solution.Workspace.Options.GetOption(InlineHintsOptions.ColorHints, document?.Project.Language) ?? false;
+
             var selectedSpans = new List<ITagSpan<IntraTextAdornmentTag>>();
-            foreach (var tagSpan in _cache)
+            for (var i = 0; i < _cache.Count; i++)
             {
-                if (spans.IntersectsWith(tagSpan.Span))
+                var tagSpan = _cache[i].mappingTagSpan.Span.GetSpans(snapshot)[0];
+                if (spans.IntersectsWith(tagSpan))
                 {
-                    selectedSpans.Add(tagSpan);
+                    if (_cache[i].tagSpan is not { } hintTagSpan)
+                    {
+                        var parameterHintUITag = InlineHintsTag.Create(
+                                _cache[i].mappingTagSpan.Tag.Hint, Format, _textView, tagSpan, _taggerProvider, _formatMap, classify);
+                        hintTagSpan = new TagSpan<IntraTextAdornmentTag>(tagSpan, parameterHintUITag);
+                        _cache[i] = (_cache[i].mappingTagSpan, hintTagSpan);
+                    }
+
+                    selectedSpans.Add(hintTagSpan);
                 }
             }
 


### PR DESCRIPTION
Fixes: [AB#1361128](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1361128)

Reconfigured code surrounding the creation of inline hint tags. Now we make sure we are in a span that is going to have a hint added prior to calling for the creation of a hint.
Also, Measure is very expensive and I was calling it on the border object rather than the textblock, but it was only necessary for the textblock.