### PR TITLE
prevent Editor's typing responsiveness canceling the rename operation

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/AbstractRenameCommandHandler_ReturnHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/AbstractRenameCommandHandler_ReturnHandler.cs
@@ -16,6 +16,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             if (_renameService.ActiveSession != null)
             {
+                // Prevent Editor's typing responsiveness auto canceling the rename operation.
+                // InlineRenameSession will call IUIThreadOperationExecutor to sets up our own IUIThreadOperationContext
+                context.OperationContext.TakeOwnership();
+
                 _renameService.ActiveSession.Commit();
                 SetFocusToTextView(args.TextView);
                 return true;


### PR DESCRIPTION
**Problem:**
VS Editor will restore the Typing Responsiveness auto-canceling the UI operation after a set delay.
This will cause the Threaded Wait Dialog to display the "Exceeded the execution timeout" message
![image](https://user-images.githubusercontent.com/1673956/128427407-1dc8c67d-d9c9-42b9-8cff-3f46b7afe646.png)

**Solution:**
This fix prevents the operation from timing out. The Dialog will no longer display the timeout message.
This gif shows vastly exaggerated delays during inline rename. Editor is set to cancel the operation after 250ms.
![roslyn individual operation context](https://user-images.githubusercontent.com/1673956/128427495-80588c84-4184-440f-b649-7e05989278da.gif)

