### PR TITLE
Add ISB External Access APIs for IntelliCode

### DIFF
--- a/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaRemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaRemoteHostClient.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
 {
+    [Obsolete]
     internal static class PythiaRemoteHostClient
     {
         public static Task<Optional<T>> TryRunRemoteAsync<T>(Workspace workspace, string serviceName, string targetName, Solution? solution, IReadOnlyList<object?> arguments, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaPinnedSolutionInfoWrapper.cs
+++ b/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaPinnedSolutionInfoWrapper.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+using Microsoft.CodeAnalysis.Remote;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
+{
+    [DataContract]
+    internal readonly struct PythiaPinnedSolutionInfoWrapper
+    {
+        [DataMember(Order = 0)]
+        internal readonly PinnedSolutionInfo UnderlyingObject;
+
+        public PythiaPinnedSolutionInfoWrapper(PinnedSolutionInfo underlyingObject)
+            => UnderlyingObject = underlyingObject;
+
+        public static implicit operator PythiaPinnedSolutionInfoWrapper(PinnedSolutionInfo info)
+            => new(info);
+    }
+}

--- a/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteHostClient.cs
+++ b/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteHostClient.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Remote;
 
-#pragma warning disable 436
+#pragma warning disable 436 // duplicate types - can remove once PythiaRemoteHostClient is removed from Workspaces 
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
 {

--- a/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteHostClient.cs
+++ b/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteHostClient.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Remote;
+
+#pragma warning disable 436
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
+{
+    internal readonly struct PythiaRemoteHostClient
+    {
+        private readonly ServiceHubRemoteHostClient _client;
+        private readonly PythiaServiceDescriptorsWrapper _serviceDescriptors;
+        private readonly PythiaRemoteServiceCallbackDispatcherRegistry _callbackDispatchers;
+
+        internal PythiaRemoteHostClient(ServiceHubRemoteHostClient client, PythiaServiceDescriptorsWrapper serviceDescriptors, PythiaRemoteServiceCallbackDispatcherRegistry callbackDispatchers)
+        {
+            _client = client;
+            _serviceDescriptors = serviceDescriptors;
+            _callbackDispatchers = callbackDispatchers;
+        }
+
+        public static async Task<PythiaRemoteHostClient?> TryGetClientAsync(HostWorkspaceServices services, PythiaServiceDescriptorsWrapper serviceDescriptors, PythiaRemoteServiceCallbackDispatcherRegistry callbackDispatchers, CancellationToken cancellationToken = default)
+        {
+            var client = await RemoteHostClient.TryGetClientAsync(services, cancellationToken).ConfigureAwait(false);
+            if (client is null)
+                return null;
+
+            return new PythiaRemoteHostClient((ServiceHubRemoteHostClient)client, serviceDescriptors, callbackDispatchers);
+        }
+
+        private PythiaRemoteServiceConnectionWrapper<TService> CreateConnection<TService>(object? callbackTarget) where TService : class
+            => new(_client.CreateConnection<TService>(_serviceDescriptors.UnderlyingObject, _callbackDispatchers, callbackTarget));
+
+        // no solution, no callback:
+
+        public async ValueTask<bool> TryInvokeAsync<TService>(Func<TService, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken) where TService : class
+        {
+            using var connection = CreateConnection<TService>(callbackTarget: null);
+            return await connection.TryInvokeAsync(invocation, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask<Optional<TResult>> TryInvokeAsync<TService, TResult>(Func<TService, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken) where TService : class
+        {
+            using var connection = CreateConnection<TService>(callbackTarget: null);
+            return await connection.TryInvokeAsync(invocation, cancellationToken).ConfigureAwait(false);
+        }
+
+        // no solution, callback:
+
+        public async ValueTask<bool> TryInvokeAsync<TService>(Func<TService, PythiaRemoteServiceCallbackIdWrapper, CancellationToken, ValueTask> invocation, object callbackTarget, CancellationToken cancellationToken) where TService : class
+        {
+            using var connection = CreateConnection<TService>(callbackTarget);
+            return await connection.TryInvokeAsync(invocation, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask<Optional<TResult>> TryInvokeAsync<TService, TResult>(Func<TService, PythiaRemoteServiceCallbackIdWrapper, CancellationToken, ValueTask<TResult>> invocation, object callbackTarget, CancellationToken cancellationToken) where TService : class
+        {
+            using var connection = CreateConnection<TService>(callbackTarget);
+            return await connection.TryInvokeAsync(invocation, cancellationToken).ConfigureAwait(false);
+        }
+
+        // solution, no callback:
+
+        public async ValueTask<bool> TryInvokeAsync<TService>(Solution solution, Func<TService, PythiaPinnedSolutionInfoWrapper, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken) where TService : class
+        {
+            using var connection = CreateConnection<TService>(callbackTarget: null);
+            return await connection.TryInvokeAsync(solution, invocation, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask<Optional<TResult>> TryInvokeAsync<TService, TResult>(Solution solution, Func<TService, PythiaPinnedSolutionInfoWrapper, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken) where TService : class
+        {
+            using var connection = CreateConnection<TService>(callbackTarget: null);
+            return await connection.TryInvokeAsync(solution, invocation, cancellationToken).ConfigureAwait(false);
+        }
+
+        // solution, callback:
+
+        public async ValueTask<bool> TryInvokeAsync<TService>(Solution solution, Func<TService, PythiaPinnedSolutionInfoWrapper, PythiaRemoteServiceCallbackIdWrapper, CancellationToken, ValueTask> invocation, object callbackTarget, CancellationToken cancellationToken) where TService : class
+        {
+            using var connection = CreateConnection<TService>(callbackTarget);
+            return await connection.TryInvokeAsync(solution, invocation, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask<Optional<TResult>> TryInvokeAsync<TService, TResult>(Solution solution, Func<TService, PythiaPinnedSolutionInfoWrapper, PythiaRemoteServiceCallbackIdWrapper, CancellationToken, ValueTask<TResult>> invocation, object callbackTarget, CancellationToken cancellationToken) where TService : class
+        {
+            using var connection = CreateConnection<TService>(callbackTarget);
+            return await connection.TryInvokeAsync(solution, invocation, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteServiceCallbackDispatcher.cs
+++ b/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteServiceCallbackDispatcher.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Remote;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
+{
+    internal abstract class PythiaRemoteServiceCallbackDispatcher : IRemoteServiceCallbackDispatcher
+    {
+        private readonly RemoteServiceCallbackDispatcher _dispatcher = new();
+
+        public object GetCallback(PythiaRemoteServiceCallbackIdWrapper callbackId)
+            => _dispatcher.GetCallback(callbackId.UnderlyingObject);
+
+        RemoteServiceCallbackDispatcher.Handle IRemoteServiceCallbackDispatcher.CreateHandle(object? instance)
+            => _dispatcher.CreateHandle(instance);
+    }
+}

--- a/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteServiceCallbackDispatcherRegistry.cs
+++ b/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteServiceCallbackDispatcherRegistry.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Remote;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
+{
+    internal sealed class PythiaRemoteServiceCallbackDispatcherRegistry : IRemoteServiceCallbackDispatcherProvider
+    {
+        public static readonly PythiaRemoteServiceCallbackDispatcherRegistry Empty = new(Array.Empty<(Type, PythiaRemoteServiceCallbackDispatcher)>());
+
+        private readonly ImmutableDictionary<Type, PythiaRemoteServiceCallbackDispatcher> _lazyDispatchers;
+
+        public PythiaRemoteServiceCallbackDispatcherRegistry(IEnumerable<(Type serviceType, PythiaRemoteServiceCallbackDispatcher dispatcher)> lazyDispatchers)
+        {
+            _lazyDispatchers = lazyDispatchers.ToImmutableDictionary(e => e.serviceType, e => e.dispatcher);
+        }
+
+        IRemoteServiceCallbackDispatcher IRemoteServiceCallbackDispatcherProvider.GetDispatcher(Type serviceType)
+            => _lazyDispatchers[serviceType];
+    }
+}

--- a/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteServiceCallbackIdWrapper.cs
+++ b/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteServiceCallbackIdWrapper.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+using Microsoft.CodeAnalysis.Remote;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
+{
+    [DataContract]
+    internal readonly struct PythiaRemoteServiceCallbackIdWrapper
+    {
+        [DataMember(Order = 0)]
+        internal RemoteServiceCallbackId UnderlyingObject { get; }
+
+        public PythiaRemoteServiceCallbackIdWrapper(RemoteServiceCallbackId underlyingObject)
+            => UnderlyingObject = underlyingObject;
+
+        public static implicit operator PythiaRemoteServiceCallbackIdWrapper(RemoteServiceCallbackId id)
+            => new(id);
+    }
+}

--- a/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteServiceConnectionWrapper.cs
+++ b/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaRemoteServiceConnectionWrapper.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Remote;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
+{
+    internal readonly struct PythiaRemoteServiceConnectionWrapper<TService> : IDisposable
+        where TService : class
+    {
+        internal RemoteServiceConnection<TService> UnderlyingObject { get; }
+
+        internal PythiaRemoteServiceConnectionWrapper(RemoteServiceConnection<TService> underlyingObject)
+            => UnderlyingObject = underlyingObject;
+
+        public void Dispose()
+            => UnderlyingObject.Dispose();
+
+        // no solution, no callback
+
+        public ValueTask<bool> TryInvokeAsync(Func<TService, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+            => UnderlyingObject.TryInvokeAsync(invocation, cancellationToken);
+
+        public ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Func<TService, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+            => UnderlyingObject.TryInvokeAsync(invocation, cancellationToken);
+
+        // no solution, callback
+
+        public ValueTask<bool> TryInvokeAsync(Func<TService, PythiaRemoteServiceCallbackIdWrapper, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+            => UnderlyingObject.TryInvokeAsync(
+                (service, callbackId, cancellationToken) => invocation(service, callbackId, cancellationToken),
+                cancellationToken);
+
+        public ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Func<TService, PythiaRemoteServiceCallbackIdWrapper, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+            => UnderlyingObject.TryInvokeAsync(
+                (service, callbackId, cancellationToken) => invocation(service, callbackId, cancellationToken),
+                cancellationToken);
+
+        // solution, no callback
+
+        public ValueTask<bool> TryInvokeAsync(Solution solution, Func<TService, PythiaPinnedSolutionInfoWrapper, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+            => UnderlyingObject.TryInvokeAsync(
+                solution,
+                (service, solutionInfo, cancellationToken) => invocation(service, solutionInfo, cancellationToken),
+                cancellationToken);
+
+        public ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Solution solution, Func<TService, PythiaPinnedSolutionInfoWrapper, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+            => UnderlyingObject.TryInvokeAsync(
+                solution,
+                (service, solutionInfo, cancellationToken) => invocation(service, solutionInfo, cancellationToken),
+                cancellationToken);
+
+        // solution, callback
+
+        public ValueTask<bool> TryInvokeAsync(Solution solution, Func<TService, PythiaPinnedSolutionInfoWrapper, PythiaRemoteServiceCallbackIdWrapper, CancellationToken, ValueTask> invocation, CancellationToken cancellationToken)
+            => UnderlyingObject.TryInvokeAsync(
+                solution,
+                (service, solutionInfo, callbackId, cancellationToken) => invocation(service, solutionInfo, callbackId, cancellationToken),
+                cancellationToken);
+
+        public ValueTask<Optional<TResult>> TryInvokeAsync<TResult>(Solution solution, Func<TService, PythiaPinnedSolutionInfoWrapper, PythiaRemoteServiceCallbackIdWrapper, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken)
+            => UnderlyingObject.TryInvokeAsync(
+                solution,
+                (service, solutionInfo, callbackId, cancellationToken) => invocation(service, solutionInfo, callbackId, cancellationToken),
+                cancellationToken);
+    }
+}

--- a/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaServiceDescriptorsWrapper.cs
+++ b/src/Workspaces/Remote/Core/ExternalAccess/Pythia/Api/PythiaServiceDescriptorsWrapper.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime;
+using MessagePack;
+using MessagePack.Formatters;
+using Microsoft.CodeAnalysis.Remote;
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
+{
+    internal readonly struct PythiaServiceDescriptorsWrapper
+    {
+        internal readonly ServiceDescriptors UnderlyingObject;
+
+        public PythiaServiceDescriptorsWrapper(
+            string componentName,
+            Func<string, string> featureDisplayNameProvider,
+            ImmutableArray<IMessagePackFormatter> additionalFormatters,
+            ImmutableArray<IFormatterResolver> additionalResolvers,
+            IEnumerable<(Type serviceInterface, Type? callbackInterface)> interfaces)
+            => UnderlyingObject = new ServiceDescriptors(componentName, featureDisplayNameProvider, new RemoteSerializationOptions(additionalFormatters, additionalResolvers), interfaces);
+
+        /// <summary>
+        /// To be called from a service factory in OOP.
+        /// </summary>
+        public ServiceJsonRpcDescriptor GetDescriptorForServiceFactory(Type serviceInterface)
+            => UnderlyingObject.GetServiceDescriptorForServiceFactory(serviceInterface);
+
+        public MessagePackSerializerOptions MessagePackOptions
+            => UnderlyingObject.Options.MessagePackOptions;
+    }
+}

--- a/src/Workspaces/Remote/ServiceHub/ExternalAccess/Pythia/Api/PythiaBrokeredServiceImplementation.cs
+++ b/src/Workspaces/Remote/ServiceHub/ExternalAccess/Pythia/Api/PythiaBrokeredServiceImplementation.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Remote;
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
+{
+    internal static class PythiaBrokeredServiceImplementation
+    {
+        public static ValueTask<T> RunServiceAsync<T>(Func<CancellationToken, ValueTask<T>> implementation, CancellationToken cancellationToken)
+            => BrokeredServiceBase.RunServiceImplAsync<T>(implementation, cancellationToken);
+
+        public static ValueTask RunServiceAsync(Func<CancellationToken, ValueTask> implementation, CancellationToken cancellationToken)
+            => BrokeredServiceBase.RunServiceImplAsync(implementation, cancellationToken);
+
+        public static ValueTask<Solution> GetSolutionAsync(this PythiaPinnedSolutionInfoWrapper solutionInfo, ServiceBrokerClient client, CancellationToken cancellationToken)
+            => RemoteWorkspaceManager.Default.GetSolutionAsync(client, solutionInfo.UnderlyingObject, cancellationToken);
+    }
+}


### PR DESCRIPTION
These files are copies of equivalent Razor sources.

Pythia PR switching to these APIs: https://devdiv.visualstudio.com/DevDiv/_git/Pythia/pullrequest/343326