### PR TITLE
ValueTracking: Don't wrap TreeView in ScrollViewer

### DIFF
--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTree.xaml
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTree.xaml
@@ -37,37 +37,35 @@
             Visibility="{Binding IsLoading, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
             Foreground="{DynamicResource {x:Static vs:ProgressBarColors.IndicatorFillBrushKey}}"
             Background="{DynamicResource {x:Static vs:ProgressBarColors.BackgroundBrushKey}}" />
-        
-        <ScrollViewer Grid.Row="1" Grid.Column="0" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-            <TreeView  x:Name="ValueTrackingTreeView" ItemsSource="{Binding Roots}" SelectedItemChanged="ValueTrackingTreeView_SelectedItemChanged" BorderThickness="0" PreviewKeyDown="ValueTrackingTreeView_PreviewKeyDown" MouseDown="ValueTrackingTreeView_MouseClickPreview" PreviewMouseDoubleClick="ValueTrackingTreeView_MouseClickPreview">
-                <TreeView.ItemContainerStyle>
-                    <Style TargetType="{x:Type TreeViewItem}">
-                        <Setter Property="IsExpanded" Value="{Binding IsNodeExpanded, Mode=TwoWay}" />
-                        <Setter Property="IsSelected" Value="{Binding IsNodeSelected, Mode=TwoWay}" />
-                    </Style>
-                </TreeView.ItemContainerStyle>
-                <TreeView.Resources>
-                    <HierarchicalDataTemplate DataType="{x:Type local:TreeItemViewModel}" ItemsSource="{Binding ChildItems}">
-                        <StackPanel Orientation="Horizontal">
-                            <Image Source="{Binding GlyphImage}" />
-                            <local:BindableTextBlock InlineCollection="{Binding Inlines}" Margin="0 0 5 0" />
-                        </StackPanel>
-                    </HierarchicalDataTemplate>
-                    <DataTemplate DataType="{x:Type local:EmptyTreeViewItem}">
-                    </DataTemplate>
-                    <DataTemplate DataType="{x:Type local:ComputingTreeViewItem}">
-                        <StackPanel Orientation="Horizontal">
-                            <vs:ProgressControl Margin="2" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                <vs:ProgressControl.RenderTransform>
-                                    <ScaleTransform ScaleX="0.50" ScaleY="0.50" />
-                                </vs:ProgressControl.RenderTransform>
-                            </vs:ProgressControl>
-                            <TextBlock Text="{Binding Text}" Margin="0 0 5 0" />
-                        </StackPanel>
-                    </DataTemplate>
-                </TreeView.Resources>
-            </TreeView>
-        </ScrollViewer>
+
+        <TreeView Grid.Row="1" Grid.Column="0" x:Name="ValueTrackingTreeView" ItemsSource="{Binding Roots}" SelectedItemChanged="ValueTrackingTreeView_SelectedItemChanged" BorderThickness="0" PreviewKeyDown="ValueTrackingTreeView_PreviewKeyDown" MouseDown="ValueTrackingTreeView_MouseClickPreview" PreviewMouseDoubleClick="ValueTrackingTreeView_MouseClickPreview">
+            <TreeView.ItemContainerStyle>
+                <Style TargetType="{x:Type TreeViewItem}">
+                    <Setter Property="IsExpanded" Value="{Binding IsNodeExpanded, Mode=TwoWay}" />
+                    <Setter Property="IsSelected" Value="{Binding IsNodeSelected, Mode=TwoWay}" />
+                </Style>
+            </TreeView.ItemContainerStyle>
+            <TreeView.Resources>
+                <HierarchicalDataTemplate DataType="{x:Type local:TreeItemViewModel}" ItemsSource="{Binding ChildItems}">
+                    <StackPanel Orientation="Horizontal">
+                        <Image Source="{Binding GlyphImage}" />
+                        <local:BindableTextBlock InlineCollection="{Binding Inlines}" Margin="0 0 5 0" />
+                    </StackPanel>
+                </HierarchicalDataTemplate>
+                <DataTemplate DataType="{x:Type local:EmptyTreeViewItem}">
+                </DataTemplate>
+                <DataTemplate DataType="{x:Type local:ComputingTreeViewItem}">
+                    <StackPanel Orientation="Horizontal">
+                        <vs:ProgressControl Margin="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <vs:ProgressControl.RenderTransform>
+                                <ScaleTransform ScaleX="0.50" ScaleY="0.50" />
+                            </vs:ProgressControl.RenderTransform>
+                        </vs:ProgressControl>
+                        <TextBlock Text="{Binding Text}" Margin="0 0 5 0" />
+                    </StackPanel>
+                </DataTemplate>
+            </TreeView.Resources>
+        </TreeView>
 
         <GridSplitter 
             Grid.Column="1" 


### PR DESCRIPTION
Apparently it doesn't work.

Fixes #55038