### PR TITLE
Background import

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCreateServicesOnTextViewConnection.cs
@@ -3,12 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
-using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
@@ -24,8 +24,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpCreateServicesOnTextViewConnection(
             VisualStudioWorkspace workspace,
-            [ImportMany] IEnumerable<Lazy<ILanguageService, LanguageServiceMetadata>> languageServices)
-            : base(workspace, languageServices, LanguageNames.CSharp)
+            IAsynchronousOperationListenerProvider listenerProvider,
+            IThreadingContext threadingContext)
+            : base(workspace, listenerProvider, threadingContext, LanguageNames.CSharp)
         {
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
@@ -61,11 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
             var languageServices = _workspace.Services.GetExtendedLanguageServices(_languageName);
 
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(_threadingContext.DisposalToken);
-
             _ = languageServices.GetService<ISnippetInfoService>();
-
-            await TaskScheduler.Default;
 
             // Preload completion providers on a background thread since assembly loads can be slow
             // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1242321

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
@@ -2,16 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
@@ -23,26 +23,30 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
     internal abstract class AbstractCreateServicesOnTextViewConnection : IWpfTextViewConnectionListener
     {
         private readonly VisualStudioWorkspace _workspace;
-        private readonly IEnumerable<Lazy<ILanguageService, LanguageServiceMetadata>> _languageServices;
+        private readonly IAsynchronousOperationListener _listener;
+        private readonly IThreadingContext _threadingContext;
         private readonly string _languageName;
         private bool _initialized = false;
 
         public AbstractCreateServicesOnTextViewConnection(
             VisualStudioWorkspace workspace,
-            IEnumerable<Lazy<ILanguageService, LanguageServiceMetadata>> languageServices,
+            IAsynchronousOperationListenerProvider listenerProvider,
+            IThreadingContext threadingContext,
             string languageName)
         {
             _workspace = workspace;
+            _listener = listenerProvider.GetListener(FeatureAttribute.Workspace);
+            _threadingContext = threadingContext;
             _languageName = languageName;
-            _languageServices = languageServices;
         }
 
         void IWpfTextViewConnectionListener.SubjectBuffersConnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)
         {
             if (!_initialized)
             {
-                CreateServicesOnUIThread();
-                CreateServicesInBackground();
+                var token = _listener.BeginAsyncOperation(nameof(InitializeServicesAsync));
+                InitializeServicesAsync().CompletesAsyncOperation(token);
+
                 _initialized = true;
             }
         }
@@ -51,35 +55,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         {
         }
 
-        /// <summary>
-        /// Must be invoked from the UI thread.
-        /// </summary>
-        private void CreateServicesOnUIThread()
+        private async Task InitializeServicesAsync()
         {
-            var serviceTypeAssemblyQualifiedName = typeof(ISnippetInfoService).AssemblyQualifiedName;
-            foreach (var languageService in _languageServices)
-            {
-                if (languageService.Metadata.ServiceType == serviceTypeAssemblyQualifiedName &&
-                    languageService.Metadata.Language == _languageName)
-                {
-                    _ = languageService.Value;
-                    break;
-                }
-            }
-        }
+            await TaskScheduler.Default;
 
-        private void CreateServicesInBackground()
-        {
-            _ = Task.Run(ImportCompletionProviders);
+            var languageServices = _workspace.Services.GetExtendedLanguageServices(_languageName);
+
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(_threadingContext.DisposalToken);
+
+            _ = languageServices.GetService<ISnippetInfoService>();
+
+            await TaskScheduler.Default;
 
             // Preload completion providers on a background thread since assembly loads can be slow
             // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1242321
-            void ImportCompletionProviders()
+            if (languageServices.GetService<CompletionService>() is CompletionServiceWithProviders service)
             {
-                if (_workspace.Services.GetLanguageService<CompletionService>(_languageName) is CompletionServiceWithProviders service)
-                {
-                    _ = service.GetImportedProviders().SelectAsArray(p => p.Value);
-                }
+                _ = service.GetImportedProviders().SelectAsArray(p => p.Value);
             }
         }
     }

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCreateServicesOnTextViewConnection.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCreateServicesOnTextViewConnection.vb
@@ -5,8 +5,9 @@
 Imports System.ComponentModel.Composition
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor
-Imports Microsoft.CodeAnalysis.Host
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 Imports Microsoft.VisualStudio.Text.Editor
 Imports Microsoft.VisualStudio.Utilities
@@ -20,8 +21,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
-        Public Sub New(workspace As VisualStudioWorkspace, <ImportMany> languageServices As IEnumerable(Of Lazy(Of ILanguageService, LanguageServiceMetadata)))
-            MyBase.New(workspace, languageServices, languageName:=LanguageNames.VisualBasic)
+        Public Sub New(
+            workspace As VisualStudioWorkspace,
+            listenerProvider As IAsynchronousOperationListenerProvider,
+            threadingContext As IThreadingContext)
+
+            MyBase.New(workspace, listenerProvider, threadingContext, languageName:=LanguageNames.VisualBasic)
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Moves remaining initialization in `AbstractCreateServicesOnTextViewConnection` to the thread pool.

Follow-up to #55448