### PR TITLE
Remove redundant check in `IsGlobalMain`

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -5447,10 +5447,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                  => obj.GetHashCode();
         }
 
-#pragma warning disable format
         private static bool IsGlobalMain(ISymbol symbol)
-            => symbol is IMethodSymbol { Name: WellKnownMemberNames.TopLevelStatementsEntryPointMethodName, ContainingType.Name: WellKnownMemberNames.TopLevelStatementsEntryPointTypeName };
-#pragma warning restore format
+            => symbol is IMethodSymbol { Name: WellKnownMemberNames.TopLevelStatementsEntryPointMethodName };
 
         private static bool InGenericContext(ISymbol symbol, out bool isGenericMethod)
         {


### PR DESCRIPTION
Only need to check the unspeakable `Main` name. The check is either redundant or *may* be incorrect in case the following can happen:

1. Constant is changed to `Program`.
2. Analyzer is run in an older version of the compiler where it used `<Program>$`
3. The method will incorrectly return false since `Program` != `<Program>$`

cc @davidwengier @tmat 