### PR TITLE
Bug fix extract local function errors C#7 and below

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -1864,10 +1864,10 @@ class Program
     void M()
     {
         int a = 1;
-        var t = {|Rename:GetT|}(a);
+        var t = {|Rename:GetT|}();
         System.Console.Write(t.a);
 
-        (int a, int b) GetT(int a)
+        (int a, int b) GetT()
         {
             return (a, b: 2);
         }
@@ -1893,10 +1893,10 @@ class Program
     void M()
     {
         int x, y;
-        {|Rename:NewMethod|}(out x, out y);
+        {|Rename:NewMethod|}();
         System.Console.Write(x + y);
 
-        void NewMethod(out int x, out int y)
+        void NewMethod()
         {
             var (x, y) = (1, 2);
         }
@@ -1922,10 +1922,10 @@ class Program
     void M()
     {
         int x, y;
-        {|Rename:NewMethod|}(out x, out y);
+        {|Rename:NewMethod|}();
         System.Console.Write(x + y);
 
-        void NewMethod(out int x, out int y)
+        void NewMethod()
         {
             (x, y) = (1, 2);
         }
@@ -3234,9 +3234,9 @@ class Program
     static void Main(string[] args)
     {
         bool b = true;
-        System.Console.WriteLine({|Rename:NewMethod|}(b) ? b = true : b = false);
+        System.Console.WriteLine({|Rename:NewMethod|}() ? b = true : b = false);
 
-        bool NewMethod(bool b)
+        bool NewMethod()
         {
             return b != true;
         }
@@ -3261,9 +3261,9 @@ class Program
     static void Main(string[] args)
     {
         bool b = true;
-        System.Console.WriteLine({|Rename:NewMethod|}(b) ? b = true : b = false);
+        System.Console.WriteLine({|Rename:NewMethod|}() ? b = true : b = false);
 
-        bool NewMethod(bool b)
+        bool NewMethod()
         {
             return b != true;
         }
@@ -4890,7 +4890,7 @@ public class Tests
     public void Test1()
     {
         const string NAME = ""SOMETEXT"";
-        {|Rename:NewMethod|}(NAME);
+        {|Rename:NewMethod|}();
 
         void NewMethod()
         {

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -4851,5 +4851,55 @@ class C
     }
 }", codeActionIndex: 1);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        public async Task TestExtractLocalMethodNaming()
+        {
+            var code = @"
+using NUnit.Framework;
+
+public class Tests
+{
+    public string SomeOtherMethod(int k)
+    {
+        return "";
+    }
+
+    int j = 2;
+    [Test]
+    public void Test1()
+    {
+        const string NAME = ""SOMETEXT"";
+        [|Assert.AreEqual(string.Format(NAME, 0, 0), SomeOtherMethod(j));|]
+        }
+    }
+}";
+
+            var expected = @"
+using NUnit.Framework;
+
+public class Tests
+{
+    public string SomeOtherMethod(int k)
+    {
+        return "";
+    }
+
+    int j = 2;
+    [Test]
+    public void Test1()
+    {
+        const string NAME = ""SOMETEXT"";
+        {|Rename:NewMethod|}(NAME);
+
+            void NewMethod(string NAME1)
+            {
+                Assert.AreEqual(string.Format(NAME1, 0, 0), SomeOtherMethod(j));
+            }
+        }
+    }
+}";
+            await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp9), index: CodeActionIndex);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -4852,6 +4852,7 @@ class C
 }", codeActionIndex: 1);
         }
 
+        [WorkItem(45422, "https://github.com/dotnet/roslyn/issues/55031")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public async Task TestExtractLocalMethodNaming()
         {
@@ -4871,7 +4872,6 @@ public class Tests
     {
         const string NAME = ""SOMETEXT"";
         [|Assert.AreEqual(string.Format(NAME, 0, 0), SomeOtherMethod(j));|]
-        }
     }
 }";
 
@@ -4892,14 +4892,13 @@ public class Tests
         const string NAME = ""SOMETEXT"";
         {|Rename:NewMethod|}(NAME);
 
-            void NewMethod(string NAME1)
-            {
-                Assert.AreEqual(string.Format(NAME1, 0, 0), SomeOtherMethod(j));
-            }
+        void NewMethod()
+        {
+            Assert.AreEqual(string.Format(NAME, 0, 0), SomeOtherMethod(j));
         }
     }
 }";
