### PR TITLE
Fix emit of synthesized types nested in a reloadable type

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -2394,6 +2394,167 @@ class C
         }
 
         [Fact]
+        public void ReplaceType_AsyncLambda()
+        {
+            var source0 = @"
+using System.Threading.Tasks;
+class C
+{
+    void F(int x) { Task.Run(async() => {}); }
+}
+";
+            var source1 = @"
+using System.Threading.Tasks;
+class C
+{
+    void F(bool y) { Task.Run(async() => {}); }
+}
+";
+            var source2 = @"
+using System.Threading.Tasks;
+class C
+{
+    void F(uint z) { Task.Run(async() => {}); }
+}
+";
+
+            var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll, targetFramework: TargetFramework.NetStandard20);
+            var compilation1 = compilation0.WithSource(source1);
+            var compilation2 = compilation1.WithSource(source2);
+
+            var c0 = compilation0.GetMember<NamedTypeSymbol>("C");
+            var c1 = compilation1.GetMember<NamedTypeSymbol>("C");
+            var c2 = compilation2.GetMember<NamedTypeSymbol>("C");
+            var f2 = c2.GetMember<MethodSymbol>("F");
+
+            // Verify full metadata contains expected rows.
+            var bytes0 = compilation0.EmitToArray();
+            using var md0 = ModuleMetadata.CreateFromImage(bytes0);
+            var reader0 = md0.MetadataReader;
+
+            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "<>c", "<<F>b__0_0>d");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(
+                md0,
+                EmptyLocalsProvider);
+
+            // This update emulates "Reloadable" type behavior - a new type is generated instead of updating the existing one.
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Replace, null, c1)));
+
+            // Verify delta metadata contains expected rows.
+            using var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+            var readers = new[] { reader0, reader1 };
+
+            // A new nested type <>c is generated in C#1
+            CheckNames(readers, reader1.GetTypeDefNames(), "C#1", "<>c", "<<F>b__0#1_0#1>d");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C#1", "<>c", "<<F>b__0#1_0#1>d");
+
+            // This update emulates "Reloadable" type behavior - a new type is generated instead of updating the existing one.
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Replace, null, c2)));
+
+            // Verify delta metadata contains expected rows.
+            using var md2 = diff2.GetMetadata();
+            var reader2 = md2.Reader;
+            readers = new[] { reader0, reader1, reader2 };
+
+            // A new nested type <>c is generated in C#2
+            CheckNames(readers, reader2.GetTypeDefNames(), "C#2", "<>c", "<<F>b__0#2_0#2>d");
+            CheckNames(readers, diff2.EmitResult.ChangedTypes, "C#2", "<>c", "<<F>b__0#2_0#2>d");
+        }
+
+        [Fact]
+        public void ReplaceType_AsyncLambda_InNestedType()
+        {
+            var source0 = @"
+using System.Threading.Tasks;
+class C
+{
+    class D
+    {
+        void F(int x) { Task.Run(async() => {}); }
+    }
+}
+";
+            var source1 = @"
+using System.Threading.Tasks;
+class C
+{
+    class D
+    {
+        void F(bool y) { Task.Run(async() => {}); }
+    }
+}
+";
+            var source2 = @"
+using System.Threading.Tasks;
+class C
+{
+    class D
+    {
+        void F(uint z) { Task.Run(async() => {}); }
+    }
+}
+";
+
+            var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll, targetFramework: TargetFramework.NetStandard20);
+            var compilation1 = compilation0.WithSource(source1);
+            var compilation2 = compilation1.WithSource(source2);
+
+            var c0 = compilation0.GetMember<NamedTypeSymbol>("C");
+            var c1 = compilation1.GetMember<NamedTypeSymbol>("C");
+            var c2 = compilation2.GetMember<NamedTypeSymbol>("C");
+            var f2 = c2.GetMember<MethodSymbol>("F");
+
+            // Verify full metadata contains expected rows.
+            var bytes0 = compilation0.EmitToArray();
+            using var md0 = ModuleMetadata.CreateFromImage(bytes0);
+            var reader0 = md0.MetadataReader;
+
+            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "D", "<>c", "<<F>b__0_0>d");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(
+                md0,
+                EmptyLocalsProvider);
+
+            // This update emulates "Reloadable" type behavior - a new type is generated instead of updating the existing one.
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Replace, null, c1)));
+
+            // Verify delta metadata contains expected rows.
+            using var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+            var readers = new[] { reader0, reader1 };
+
+            // A new nested type <>c is generated in C#1
+            CheckNames(readers, reader1.GetTypeDefNames(), "C#1", "D", "<>c", "<<F>b__0#1_0#1>d");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C#1", "D", "<>c", "<<F>b__0#1_0#1>d");
+
+            // This update emulates "Reloadable" type behavior - a new type is generated instead of updating the existing one.
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Replace, null, c2)));
+
+            // Verify delta metadata contains expected rows.
+            using var md2 = diff2.GetMetadata();
+            var reader2 = md2.Reader;
+            readers = new[] { reader0, reader1, reader2 };
+
+            // A new nested type <>c is generated in C#2
+            CheckNames(readers, reader2.GetTypeDefNames(), "C#2", "D", "<>c", "<<F>b__0#2_0#2>d");
+            CheckNames(readers, diff2.EmitResult.ChangedTypes, "C#2", "D", "<>c", "<<F>b__0#2_0#2>d");
+        }
+
+        [Fact]
         public void AddNestedTypeAndMembers()
         {
             var source0 =

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.Emit
         {
             foreach (var def in _changedTypeDefs)
             {
-                types.Add(MetadataTokens.TypeDefinitionHandle(_typeDefs.GetRowId(def)));
+                types.Add(GetTypeDefinitionHandle(def));
             }
         }
 
@@ -856,7 +856,7 @@ namespace Microsoft.CodeAnalysis.Emit
             {
                 if (index.IsAddedNotChanged(member))
                 {
-                    int typeRowId = _typeDefs.GetRowId(member.ContainingTypeDefinition);
+                    int typeRowId = MetadataTokens.GetRowNumber(GetTypeDefinitionHandle(member.ContainingTypeDefinition));
                     int mapRowId = map.GetRowId(typeRowId);
 
                     metadata.AddEncLogEntry(
@@ -881,7 +881,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 if (index.IsAddedNotChanged(member))
                 {
                     metadata.AddEncLogEntry(
-                        entity: MetadataTokens.TypeDefinitionHandle(_typeDefs.GetRowId(member.ContainingTypeDefinition)),
+                        entity: GetTypeDefinitionHandle(member.ContainingTypeDefinition),
                         code: addCode);
                 }
 

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Emit
             return this.GetChange(symbol) != SymbolChange.None;
         }
 
-        private bool ExistsInPreviousGeneration(ISymbolInternal symbol)
+        private bool DefinitionExistsInPreviousGeneration(ISymbolInternal symbol)
         {
             var definition = (IDefinition)symbol.GetCciAdapter();
 
@@ -106,12 +106,12 @@ namespace Microsoft.CodeAnalysis.Emit
 
                         // The container of the synthesized symbol doesn't exist, we need to add the symbol.
                         // This may happen e.g. for members of a state machine type when a non-iterator method is changed to an iterator.
-                        if (!ExistsInPreviousGeneration(synthesizedSymbol.ContainingType))
+                        if (!DefinitionExistsInPreviousGeneration(synthesizedSymbol.ContainingType))
                         {
                             return SymbolChange.Added;
                         }
 
-                        if (!ExistsInPreviousGeneration(synthesizedSymbol))
+                        if (!DefinitionExistsInPreviousGeneration(synthesizedSymbol))
                         {
                             // A method was changed to a method containing a lambda, to an iterator, or to an async method.
                             // The state machine or closure class has been added.
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
                     case SymbolChange.Added:
                         // The method has been added - add the synthesized member as well, unless it already exists.
-                        if (!ExistsInPreviousGeneration(synthesizedSymbol))
+                        if (!DefinitionExistsInPreviousGeneration(synthesizedSymbol))
                         {
                             return SymbolChange.Added;
                         }
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Emit
                     }
 
                     // If the definition did not exist in the previous generation, it was added.
-                    return ExistsInPreviousGeneration(internalSymbol) ? SymbolChange.None : SymbolChange.Added;
+                    return DefinitionExistsInPreviousGeneration(internalSymbol) ? SymbolChange.None : SymbolChange.Added;
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(containerChange);

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -64,30 +64,54 @@ namespace Microsoft.CodeAnalysis.Emit
             return this.GetChange(symbol) != SymbolChange.None;
         }
 
+        private bool ExistsInPreviousGeneration(ISymbolInternal symbol)
+        {
+            var definition = (IDefinition)symbol.GetCciAdapter();
+
+            if (!_definitionMap.DefinitionExists(definition))
+            {
+                return false;
+            }
+
+            // Definition map does not consider types that are being replaced,
+            // hence we need to check - type that is being replaced is not considered
+            // existing in the previous generation.
+            var current = symbol.GetISymbol();
+            do
+            {
+                if (_replacedSymbols.Contains(current))
+                {
+                    return false;
+                }
+
+                current = current.ContainingType;
+            }
+            while (current is not null);
+
+            return true;
+        }
+
         public SymbolChange GetChange(IDefinition def)
         {
             var symbol = def.GetInternalSymbol();
-            if (symbol is ISynthesizedMethodBodyImplementationSymbol synthesizedDef)
+            if (symbol is ISynthesizedMethodBodyImplementationSymbol synthesizedSymbol)
             {
-                RoslynDebug.Assert(synthesizedDef.Method != null);
+                RoslynDebug.Assert(synthesizedSymbol.Method != null);
 
-                var generator = synthesizedDef.Method;
-                ISymbolInternal synthesizedSymbol = synthesizedDef;
-
-                var change = GetChange((IDefinition)generator.GetCciAdapter());
-                switch (change)
+                var generatorChange = GetChange((IDefinition)synthesizedSymbol.Method.GetCciAdapter());
+                switch (generatorChange)
                 {
                     case SymbolChange.Updated:
                         // The generator has been updated. Some synthesized members should be reused, others updated or added.
 
                         // The container of the synthesized symbol doesn't exist, we need to add the symbol.
                         // This may happen e.g. for members of a state machine type when a non-iterator method is changed to an iterator.
-                        if (!_definitionMap.DefinitionExists((IDefinition)synthesizedSymbol.ContainingType.GetCciAdapter()))
+                        if (!ExistsInPreviousGeneration(synthesizedSymbol.ContainingType))
                         {
                             return SymbolChange.Added;
                         }
 
-                        if (!_definitionMap.DefinitionExists(def))
+                        if (!ExistsInPreviousGeneration(synthesizedSymbol))
                         {
                             // A method was changed to a method containing a lambda, to an iterator, or to an async method.
                             // The state machine or closure class has been added.
@@ -98,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Emit
                         // not updated since it's form doesn't depend on the content of the generator.
                         // For example, when an iterator method changes all methods that implement IEnumerable 
                         // but MoveNext can be reused as they are.
-                        if (!synthesizedDef.HasMethodBodyDependency)
+                        if (!synthesizedSymbol.HasMethodBodyDependency)
                         {
                             return SymbolChange.None;
                         }
@@ -118,8 +142,8 @@ namespace Microsoft.CodeAnalysis.Emit
                         return SymbolChange.None;
 
                     case SymbolChange.Added:
-                        // The method has been added - add the synthesized member as well, unless they already exist.
-                        if (!_definitionMap.DefinitionExists(def))
+                        // The method has been added - add the synthesized member as well, unless it already exists.
+                        if (!ExistsInPreviousGeneration(synthesizedSymbol))
                         {
                             return SymbolChange.Added;
                         }
@@ -146,16 +170,16 @@ namespace Microsoft.CodeAnalysis.Emit
 
                     default:
                         // The method had to change, otherwise the synthesized symbol wouldn't be generated
-                        throw ExceptionUtilities.UnexpectedValue(change);
+                        throw ExceptionUtilities.UnexpectedValue(generatorChange);
                 }
             }
 
-            if (symbol is object)
+            if (symbol is not null)
             {
                 return GetChange(symbol.GetISymbol());
             }
 
-            // If the def existed in the previous generation, the def is unchanged
+            // If the def that has no associated internal symbol existed in the previous generation, the def is unchanged
             // (although it may contain changed defs); otherwise, it was added.
             if (_definitionMap.DefinitionExists(def))
             {
@@ -192,19 +216,18 @@ namespace Microsoft.CodeAnalysis.Emit
 
                 case SymbolChange.Updated:
                 case SymbolChange.ContainsChanges:
-                    var adapter = GetISymbolInternalOrNull(symbol)?.GetCciAdapter();
-
-                    if (adapter is IDefinition definition)
+                    var internalSymbol = GetISymbolInternalOrNull(symbol);
+                    if (internalSymbol is { Kind: not SymbolKind.Namespace })
                     {
                         // If the definition did not exist in the previous generation, it was added.
-                        return _definitionMap.DefinitionExists(definition) ? SymbolChange.None : SymbolChange.Added;
+                        return ExistsInPreviousGeneration(internalSymbol) ? SymbolChange.None : SymbolChange.Added;
                     }
 
-                    if (adapter is INamespace @namespace)
+                    if (internalSymbol is { Kind: SymbolKind.Namespace })
                     {
                         // If the namespace did not exist in the previous generation, it was added.
                         // Otherwise the namespace may contain changes.
-                        return _definitionMap.NamespaceExists(@namespace) ? SymbolChange.ContainsChanges : SymbolChange.Added;
+                        return _definitionMap.NamespaceExists((INamespace)internalSymbol.GetCciAdapter()) ? SymbolChange.ContainsChanges : SymbolChange.Added;
                     }
 
                     return SymbolChange.None;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -217,20 +217,20 @@ namespace Microsoft.CodeAnalysis.Emit
                 case SymbolChange.Updated:
                 case SymbolChange.ContainsChanges:
                     var internalSymbol = GetISymbolInternalOrNull(symbol);
-                    if (internalSymbol is { Kind: not SymbolKind.Namespace })
+                    if (internalSymbol is null)
                     {
-                        // If the definition did not exist in the previous generation, it was added.
-                        return ExistsInPreviousGeneration(internalSymbol) ? SymbolChange.None : SymbolChange.Added;
+                        return SymbolChange.None;
                     }
 
-                    if (internalSymbol is { Kind: SymbolKind.Namespace })
+                    if (internalSymbol.Kind == SymbolKind.Namespace)
                     {
                         // If the namespace did not exist in the previous generation, it was added.
                         // Otherwise the namespace may contain changes.
                         return _definitionMap.NamespaceExists((INamespace)internalSymbol.GetCciAdapter()) ? SymbolChange.ContainsChanges : SymbolChange.Added;
                     }
 
-                    return SymbolChange.None;
+                    // If the definition did not exist in the previous generation, it was added.
+                    return ExistsInPreviousGeneration(internalSymbol) ? SymbolChange.None : SymbolChange.Added;
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(containerChange);


### PR DESCRIPTION
Fixes emit for the following scenario: 

```C#
  [System.Runtime.CompilerServices.CreateNewOnMetadataUpdateAttribute]
  internal class Test
  {
        public void Do()
        {
            Task.Run(async() => {}).Wait();
        }
  }
```