### PR TITLE
Avoid logging analyzer telemetry during shutdown

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -582,8 +582,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     {
                         base.Shutdown();
 
-                        SolutionCrawlerLogger.LogIncrementalAnalyzerProcessorStatistics(Processor._registration.CorrelationId, Processor._registration.GetSolutionToAnalyze(), Processor._logAggregator, Analyzers);
-
                         _workItemQueue.Dispose();
 
                         _projectCache?.Dispose();


### PR DESCRIPTION
Analyzer telemetry during shutdown fails the hard requirement that telemetry overhead must not be observable. This pull request removes the telemetry calls, which can be revisited in the future under a different strategy which meets requirements.

Fixes #55331