### PR TITLE
Treat overload with Delegate parameter as not applicable if lambda delegate type cannot be inferred

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1878,6 +1878,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
+            if (reason == LambdaConversionResult.CannotInferDelegateType)
+            {
+                Debug.Assert(targetType.SpecialType == SpecialType.System_Delegate || targetType.IsNonGenericExpressionType());
+                Error(diagnostics, ErrorCode.ERR_CannotInferDelegateType, syntax);
+                var lambda = anonymousFunction.BindForErrorRecovery();
+                diagnostics.AddRange(lambda.Diagnostics);
+                return;
+            }
+
             // At this point we know that we have either a delegate type or an expression type for the target.
 
             // The target type is a valid delegate or expression tree type. Is there something wrong with the

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/LambdaConversionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/LambdaConversionResult.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         StaticTypeInImplicitlyTypedLambda,
         ExpressionTreeMustHaveDelegateTypeArgument,
         ExpressionTreeFromAnonymousMethod,
+        CannotInferDelegateType,
         BindingFailed
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -1682,12 +1682,9 @@ class C
 
             comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics(
-                // (6,65): error CS8917: The delegate type could not be inferred.
+                // (6,30): error CS0019: Operator '==' cannot be applied to operands of type '<null>' and 'lambda expression'
                 //         System.Console.Write((null, null, null, null) == (null, x => x, Main, (int i) => { int j = 0; return i + j; }));
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "x => x").WithLocation(6, 65),
-                // (6,65): error CS8917: The delegate type could not be inferred.
-                //         System.Console.Write((null, null, null, null) == (null, x => x, Main, (int i) => { int j = 0; return i + j; }));
-                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "x => x").WithLocation(6, 65));
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "(null, null, null, null) == (null, x => x, Main, (int i) => { int j = 0; return i + j; })").WithArguments("==", "<null>", "lambda expression").WithLocation(6, 30));
             verify(comp, inferDelegate: true);
 
             static void verify(CSharpCompilation comp, bool inferDelegate)
@@ -1714,7 +1711,7 @@ class C
                 // ... its first lambda ...
                 var firstLambda = tuple2.Arguments[1].Expression;
                 Assert.Null(model.GetTypeInfo(firstLambda).Type);
-                verifyType("System.Delegate", model.GetTypeInfo(firstLambda).ConvertedType, inferDelegate);
+                verifyType("System.Delegate", model.GetTypeInfo(firstLambda).ConvertedType, inferDelegate: false); // cannot infer delegate type for x => x
 
                 // ... its method group ...
                 var methodGroup = tuple2.Arguments[2].Expression;


### PR DESCRIPTION
Fixes #55319 

Relates to test plan https://github.com/dotnet/roslyn/issues/52192