### PR TITLE
Move IAddMissingImportsFeatureService to use OOP

### DIFF
--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -559,7 +559,6 @@ namespace Microsoft.CodeAnalysis.AddImport
                .Where(diagnostic => diagnosticIds.Contains(diagnostic.Id))
                .ToImmutableArray();
 
-
             var getFixesForDiagnosticsTasks = diagnostics
                 .GroupBy(diagnostic => diagnostic.Location.SourceSpan)
                 .Select(diagnosticsForSourceSpan => GetFixesForDiagnosticsAsync(

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -555,6 +555,8 @@ namespace Microsoft.CodeAnalysis.AddImport
             var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            // Get the diagnostics that indicate a missing import.
             var diagnostics = semanticModel.GetDiagnostics(span, cancellationToken)
                .Where(diagnostic => diagnosticIds.Contains(diagnostic.Id))
                .ToImmutableArray();

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -517,6 +517,75 @@ namespace Microsoft.CodeAnalysis.AddImport
             return fixesForDiagnosticBuilder.ToImmutableAndFree();
         }
 
+        public async Task<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(
+            Document document, TextSpan span, ImmutableArray<string> diagnosticIds,
+            ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
+            ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
+        {
+            var client = await RemoteHostClient.TryGetClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
+            if (client != null)
+            {
+                var result = await client.TryInvokeAsync<IRemoteMissingImportDiscoveryService, ImmutableArray<AddImportFixData>>(
+                    document.Project.Solution,
+                    (service, solutionInfo, callbackId, cancellationToken) =>
+                        service.GetUniqueFixesAsync(solutionInfo, callbackId, document.Id, span, diagnosticIds, searchReferenceAssemblies, packageSources, cancellationToken),
+                    callbackTarget: symbolSearchService,
+                    cancellationToken).ConfigureAwait(false);
+
+                return result.HasValue ? result.Value : ImmutableArray<AddImportFixData>.Empty;
+            }
+
+            return await GetUniqueFixesAsyncInCurrentProcessAsync(
+                document, span, diagnosticIds,
+                symbolSearchService, searchReferenceAssemblies,
+                packageSources, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<ImmutableArray<AddImportFixData>> GetUniqueFixesAsyncInCurrentProcessAsync(
+            Document document,
+            TextSpan span,
+            ImmutableArray<string> diagnosticIds,
+            ISymbolSearchService symbolSearchService,
+            bool searchReferenceAssemblies,
+            ImmutableArray<PackageSource> packageSources,
+            CancellationToken cancellationToken)
+        {
+            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var placeSystemNamespaceFirst = documentOptions.GetOption(GenerationOptions.PlaceSystemNamespaceFirst);
+            var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
+
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var diagnostics = semanticModel.GetDiagnostics(span, cancellationToken)
+               .Where(diagnostic => diagnosticIds.Contains(diagnostic.Id))
+               .ToImmutableArray();
+
+
+            var getFixesForDiagnosticsTasks = diagnostics
+                .GroupBy(diagnostic => diagnostic.Location.SourceSpan)
+                .Select(diagnosticsForSourceSpan => GetFixesForDiagnosticsAsync(
+                        document, diagnosticsForSourceSpan.Key, diagnosticsForSourceSpan.AsImmutable(),
+                        maxResultsPerDiagnostic: 2, symbolSearchService, searchReferenceAssemblies, packageSources, cancellationToken));
+
+            using var _ = ArrayBuilder<AddImportFixData>.GetInstance(out var fixes);
+            foreach (var getFixesForDiagnosticsTask in getFixesForDiagnosticsTasks)
+            {
+                var fixesForDiagnostics = await getFixesForDiagnosticsTask.ConfigureAwait(false);
+
+                foreach (var fixesForDiagnostic in fixesForDiagnostics)
+                {
+                    // When there is more than one potential fix for a missing import diagnostic,
+                    // which is possible when the same class name is present in multiple namespaces,
+                    // we do not want to choose for the user and be wrong. We will not attempt to
+                    // fix this diagnostic and instead leave it for the user to resolve since they
+                    // will have more context for determining the proper fix.
+                    if (fixesForDiagnostic.Fixes.Length == 1)
+                        fixes.Add(fixesForDiagnostic.Fixes[0]);
+                }
+            }
+
+            return fixes.ToImmutable();
+        }
+
         public ImmutableArray<CodeAction> GetCodeActionsForFixes(
             Document document, ImmutableArray<AddImportFixData> fixes,
             IPackageInstallerService? installerService, int maxResults)

--- a/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
@@ -41,5 +41,15 @@ namespace Microsoft.CodeAnalysis.AddImport
         ImmutableArray<CodeAction> GetCodeActionsForFixes(
             Document document, ImmutableArray<AddImportFixData> fixes,
             IPackageInstallerService? installerService, int maxResults);
+
+        /// <summary>
+        /// Gets data for how to fix a particular <see cref="Diagnostic" /> id within the specified Document.
+        /// Similar to <see cref="GetFixesAsync(Document, TextSpan, string, int, bool, bool, ISymbolSearchService, bool, ImmutableArray{PackageSource}, CancellationToken)"/> 
+        /// except it only returns fix data when there is a single using fix for a given span
+        /// </summary>
+        Task<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(
+            Document document, TextSpan span, ImmutableArray<string> diagnosticIds
+            ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
+            ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// except it only returns fix data when there is a single using fix for a given span
         /// </summary>
         Task<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(
-            Document document, TextSpan span, ImmutableArray<string> diagnosticIds
+            Document document, TextSpan span, ImmutableArray<string> diagnosticIds,
             ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
     }

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -26,5 +26,8 @@ namespace Microsoft.CodeAnalysis.AddImport
         ValueTask<ImmutableArray<AddImportFixData>> GetFixesAsync(
             PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId documentId, TextSpan span, string diagnosticId, int maxResults,
             bool placeSystemNamespaceFirst, bool allowInHiddenRegions, bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(
+            PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId id, TextSpan span, ImmutableArray<string> diagnosticIds, 
+            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId documentId, TextSpan span, string diagnosticId, int maxResults,
             bool placeSystemNamespaceFirst, bool allowInHiddenRegions, bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(
-            PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId id, TextSpan span, ImmutableArray<string> diagnosticIds, 
+            PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId id, TextSpan span, ImmutableArray<string> diagnosticIds,
             bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             var packageSources = ImmutableArray<PackageSource>.Empty;
 
             var unambiguousFixes = await addImportFeatureService.GetUniqueFixesAsync(
-                document, textSpan, FixableDiagnosticIds, symbolSearchService, 
+                document, textSpan, FixableDiagnosticIds, symbolSearchService,
                 searchReferenceAssemblies: true, packageSources, cancellationToken).ConfigureAwait(false);
 
             // We do not want to add project or framework references without the user's input, so filter those out.

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Packaging;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.SymbolSearch;
@@ -52,15 +51,17 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
         public async Task<AddMissingImportsAnalysisResult> AnalyzeAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
         {
             // Get the diagnostics that indicate a missing import.
-            var diagnostics = await GetDiagnosticsAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
-            if (diagnostics.IsEmpty)
-            {
-                return new AddMissingImportsAnalysisResult(
-                    ImmutableArray<AddImportFixData>.Empty);
-            }
+            var addImportFeatureService = document.GetRequiredLanguageService<IAddImportFeatureService>();
 
-            // Find fixes for the diagnostic where there is only a single fix.
-            var unambiguousFixes = await GetUnambiguousFixesAsync(document, diagnostics, cancellationToken).ConfigureAwait(false);
+            var solution = document.Project.Solution;
+            var symbolSearchService = solution.Workspace.Services.GetRequiredService<ISymbolSearchService>();
+
+            // Since we are not currently considering NuGet packages, pass an empty array
+            var packageSources = ImmutableArray<PackageSource>.Empty;
+
+            var unambiguousFixes = await addImportFeatureService.GetUniqueFixesAsync(
+                document, textSpan, FixableDiagnosticIds, symbolSearchService, 
+                searchReferenceAssemblies: true, packageSources, cancellationToken).ConfigureAwait(false);
 
             // We do not want to add project or framework references without the user's input, so filter those out.
             var usableFixes = unambiguousFixes.WhereAsArray(fixData => DoesNotAddReference(fixData, document.Project.Id));
@@ -73,54 +74,6 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             return (fixData.ProjectReferenceToAdd is null || fixData.ProjectReferenceToAdd == currentProjectId)
                 && (fixData.PortableExecutableReferenceProjectId is null || fixData.PortableExecutableReferenceProjectId == currentProjectId)
                 && string.IsNullOrEmpty(fixData.AssemblyReferenceAssemblyName);
-        }
-
-        private async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
-        {
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            if (semanticModel is null)
-            {
-                return ImmutableArray<Diagnostic>.Empty;
-            }
-
-            return semanticModel.GetDiagnostics(textSpan, cancellationToken)
-                .Where(diagnostic => FixableDiagnosticIds.Contains(diagnostic.Id))
-                .ToImmutableArray();
-        }
-
-        private static async Task<ImmutableArray<AddImportFixData>> GetUnambiguousFixesAsync(Document document, ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
-        {
-            var solution = document.Project.Solution;
-            var symbolSearchService = solution.Workspace.Services.GetRequiredService<ISymbolSearchService>();
-            // Since we are not currently considering NuGet packages, pass an empty array
-            var packageSources = ImmutableArray<PackageSource>.Empty;
-            var addImportService = document.GetRequiredLanguageService<IAddImportFeatureService>();
-
-            // We only need to receive 2 results back per diagnostic to determine that the fix is ambiguous.
-            var getFixesForDiagnosticsTasks = diagnostics
-                .GroupBy(diagnostic => diagnostic.Location.SourceSpan)
-                .Select(diagnosticsForSourceSpan => addImportService
-                    .GetFixesForDiagnosticsAsync(document, diagnosticsForSourceSpan.Key, diagnosticsForSourceSpan.AsImmutable(),
-                        maxResultsPerDiagnostic: 2, symbolSearchService, searchReferenceAssemblies: true, packageSources, cancellationToken));
-
-            using var _ = ArrayBuilder<AddImportFixData>.GetInstance(out var fixes);
-            foreach (var getFixesForDiagnosticsTask in getFixesForDiagnosticsTasks)
-            {
-                var fixesForDiagnostics = await getFixesForDiagnosticsTask.ConfigureAwait(false);
-
-                foreach (var fixesForDiagnostic in fixesForDiagnostics)
-                {
-                    // When there is more than one potential fix for a missing import diagnostic,
-                    // which is possible when the same class name is present in multiple namespaces,
-                    // we do not want to choose for the user and be wrong. We will not attempt to
-                    // fix this diagnostic and instead leave it for the user to resolve since they
-                    // will have more context for determining the proper fix.
-                    if (fixesForDiagnostic.Fixes.Length == 1)
-                        fixes.Add(fixesForDiagnostic.Fixes[0]);
-                }
-            }
-
-            return fixes.ToImmutable();
         }
 
         private static async Task<Document> ApplyFixesAsync(Document document, ImmutableArray<AddImportFixData> fixes, CancellationToken cancellationToken)


### PR DESCRIPTION
IAddMissingImportsFeatureService wraps IAddImportFeatureService with some logic for reducing fixes that will be taken. The work to get diagnostics was previously done inproc, which can be expensive. This moves that work to IAddImportFeatureService via a new `GetUniqueFixesAsync` api and utilizes OOP when possible