### PR TITLE
Try to fix the analyzer path when loading in OOP

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoaderService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteAnalyzerAssemblyLoaderService.cs
@@ -5,8 +5,10 @@
 using System;
 using System.Composition;
 using System.IO;
+using System.Reflection;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 {
@@ -16,16 +18,52 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
     [ExportWorkspaceService(typeof(IAnalyzerAssemblyLoaderProvider), WorkspaceKind.RemoteWorkspace), Shared]
     internal sealed class RemoteAnalyzerAssemblyLoaderService : IAnalyzerAssemblyLoaderProvider
     {
-        private readonly DefaultAnalyzerAssemblyLoader _loader = new DefaultAnalyzerAssemblyLoader();
-        private readonly ShadowCopyAnalyzerAssemblyLoader _shadowCopyLoader = new ShadowCopyAnalyzerAssemblyLoader(Path.Combine(Path.GetTempPath(), "VS", "AnalyzerAssemblyLoader"));
+        private readonly RemoteAnalyzerAssemblyLoader _loader;
+        private readonly ShadowCopyAnalyzerAssemblyLoader _shadowCopyLoader;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public RemoteAnalyzerAssemblyLoaderService()
         {
+            _loader = new(Path.GetDirectoryName(Path.GetFullPath(typeof(RemoteAnalyzerAssemblyLoader).GetTypeInfo().Assembly.Location)));
+            _shadowCopyLoader = new(Path.Combine(Path.GetTempPath(), "VS", "AnalyzerAssemblyLoader"));
         }
 
         public IAnalyzerAssemblyLoader GetLoader(in AnalyzerAssemblyLoaderOptions options)
             => options.ShadowCopy ? _shadowCopyLoader : _loader;
+
+        // For analyzers shipped in Roslyn, different set of assemblies might be used when running
+        // in-proc and OOP e.g. in-proc (VS) running on desktop clr and OOP running on ServiceHub .Net6
+        // host. We need to make sure to use the right one for OOP.
+        private class RemoteAnalyzerAssemblyLoader : DefaultAnalyzerAssemblyLoader
+        {
+            private readonly string? _baseDirectory;
+
+            protected override Assembly LoadImpl(string fullPath)
+                => base.LoadImpl(FixPath(fullPath));
+
+            public RemoteAnalyzerAssemblyLoader(string? baseDirectory)
+            {
+                _baseDirectory = baseDirectory;
+            }
+
+            private string FixPath(string fullPath)
+            {
+                if (_baseDirectory == null)
+                {
+                    return fullPath;
+                }
+
+                var assemblyName = Path.GetFileName(fullPath);
+                var fixedPath = Path.GetFullPath(Path.Combine(_baseDirectory, assemblyName));
+
+                if (!PathUtilities.PathsEqual(fixedPath, Path.GetFullPath(fullPath)) && File.Exists(fixedPath))
+                {
+                    return fixedPath;
+                }
+
+                return fullPath;
+            }
+        }
     }
 }


### PR DESCRIPTION
This is just cherry-picking the change from main-vs-deps to main, to make it easier to resolve potential conflict with https://github.com/dotnet/roslyn/pull/55098. They were originally made in https://github.com/dotnet/roslyn/pull/55425

FYI @tmat @RikkiGibson 