### PR TITLE
Fix LSP completions when all items have default commit characters

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
@@ -49,8 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             {
                 // '<' should not filter the completion list, even though it's in generic items like IList<>
                 var generalBaseline = CompletionItemRules.Default.
-                    WithFilterCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, '<')).
-                    WithCommitCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Add, '<'));
+                    WithFilterCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, '<'));
 
                 var importDirectiveBaseline = CompletionItemRules.Create(commitCharacterRules:
                     ImmutableArray.Create(CharacterSetModificationRule.Create(CharacterSetModificationKind.Replace, '.', ';')));

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -356,6 +356,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             static void PromoteCommonCommitCharactersOntoList(LSP.VSCompletionList completionList)
             {
+                var defaultCommitCharacters = CompletionRules.Default.DefaultCommitCharacters.Select(c => c.ToString()).ToArray();
                 var commitCharacterReferences = new Dictionary<object, int>();
                 var mostUsedCount = 0;
                 string[]? mostUsedCommitCharacters = null;
@@ -365,7 +366,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     var commitCharacters = completionItem.CommitCharacters;
                     if (commitCharacters == null)
                     {
-                        continue;
+                        // The commit characters on the item are null, this means the commit characters are actually
+                        // the default commit characters we passed in the initialize request.
+                        commitCharacters = defaultCommitCharacters;
                     }
 
                     commitCharacterReferences.TryGetValue(commitCharacters, out var existingCount);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -71,14 +71,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
         [Fact]
         public async Task TestGetCompletions_PromotesNothingWhenNoCommitCharactersAsync()
         {
-            var clientCapabilities = new LSP.VSInternalClientCapabilities
+            var clientCapabilities = new LSP.VSClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,
                 TextDocument = new LSP.TextDocumentClientCapabilities()
                 {
-                    Completion = new LSP.VSInternalCompletionSetting()
+                    Completion = new LSP.VSCompletionSetting()
                     {
-                        CompletionList = new LSP.VSInternalCompletionListSetting()
+                        CompletionList = new LSP.VSCompletionListSetting()
                         {
                             CommitCharacters = true,
                         }
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             using var testLspServer = CreateTestLspServer(markup, out var locations);
             var completionParams = CreateCompletionParams(
                 locations["caret"].Single(),
-                invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
+                invokeKind: LSP.VSCompletionInvokeKind.Explicit,
                 triggerCharacter: "\0",
                 triggerKind: LSP.CompletionTriggerKind.Invoked);
 
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities).ConfigureAwait(false);
             Assert.All(results.Items, item => Assert.Null(item.CommitCharacters));
-            var vsCompletionList = Assert.IsAssignableFrom<LSP.VSInternalCompletionList>(results);
+            var vsCompletionList = Assert.IsAssignableFrom<LSP.VSCompletionList>(results);
             Assert.Equal(expectedCommitCharacters, vsCompletionList.CommitCharacters.Value.First);
         }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -69,6 +69,49 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
         }
 
         [Fact]
+        public async Task TestGetCompletions_PromotesNothingWhenNoCommitCharactersAsync()
+        {
+            var clientCapabilities = new LSP.VSInternalClientCapabilities
+            {
+                SupportsVisualStudioExtensions = true,
+                TextDocument = new LSP.TextDocumentClientCapabilities()
+                {
+                    Completion = new LSP.VSInternalCompletionSetting()
+                    {
+                        CompletionList = new LSP.VSInternalCompletionListSetting()
+                        {
+                            CommitCharacters = true,
+                        }
+                    }
+                }
+            };
+            var markup =
+@"namespace M
+{{|caret:|}
+}";
+            using var testLspServer = CreateTestLspServer(markup, out var locations);
+            var completionParams = CreateCompletionParams(
+                locations["caret"].Single(),
+                invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
+                triggerCharacter: "\0",
+                triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+            var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
+
+            var expected = await CreateCompletionItemAsync(label: "A", kind: LSP.CompletionItemKind.Class, tags: new string[] { "Class", "Internal" },
+                request: completionParams, document: document, commitCharacters: CompletionRules.Default.DefaultCommitCharacters, insertText: "A").ConfigureAwait(false);
+            var expectedCommitCharacters = expected.CommitCharacters;
+
+            // Null out the commit characters since we're expecting the commit characters will be lifted onto the completion list.
+            expected.CommitCharacters = null;
+
+            var results = await RunGetCompletionsAsync(testLspServer, completionParams, clientCapabilities).ConfigureAwait(false);
+            Assert.All(results.Items, item => Assert.Null(item.CommitCharacters));
+            var vsCompletionList = Assert.IsAssignableFrom<LSP.VSInternalCompletionList>(results);
+            Assert.Equal(expectedCommitCharacters, vsCompletionList.CommitCharacters.Value.First);
+        }
+
+        [Fact]
         public async Task TestGetCompletionsAsync()
         {
             var markup =

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
             var expected = await CreateCompletionItemAsync(label: "A", kind: LSP.CompletionItemKind.Class, tags: new string[] { "Class", "Internal" },
-                request: completionParams, document: document, commitCharacters: CompletionRules.Default.DefaultCommitCharacters, insertText: "A").ConfigureAwait(false);
+                request: completionParams, document: document, commitCharacters: null, insertText: "A").ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
             var expected = await CreateCompletionItemAsync(label: "A", kind: LSP.CompletionItemKind.Class, tags: new string[] { "Class", "Internal" },
-                request: completionParams, document: document, commitCharacters: CompletionRules.Default.DefaultCommitCharacters, insertText: "A").ConfigureAwait(false);
+                request: completionParams, document: document, commitCharacters: null, insertText: "A").ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());


### PR DESCRIPTION
Fixes an exception stack trace seen in https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1362284

Also fixes behavior of promotion of commit characters to the list to include default commit characters