-            await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp9), index: CodeActionIndex);
+            await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp7), index: CodeActionIndex);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -5021,7 +5021,7 @@ public class Class
     public void M()
     {
         _ = from a in new object[0]
-            select NewMethod(a);
+            select {|Rename:NewMethod|}(a);
 
         string NewMethod(object a)
         {

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -4854,7 +4854,7 @@ class C
 
         [WorkItem(45422, "https://github.com/dotnet/roslyn/issues/55031")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
-        public async Task TestExtractLocalMethodNaming()
+        public async Task TestExtractLocalConst_CSharp7()
         {
             var code = @"
 using NUnit.Framework;
@@ -4890,6 +4890,102 @@ public class Tests
     public void Test1()
     {
         const string NAME = ""SOMETEXT"";
+        {|Rename:NewMethod|}();
+
+        void NewMethod()
+        {
+            Assert.AreEqual(string.Format(NAME, 0, 0), SomeOtherMethod(j));
+        }
+    }
+}";
+            await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp7), index: CodeActionIndex);
+        }
+
+        [WorkItem(45422, "https://github.com/dotnet/roslyn/issues/55031")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        public async Task TestExtractParameter_CSharp7()
+        {
+            var code = @"
+using NUnit.Framework;
+
+public class Tests
+{
+    public string SomeOtherMethod(int k)
+    {
+        return "";
+    }
+
+    int j = 2;
+    [Test]
+    public void Test1(string NAME)
+    {
+        [|Assert.AreEqual(string.Format(NAME, 0, 0), SomeOtherMethod(j));|]
+    }
+}";
+
+            var expected = @"
+using NUnit.Framework;
+
+public class Tests
+{
+    public string SomeOtherMethod(int k)
+    {
+        return "";
+    }
+
+    int j = 2;
+    [Test]
+    public void Test1(string NAME)
+    {
+        {|Rename:NewMethod|}();
+
+        void NewMethod()
+        {
+            Assert.AreEqual(string.Format(NAME, 0, 0), SomeOtherMethod(j));
+        }
+    }
+}";
+            await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp7), index: CodeActionIndex);
+        }
+
+        [WorkItem(45422, "https://github.com/dotnet/roslyn/issues/55031")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        public async Task TestExtractLocal_CSharp7()
+        {
+            var code = @"
+using NUnit.Framework;
+
+public class Tests
+{
+    public string SomeOtherMethod(int k)
+    {
+        return "";
+    }
+
+    int j = 2;
+    [Test]
+    public void Test1()
+    {
+        var NAME = ""SOMETEXT"";
+        [|Assert.AreEqual(string.Format(NAME, 0, 0), SomeOtherMethod(j));|]
+    }
+}";
+
+            var expected = @"
+using NUnit.Framework;
+
+public class Tests
+{
+    public string SomeOtherMethod(int k)
+    {
+        return "";
+    }
+
+    int j = 2;
+    [Test]
+    public void Test1()
+    {
+        var NAME = ""SOMETEXT"";
         {|Rename:NewMethod|}();
 
         void NewMethod()

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -4852,7 +4852,7 @@ class C
 }", codeActionIndex: 1);
         }
 
-        [WorkItem(45422, "https://github.com/dotnet/roslyn/issues/55031")]
+        [WorkItem(55031, "https://github.com/dotnet/roslyn/issues/55031")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public async Task TestExtractLocalConst_CSharp7()
         {
@@ -4901,7 +4901,7 @@ public class Tests
             await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp7), index: CodeActionIndex);
         }
 
-        [WorkItem(45422, "https://github.com/dotnet/roslyn/issues/55031")]
+        [WorkItem(55031, "https://github.com/dotnet/roslyn/issues/55031")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public async Task TestExtractParameter_CSharp7()
         {
@@ -4948,7 +4948,7 @@ public class Tests
             await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp7), index: CodeActionIndex);
         }
 
