### PR TITLE
Call new document formatting service from extract type

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -534,7 +534,7 @@ class Test : MyBase
         }
 
         [Fact]
-        public async Task TestFileHeader()
+        public async Task TestFileHeader1()
         {
             var input = @"
 <Workspace>
@@ -577,6 +577,51 @@ internal class MyBase
 </Workspace>";
 
             await TestExtractClassAsync(input, expected);
+        }
+
+        [Fact]
+        public async Task TestFileHeader2()
+        {
+            var input = @"
+<Workspace>
+    <Project Language=""C#"">
+        <Document FilePath=""Test.cs"">// this is my document header
+// that should be ignored
+
+class Test
+{
+    int [||]Method()
+    {
+        return 1 + 1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"">
+        <Document FilePath=""Test.cs"">// this is my document header
+// that should be ignored
+
+class Test : MyBase
+{
+}
+        </Document>
+        <Document FilePath=""MyBase.cs"">// this is my real document header
+
+internal class MyBase
+{
+    int Method()
+    {
+        return 1 + 1;
+    }
+}</Document>
+    </Project>
+</Workspace>";
+
+            await TestExtractClassAsync(input, expected, testParameters: new TestParameters(options: Option(CodeStyleOptions2.FileHeaderTemplate, "this is my real document header")));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -534,7 +534,7 @@ class Test : MyBase
         }
 
         [Fact]
-        public async Task TestFileHeader1()
+        public async Task TestFileHeader_FromExistingFile()
         {
             var input = @"
 <Workspace>
@@ -580,7 +580,7 @@ internal class MyBase
         }
 
         [Fact]
-        public async Task TestFileHeader2()
+        public async Task TestFileHeader_FromOption()
         {
             var input = @"
 <Workspace>

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -468,7 +468,7 @@ namespace OuterNamespace
 
             Assert.Equal(@"namespace OuterNamespace.InnerNamespace;
 
-interface IMyClass
+internal interface IMyClass
 {
     void Goo();
 }", interfaceCode);
@@ -505,7 +505,7 @@ namespace OuterNamespace
 
             Assert.Equal(@"namespace OuterNamespace.InnerNamespace
 {
-    interface IMyClass
+    internal interface IMyClass
     {
         void Goo();
     }
@@ -543,7 +543,7 @@ namespace OuterNamespace
 
             Assert.Equal(@"namespace OuterNamespace.InnerNamespace
 {
-    interface IMyClass
+    internal interface IMyClass
     {
         void Goo();
     }
@@ -890,6 +890,35 @@ public interface IC4<A, B, C>
 }";
 
             await TestExtractInterfaceCommandCSharpAsync(markup, expectedSuccess: true, expectedInterfaceCode: expectedInterfaceCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
+        public async Task ExtractInterface_CodeGen_AccessibilityModifiers()
+        {
+            var markup = @"
+using System;
+
+abstract class MyClass$$
+{
+    public void Goo() { }
+}";
+
+            using var testState = ExtractInterfaceTestState.Create(
+                markup, LanguageNames.CSharp,
+                options: new OptionsCollection(LanguageNames.CSharp)
+                {
+                    { CodeStyleOptions2.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Always, NotificationOption2.Silent }
+                });
+
+            var result = await testState.ExtractViaCommandAsync();
+
+            var interfaceDocument = result.UpdatedSolution.GetRequiredDocument(result.NavigationDocumentId);
+            var interfaceCode = (await interfaceDocument.GetTextAsync()).ToString();
+
+            Assert.Equal(@"internal interface IMyClass
+{
+    void Goo();
+}", interfaceCode);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]

--- a/src/EditorFeatures/TestUtilities/ExtractInterface/AbstractExtractInterfaceTests.cs
+++ b/src/EditorFeatures/TestUtilities/ExtractInterface/AbstractExtractInterfaceTests.cs
@@ -6,6 +6,8 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Xunit;
@@ -93,7 +95,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.ExtractInterface
             string expectedInterfaceCode = null,
             CompilationOptions compilationOptions = null)
         {
-            using var testState = ExtractInterfaceTestState.Create(markup, languageName, compilationOptions);
+            using var testState = ExtractInterfaceTestState.Create(markup, languageName, compilationOptions,
+                options: new OptionsCollection(languageName)
+                {
+                    { CodeStyleOptions2.RequireAccessibilityModifiers, AccessibilityModifiersRequired.Never, NotificationOption2.Silent }
+                });
 
             var result = await testState.ExtractViaCommandAsync();
 

--- a/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
@@ -60,10 +60,6 @@ namespace Microsoft.CodeAnalysis.ExtractClass
         {
             if (options is ExtractClassOptions extractClassOptions)
             {
-                // Find the original type
-                var syntaxFacts = _document.GetRequiredLanguageService<ISyntaxFactsService>();
-                var root = await _document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
                 // Map the symbols we're removing to annotations
                 // so we can find them easily
                 var codeGenerator = _document.GetRequiredLanguageService<ICodeGenerationService>();
@@ -73,7 +69,6 @@ namespace Microsoft.CodeAnalysis.ExtractClass
                     _selectedTypeDeclarationNode,
                     cancellationToken).ConfigureAwait(false);
 
-                var fileBanner = syntaxFacts.GetFileBanner(root);
                 var namespaceService = _document.GetRequiredLanguageService<AbstractExtractInterfaceService>();
 
                 // Create the symbol for the new type 
@@ -104,7 +99,7 @@ namespace Microsoft.CodeAnalysis.ExtractClass
                         _document.Project.Id,
                         _document.Folders,
                         newType,
-                        fileBanner,
+                        _document,
                         cancellationToken).ConfigureAwait(false);
 
                 // Update the original type to have the new base

--- a/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
+++ b/src/Features/Core/Portable/ExtractInterface/AbstractExtractInterfaceService.cs
@@ -180,10 +180,6 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
                 refactoringResult.TypeNode,
                 cancellationToken).ConfigureAwait(false);
 
-            var syntaxFactsService = refactoringResult.DocumentToExtractFrom.GetLanguageService<ISyntaxFactsService>();
-            var originalDocumentSyntaxRoot = await refactoringResult.DocumentToExtractFrom.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var fileBanner = syntaxFactsService.GetFileBanner(originalDocumentSyntaxRoot);
-
             var (unformattedInterfaceDocument, _) = await ExtractTypeHelpers.AddTypeToNewFileAsync(
                 symbolMapping.AnnotatedSolution,
                 containingNamespaceDisplay,
@@ -191,7 +187,7 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
                 refactoringResult.DocumentToExtractFrom.Project.Id,
                 refactoringResult.DocumentToExtractFrom.Folders,
                 extractedInterfaceSymbol,
-                fileBanner,
+                refactoringResult.DocumentToExtractFrom,
                 cancellationToken).ConfigureAwait(false);
 
             var completedUnformattedSolution = await GetSolutionWithOriginalTypeUpdatedAsync(

--- a/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             ProjectId projectId,
             IEnumerable<string> folders,
             INamedTypeSymbol newSymbol,
-            ImmutableArray<SyntaxTrivia> fileBanner,
+            Document hintDocument,
             CancellationToken cancellationToken)
         {
             var newDocumentId = DocumentId.CreateNewId(projectId, debugName: fileName);
@@ -73,14 +73,19 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 options: options,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
+            var formattingSerivce = newTypeDocument.GetLanguageService<INewDocumentFormattingService>();
+            if (formattingSerivce is not null)
+            {
+                newTypeDocument = await formattingSerivce.FormatNewDocumentAsync(newTypeDocument, hintDocument, cancellationToken).ConfigureAwait(false);
+            }
+
             var syntaxRoot = await newTypeDocument.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var rootWithBanner = syntaxRoot.WithPrependedLeadingTrivia(fileBanner);
 
             var typeAnnotation = new SyntaxAnnotation();
             var syntaxFacts = newTypeDocument.GetRequiredLanguageService<ISyntaxFactsService>();
 
-            var declarationNode = rootWithBanner.DescendantNodes().First(syntaxFacts.IsTypeDeclaration);
-            var annotatedRoot = rootWithBanner.ReplaceNode(declarationNode, declarationNode.WithAdditionalAnnotations(typeAnnotation));
+            var declarationNode = syntaxRoot.DescendantNodes().First(syntaxFacts.IsTypeDeclaration);
+            var annotatedRoot = syntaxRoot.ReplaceNode(declarationNode, declarationNode.WithAdditionalAnnotations(typeAnnotation));
 
             newTypeDocument = newTypeDocument.WithSyntaxRoot(annotatedRoot);
 


### PR DESCRIPTION
This makes Extract Type/Interface use the new document formatting service, so it now supports file header templates from .editorconfig, and using directive placement options, and other fun things.