### PR TITLE
Add help link to pull diagnostics errors

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Features/Diagnostics/XamlDiagnostic.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Diagnostics/XamlDiagnostic.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Diagnostics
         public int Length { get; set; }
         public string? Tool { get; set; }
         public string? ExtendedMessage { get; set; }
+        public string? HelpLink { get; set; }
         public string[]? CustomTags { get; set; }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -192,8 +192,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
 
         private static CodeDescription? GetCodeDescription(string? helpLink)
         {
-            if (!string.IsNullOrEmpty(helpLink)
-                && Uri.TryCreate(helpLink, UriKind.RelativeOrAbsolute, out var uri))
+            if (Uri.TryCreate(helpLink, UriKind.RelativeOrAbsolute, out var uri))
             {
                 return new CodeDescription
                 {

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -134,6 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 Range = ProtocolConversions.TextSpanToRange(new TextSpan(d.Offset, d.Length), text),
                 Tags = ConvertTags(d),
                 Source = d.Tool,
+                CodeDescription = GetCodeDescription(d.HelpLink),
                 Projects = new[]
                 {
                     new ProjectAndContext
@@ -187,6 +188,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 result.Add(DiagnosticTag.Unnecessary);
 
             return result.ToArray();
+        }
+
+        private static CodeDescription? GetCodeDescription(string? helpLink)
+        {
+            if (!string.IsNullOrEmpty(helpLink)
+                && Uri.TryCreate(helpLink, UriKind.RelativeOrAbsolute, out var uri))
+            {
+                return new CodeDescription
+                {
+                    Href = uri,
+                };
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Adding help link to pull diagnostics errors which users can click on and get help information. The XAML language service has already generated the link and we just pass it to the VsDiagnostic CodeDescription.

![image](https://user-images.githubusercontent.com/14283750/128423207-14e90e29-a83b-4686-8b70-0b220a7738a1.png)