-        [WorkItem(45422, "https://github.com/dotnet/roslyn/issues/55031")]
+        [WorkItem(55031, "https://github.com/dotnet/roslyn/issues/55031")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public async Task TestExtractLocal_CSharp7()
         {
@@ -4991,6 +4991,41 @@ public class Tests
         void NewMethod()
         {
             Assert.AreEqual(string.Format(NAME, 0, 0), SomeOtherMethod(j));
+        }
+    }
+}";
+            await TestAsync(code, expected, TestOptions.Script.WithLanguageVersion(LanguageVersion.CSharp7), index: CodeActionIndex);
+        }
+
+        [WorkItem(55031, "https://github.com/dotnet/roslyn/issues/55031")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        public async Task TestExtractRangeVariable_CSharp7()
+        {
+            var code = @"
+using System.Linq;
+
+public class Class
+{
+    public void M()
+    {
+        _ = from a in new object[0]
+            select [|a.ToString()|];
+    }
+}";
+
+            var expected = @"
+using System.Linq;
+
+public class Class
+{
+    public void M()
+    {
+        _ = from a in new object[0]
+            select NewMethod(a);
+
+        string NewMethod(object a)
+        {
+            return a.ToString();
         }
     }
 }";

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CodeRefactorings.ExtractMethod;
 using Microsoft.CodeAnalysis.CodeStyle;

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     explicitInterfaceImplementations: default,
                     name: _methodName.ToString(),
                     typeParameters: CreateMethodTypeParameters(),
-                    parameters: CreateMethodParameters(localFunction),
+                    parameters: CreateMethodParameters(),
                     statements: result.Data,
                     methodKind: localFunction ? MethodKind.LocalFunction : MethodKind.Ordinary);
 
@@ -584,16 +584,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 var methodName = CreateMethodNameForInvocation().WithAdditionalAnnotations(Simplifier.Annotation);
                 var arguments = new List<ArgumentSyntax>();
 
-                //if (!(LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root)))
-                //{
                 foreach (var argument in AnalyzerResult.MethodParameters)
                 {
-                    var modifier = GetParameterRefSyntaxKind(argument.ParameterModifier);
-                    var refOrOut = modifier == SyntaxKind.None ? default : SyntaxFactory.Token(modifier);
-
-                    arguments.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(argument.Name)).WithRefOrOutKeyword(refOrOut));
+                    if (!(LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root)) || !argument.CanBeCapturedByLocalFunction)
+                    {
+                        var modifier = GetParameterRefSyntaxKind(argument.ParameterModifier);
+                        var refOrOut = modifier == SyntaxKind.None ? default : SyntaxFactory.Token(modifier);
+                        arguments.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(argument.Name)).WithRefOrOutKeyword(refOrOut));
+                    }
                 }
-                //}
 
                 var invocation = SyntaxFactory.InvocationExpression(methodName,
                                     SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)));

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -584,16 +584,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 var methodName = CreateMethodNameForInvocation().WithAdditionalAnnotations(Simplifier.Annotation);
                 var arguments = new List<ArgumentSyntax>();
 
-                if (!(LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root)))
+                //if (!(LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root)))
+                //{
+                foreach (var argument in AnalyzerResult.MethodParameters)
                 {
-                    foreach (var argument in AnalyzerResult.MethodParameters)
-                    {
-                        var modifier = GetParameterRefSyntaxKind(argument.ParameterModifier);
-                        var refOrOut = modifier == SyntaxKind.None ? default : SyntaxFactory.Token(modifier);
+                    var modifier = GetParameterRefSyntaxKind(argument.ParameterModifier);
+                    var refOrOut = modifier == SyntaxKind.None ? default : SyntaxFactory.Token(modifier);
 
-                        arguments.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(argument.Name)).WithRefOrOutKeyword(refOrOut));
-                    }
+                    arguments.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(argument.Name)).WithRefOrOutKeyword(refOrOut));
                 }
+                //}
 
                 var invocation = SyntaxFactory.InvocationExpression(methodName,
                                     SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)));

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     explicitInterfaceImplementations: default,
                     name: _methodName.ToString(),
                     typeParameters: CreateMethodTypeParameters(),
-                    parameters: CreateMethodParameters(),
+                    parameters: CreateMethodParameters(localFunction),
                     statements: result.Data,
                     methodKind: localFunction ? MethodKind.LocalFunction : MethodKind.Ordinary);
 
@@ -173,6 +173,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
                 return statements.CastArray<SyntaxNode>();
             }
+
+            protected override bool ShouldLocalFunctionCaptureParameter(SyntaxNode node)
+            => ((CSharpParseOptions)node.SyntaxTree.Options).LanguageVersion < LanguageVersion.CSharp8;
 
             private static bool IsExpressionBodiedMember(SyntaxNode node)
                 => node is MemberDeclarationSyntax member && member.GetExpressionBody() != null;

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -583,10 +583,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
                 var methodName = CreateMethodNameForInvocation().WithAdditionalAnnotations(Simplifier.Annotation);
                 var arguments = new List<ArgumentSyntax>();
