### PR TITLE
Update PooledObjects.Package with NETFramework.ReferenceAssemblies dependency

### DIFF
--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(MicrosoftNETFrameworkReferenceAssembliesVersion)" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Debugging.Package"/>


### PR DESCRIPTION
Reported on teams:

> i just sync'ed to main and i'm getting this now:
```
Severity    Code    Description    Project    File    Line    Suppression State
Error    MSB3644    The reference assemblies for .NETFramework,Version=v4.5 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks    Microsoft.CodeAnalysis.PooledObjects.Package    C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets    1217 
```

The net45 targeting pack is no longer installable through the VS 2022 installer. This moves the project to build against net46 which is installed by default with VS2022.