### PR TITLE
🐇 Ensure recoverable syntax trees are pushed to temporary storage

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -133,7 +133,17 @@ namespace Microsoft.CodeAnalysis
             using (Logger.LogBlock(FunctionId.Workspace_Document_State_FullyParseSyntaxTree, s_fullParseLog, filePath, mode, cancellationToken))
             {
                 var textAndVersion = await newTextSource.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                return CreateTreeAndVersion(newTextSource, cacheKey, filePath, options, languageServices, mode, textAndVersion, cancellationToken);
+                var treeAndVersion = CreateTreeAndVersion(newTextSource, cacheKey, filePath, options, languageServices, mode, textAndVersion, cancellationToken);
+
+                // The tree may be a RecoverableSyntaxTree. In its initial state, the RecoverableSyntaxTree keeps a
+                // strong reference to the root SyntaxNode, and only transitions to a weak reference backed by temporary
+                // storage after the first time GetRoot (or GetRootAsync) is called. Since we know we are creating a
+                // RecoverableSyntaxTree for the purpose of avoiding problematic memory overhead, we call GetRoot
+                // immediately to force the object to weakly hold its data from the start.
+                // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1307180
+                await treeAndVersion.Tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+
+                return treeAndVersion;
             }
         }
 
@@ -149,7 +159,17 @@ namespace Microsoft.CodeAnalysis
             using (Logger.LogBlock(FunctionId.Workspace_Document_State_FullyParseSyntaxTree, s_fullParseLog, filePath, mode, cancellationToken))
             {
                 var textAndVersion = newTextSource.GetValue(cancellationToken);
-                return CreateTreeAndVersion(newTextSource, cacheKey, filePath, options, languageServices, mode, textAndVersion, cancellationToken);
+                var treeAndVersion = CreateTreeAndVersion(newTextSource, cacheKey, filePath, options, languageServices, mode, textAndVersion, cancellationToken);
+
+                // The tree may be a RecoverableSyntaxTree. In its initial state, the RecoverableSyntaxTree keeps a
+                // strong reference to the root SyntaxNode, and only transitions to a weak reference backed by temporary
+                // storage after the first time GetRoot (or GetRootAsync) is called. Since we know we are creating a
+                // RecoverableSyntaxTree for the purpose of avoiding problematic memory overhead, we call GetRoot
+                // immediately to force the object to weakly hold its data from the start.
+                // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1307180
+                treeAndVersion.Tree.GetRoot(cancellationToken);
+
+                return treeAndVersion;
             }
         }
 


### PR DESCRIPTION
Ensure recoverable syntax trees transition to weak references on creation, similar to how we handled recoverable text in #45477.

Fixes [AB#1307180](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1307180)