+                var isLocalFunction = LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root);
 
                 foreach (var argument in AnalyzerResult.MethodParameters)
                 {
-                    if (!(LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root)) || !argument.CanBeCapturedByLocalFunction)
+                    if (!isLocalFunction || !argument.CanBeCapturedByLocalFunction)
                     {
                         var modifier = GetParameterRefSyntaxKind(argument.ParameterModifier);
                         var refOrOut = modifier == SyntaxKind.None ? default : SyntaxFactory.Token(modifier);

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -582,14 +582,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             protected override ExpressionSyntax CreateCallSignature()
             {
                 var methodName = CreateMethodNameForInvocation().WithAdditionalAnnotations(Simplifier.Annotation);
-
                 var arguments = new List<ArgumentSyntax>();
-                foreach (var argument in AnalyzerResult.MethodParameters)
-                {
-                    var modifier = GetParameterRefSyntaxKind(argument.ParameterModifier);
-                    var refOrOut = modifier == SyntaxKind.None ? default : SyntaxFactory.Token(modifier);
 
-                    arguments.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(argument.Name)).WithRefOrOutKeyword(refOrOut));
+                if (!(LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root)))
+                {
+                    foreach (var argument in AnalyzerResult.MethodParameters)
+                    {
+                        var modifier = GetParameterRefSyntaxKind(argument.ParameterModifier);
+                        var refOrOut = modifier == SyntaxKind.None ? default : SyntaxFactory.Token(modifier);
+
+                        arguments.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(argument.Name)).WithRefOrOutKeyword(refOrOut));
+                    }
                 }
 
                 var invocation = SyntaxFactory.InvocationExpression(methodName,

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -336,10 +336,10 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             protected ImmutableArray<IParameterSymbol> CreateMethodParameters()
             {
                 var parameters = ArrayBuilder<IParameterSymbol>.GetInstance();
-
+                var isLocalFunction = LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root);
                 foreach (var parameter in AnalyzerResult.MethodParameters)
                 {
-                    if (!(LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root)) || !parameter.CanBeCapturedByLocalFunction)
+                    if (!isLocalFunction || !parameter.CanBeCapturedByLocalFunction)
                     {
                         var refKind = GetRefKind(parameter.ParameterModifier);
                         var type = parameter.GetVariableType(SemanticDocument);

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -333,28 +333,25 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 return typeParameters.ToImmutableAndFree();
             }
 
-            protected ImmutableArray<IParameterSymbol> CreateMethodParameters(bool localFunction)
+            protected ImmutableArray<IParameterSymbol> CreateMethodParameters()
             {
-                /*var root = SemanticDocument.Root;
-                if (localFunction && ShouldLocalFunctionCaptureParameter(root))
-                {
-                    return ImmutableArray.Create<IParameterSymbol>();
-                }*/
-
                 var parameters = ArrayBuilder<IParameterSymbol>.GetInstance();
 
                 foreach (var parameter in AnalyzerResult.MethodParameters)
                 {
-                    var refKind = GetRefKind(parameter.ParameterModifier);
-                    var type = parameter.GetVariableType(SemanticDocument);
+                    if (!(LocalFunction && ShouldLocalFunctionCaptureParameter(SemanticDocument.Root)) || !parameter.CanBeCapturedByLocalFunction)
+                    {
+                        var refKind = GetRefKind(parameter.ParameterModifier);
+                        var type = parameter.GetVariableType(SemanticDocument);
 
-                    parameters.Add(
-                        CodeGenerationSymbolFactory.CreateParameterSymbol(
-                            attributes: ImmutableArray<AttributeData>.Empty,
-                            refKind: refKind,
-                            isParams: false,
-                            type: type,
-                            name: parameter.Name));
+                        parameters.Add(
+                            CodeGenerationSymbolFactory.CreateParameterSymbol(
+                                attributes: ImmutableArray<AttributeData>.Empty,
+                                refKind: refKind,
+                                isParams: false,
+                                type: type,
+                                name: parameter.Name));
+                    }
                 }
 
                 return parameters.ToImmutableAndFree();

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -335,11 +335,11 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
             protected ImmutableArray<IParameterSymbol> CreateMethodParameters(bool localFunction)
             {
-                var root = SemanticDocument.Root;
+                /*var root = SemanticDocument.Root;
                 if (localFunction && ShouldLocalFunctionCaptureParameter(root))
                 {
                     return ImmutableArray.Create<IParameterSymbol>();
-                }
+                }*/
 
                 var parameters = ArrayBuilder<IParameterSymbol>.GetInstance();
 

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -63,6 +63,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             protected abstract Task<SyntaxNode> GenerateBodyForCallSiteContainerAsync(CancellationToken cancellationToken);
             protected abstract SyntaxNode GetPreviousMember(SemanticDocument document);
             protected abstract OperationStatus<IMethodSymbol> GenerateMethodDefinition(bool localFunction, CancellationToken cancellationToken);
+            protected abstract bool ShouldLocalFunctionCaptureParameter(SyntaxNode node);
 
             protected abstract SyntaxToken CreateIdentifier(string name);
             protected abstract SyntaxToken CreateMethodName();
@@ -332,8 +333,14 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 return typeParameters.ToImmutableAndFree();
             }
 
-            protected ImmutableArray<IParameterSymbol> CreateMethodParameters()
+            protected ImmutableArray<IParameterSymbol> CreateMethodParameters(bool localFunction)
             {
+                var root = SemanticDocument.Root;
+                if (localFunction && ShouldLocalFunctionCaptureParameter(root))
+                {
+                    return ImmutableArray.Create<IParameterSymbol>();
+                }
+
                 var parameters = ArrayBuilder<IParameterSymbol>.GetInstance();
 
                 foreach (var parameter in AnalyzerResult.MethodParameters)

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
@@ -110,6 +110,13 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
             public string Name => _variableSymbol.Name;
 
+            /// <summary>
+            /// Returns true, if the variable could be either passed as a parameter
+            /// to the new local function or the local function can capture the variable.
+            /// </summary>
+            public bool CanBeCapturedByLocalFunction
+                => _variableSymbol.CanBeCapturedByLocalFunction;
+
             public bool OriginalTypeHadAnonymousTypeOrDelegate => _variableSymbol.OriginalTypeHadAnonymousTypeOrDelegate;
 
             public ITypeSymbol OriginalType => _variableSymbol.OriginalType;

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
             public abstract int DisplayOrder { get; }
             public abstract string Name { get; }
+            public abstract bool CanBeCapturedByLocalFunction { get; }
 
             public abstract bool GetUseSaferDeclarationBehavior(CancellationToken cancellationToken);
             public abstract SyntaxAnnotation IdentifierTokenAnnotation { get; }
@@ -174,6 +175,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers));
                 }
             }
