### PR TITLE
Add IFieldSymbol.FixedSize API

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/FieldSymbol.cs
@@ -83,6 +83,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool IFieldSymbol.IsFixedSizeBuffer => _underlying.IsFixedSizeBuffer;
 
+        int IFieldSymbol.FixedSize => _underlying.FixedSize;
+
         bool IFieldSymbol.HasConstantValue => _underlying.HasConstantValue;
 
         object IFieldSymbol.ConstantValue => _underlying.ConstantValue;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
@@ -481,7 +481,7 @@ class K
                 "Error: Field name value__ is reserved for Enums only.");
         }
 
-        [WorkItem(26364, "https://github.com/dotnet/roslyn/issues/26364")]
+        [WorkItem(26364, "https://github.com/dotnet/roslyn/issues/26364"), WorkItem(54799, "https://github.com/dotnet/roslyn/issues/54799")]
         [Fact]
         public void FixedSizeBufferTrue()
         {
@@ -492,15 +492,16 @@ unsafe struct S
     private fixed byte goo[10];
 }
 ";
-            var comp = CreateEmptyCompilation(text);
+            var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var s = global.GetTypeMember("S");
-            var goo = s.GetMember<FieldSymbol>("goo");
+            var goo = (IFieldSymbol)s.GetMember("goo").GetPublicSymbol();
 
             Assert.True(goo.IsFixedSizeBuffer);
+            Assert.Equal(10, goo.FixedSize);
         }
 
-        [WorkItem(26364, "https://github.com/dotnet/roslyn/issues/26364")]
+        [WorkItem(26364, "https://github.com/dotnet/roslyn/issues/26364"), WorkItem(54799, "https://github.com/dotnet/roslyn/issues/54799")]
         [Fact]
         public void FixedSizeBufferFalse()
         {
@@ -511,12 +512,13 @@ unsafe struct S
     private byte goo;
 }
 ";
-            var comp = CreateEmptyCompilation(text);
+            var comp = CreateCompilation(text);
             var global = comp.GlobalNamespace;
             var s = global.GetTypeMember("S");
-            var goo = s.GetMember<FieldSymbol>("goo");
+            var goo = (IFieldSymbol)s.GetMember("goo").GetPublicSymbol();
 
             Assert.False(goo.IsFixedSizeBuffer);
+            Assert.Equal(0, goo.FixedSize);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -14,6 +14,7 @@ Microsoft.CodeAnalysis.GeneratorDriverOptions
 Microsoft.CodeAnalysis.GeneratorDriverOptions.GeneratorDriverOptions() -> void
 Microsoft.CodeAnalysis.GeneratorDriverOptions.GeneratorDriverOptions(Microsoft.CodeAnalysis.IncrementalGeneratorOutputKind disabledOutputs) -> void
 Microsoft.CodeAnalysis.GeneratorExtensions
+Microsoft.CodeAnalysis.IFieldSymbol.FixedSize.get -> int
 Microsoft.CodeAnalysis.IFieldSymbol.IsExplicitlyNamedTupleElement.get -> bool
 Microsoft.CodeAnalysis.GeneratorExecutionContext.SyntaxContextReceiver.get -> Microsoft.CodeAnalysis.ISyntaxContextReceiver?
 Microsoft.CodeAnalysis.GeneratorInitializationContext.RegisterForSyntaxNotifications(Microsoft.CodeAnalysis.SyntaxContextReceiverCreator! receiverCreator) -> void

--- a/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
@@ -49,6 +49,14 @@ namespace Microsoft.CodeAnalysis
         bool IsFixedSizeBuffer { get; }
 
         /// <summary>
+        /// If IsFixedSizeBuffer is true, the value between brackets in the fixed-size-buffer declaration.
+        /// If IsFixedSizeBuffer is false FixedSize is 0.
+        /// Note that for fixed-size buffer declaration, this.Type will be a pointer type, of which
+        /// the pointed-to type will be the declared element type of the fixed-size buffer.
+        /// </summary>
+        int FixedSize { get; }
+
+        /// <summary>
         /// Gets the type of this field.
         /// </summary>
         ITypeSymbol Type { get; }

--- a/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// If IsFixedSizeBuffer is true, the value between brackets in the fixed-size-buffer declaration.
-        /// If IsFixedSizeBuffer is false FixedSize is 0.
+        /// If IsFixedSizeBuffer is false or there is an error (such as a bad constant value in source), FixedSize is 0.
         /// Note that for fixed-size buffer declaration, this.Type will be a pointer type, of which
         /// the pointed-to type will be the declared element type of the fixed-size buffer.
         /// </summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
@@ -428,6 +428,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property IFieldSymbol_FixedSize As Integer Implements IFieldSymbol.FixedSize
+            Get
+                Return 0
+            End Get
+        End Property
+
         Private ReadOnly Property IFieldSymbol_Type As ITypeSymbol Implements IFieldSymbol.Type
             Get
                 Return Me.Type

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/FieldTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/FieldTests.vb
@@ -541,6 +541,7 @@ End Class
         End Sub
 
         <WorkItem(26364, "https://github.com/dotnet/roslyn/issues/26364")>
+        <WorkItem(54799, "https://github.com/dotnet/roslyn/issues/54799")>
         <Fact>
         Public Sub FixedSizeBufferFalse()
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40(
@@ -556,6 +557,7 @@ End Structure
             Dim goo = DirectCast(s.GetMember(Of FieldSymbol)("goo"), IFieldSymbol)
 
             Assert.False(goo.IsFixedSizeBuffer)
+            Assert.Equal(0, goo.FixedSize)
         End Sub
 
 

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedFieldSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedFieldSymbol.cs
@@ -41,6 +41,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public bool IsFixedSizeBuffer => _symbol.IsFixedSizeBuffer;
 
+            public int FixedSize => _symbol.FixedSize;
+
             public ITypeSymbol Type => _symbol.Type;
 
             public NullableAnnotation NullableAnnotation => _symbol.NullableAnnotation;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
@@ -77,6 +77,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public bool IsFixedSizeBuffer => false;
 
+        public int FixedSize => 0;
+
         public ImmutableArray<CustomModifier> CustomModifiers
         {
             get


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/54799 by exposing existing internal functionality.
