### PR TITLE
Fix matchnamespacetofolder analyzer/codefix

### DIFF
--- a/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
+++ b/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
@@ -504,6 +504,47 @@ $@"namespace NS1
         }
 
         [Fact]
+        public async Task DocumentAtRoot_NoDiagnostic()
+        {
+            var folder = CreateFolderPath();
+
+            var code = $@"
+namespace {DefaultNamespace}
+{{
+    class C {{ }}
+}}";
+
+            await RunTestAsync(
+                "File1.cs",
+                code,
+                folder);
+        }
+
+        [Fact]
+        public async Task DocumentAtRoot_ChangeNamespace()
+        {
+            var folder = CreateFolderPath();
+
+            var code = $@"
+namespace {DefaultNamespace}.Test
+{{
+    class C {{ }}
+}}";
+
+            var fixedCode = $@"
+namespace {DefaultNamespace}
+{{
+    class C {{ }}
+}}";
+
+            await RunTestAsync(
+                "File1.cs",
+                code,
+                folder,
+                fixedCode: fixedCode);
+        }
+
+        [Fact]
         public async Task ChangeNamespace_WithAliasReferencesInOtherDocument()
         {
             var declaredNamespace = $"Bar.Baz";

--- a/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
+++ b/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
@@ -525,14 +525,14 @@ namespace {DefaultNamespace}
         {
             var folder = CreateFolderPath();
 
-            var code = $@"
-namespace {DefaultNamespace}.Test
+            var code =
+$@"namespace [|{DefaultNamespace}.Test|]
 {{
     class C {{ }}
 }}";
 
-            var fixedCode = $@"
-namespace {DefaultNamespace}
+            var fixedCode =
+$@"namespace {DefaultNamespace}
 {{
     class C {{ }}
 }}";

--- a/src/Analyzers/Core/CodeFixes/MatchFolderAndNamespace/AbstractChangeNamespaceToMatchFolderCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/MatchFolderAndNamespace/AbstractChangeNamespaceToMatchFolderCodeFixProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.MatchFolderAndNamespace
             // us to keep in line with the sync methodology that we have as a public API and not have 
             // to rewrite or move the complex logic. RenameDocumentAsync is designed to behave the same
             // as the intent of this analyzer/codefix pair.
-            var targetFolders = PathMetadataUtilities.BuildFoldersFromNamespace(targetNamespace);
+            var targetFolders = PathMetadataUtilities.BuildFoldersFromNamespace(targetNamespace, document.Project.DefaultNamespace);
             var documentWithNoFolders = document.WithFolders(Array.Empty<string>());
             var renameActionSet = await Renamer.RenameDocumentAsync(
                 documentWithNoFolders,

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.State.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.State.cs
@@ -127,10 +127,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.SyncNamespace
 
                 // Namespace can't be changed if we can't construct a valid qualified identifier from folder names.
                 // In this case, we might still be able to provide refactoring to move file to new location.
-                var namespaceFromFolders = PathMetadataUtilities.TryBuildNamespaceFromFolders(document.Folders, syntaxFacts);
-                var targetNamespace = namespaceFromFolders == null
-                    ? null
-                    : ConcatNamespace(defaultNamespace, namespaceFromFolders);
+                var targetNamespace = PathMetadataUtilities.TryBuildNamespaceFromFolders(document.Folders, syntaxFacts, defaultNamespace);
 
                 // No action required if namespace already matches folders.
                 if (syntaxFacts.StringComparer.Equals(targetNamespace, declaredNamespace))
@@ -185,23 +182,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.SyncNamespace
                 }
 
                 return defaultNamespaceFromProjects.Single();
-            }
-
-            private static string ConcatNamespace(string rootNamespace, string namespaceSuffix)
-            {
-                Debug.Assert(rootNamespace != null && namespaceSuffix != null);
-                if (namespaceSuffix.Length == 0)
-                {
-                    return rootNamespace;
-                }
-                else if (rootNamespace.Length == 0)
-                {
-                    return namespaceSuffix;
-                }
-                else
-                {
-                    return rootNamespace + "." + namespaceSuffix;
-                }
             }
 
             /// <summary>

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1272,7 +1272,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     $"This Workspace does not support changing a document's {nameof(document.Id)}.");
             }
 
-            if (document.Folders != updatedInfo.Folders)
+            if (document.Folders != updatedInfo.Folders && !document.Folders.SequenceEqual(updatedInfo.Folders))
             {
                 throw new InvalidOperationException(
                     $"This Workspace does not support changing a document's {nameof(document.Folders)}.");

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PathMetadataUtilities.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PathMetadataUtilities.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Roslyn.Utilities;
@@ -25,6 +26,11 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         public static string? TryBuildNamespaceFromFolders(IEnumerable<string> folders, ISyntaxFacts syntaxFacts, string? rootNamespace = null)
         {
             var parts = folders.SelectMany(folder => folder.Split(NamespaceSeparatorArray)).SelectAsArray(syntaxFacts.EscapeIdentifier);
+
+            if (parts.IsDefaultOrEmpty)
+            {
+                return rootNamespace;
+            }
 
             var constructedNamespace = parts.All(syntaxFacts.IsValidIdentifier)
                 ? string.Join(".", parts)


### PR DESCRIPTION
Fix issues where the namespace for documents at the root would be incorrect.

Fixes: #54757