+
+            public override bool CanBeCapturedByLocalFunction => true;
         }
 
         protected class LocalVariableSymbol<T> : VariableSymbol, IComparable<LocalVariableSymbol<T>> where T : SyntaxNode
@@ -243,6 +246,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
 
             public override SyntaxAnnotation IdentifierTokenAnnotation => _annotation;
+
+            public override bool CanBeCapturedByLocalFunction => true;
 
             public override void AddIdentifierTokenAnnotationPair(
                 List<Tuple<SyntaxToken, SyntaxAnnotation>> annotations, CancellationToken cancellationToken)
@@ -336,6 +341,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers));
                 }
             }
+
+            public override bool CanBeCapturedByLocalFunction => false;
         }
     }
 }

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     explicitInterfaceImplementations:=Nothing,
                     name:=_methodName.ToString(),
                     typeParameters:=CreateMethodTypeParameters(),
-                    parameters:=CreateMethodParameters(localFunction),
+                    parameters:=CreateMethodParameters(),
                     statements:=statements.Cast(Of SyntaxNode).ToImmutableArray())
 
                 Return result.With(

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -59,6 +59,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return Me.InsertionPoint.With(document).GetContext()
             End Function
 
+            Protected Overrides Function ShouldLocalFunctionCaptureParameter(node As SyntaxNode) As Boolean
+                Return False
+            End Function
+
             Protected Overrides Function GenerateMethodDefinition(localFunction As Boolean, cancellationToken As CancellationToken) As OperationStatus(Of IMethodSymbol)
                 Dim result = CreateMethodBody(cancellationToken)
                 Dim statements = result.Data
@@ -72,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                     explicitInterfaceImplementations:=Nothing,
                     name:=_methodName.ToString(),
                     typeParameters:=CreateMethodTypeParameters(),
-                    parameters:=CreateMethodParameters(),
+                    parameters:=CreateMethodParameters(localFunction),
                     statements:=statements.Cast(Of SyntaxNode).ToImmutableArray())
 
                 Return result.With(


### PR DESCRIPTION
Fixes: #55031

Opts to capture variables instead of creating new parameters in language versions below c#8 because they do not support static local functions.

* Need to fix the call to the new method