### PR TITLE
Make dynamic path map case insensitive to match source files

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -116,7 +116,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// The workspace snapshot will only have a document with  <see cref="DynamicFileInfo.FilePath"/> (the value) but not the
         /// original dynamic file path (the key).
         /// </summary>
-        private readonly Dictionary<string, string?> _dynamicFilePathMaps = new();
+        /// <remarks>
+        /// We use the same string comparer as in the <see cref="BatchingDocumentCollection"/> used by _sourceFiles, below, as these
+        /// files are added to that collection too.
+        /// </remarks>
+        private readonly Dictionary<string, string?> _dynamicFilePathMaps = new(StringComparer.OrdinalIgnoreCase);
 
         private readonly BatchingDocumentCollection _sourceFiles;
         private readonly BatchingDocumentCollection _additionalFiles;

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/DynamicFileTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/DynamicFileTests.vb
@@ -49,6 +49,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         End Function
 
         <WpfFact>
+        Public Async Function DynamicFileNamesAreCaseInsensitive() As Task
+            Using environment = New TestEnvironment(GetType(TestDynamicFileInfoProviderThatProducesFiles))
+                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "project", LanguageNames.CSharp, CancellationToken.None)
+
+                project.AddDynamicSourceFile("DynamicFile.cshtml", ImmutableArray(Of String).Empty)
+
+                project.RemoveDynamicSourceFile("dynamicfile.cshtml")
+            End Using
+        End Function
+
+        <WpfFact>
         Public Async Function AddAndRemoveFileAndAddAgain() As Task
             Using environment = New TestEnvironment(GetType(TestDynamicFileInfoProviderThatProducesFiles))
                 Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/55362
Fixes https://github.com/dotnet/aspnetcore/issues/34963

Simple change, _really_ painful to track down.

/cc @NTaylorMullen 