### PR TITLE
Add GoToDefinition for XAML LSP

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Features/Definitions/IXamlGoToDefinitionService.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Definitions/IXamlGoToDefinitionService.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
+{
+    internal interface IXamlGoToDefinitionService : ILanguageService
+    {
+        Task<ImmutableArray<XamlDefinition>> GetDefinitionsAsync(TextDocument document, int position, CancellationToken cancellationToken);
+    }
+}

--- a/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlDefinition.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlDefinition.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
+{
+    public abstract class XamlDefinition
+    { }
+}

--- a/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSourceDefinition.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSourceDefinition.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
+{
+    /// <summary>
+    /// XamlDefinition with file path and TextSpan or line and column.
+    /// </summary>
+    internal sealed class XamlSourceDefinition : XamlDefinition
+    {
+        private readonly TextSpan? _span;
+        private readonly int _line, _character;
+
+        public XamlSourceDefinition(string filePath, TextSpan span)
+        {
+            FilePath = filePath;
+            _span = span;
+        }
+
+        public XamlSourceDefinition(string filePath, int line, int character)
+        {
+            FilePath = filePath;
+            _line = line;
+            _character = character;
+        }
+
+        public string FilePath { get; }
+
+        /// <summary>
+        /// When XamlSourceDefinition was created, the creator may have had a textSpan or line/column.
+        /// We should either use _span or _line _character. This property will tell you which one to use.
+        /// </summary>
+        private bool CanUseSpan => _span != null;
+
+        public TextSpan? GetTextSpan(SourceText text)
+        {
+            if (CanUseSpan)
+            {
+                return _span;
+            }
+
+            // Convert the line column to TextSpan
+            if (_line < text.Lines.Count)
+            {
+                var character = Math.Min(_character, text.Lines[_line].Span.Length);
+                var start = text.Lines.GetPosition(new LinePosition(_line, character));
+                return new TextSpan(start, 0);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSourceDefinition.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSourceDefinition.cs
@@ -21,11 +21,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
             _span = span;
         }
 
-        public XamlSourceDefinition(string filePath, int line, int character)
+        public XamlSourceDefinition(string filePath, int line, int column)
         {
             FilePath = filePath;
             _line = line;
-            _column = character;
+            _column = column;
         }
 
         public string FilePath { get; }
@@ -46,8 +46,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
             // Convert the line column to TextSpan
             if (_line < text.Lines.Count)
             {
-                var character = Math.Min(_column, text.Lines[_line].Span.Length);
-                var start = text.Lines.GetPosition(new LinePosition(_line, character));
+                var column = Math.Min(_column, text.Lines[_line].Span.Length);
+                var start = text.Lines.GetPosition(new LinePosition(_line, column));
                 return new TextSpan(start, 0);
             }
 

--- a/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSourceDefinition.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSourceDefinition.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
     internal sealed class XamlSourceDefinition : XamlDefinition
     {
         private readonly TextSpan? _span;
-        private readonly int _line, _character;
+        private readonly int _line, _column;
 
         public XamlSourceDefinition(string filePath, TextSpan span)
         {
@@ -25,14 +25,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
         {
             FilePath = filePath;
             _line = line;
-            _character = character;
+            _column = character;
         }
 
         public string FilePath { get; }
 
         /// <summary>
         /// When XamlSourceDefinition was created, the creator may have had a textSpan or line/column.
-        /// We should either use _span or _line _character. This property will tell you which one to use.
+        /// We should either use _span or _line _column. This property will tell you which one to use.
         /// </summary>
         private bool CanUseSpan => _span != null;
 
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
             // Convert the line column to TextSpan
             if (_line < text.Lines.Count)
             {
-                var character = Math.Min(_character, text.Lines[_line].Span.Length);
+                var character = Math.Min(_column, text.Lines[_line].Span.Length);
                 var start = text.Lines.GetPosition(new LinePosition(_line, character));
                 return new TextSpan(start, 0);
             }

--- a/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSymbolDefinition.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSymbolDefinition.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
+{
+    /// <summary>
+    /// XamlDefinition with symbol.
+    /// </summary>
+    internal sealed class XamlSymbolDefinition : XamlDefinition
+    {
+        public ISymbol Symbol { get; }
+
+        public XamlSymbolDefinition(ISymbol symbol)
+        {
+            Symbol = symbol;
+        }
+    }
+}

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlCapabilities.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlCapabilities.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             SupportsDiagnosticRequests = true,
             OnTypeRenameProvider = new DocumentOnTypeRenameOptions { WordPattern = OnTypeRenameHandler.NamePattern },
             ExecuteCommandProvider = new ExecuteCommandOptions { Commands = new[] { StringConstants.CreateEventHandlerCommand } },
+            DefinitionProvider = true,
         };
 
         /// <summary>

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
             {
                 var task = Task.Run(async () =>
                 {
-                    foreach(var location in await this.GetLocationsAsync(definition, context, cancellationToken).ConfigureAwait(false))
+                    foreach (var location in await this.GetLocationsAsync(definition, context, cancellationToken).ConfigureAwait(false))
                     {
                         locations.Add(location);
                     }
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
             }
             else
             {
-                throw new InvalidOperationException("Unexpected XamlDefinition Type");
+                throw new InvalidOperationException($"Unexpected {nameof(XamlDefinition)} Type");
             }
 
             return locations.ToArray();

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Composition;
 using System.IO;
 using System.Linq;
@@ -47,106 +48,134 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
 
         public override async Task<LSP.Location[]> HandleRequestAsync(TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
         {
-            var locations = ArrayBuilder<LSP.Location>.GetInstance();
+            var locations = new ConcurrentBag<LSP.Location>();
 
             var document = context.Document;
             if (document == null)
             {
-                return locations.ToArrayAndFree();
+                return locations.ToArray();
             }
 
-            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
             var xamlGoToDefinitionService = document.Project.LanguageServices.GetService<IXamlGoToDefinitionService>();
             if (xamlGoToDefinitionService == null)
             {
-                return locations.ToArrayAndFree();
+                return locations.ToArray();
             }
 
+            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
             var definitions = await xamlGoToDefinitionService.GetDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
+
+            using var _ = ArrayBuilder<Task>.GetInstance(out var tasks);
+
             foreach (var definition in definitions)
             {
-                locations.AddRange(await this.GetLocationsAsync(definition, context, cancellationToken).ConfigureAwait(false));
+                var task = Task.Run(async () =>
+                {
+                    foreach(var location in await this.GetLocationsAsync(definition, context, cancellationToken).ConfigureAwait(false))
+                    {
+                        locations.Add(location);
+                    }
+                }, cancellationToken);
+                tasks.Add(task);
             }
 
-            return locations.ToArrayAndFree();
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            return locations.ToArray();
         }
 
         private async Task<LSP.Location[]> GetLocationsAsync(XamlDefinition definition, RequestContext context, CancellationToken cancellationToken)
         {
-            var locations = ArrayBuilder<LSP.Location>.GetInstance();
+            using var _ = ArrayBuilder<LSP.Location>.GetInstance(out var locations);
 
             if (definition is XamlSourceDefinition sourceDefinition)
             {
-                Contract.ThrowIfNull(sourceDefinition.FilePath);
-
-                var document = context.Solution?.GetDocuments(ProtocolConversions.GetUriFromFilePath(sourceDefinition.FilePath)).FirstOrDefault();
-                if (document != null)
-                {
-                    var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                    var span = sourceDefinition.GetTextSpan(sourceText);
-                    if (span != null)
-                    {
-                        var location = await ProtocolConversions.TextSpanToLocationAsync(
-                                                    document,
-                                                    span.Value,
-                                                    isStale: false,
-                                                    cancellationToken).ConfigureAwait(false);
-                        locations.AddIfNotNull(location);
-                    }
-                }
-                else
-                {
-                    // Cannot find the file in solution. This is probably a file lives outside of the solution like generic.xaml
-                    // which lives in the Windows SDK folder. Try getting the SourceText from the file path.
-                    using var fileStream = new FileStream(sourceDefinition.FilePath, FileMode.Open, FileAccess.Read);
-                    var sourceText = SourceText.From(fileStream);
-                    var span = sourceDefinition.GetTextSpan(sourceText);
-                    if (span != null)
-                    {
-                        locations.Add(new LSP.Location
-                        {
-                            Uri = new Uri(sourceDefinition.FilePath),
-                            Range = ProtocolConversions.TextSpanToRange(span.Value, sourceText),
-                        });
-                    }
-                }
+                locations.AddIfNotNull(await GetSourceDefinitionLocationAsync(sourceDefinition, context, cancellationToken).ConfigureAwait(false));
             }
             else if (definition is XamlSymbolDefinition symbolDefinition)
             {
-                Contract.ThrowIfNull(symbolDefinition.Symbol);
-                var symbol = symbolDefinition.Symbol;
-
-                if (symbol.Locations.First().IsInMetadata && _metadataAsSourceFileService != null)
-                {
-                    var project = context.Document?.GetCodeProject();
-                    if (project != null)
-                    {
-                        var declarationFile = await _metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol, allowDecompilation: false, cancellationToken).ConfigureAwait(false);
-                        var linePosSpan = declarationFile.IdentifierLocation.GetLineSpan().Span;
-                        locations.Add(new LSP.Location
-                        {
-                            Uri = new Uri(declarationFile.FilePath),
-                            Range = ProtocolConversions.LinePositionToRange(linePosSpan),
-                        });
-                    }
-                }
-                else
-                {
-                    var items = NavigableItemFactory.GetItemsFromPreferredSourceLocations(context.Solution, symbol, displayTaggedParts: null, cancellationToken);
-                    foreach (var item in items)
-                    {
-                        var location = await ProtocolConversions.TextSpanToLocationAsync(
-                            item.Document, item.SourceSpan, item.IsStale, cancellationToken).ConfigureAwait(false);
-                        locations.AddIfNotNull(location);
-                    }
-                }
+                locations.AddRange(await GetSymbolDefinitionLocationsAsync(symbolDefinition, context, _metadataAsSourceFileService, cancellationToken).ConfigureAwait(false));
             }
             else
             {
                 throw new InvalidOperationException("Unexpected XamlDefinition Type");
             }
 
-            return locations.ToArrayAndFree();
+            return locations.ToArray();
+        }
+
+        private static async Task<LSP.Location?> GetSourceDefinitionLocationAsync(XamlSourceDefinition sourceDefinition, RequestContext context, CancellationToken cancellationToken)
+        {
+            Contract.ThrowIfNull(sourceDefinition.FilePath);
+
+            var document = context.Solution?.GetDocuments(ProtocolConversions.GetUriFromFilePath(sourceDefinition.FilePath)).FirstOrDefault();
+            if (document != null)
+            {
+                var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var span = sourceDefinition.GetTextSpan(sourceText);
+                if (span != null)
+                {
+                    return await ProtocolConversions.TextSpanToLocationAsync(
+                                                document,
+                                                span.Value,
+                                                isStale: false,
+                                                cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                // Cannot find the file in solution. This is probably a file lives outside of the solution like generic.xaml
+                // which lives in the Windows SDK folder. Try getting the SourceText from the file path.
+                using var fileStream = new FileStream(sourceDefinition.FilePath, FileMode.Open, FileAccess.Read);
+                var sourceText = SourceText.From(fileStream);
+                var span = sourceDefinition.GetTextSpan(sourceText);
+                if (span != null)
+                {
+                    return new LSP.Location
+                    {
+                        Uri = new Uri(sourceDefinition.FilePath),
+                        Range = ProtocolConversions.TextSpanToRange(span.Value, sourceText),
+                    };
+                }
+            }
+
+            return null;
+        }
+
+        private static async Task<LSP.Location[]> GetSymbolDefinitionLocationsAsync(XamlSymbolDefinition symbolDefinition, RequestContext context, IMetadataAsSourceFileService metadataAsSourceFileService, CancellationToken cancellationToken)
+        {
+            Contract.ThrowIfNull(symbolDefinition.Symbol);
+
+            using var _ = ArrayBuilder<LSP.Location>.GetInstance(out var locations);
+
+            var symbol = symbolDefinition.Symbol;
+
+            if (symbol.Locations.First().IsInMetadata)
+            {
+                var project = context.Document?.GetCodeProject();
+                if (project != null)
+                {
+                    var declarationFile = await metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol, allowDecompilation: false, cancellationToken).ConfigureAwait(false);
+                    var linePosSpan = declarationFile.IdentifierLocation.GetLineSpan().Span;
+                    locations.Add(new LSP.Location
+                    {
+                        Uri = new Uri(declarationFile.FilePath),
+                        Range = ProtocolConversions.LinePositionToRange(linePosSpan),
+                    });
+                }
+            }
+            else
+            {
+                var items = NavigableItemFactory.GetItemsFromPreferredSourceLocations(context.Solution, symbol, displayTaggedParts: null, cancellationToken);
+                foreach (var item in items)
+                {
+                    var location = await ProtocolConversions.TextSpanToLocationAsync(
+                        item.Document, item.SourceSpan, item.IsStale, cancellationToken).ConfigureAwait(false);
+                    locations.AddIfNotNull(location);
+                }
+            }
+
+            return locations.ToArray();
         }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
@@ -1,0 +1,152 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Xaml;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.MetadataAsSource;
+using Microsoft.CodeAnalysis.Navigation;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions;
+using Roslyn.Utilities;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageServer.Handler.Definitions
+{
+    [ExportLspRequestHandlerProvider(StringConstants.XamlLanguageName), Shared]
+    [ProvidesMethod(Methods.TextDocumentDefinitionName)]
+    internal class GoToDefinitionHandler : AbstractStatelessRequestHandler<TextDocumentPositionParams, LSP.Location[]>
+    {
+        private readonly IMetadataAsSourceFileService _metadataAsSourceFileService;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public GoToDefinitionHandler(IMetadataAsSourceFileService metadataAsSourceFileService)
+        {
+            _metadataAsSourceFileService = metadataAsSourceFileService;
+        }
+
+        public override string Method => Methods.TextDocumentDefinitionName;
+
+        public override bool MutatesSolutionState => false;
+
+        public override bool RequiresLSPSolution => true;
+
+        public override TextDocumentIdentifier? GetTextDocumentIdentifier(TextDocumentPositionParams request) => request.TextDocument;
+
+        public override async Task<LSP.Location[]> HandleRequestAsync(TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
+        {
+            var locations = ArrayBuilder<LSP.Location>.GetInstance();
+
+            var document = context.Document;
+            if (document == null)
+            {
+                return locations.ToArrayAndFree();
+            }
+
+            var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
+            var xamlGoToDefinitionService = document.Project.LanguageServices.GetService<IXamlGoToDefinitionService>();
+            if (xamlGoToDefinitionService == null)
+            {
+                return locations.ToArrayAndFree();
+            }
+
+            var definitions = await xamlGoToDefinitionService.GetDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
+            foreach (var definition in definitions)
+            {
+                locations.AddRange(await this.GetLocationsAsync(definition, context, cancellationToken).ConfigureAwait(false));
+            }
+
+            return locations.ToArrayAndFree();
+        }
+
+        private async Task<LSP.Location[]> GetLocationsAsync(XamlDefinition definition, RequestContext context, CancellationToken cancellationToken)
+        {
+            var locations = ArrayBuilder<LSP.Location>.GetInstance();
+
+            if (definition is XamlSourceDefinition sourceDefinition)
+            {
+                Contract.ThrowIfNull(sourceDefinition.FilePath);
+
+                var document = context.Solution?.GetDocuments(ProtocolConversions.GetUriFromFilePath(sourceDefinition.FilePath)).FirstOrDefault();
+                if (document != null)
+                {
+                    var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                    var span = sourceDefinition.GetTextSpan(sourceText);
+                    if (span != null)
+                    {
+                        var location = await ProtocolConversions.TextSpanToLocationAsync(
+                                                    document,
+                                                    span.Value,
+                                                    isStale: false,
+                                                    cancellationToken).ConfigureAwait(false);
+                        locations.AddIfNotNull(location);
+                    }
+                }
+                else
+                {
+                    // Cannot find the file in solution. This is probably a file lives outside of the solution like generic.xaml
+                    // which lives in the Windows SDK folder. Try getting the SourceText from the file path.
+                    using var fileStream = new FileStream(sourceDefinition.FilePath, FileMode.Open, FileAccess.Read);
+                    var sourceText = SourceText.From(fileStream);
+                    var span = sourceDefinition.GetTextSpan(sourceText);
+                    if (span != null)
+                    {
+                        locations.Add(new LSP.Location
+                        {
+                            Uri = new Uri(sourceDefinition.FilePath),
+                            Range = ProtocolConversions.TextSpanToRange(span.Value, sourceText),
+                        });
+                    }
+                }
+            }
+            else if (definition is XamlSymbolDefinition symbolDefinition)
+            {
+                Contract.ThrowIfNull(symbolDefinition.Symbol);
+                var symbol = symbolDefinition.Symbol;
+
+                if (symbol.Locations.First().IsInMetadata && _metadataAsSourceFileService != null)
+                {
+                    var project = context.Document?.GetCodeProject();
+                    if (project != null)
+                    {
+                        var declarationFile = await _metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol, allowDecompilation: false, cancellationToken).ConfigureAwait(false);
+                        var linePosSpan = declarationFile.IdentifierLocation.GetLineSpan().Span;
+                        locations.Add(new LSP.Location
+                        {
+                            Uri = new Uri(declarationFile.FilePath),
+                            Range = ProtocolConversions.LinePositionToRange(linePosSpan),
+                        });
+                    }
+                }
+                else
+                {
+                    var items = NavigableItemFactory.GetItemsFromPreferredSourceLocations(context.Solution, symbol, displayTaggedParts: null, cancellationToken);
+                    foreach (var item in items)
+                    {
+                        var location = await ProtocolConversions.TextSpanToLocationAsync(
+                            item.Document, item.SourceSpan, item.IsStale, cancellationToken).ConfigureAwait(false);
+                        locations.AddIfNotNull(location);
+                    }
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("Unexpected XamlDefinition Type");
+            }
+
+            return locations.ToArrayAndFree();
+        }
+    }
+}


### PR DESCRIPTION
This PR enables GoToDefinition for LSP XAML. The GoToDefinitionHandler uses IXamlGoToDefinitionService, which will be implemented in XAML language service to get the definitions of the given document and position. There are two types of XamlDefinition we are getting from the XAML language service:

- XamlSourceDefinition has the file path and textSpan (or line and column).  This is usually the case when the definition is in a XAML file.
- XamlSymbolDefinition contains just the symbol. We then use Roslyn to find the locations of the given symbol.