### PR TITLE
Generate minimal canonical records from tuples

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -139,7 +139,7 @@ class Test
 {
     void Method()
     {
-        var t1 = [||](a: 1, b: 2);
+        var t1 = [||](a: 1, B: 2);
     }
 }
 ";
@@ -148,20 +148,20 @@ class Test
 {
     void Method()
     {
-        var t1 = new NewStruct(A: 1, B: 2);
+        var t1 = new NewStruct(a: 1, B: 2);
     }
 }
 
-internal record struct NewStruct(int A, int B)
+internal record struct NewStruct(int a, int B)
 {
-    public static implicit operator (int a, int b)(NewStruct value)
+    public static implicit operator (int a, int B)(NewStruct value)
     {
-        return (value.A, value.B);
+        return (value.a, value.B);
     }
 
-    public static implicit operator NewStruct((int a, int b) value)
+    public static implicit operator NewStruct((int a, int B) value)
     {
-        return new NewStruct(value.a, value.b);
+        return new NewStruct(value.a, value.B);
     }
 }";
             await TestAsync(text, expected, languageVersion: LanguageVersion.Preview, options: PreferImplicitTypeWithInfo(), testHost: host);
@@ -188,15 +188,15 @@ class Test
 {
     void Method()
     {
-        var t1 = new NewStruct(A: 1, B: 2);
+        var t1 = new NewStruct(a: 1, b: 2);
     }
 }
 
