### PR TITLE
Disable RestoreUseStaticGraphEvaluation

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -267,7 +267,7 @@ function BuildSolution() {
       /p:TreatWarningsAsErrors=$warnAsError `
       /p:EnableNgenOptimization=$applyOptimizationData `
       /p:IbcOptimizationDataDir=$ibcDir `
-      /p:RestoreUseStaticGraphEvaluation=true `
+      /p:RestoreUseStaticGraphEvaluation=false `
       /p:VisualStudioIbcDrop=$ibcDropName `
       /p:VisualStudioDropAccessToken=$officialVisualStudioDropAccessToken `
       $suppressExtensionDeployment `

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -13,7 +13,7 @@
     <CommonExtensionInstallationRoot>CommonExtensions</CommonExtensionInstallationRoot>
     <LanguageServicesExtensionInstallationFolder>Microsoft\ManagedLanguages\VBCSharp\LanguageServices</LanguageServicesExtensionInstallationFolder>
 
-    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
 
     <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -61,7 +61,7 @@ function Run-Build([string]$rootDir, [string]$logFileName) {
      /p:BootstrapBuildPath=$bootstrapDir `
      /p:RunAnalyzers=false `
      /p:RunAnalyzersDuringBuild=false `
-     /p:RestoreUseStaticGraphEvaluation=true `
+     /p:RestoreUseStaticGraphEvaluation=false `
      /bl:$logFilePath
 
   Stop-Processes


### PR DESCRIPTION
Mitigates https://github.com/dotnet/roslyn/issues/55358 until someone figures out why setting it to 'true' breaks building on different machines.