### PR TITLE
include help link uri in lsp pull diagnostics

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -346,6 +346,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             }
         }
 
+        public static LSP.CodeDescription? HelpLinkToCodeDescription(string? helpLink)
+        {
+            if (Uri.TryCreate(helpLink, UriKind.RelativeOrAbsolute, out var uri))
+            {
+                return new LSP.CodeDescription
+                {
+                    Href = uri,
+                };
+            }
+
+            return null;
+        }
+
         public static LSP.SymbolKind NavigateToKindToSymbolKind(string kind)
         {
             if (Enum.TryParse<LSP.SymbolKind>(kind, out var symbolKind))

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -318,6 +318,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             {
                 Source = GetType().Name,
                 Code = diagnosticData.Id,
+                CodeDescription = ProtocolConversions.HelpLinkToCodeDescription(diagnosticData.HelpLink),
                 Message = diagnosticData.Message,
                 Severity = ConvertDiagnosticSeverity(diagnosticData.Severity),
                 Range = ProtocolConversions.LinePositionToRange(DiagnosticData.GetLinePositionSpan(diagnosticData.DataLocation, text, useMappedSpan)),

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -60,6 +60,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
                 testLspServer, document.GetURI());
 
             Assert.Equal("CS1513", results.Single().Diagnostics.Single().Code);
+            Assert.NotNull(results.Single().Diagnostics.Single().CodeDescription!.Href);
         }
 
         [Fact]

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -189,7 +189,5 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
 
             return result.ToArray();
         }
-
-        
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 Range = ProtocolConversions.TextSpanToRange(new TextSpan(d.Offset, d.Length), text),
                 Tags = ConvertTags(d),
                 Source = d.Tool,
-                CodeDescription = GetCodeDescription(d.HelpLink),
+                CodeDescription = ProtocolConversions.HelpLinkToCodeDescription(d.HelpLink),
                 Projects = new[]
                 {
                     new ProjectAndContext
@@ -190,17 +190,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
             return result.ToArray();
         }
 
-        private static CodeDescription? GetCodeDescription(string? helpLink)
-        {
-            if (Uri.TryCreate(helpLink, UriKind.RelativeOrAbsolute, out var uri))
-            {
-                return new CodeDescription
-                {
-                    Href = uri,
-                };
-            }
-
-            return null;
-        }
+        
     }
 }


### PR DESCRIPTION
Realized this was not being set for c# LSP pull diagnostics after the xaml PR.