-internal record struct NewStruct(int A, int B)
+internal record struct NewStruct(int a, int b)
 {
     public static implicit operator (int a, int b)(NewStruct value)
     {
-        return (value.A, value.B);
+        return (value.a, value.b);
     }
 
     public static implicit operator NewStruct((int a, int b) value)

--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -148,15 +148,15 @@ class Test
 {
     void Method()
     {
-        var t1 = new NewStruct(a: 1, b: 2);
+        var t1 = new NewStruct(A: 1, B: 2);
     }
 }
 
-internal record struct NewStruct(int a, int b)
+internal record struct NewStruct(int A, int B)
 {
     public static implicit operator (int a, int b)(NewStruct value)
     {
-        return (value.a, value.b);
+        return (value.A, value.B);
     }
 
     public static implicit operator NewStruct((int a, int b) value)
@@ -188,15 +188,15 @@ class Test
 {
     void Method()
     {
-        var t1 = new NewStruct(a: 1, b: 2);
+        var t1 = new NewStruct(A: 1, B: 2);
     }
 }
 
-internal record struct NewStruct(int a, int b)
+internal record struct NewStruct(int A, int B)
 {
     public static implicit operator (int a, int b)(NewStruct value)
     {
-        return (value.a, value.b);
+        return (value.A, value.B);
     }
 
     public static implicit operator NewStruct((int a, int b) value)
@@ -208,7 +208,7 @@ internal record struct NewStruct(int a, int b)
         }
 
         [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)]
-        public async Task ConvertSingleTupleTypeToRecord_MismatchedNameCasing(TestHost host)
+        public async Task ConvertSingleTupleTypeToRecord_MatchedNameCasing(TestHost host)
         {
             var text = @"
 class Test
@@ -224,27 +224,12 @@ class Test
 {
     void Method()
     {
-        var t1 = new NewStruct(a: 1, b: 2);
+        var t1 = new NewStruct(A: 1, B: 2);
     }
 }
 
-internal record struct NewStruct
+internal record struct NewStruct(int A, int B)
 {
-    public int A;
-    public int B;
-
-    public NewStruct(int a, int b)
-    {
-        A = a;
-        B = b;
-    }
-
-    public void Deconstruct(out int a, out int b)
-    {
-        a = A;
-        b = B;
-    }
-
     public static implicit operator (int A, int B)(NewStruct value)
     {
         return (value.A, value.B);

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -723,7 +723,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             if (expr is TLiteralExpressionSyntax)
             {
                 var argumentName = generator.SyntaxFacts.GetNameForArgument(argument);
-                var newArgumentName = isRecord ? argumentName : parameterNamingRule.NamingStyle.MakeCompliant(name).First();
+                var newArgumentName = isRecord ? argumentName : parameterNamingRule.NamingStyle.MakeCompliant(argumentName).First();
 
                 return GetArgumentWithChangedName(argument, newArgumentName);
             }
@@ -915,7 +915,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             using var _ = PooledDictionary<string, ISymbol>.GetInstance(out var parameterToPropMap);
             var parameters = fields.SelectAsArray(field =>
             {
-                var parameterName = isRecord ? field.Name : parameterNamingRule.NamingStyle.MakeCompliant(name).First();
+                var parameterName = isRecord ? field.Name : parameterNamingRule.NamingStyle.MakeCompliant(field.Name).First();
                 var parameter = CodeGenerationSymbolFactory.CreateParameterSymbol(
                     field.Type, parameterName);
 

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -723,7 +723,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             if (expr is TLiteralExpressionSyntax)
             {
                 var argumentName = generator.SyntaxFacts.GetNameForArgument(argument);
-                var newArgumentName = GetConstructorParameterName(isRecord, parameterNamingRule, argumentName);
+                var newArgumentName = isRecord ? name : parameterNamingRule.NamingStyle.MakeCompliant(name).First();
 
                 return GetArgumentWithChangedName(argument, newArgumentName);
             }
@@ -915,8 +915,9 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             using var _ = PooledDictionary<string, ISymbol>.GetInstance(out var parameterToPropMap);
             var parameters = fields.SelectAsArray(field =>
             {
+                var parameterName = isRecord ? name : parameterNamingRule.NamingStyle.MakeCompliant(name).First();
                 var parameter = CodeGenerationSymbolFactory.CreateParameterSymbol(
-                    field.Type, GetConstructorParameterName(isRecord, parameterNamingRule, field.Name));
+                    field.Type, parameterName);
 
                 parameterToPropMap[parameter.Name] = field;
 
@@ -933,11 +934,6 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
 
             return constructor;
         }
-
-        private static string GetConstructorParameterName(bool isRecord, NamingRule parameterNamingRule, string name)
-            => isRecord
-            ? name
-            : parameterNamingRule.NamingStyle.MakeCompliant(name).First();
 
         private class MyCodeAction : CodeAction.SolutionChangeAction
         {

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -723,7 +723,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             if (expr is TLiteralExpressionSyntax)
             {
                 var argumentName = generator.SyntaxFacts.GetNameForArgument(argument);
-                var newArgumentName = isRecord ? name : parameterNamingRule.NamingStyle.MakeCompliant(name).First();
+                var newArgumentName = isRecord ? argumentName : parameterNamingRule.NamingStyle.MakeCompliant(name).First();
 
                 return GetArgumentWithChangedName(argument, newArgumentName);
             }
@@ -915,7 +915,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             using var _ = PooledDictionary<string, ISymbol>.GetInstance(out var parameterToPropMap);
             var parameters = fields.SelectAsArray(field =>
             {
-                var parameterName = isRecord ? name : parameterNamingRule.NamingStyle.MakeCompliant(name).First();
+                var parameterName = isRecord ? field.Name : parameterNamingRule.NamingStyle.MakeCompliant(name).First();
                 var parameter = CodeGenerationSymbolFactory.CreateParameterSymbol(
                     field.Type, parameterName);
 

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -870,9 +870,9 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             const string ValueName = "value";
 
             var valueNode = generator.IdentifierName(ValueName);
-            var arguments = tupleType.TupleElements.SelectAsArray(
-               field => generator.Argument(
-                   generator.MemberAccessExpression(valueNode, field.Name)));
+            var arguments = tupleType.TupleElements.SelectAsArray<IFieldSymbol, SyntaxNode>(
+                field => generator.Argument(
+                    generator.MemberAccessExpression(valueNode, field.Name)));
 
             var convertToTupleStatement = generator.ReturnStatement(
                 generator.TupleExpression(arguments));


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/54897

Right now the way this refactoring works is if a tuple uses property naming style for its elements, the refactoring doesn't use primary constructors, and if the tuple elements use parameter naming style then it does.

It seems to me if the user selects to convert to records (since converting to struct is also an option) then we should lean in to the record syntax and always generate a primary constructor.
