### PR TITLE
Use new document formatting service when generating types

### DIFF
--- a/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
@@ -58,16 +58,17 @@ namespace Microsoft.CodeAnalysis.FileHeaders
 #endif
             var newLineTrivia = EndOfLine(newLineText);
 
-            return GetTransformedSyntaxRootAsync(SyntaxFacts, FileHeaderHelper, newLineTrivia, document, cancellationToken);
+            return GetTransformedSyntaxRootAsync(SyntaxFacts, FileHeaderHelper, newLineTrivia, document, fileHeaderTemplate: null, cancellationToken);
         }
 
-        internal static async Task<SyntaxNode> GetTransformedSyntaxRootAsync(ISyntaxFacts syntaxFacts, AbstractFileHeaderHelper fileHeaderHelper, SyntaxTrivia newLineTrivia, Document document, CancellationToken cancellationToken)
+        internal static async Task<SyntaxNode> GetTransformedSyntaxRootAsync(ISyntaxFacts syntaxFacts, AbstractFileHeaderHelper fileHeaderHelper, SyntaxTrivia newLineTrivia, Document document, string? fileHeaderTemplate, CancellationToken cancellationToken)
         {
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
 
-            if (!document.Project.AnalyzerOptions.TryGetEditorConfigOption<string>(CodeStyleOptions2.FileHeaderTemplate, tree, out var fileHeaderTemplate)
-                || string.IsNullOrEmpty(fileHeaderTemplate))
+            if (string.IsNullOrEmpty(fileHeaderTemplate)
+                && (!document.Project.AnalyzerOptions.TryGetEditorConfigOption<string>(CodeStyleOptions2.FileHeaderTemplate, tree, out fileHeaderTemplate)
+                || string.IsNullOrEmpty(fileHeaderTemplate)))
             {
                 // This exception would show up as a gold bar, but as indicated we do not believe this is reachable.
                 throw ExceptionUtilities.Unreachable;

--- a/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/FileHeaders/AbstractFileHeaderCodeFixProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var root = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
 
-            if (string.IsNullOrEmpty(fileHeaderTemplate)
+            if (fileHeaderTemplate is null
                 && (!document.Project.AnalyzerOptions.TryGetEditorConfigOption<string>(CodeStyleOptions2.FileHeaderTemplate, tree, out fileHeaderTemplate)
                 || string.IsNullOrEmpty(fileHeaderTemplate)))
             {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.AddImports;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -3406,6 +3407,53 @@ expectedContainers: ImmutableArray.Create("Goo"),
 expectedDocumentName: "Bar.cs");
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public async Task TestGenerateIntoNewFileWithUsings1()
+        {
+            await TestAddDocumentInRegularAndScriptAsync(
+@"class Class { void F() { new [|Goo|].Bar(new System.Collections.Generic.List<int>()); } }",
+@"using System.Collections.Generic;
+
+namespace Goo
+{
+    internal class Bar
+    {
+        private List<int> list;
+
+        public Bar(List<int> list)
+        {
+            this.list = list;
+        }
+    }
+}",
+expectedContainers: ImmutableArray.Create("Goo"),
+expectedDocumentName: "Bar.cs");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public async Task TestGenerateIntoNewFileWithUsings2()
+        {
+            await TestAddDocumentInRegularAndScriptAsync(
+@"class Class { void F() { new [|Goo|].Bar(new System.Collections.Generic.List<int>()); } }",
+@"namespace Goo
+{
+    using System.Collections.Generic;
+
+    internal class Bar
+    {
+        private List<int> list;
+
+        public Bar(List<int> list)
+        {
+            this.list = list;
+        }
+    }
+}",
+expectedContainers: ImmutableArray.Create("Goo"),
+expectedDocumentName: "Bar.cs",
+parameters: new TestParameters(options: Option(CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, AddImportPlacement.InsideNamespace, NotificationOption2.Error)));
+        }
+
         [WorkItem(539620, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539620")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task TestDeclarationSpan()
@@ -5416,6 +5464,28 @@ internal class Goo
 }",
     expectedContainers: ImmutableArray<string>.Empty,
     expectedDocumentName: "Goo.cs");
+        }
+
+        [WorkItem(17361, "https://github.com/dotnet/roslyn/issues/17361")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        public async Task TestPreserveFileBanner4()
+        {
+            await TestAddDocumentInRegularAndScriptAsync(
+@"class Program
+{
+    void Main ( )
+    {
+        [|Goo|] f ;
+    }
+} ",
+@"// I am a banner
+
+internal class Goo
+{
+}",
+expectedContainers: ImmutableArray<string>.Empty,
+expectedDocumentName: "Goo.cs",
+new TestParameters(options: Option(CodeStyleOptions2.FileHeaderTemplate, "I am a banner")));
         }
 
         [WorkItem(22293, "https://github.com/dotnet/roslyn/issues/22293")]

--- a/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.AddImports;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Test.Utilities.Formatting;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
+{
+    public class CSharpNewDocumentFormattingServiceTests : AbstractNewDocumentFormattingServiceTests
+    {
+        protected override string Language => LanguageNames.CSharp;
+        protected override TestWorkspace CreateTestWorkspace(string testCode)
+            => TestWorkspace.CreateCSharp(testCode);
+
+        [Fact]
+        public async Task TestFileBanners()
+        {
+            await TestAsync(testCode: @"using System;
+
+namespace Goo
+{
+}",
+            expected: @"// This is a banner.
+
+using System;
+
+namespace Goo
+{
+}",
+            options:
+                (CodeStyleOptions2.FileHeaderTemplate, "This is a banner."));
+        }
+
+        [Fact]
+        public async Task TestAccessibilityModifiers()
+        {
+            await TestAsync(testCode: @"using System;
+
+namespace Goo
+{
+    class C
+    {
+    }
+}",
+            expected: @"using System;
+
+namespace Goo
+{
+    internal class C
+    {
+    }
+}",
+            options:
+                (CodeStyleOptions2.RequireAccessibilityModifiers, new CodeStyleOption2<AccessibilityModifiersRequired>(AccessibilityModifiersRequired.Always, NotificationOption2.Error)));
+        }
+
+        [Fact]
+        public async Task TestUsingDirectivePlacement()
+        {
+            await TestAsync(testCode: @"using System;
+
+namespace Goo
+{
+}",
+            expected: @"namespace Goo
+{
+    using System;
+}",
+            options:
+                (CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, new CodeStyleOption2<AddImportPlacement>(AddImportPlacement.InsideNamespace, NotificationOption2.Error)));
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
@@ -19,6 +19,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
             => TestWorkspace.CreateCSharp(testCode);
 
         [Fact]
+        public async Task TestOrganizeUsingsWithNoUsings()
+        {
+            var testCode = @"namespace Goo
+{
+}";
+            await TestAsync(
+                testCode: testCode,
+                expected: testCode,
+                options:
+                    (CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, new CodeStyleOption2<AddImportPlacement>(AddImportPlacement.OutsideNamespace, NotificationOption2.Error)));
+        }
+
+        [Fact]
         public async Task TestFileBanners()
         {
             await TestAsync(testCode: @"using System;

--- a/src/EditorFeatures/TestUtilities/Formatting/AbstractNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/TestUtilities/Formatting/AbstractNewDocumentFormattingServiceTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.Formatting
                 var document = workspace.CurrentSolution.Projects.First().Documents.First();
 
                 var formattingService = document.GetRequiredLanguageService<INewDocumentFormattingService>();
-                var formattedDocument = await formattingService.FormatNewDocumentAsync(document, CancellationToken.None);
+                var formattedDocument = await formattingService.FormatNewDocumentAsync(document, hintDocument: null, CancellationToken.None);
 
                 // Format to match what AbstractEditorFactory does
                 formattedDocument = await Formatter.FormatAsync(formattedDocument);

--- a/src/EditorFeatures/TestUtilities/Formatting/AbstractNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/TestUtilities/Formatting/AbstractNewDocumentFormattingServiceTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.Test.Utilities.Formatting
+{
+    [UseExportProvider]
+    public abstract class AbstractNewDocumentFormattingServiceTests
+    {
+        protected abstract string Language { get; }
+        protected abstract TestWorkspace CreateTestWorkspace(string testCode);
+
+        internal Task TestAsync<T>(string testCode, string expected, params (PerLanguageOption2<T>, T)[] options)
+        {
+            return TestCoreAsync<T>(testCode,
+                expected,
+                options.Select(o => (new OptionKey(o.Item1, Language), o.Item2)).ToArray());
+        }
+
+        internal Task TestAsync<T>(string testCode, string expected, params (Option2<T>, T)[] options)
+        {
+            return TestCoreAsync<T>(testCode,
+                expected,
+                options.Select(o => (new OptionKey(o.Item1), o.Item2)).ToArray());
+        }
+
+        private async Task TestCoreAsync<T>(string testCode, string expected, (OptionKey, T)[] options)
+        {
+            using (var workspace = CreateTestWorkspace(testCode))
+            {
+                var workspaceOptions = workspace.Options;
+                foreach (var option in options)
+                {
+                    workspaceOptions = workspaceOptions.WithChangedOption(option.Item1, option.Item2);
+                }
+
+                workspace.SetOptions(workspaceOptions);
+
+                var document = workspace.CurrentSolution.Projects.First().Documents.First();
+
+                var formattingService = document.GetRequiredLanguageService<INewDocumentFormattingService>();
+                var formattedDocument = await formattingService.FormatNewDocumentAsync(document, CancellationToken.None);
+
+                // Format to match what AbstractEditorFactory does
+                formattedDocument = await Formatter.FormatAsync(formattedDocument);
+
+                var actual = await formattedDocument.GetTextAsync();
+                AssertEx.EqualOrDiff(expected, actual.ToString());
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/Formatting/VisualBasicNewDocumentFormattingServiceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/VisualBasicNewDocumentFormattingServiceTests.vb
@@ -1,0 +1,57 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.CodeStyle
+Imports Microsoft.CodeAnalysis.Editor.UnitTests
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Test.Utilities.Formatting
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting
+    Public Class VisualBasicNewDocumentFormattingServiceTests
+        Inherits AbstractNewDocumentFormattingServiceTests
+
+        Protected Overrides ReadOnly Property Language As String = LanguageNames.VisualBasic
+
+        Protected Overrides Function CreateTestWorkspace(testCode As String) As TestWorkspace
+            Return TestWorkspace.CreateVisualBasic(testCode)
+        End Function
+
+        <Fact>
+        Public Async Function TestFileBanners() As Task
+            Await TestAsync(
+                testCode:="Imports System
+
+Namespace Goo
+
+End Namespace",
+                expected:="' This is a banner.
+
+Imports System
+
+Namespace Goo
+
+End Namespace",
+                (CodeStyleOptions2.FileHeaderTemplate, "This is a banner."))
+        End Function
+
+        <Fact>
+        Public Async Function TestOrganizeUsings() As Task
+            Await TestAsync(
+                testCode:="Imports Aaa
+Imports System
+
+Namespace Goo
+
+End Namespace",
+                expected:="Imports System
+Imports Aaa
+
+Namespace Goo
+
+End Namespace",
+                Array.Empty(Of (Option2(Of Object), Object)))
+        End Function
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerNewDocumentFormattingProvider.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.CSharp.AddFileBanner
 {
-    [Export(typeof(INewDocumentFormattingProvider)), Shared]
+    [Export(LanguageNames.CSharp, typeof(INewDocumentFormattingProvider)), Shared]
     internal class CSharpAddFileBannerNewDocumentFormattingProvider : AbstractAddFileBannerNewDocumentFormattingProvider
     {
         [ImportingConstructor]

--- a/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerNewDocumentFormattingProvider.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.AddFileBanner;
+using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.FileHeaders;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.FileHeaders;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.CSharp.AddFileBanner
+{
+    [Export(typeof(INewDocumentFormattingProvider)), Shared]
+    internal class CSharpAddFileBannerNewDocumentFormattingProvider : AbstractAddFileBannerNewDocumentFormattingProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpAddFileBannerNewDocumentFormattingProvider()
+        {
+        }
+
+        protected override SyntaxGenerator SyntaxGenerator => CSharpSyntaxGenerator.Instance;
+        protected override SyntaxGeneratorInternal SyntaxGeneratorInternal => CSharpSyntaxGeneratorInternal.Instance;
+        protected override AbstractFileHeaderHelper FileHeaderHelper => CSharpFileHeaderHelper.Instance;
+    }
+}

--- a/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/AddFileBanner/CSharpAddFileBannerNewDocumentFormattingProvider.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.CSharp.AddFileBanner
 {
-    [Export(LanguageNames.CSharp, typeof(INewDocumentFormattingProvider)), Shared]
+    [ExportNewDocumentFormattingProvider(LanguageNames.CSharp), Shared]
     internal class CSharpAddFileBannerNewDocumentFormattingProvider : AbstractAddFileBannerNewDocumentFormattingProvider
     {
         [ImportingConstructor]

--- a/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
@@ -27,15 +27,15 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
         {
-            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(true);
+            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var accessibilityPreferences = documentOptions.GetOption(CodeStyleOptions2.RequireAccessibilityModifiers, document.Project.Language);
             if (accessibilityPreferences.Value == AccessibilityModifiersRequired.Never)
             {
                 return document;
             }
 
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
-            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(true);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             var typeDeclarations = root.DescendantNodes().Where(node => syntaxFacts.IsTypeDeclaration(node));
             var editor = new SyntaxEditor(root, document.Project.Solution.Workspace);

--- a/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.AddAccessibilityModifiers;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.Formatting
+{
+    [Export(LanguageNames.CSharp, typeof(INewDocumentFormattingProvider)), Shared]
+    internal class CSharpAccessibilityModifiersNewDocumentFormattingProvider : INewDocumentFormattingProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpAccessibilityModifiersNewDocumentFormattingProvider()
+        {
+        }
+
+        public async Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(true);
+            var accessibilityPreferences = documentOptions.GetOption(CodeStyleOptions2.RequireAccessibilityModifiers, document.Project.Language);
+            if (accessibilityPreferences.Value == AccessibilityModifiersRequired.Never)
+            {
+                return document;
+            }
+
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(true);
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+            var typeDeclarations = root.DescendantNodes().Where(node => syntaxFacts.IsTypeDeclaration(node));
+            var editor = new SyntaxEditor(root, document.Project.Solution.Workspace);
+
+            var service = document.GetRequiredLanguageService<IAddAccessibilityModifiersService>();
+
+            foreach (var declaration in typeDeclarations)
+            {
+                if (!service.ShouldUpdateAccessibilityModifier(syntaxFacts, declaration, accessibilityPreferences.Value, out _))
+                    continue;
+
+                var type = semanticModel.GetDeclaredSymbol(declaration, cancellationToken);
+                if (type == null)
+                    continue;
+
+                AddAccessibilityModifiersHelpers.UpdateDeclaration(editor, type, declaration);
+            }
+
+            return document.WithSyntaxRoot(editor.GetChangedRoot());
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
@@ -16,7 +16,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
-    [Export(LanguageNames.CSharp, typeof(INewDocumentFormattingProvider)), Shared]
+    [ExportNewDocumentFormattingProvider(LanguageNames.CSharp), Shared]
     internal class CSharpAccessibilityModifiersNewDocumentFormattingProvider : INewDocumentFormattingProvider
     {
         [ImportingConstructor]

--- a/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
         }
 
-        public async Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken)
+        public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
         {
             var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(true);
             var accessibilityPreferences = documentOptions.GetOption(CodeStyleOptions2.RequireAccessibilityModifiers, document.Project.Language);

--- a/src/Features/CSharp/Portable/Formatting/CSharpNewDocumentFormattingService.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpNewDocumentFormattingService.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.CSharp.Formatting
+{
+    [ExportLanguageService(typeof(INewDocumentFormattingService), LanguageNames.CSharp)]
+    [Shared]
+    internal class CSharpNewDocumentFormattingService : AbstractNewDocumentFormattingService
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpNewDocumentFormattingService([ImportMany] IEnumerable<INewDocumentFormattingProvider> providers)
+            : base(providers)
+        {
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Formatting/CSharpNewDocumentFormattingService.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpNewDocumentFormattingService.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
+using System.Linq;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 
@@ -16,9 +17,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpNewDocumentFormattingService([ImportMany(LanguageNames.CSharp)] IEnumerable<INewDocumentFormattingProvider> providers)
+        public CSharpNewDocumentFormattingService([ImportMany] IEnumerable<Lazy<INewDocumentFormattingProvider, LanguageMetadata>> providers)
             : base(providers)
         {
         }
+
+        protected override string Language => LanguageNames.CSharp;
     }
 }

--- a/src/Features/CSharp/Portable/Formatting/CSharpNewDocumentFormattingService.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpNewDocumentFormattingService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpNewDocumentFormattingService([ImportMany] IEnumerable<INewDocumentFormattingProvider> providers)
+        public CSharpNewDocumentFormattingService([ImportMany(LanguageNames.CSharp)] IEnumerable<INewDocumentFormattingProvider> providers)
             : base(providers)
         {
         }

--- a/src/Features/CSharp/Portable/Formatting/CSharpOrganizeUsingsNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpOrganizeUsingsNewDocumentFormattingProvider.cs
@@ -12,8 +12,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
-    [Export(LanguageNames.CSharp, typeof(INewDocumentFormattingProvider))]
-    [Shared]
+    [ExportNewDocumentFormattingProvider(LanguageNames.CSharp), Shared]
     internal class CSharpOrganizeUsingsNewDocumentFormattingProvider : INewDocumentFormattingProvider
     {
         [ImportingConstructor]

--- a/src/Features/CSharp/Portable/Formatting/CSharpOrganizeUsingsNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpOrganizeUsingsNewDocumentFormattingProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
         }
 
-        public async Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken)
+        public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
         {
             var organizedDocument = await Formatter.OrganizeImportsAsync(document, cancellationToken).ConfigureAwait(false);
             return await MisplacedUsingDirectivesCodeFixProvider.TransformDocumentIfRequiredAsync(organizedDocument, cancellationToken).ConfigureAwait(false);

--- a/src/Features/CSharp/Portable/Formatting/CSharpOrganizeUsingsNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpOrganizeUsingsNewDocumentFormattingProvider.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.CSharp.Formatting
+{
+    [Export(LanguageNames.CSharp, typeof(INewDocumentFormattingProvider))]
+    [Shared]
+    internal class CSharpOrganizeUsingsNewDocumentFormattingProvider : INewDocumentFormattingProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpOrganizeUsingsNewDocumentFormattingProvider()
+        {
+        }
+
+        public async Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            var organizedDocument = await Formatter.OrganizeImportsAsync(document, cancellationToken).ConfigureAwait(false);
+            return await MisplacedUsingDirectivesCodeFixProvider.TransformDocumentIfRequiredAsync(organizedDocument, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.AddFileBanner
 
         public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
         {
-            var rootToFormat = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
-            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(true);
+            var rootToFormat = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
             // Apply file header preferences
             var fileHeaderTemplate = documentOptions.GetOption(CodeStyleOptions2.FileHeaderTemplate);
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.AddFileBanner
                         newLineTrivia,
                         document,
                         fileHeaderTemplate,
-                        cancellationToken).ConfigureAwait(true);
+                        cancellationToken).ConfigureAwait(false);
 
                 return document.WithSyntaxRoot(rootWithFileHeader);
             }
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.AddFileBanner
             {
                 // If there is no file header preference, see if we can use the one in the hint document
                 var syntaxFacts = hintDocument.GetRequiredLanguageService<ISyntaxFactsService>();
-                var hintSyntaxRoot = await hintDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
+                var hintSyntaxRoot = await hintDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var fileBanner = syntaxFacts.GetFileBanner(hintSyntaxRoot);
 
                 var rootWithBanner = rootToFormat.WithPrependedLeadingTrivia(fileBanner);

--- a/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.AddFileBanner
         protected abstract SyntaxGeneratorInternal SyntaxGeneratorInternal { get; }
         protected abstract AbstractFileHeaderHelper FileHeaderHelper { get; }
 
-        public async Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken)
+        public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
         {
             var rootToFormat = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
             var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(true);

--- a/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis.AddFileBanner
                         FileHeaderHelper,
                         newLineTrivia,
                         document,
+                        fileHeaderTemplate,
                         cancellationToken).ConfigureAwait(true);
 
                 return document.WithSyntaxRoot(rootWithFileHeader);

--- a/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.FileHeaders;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.AddFileBanner
+{
+    internal abstract class AbstractAddFileBannerNewDocumentFormattingProvider : INewDocumentFormattingProvider
+    {
+        protected abstract SyntaxGenerator SyntaxGenerator { get; }
+        protected abstract SyntaxGeneratorInternal SyntaxGeneratorInternal { get; }
+        protected abstract AbstractFileHeaderHelper FileHeaderHelper { get; }
+
+        public async Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            var rootToFormat = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
+            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(true);
+
+            // Apply file header preferences
+            var fileHeaderTemplate = documentOptions.GetOption(CodeStyleOptions2.FileHeaderTemplate);
+            if (!string.IsNullOrEmpty(fileHeaderTemplate))
+            {
+                var newLineText = documentOptions.GetOption(FormattingOptions.NewLine, rootToFormat.Language);
+                var newLineTrivia = SyntaxGeneratorInternal.EndOfLine(newLineText);
+                var rootWithFileHeader = await AbstractFileHeaderCodeFixProvider.GetTransformedSyntaxRootAsync(
+                        SyntaxGenerator.SyntaxFacts,
+                        FileHeaderHelper,
+                        newLineTrivia,
+                        document,
+                        cancellationToken).ConfigureAwait(true);
+
+                return document.WithSyntaxRoot(rootWithFileHeader);
+            }
+
+            return document;
+        }
+    }
+}

--- a/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Formatting
     {
         private readonly IEnumerable<INewDocumentFormattingProvider> _providers;
 
-        public AbstractNewDocumentFormattingService(IEnumerable<INewDocumentFormattingProvider> providers)
+        protected AbstractNewDocumentFormattingService(IEnumerable<INewDocumentFormattingProvider> providers)
         {
             _providers = providers;
         }

--- a/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             return _providerValues;
         }
 
-        public async Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken)
+        public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
         {
             foreach (var provider in GetProviders())
             {
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 // other, so this shouldn't cause problems.
                 try
                 {
-                    document = await provider.FormatNewDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+                    document = await provider.FormatNewDocumentAsync(document, hintDocument, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex, cancellationToken))
                 {

--- a/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
@@ -4,24 +4,35 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
     internal abstract class AbstractNewDocumentFormattingService : INewDocumentFormattingService
     {
-        private readonly IEnumerable<INewDocumentFormattingProvider> _providers;
+        private readonly IEnumerable<Lazy<INewDocumentFormattingProvider, LanguageMetadata>> _providers;
+        private IEnumerable<INewDocumentFormattingProvider>? _providerValues;
 
-        protected AbstractNewDocumentFormattingService(IEnumerable<INewDocumentFormattingProvider> providers)
+        protected abstract string Language { get; }
+
+        protected AbstractNewDocumentFormattingService(IEnumerable<Lazy<INewDocumentFormattingProvider, LanguageMetadata>> providers)
         {
             _providers = providers;
         }
 
+        private IEnumerable<INewDocumentFormattingProvider> GetProviders()
+        {
+            _providerValues ??= _providers.Where(p => p.Metadata.Language == Language).Select(p => p.Value);
+            return _providerValues;
+        }
+
         public async Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken)
         {
-            foreach (var provider in _providers)
+            foreach (var provider in GetProviders())
             {
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ErrorReporting;
+
+namespace Microsoft.CodeAnalysis.Formatting
+{
+    internal class AbstractNewDocumentFormattingService : INewDocumentFormattingService
+    {
+        private readonly IEnumerable<INewDocumentFormattingProvider> _providers;
+
+        public AbstractNewDocumentFormattingService(IEnumerable<INewDocumentFormattingProvider> providers)
+        {
+            _providers = providers;
+        }
+
+        public async Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken)
+        {
+            foreach (var provider in _providers)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    document = await provider.FormatNewDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex, cancellationToken))
+                {
+                }
+            }
+
+            return document;
+        }
+    }
+}

--- a/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
-    internal class AbstractNewDocumentFormattingService : INewDocumentFormattingService
+    internal abstract class AbstractNewDocumentFormattingService : INewDocumentFormattingService
     {
         private readonly IEnumerable<INewDocumentFormattingProvider> _providers;
 

--- a/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
@@ -36,6 +36,9 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                // If a single formatter has a bug, we still want to keep trying the others.
+                // Since they are unordered it would be inappropriate for them to depend on each
+                // other, so this shouldn't cause problems.
                 try
                 {
                     document = await provider.FormatNewDocumentAsync(document, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Formatting/ExportNewDocumentFormattingProviderAttribute.cs
+++ b/src/Features/Core/Portable/Formatting/ExportNewDocumentFormattingProviderAttribute.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+
+namespace Microsoft.CodeAnalysis.Formatting
+{
+    [MetadataAttribute]
+    [AttributeUsage(AttributeTargets.Class)]
+    internal class ExportNewDocumentFormattingProviderAttribute : ExportAttribute
+    {
+        public ExportNewDocumentFormattingProviderAttribute(string languageName)
+            : base(typeof(INewDocumentFormattingProvider))
+        {
+            Language = languageName;
+        }
+
+        public string Language { get; }
+    }
+}

--- a/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
@@ -4,11 +4,10 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
-    internal interface INewDocumentFormattingProvider : ILanguageService
+    internal interface INewDocumentFormattingProvider
     {
         /// <inheritdoc cref="INewDocumentFormattingService.FormatNewDocumentAsync(Document, CancellationToken)"/>
         Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 {
     internal interface INewDocumentFormattingProvider
     {
-        /// <inheritdoc cref="INewDocumentFormattingService.FormatNewDocumentAsync(Document, CancellationToken)"/>
-        Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken);
+        /// <inheritdoc cref="INewDocumentFormattingService.FormatNewDocumentAsync(Document, Document, CancellationToken)"/>
+        Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
@@ -4,10 +4,11 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
-    internal interface INewDocumentFormattingProvider
+    internal interface INewDocumentFormattingProvider : ILanguageService
     {
         /// <inheritdoc cref="INewDocumentFormattingService.FormatNewDocumentAsync(Document, CancellationToken)"/>
         Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Formatting
+{
+    internal interface INewDocumentFormattingProvider
+    {
+        /// <inheritdoc cref="INewDocumentFormattingService.FormatNewDocumentAsync(Document, CancellationToken)"/>
+        Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken);
+    }
+}

--- a/src/Features/Core/Portable/Formatting/INewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/INewDocumentFormattingService.cs
@@ -13,9 +13,9 @@ namespace Microsoft.CodeAnalysis.Formatting
         /// <summary>
         /// Formats a new document that is being added to a project from the Add New Item dialog.
         /// </summary>
-        /// <remarks>
-        /// Calls to this method will be on the UI thread so consider using .ConfigureAwait(true) to avoid unnecssary thread switching.
-        /// </remarks>
-        Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken);
+        /// <param name="document">The document to format.</param>
+        /// <param name="hintDocument">An optional additional document that can be used to inform the formatting operation.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Formatting/INewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/INewDocumentFormattingService.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Formatting
+{
+    internal interface INewDocumentFormattingService : ILanguageService
+    {
+        /// <summary>
+        /// Formats a new document that is being added to a project from the Add New Item dialog.
+        /// </summary>
+        /// <remarks>
+        /// Calls to this method will be on the UI thread so consider using .ConfigureAwait(true) to avoid unnecssary thread switching.
+        /// </remarks>
+        Task<Document> FormatNewDocumentAsync(Document document, CancellationToken cancellationToken);
+    }
+}

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -309,8 +309,11 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
                 if (newDocument.Project.Language == _semanticDocument.Document.Project.Language)
                 {
-                    var formattingService = newDocument.GetRequiredLanguageService<INewDocumentFormattingService>();
-                    codeGenResult = await formattingService.FormatNewDocumentAsync(codeGenResult, _semanticDocument.Document, _cancellationToken).ConfigureAwait(false);
+                    var formattingService = newDocument.GetLanguageService<INewDocumentFormattingService>();
+                    if (formattingService is not null)
+                    {
+                        codeGenResult = await formattingService.FormatNewDocumentAsync(codeGenResult, _semanticDocument.Document, _cancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 // Now, take the code that would be generated and actually create an edit that would

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 if (newDocument.Project.Language == _semanticDocument.Document.Project.Language)
                 {
                     var formattingService = newDocument.GetRequiredLanguageService<INewDocumentFormattingService>();
-                    codeGenResult = await formattingService.FormatNewDocumentAsync(codeGenResult, _cancellationToken).ConfigureAwait(false);
+                    codeGenResult = await formattingService.FormatNewDocumentAsync(codeGenResult, _semanticDocument.Document, _cancellationToken).ConfigureAwait(false);
                 }
 
                 // Now, take the code that would be generated and actually create an edit that would

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -14,10 +14,9 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeGeneration;
-using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
@@ -308,16 +307,15 @@ namespace Microsoft.CodeAnalysis.GenerateType
                         ? containers.ToList()
                         : _semanticDocument.Document.Folders.ToList();
 
+                if (newDocument.Project.Language == _semanticDocument.Document.Project.Language)
+                {
+                    var formattingService = newDocument.GetRequiredLanguageService<INewDocumentFormattingService>();
+                    codeGenResult = await formattingService.FormatNewDocumentAsync(codeGenResult, _cancellationToken).ConfigureAwait(false);
+                }
+
                 // Now, take the code that would be generated and actually create an edit that would
                 // produce a document with that code in it.
                 var newRoot = await codeGenResult.GetSyntaxRootAsync(_cancellationToken).ConfigureAwait(false);
-
-                if (newDocument.Project.Language == _semanticDocument.Document.Project.Language)
-                {
-                    var syntaxFacts = _semanticDocument.Document.GetLanguageService<ISyntaxFactsService>();
-                    var fileBanner = syntaxFacts.GetFileBanner(_semanticDocument.Root);
-                    newRoot = newRoot.WithPrependedLeadingTrivia(fileBanner);
-                }
 
                 return await CreateAddDocumentAndUpdateUsingsOrImportsOperationsAsync(
                     projectToBeUpdated,

--- a/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerNewDocumentFormattingProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerNewDocumentFormattingProvider.vb
@@ -12,7 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 Imports Microsoft.CodeAnalysis.VisualBasic.FileHeaders
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.AddFileBanner
-    <Export(LanguageNames.VisualBasic, GetType(INewDocumentFormattingProvider)), [Shared]>
+    <ExportNewDocumentFormattingProvider(LanguageNames.VisualBasic), [Shared]>
     Friend Class VisualBasicAddFileBannerNewDocumentFormattingProvider
         Inherits AbstractAddFileBannerNewDocumentFormattingProvider
 

--- a/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerNewDocumentFormattingProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerNewDocumentFormattingProvider.vb
@@ -12,7 +12,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 Imports Microsoft.CodeAnalysis.VisualBasic.FileHeaders
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.AddFileBanner
-    <Export(GetType(INewDocumentFormattingProvider)), [Shared]>
+    <Export(LanguageNames.VisualBasic, GetType(INewDocumentFormattingProvider)), [Shared]>
     Friend Class VisualBasicAddFileBannerNewDocumentFormattingProvider
         Inherits AbstractAddFileBannerNewDocumentFormattingProvider
 

--- a/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerNewDocumentFormattingProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddFileBanner/VisualBasicAddFileBannerNewDocumentFormattingProvider.vb
@@ -1,0 +1,29 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.AddFileBanner
+Imports Microsoft.CodeAnalysis.Editing
+Imports Microsoft.CodeAnalysis.FileHeaders
+Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
+Imports Microsoft.CodeAnalysis.VisualBasic.FileHeaders
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.AddFileBanner
+    <Export(GetType(INewDocumentFormattingProvider)), [Shared]>
+    Friend Class VisualBasicAddFileBannerNewDocumentFormattingProvider
+        Inherits AbstractAddFileBannerNewDocumentFormattingProvider
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+
+        Protected Overrides ReadOnly Property SyntaxGenerator As SyntaxGenerator = VisualBasicSyntaxGenerator.Instance
+        Protected Overrides ReadOnly Property SyntaxGeneratorInternal As SyntaxGeneratorInternal = VisualBasicSyntaxGeneratorInternal.Instance
+
+        Protected Overrides ReadOnly Property FileHeaderHelper As AbstractFileHeaderHelper = VisualBasicFileHeaderHelper.Instance
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/Formatting/VisualBasicNewDocumentFormattingService.vb
+++ b/src/Features/VisualBasic/Portable/Formatting/VisualBasicNewDocumentFormattingService.vb
@@ -13,8 +13,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
-        Public Sub New(<ImportMany(LanguageNames.VisualBasic)> providers As IEnumerable(Of INewDocumentFormattingProvider))
+        Public Sub New(<ImportMany> providers As IEnumerable(Of Lazy(Of INewDocumentFormattingProvider, LanguageMetadata)))
             MyBase.New(providers)
         End Sub
+
+        Protected Overrides ReadOnly Property Language As String = LanguageNames.VisualBasic
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Formatting/VisualBasicNewDocumentFormattingService.vb
+++ b/src/Features/VisualBasic/Portable/Formatting/VisualBasicNewDocumentFormattingService.vb
@@ -1,0 +1,20 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.Host.Mef
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
+    <ExportLanguageService(GetType(INewDocumentFormattingService), LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicNewDocumentFormattingService
+        Inherits AbstractNewDocumentFormattingService
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New(<ImportMany> providers As IEnumerable(Of INewDocumentFormattingProvider))
+            MyBase.New(providers)
+        End Sub
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/Formatting/VisualBasicNewDocumentFormattingService.vb
+++ b/src/Features/VisualBasic/Portable/Formatting/VisualBasicNewDocumentFormattingService.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
-        Public Sub New(<ImportMany> providers As IEnumerable(Of INewDocumentFormattingProvider))
+        Public Sub New(<ImportMany(LanguageNames.VisualBasic)> providers As IEnumerable(Of INewDocumentFormattingProvider))
             MyBase.New(providers)
         End Sub
     End Class

--- a/src/Features/VisualBasic/Portable/Formatting/VisualBasicOrganizeUsingsNewDocumentFormattingProvider.vb
+++ b/src/Features/VisualBasic/Portable/Formatting/VisualBasicOrganizeUsingsNewDocumentFormattingProvider.vb
@@ -1,0 +1,24 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Composition
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.Host.Mef
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
+    <Export(LanguageNames.VisualBasic, GetType(INewDocumentFormattingProvider)), [Shared]>
+    Friend Class VisualBasicOrganizeUsingsNewDocumentFormattingProvider
+        Implements INewDocumentFormattingProvider
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+
+        Public Function FormatNewDocumentAsync(document As Document, cancellationToken As CancellationToken) As Task(Of Document) Implements INewDocumentFormattingProvider.FormatNewDocumentAsync
+            Return Formatter.OrganizeImportsAsync(document, cancellationToken)
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/Formatting/VisualBasicOrganizeUsingsNewDocumentFormattingProvider.vb
+++ b/src/Features/VisualBasic/Portable/Formatting/VisualBasicOrganizeUsingsNewDocumentFormattingProvider.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Host.Mef
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
-    <Export(LanguageNames.VisualBasic, GetType(INewDocumentFormattingProvider)), [Shared]>
+    <ExportNewDocumentFormattingProvider(LanguageNames.VisualBasic), [Shared]>
     Friend Class VisualBasicOrganizeUsingsNewDocumentFormattingProvider
         Implements INewDocumentFormattingProvider
 

--- a/src/Features/VisualBasic/Portable/Formatting/VisualBasicOrganizeUsingsNewDocumentFormattingProvider.vb
+++ b/src/Features/VisualBasic/Portable/Formatting/VisualBasicOrganizeUsingsNewDocumentFormattingProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Function FormatNewDocumentAsync(document As Document, cancellationToken As CancellationToken) As Task(Of Document) Implements INewDocumentFormattingProvider.FormatNewDocumentAsync
+        Public Function FormatNewDocumentAsync(document As Document, hintDocument As Document, cancellationToken As CancellationToken) As Task(Of Document) Implements INewDocumentFormattingProvider.FormatNewDocumentAsync
             Return Formatter.OrganizeImportsAsync(document, cancellationToken)
         End Function
     End Class

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
@@ -32,7 +32,5 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
         protected override string ContentTypeName => ContentTypeNames.CSharpContentType;
         protected override string LanguageName => LanguageNames.CSharp;
-        protected override SyntaxGenerator SyntaxGenerator => CSharpSyntaxGenerator.Instance;
-        protected override SyntaxGeneratorInternal SyntaxGeneratorInternal => CSharpSyntaxGeneratorInternal.Instance;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
@@ -34,11 +34,5 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         protected override string LanguageName => LanguageNames.CSharp;
         protected override SyntaxGenerator SyntaxGenerator => CSharpSyntaxGenerator.Instance;
         protected override SyntaxGeneratorInternal SyntaxGeneratorInternal => CSharpSyntaxGeneratorInternal.Instance;
-
-        protected override async Task<Document> OrganizeUsingsCreatedFromTemplateAsync(Document document, CancellationToken cancellationToken)
-        {
-            var organizedDocument = await base.OrganizeUsingsCreatedFromTemplateAsync(document, cancellationToken).ConfigureAwait(false);
-            return await MisplacedUsingDirectivesCodeFixProvider.TransformDocumentIfRequiredAsync(organizedDocument, cancellationToken).ConfigureAwait(false);
-        }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpEditorFactory.cs
@@ -34,7 +34,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         protected override string LanguageName => LanguageNames.CSharp;
         protected override SyntaxGenerator SyntaxGenerator => CSharpSyntaxGenerator.Instance;
         protected override SyntaxGeneratorInternal SyntaxGeneratorInternal => CSharpSyntaxGeneratorInternal.Instance;
-        protected override AbstractFileHeaderHelper FileHeaderHelper => CSharpFileHeaderHelper.Instance;
 
         protected override async Task<Document> OrganizeUsingsCreatedFromTemplateAsync(Document document, CancellationToken cancellationToken)
         {

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -330,8 +330,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             var addedDocument = forkedSolution.GetDocument(documentId)!;
 
             // Call out to various new document formatters to tweak what they want
-            var formattingService = addedDocument.GetRequiredLanguageService<INewDocumentFormattingService>();
-            addedDocument = await formattingService.FormatNewDocumentAsync(addedDocument, cancellationToken).ConfigureAwait(true);
+            var formattingService = addedDocument.GetLanguageService<INewDocumentFormattingService>();
+            if (formattingService is not null)
+            {
+                addedDocument = await formattingService.FormatNewDocumentAsync(addedDocument, hintDocument: null, cancellationToken).ConfigureAwait(true);
+            }
 
             var rootToFormat = await addedDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
             var documentOptions = await addedDocument.GetOptionsAsync(cancellationToken).ConfigureAwait(true);

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -45,8 +45,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         protected abstract string ContentTypeName { get; }
         protected abstract string LanguageName { get; }
-        protected abstract SyntaxGenerator SyntaxGenerator { get; }
-        protected abstract SyntaxGeneratorInternal SyntaxGeneratorInternal { get; }
 
         public void SetEncoding(bool value)
             => _encoding = value;

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -47,7 +47,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         protected abstract string LanguageName { get; }
         protected abstract SyntaxGenerator SyntaxGenerator { get; }
         protected abstract SyntaxGeneratorInternal SyntaxGeneratorInternal { get; }
-        protected abstract AbstractFileHeaderHelper FileHeaderHelper { get; }
 
         public void SetEncoding(bool value)
             => _encoding = value;
@@ -340,23 +339,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             var rootToFormat = await addedDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
             var documentOptions = await addedDocument.GetOptionsAsync(cancellationToken).ConfigureAwait(true);
-
-            // Apply file header preferences
-            var fileHeaderTemplate = documentOptions.GetOption(CodeStyleOptions2.FileHeaderTemplate);
-            if (!string.IsNullOrEmpty(fileHeaderTemplate))
-            {
-                var newLineText = documentOptions.GetOption(FormattingOptions.NewLine, rootToFormat.Language);
-                var newLineTrivia = SyntaxGeneratorInternal.EndOfLine(newLineText);
-                var rootWithFileHeader = await AbstractFileHeaderCodeFixProvider.GetTransformedSyntaxRootAsync(
-                        SyntaxGenerator.SyntaxFacts,
-                        FileHeaderHelper,
-                        newLineTrivia,
-                        addedDocument,
-                        cancellationToken).ConfigureAwait(true);
-
-                addedDocument = addedDocument.WithSyntaxRoot(rootWithFileHeader);
-                rootToFormat = rootWithFileHeader;
-            }
 
             // Organize using directives
             addedDocument = await OrganizeUsingsCreatedFromTemplateAsync(addedDocument, cancellationToken).ConfigureAwait(true);

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -291,9 +291,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         int IVsEditorFactoryNotify.NotifyItemRenamed(IVsHierarchy pHier, uint itemid, string pszMkDocumentOld, string pszMkDocumentNew)
             => VSConstants.S_OK;
 
-        protected virtual Task<Document> OrganizeUsingsCreatedFromTemplateAsync(Document document, CancellationToken cancellationToken)
-            => Formatter.OrganizeImportsAsync(document, cancellationToken);
-
         private void FormatDocumentCreatedFromTemplate(IVsHierarchy hierarchy, uint itemid, string filePath, CancellationToken cancellationToken)
         {
             Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.Run(() => FormatDocumentCreatedFromTemplateAsync(hierarchy, itemid, filePath, cancellationToken));
@@ -339,10 +336,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             var rootToFormat = await addedDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
             var documentOptions = await addedDocument.GetOptionsAsync(cancellationToken).ConfigureAwait(true);
-
-            // Organize using directives
-            addedDocument = await OrganizeUsingsCreatedFromTemplateAsync(addedDocument, cancellationToken).ConfigureAwait(true);
-            rootToFormat = await addedDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
 
             // Add access modifier
             var accessibilityPreferences = documentOptions.GetOption(CodeStyleOptions2.RequireAccessibilityModifiers, addedDocument.Project.Language);

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -335,6 +335,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             var forkedSolution = solution.AddDocument(DocumentInfo.Create(documentId, filePath, loader: new FileTextLoader(filePath, defaultEncoding: null), filePath: filePath));
             var addedDocument = forkedSolution.GetDocument(documentId)!;
 
+            var formattingService = addedDocument.GetRequiredLanguageService<INewDocumentFormattingService>();
+            addedDocument = await formattingService.FormatNewDocumentAsync(addedDocument, cancellationToken).ConfigureAwait(true);
+
             var rootToFormat = await addedDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(true);
             var documentOptions = await addedDocument.GetOptionsAsync(cancellationToken).ConfigureAwait(true);
 

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
@@ -27,7 +27,5 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
         Protected Overrides ReadOnly Property SyntaxGenerator As SyntaxGenerator = VisualBasicSyntaxGenerator.Instance
         Protected Overrides ReadOnly Property SyntaxGeneratorInternal As SyntaxGeneratorInternal = VisualBasicSyntaxGeneratorInternal.Instance
-
-        Protected Overrides ReadOnly Property FileHeaderHelper As AbstractFileHeaderHelper = VisualBasicFileHeaderHelper.Instance
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicEditorFactory.vb
@@ -24,8 +24,5 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         Protected Overrides ReadOnly Property ContentTypeName As String = ContentTypeNames.VisualBasicContentType
 
         Protected Overrides ReadOnly Property LanguageName As String = LanguageNames.VisualBasic
-
-        Protected Overrides ReadOnly Property SyntaxGenerator As SyntaxGenerator = VisualBasicSyntaxGenerator.Instance
-        Protected Overrides ReadOnly Property SyntaxGeneratorInternal As SyntaxGeneratorInternal = VisualBasicSyntaxGeneratorInternal.Instance
     End Class
 End Namespace


### PR DESCRIPTION
This builds on https://github.com/dotnet/roslyn/pull/55432 so only review from [`6342b87` (#55463)](https://github.com/dotnet/roslyn/pull/55463/commits/6342b8783a19633a80127448400d978d4913209d) onwards. Will rebase etc. when that is merged.

This makes Generate Type use the new document formatting service, which realistically means Generate Type now supports file header templates from .editorconfig, and using directive placement options.