### PR TITLE
Ignore modules with bad metadata in function resolver

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.cs
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.cs
@@ -115,22 +115,19 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return module.Name;
         }
 
-        internal sealed override MetadataReader GetModuleMetadata(DkmClrModuleInstance module)
+        internal sealed override unsafe bool TryGetMetadata(DkmClrModuleInstance module, out byte* pointer, out int length)
         {
-            uint length;
-            IntPtr ptr;
             try
             {
-                ptr = module.GetMetaDataBytesPtr(out length);
+                pointer = (byte*)module.GetMetaDataBytesPtr(out var size);
+                length = (int)size;
+                return true;
             }
             catch (Exception e) when (DkmExceptionUtilities.IsBadOrMissingMetadataException(e))
             {
-                return null;
-            }
-            Debug.Assert(length > 0);
-            unsafe
-            {
-                return new MetadataReader((byte*)ptr, (int)length);
+                pointer = null;
+                length = 0;
+                return false;
             }
         }
 

--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolverBase.cs
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolverBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal abstract bool ShouldEnableFunctionResolver(TProcess process);
         internal abstract IEnumerable<TModule> GetAllModules(TProcess process);
         internal abstract string GetModuleName(TModule module);
-        internal abstract MetadataReader GetModuleMetadata(TModule module);
+        internal abstract unsafe bool TryGetMetadata(TModule module, out byte* pointer, out int length);
         internal abstract TRequest[] GetRequests(TProcess process);
         internal abstract string GetRequestModuleName(TRequest request);
         internal abstract RequestSignature GetParsedSignature(TRequest request);
@@ -57,13 +57,33 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 {
                     continue;
                 }
-                var reader = GetModuleMetadata(module);
+
+                var reader = GetMetadataReader(module);
                 if (reader == null)
                 {
+                    // ignore modules with bad metadata
                     continue;
                 }
+
                 var resolver = CreateMetadataResolver(process, module, reader, onFunctionResolved);
                 resolver.Resolve(request, signature);
+            }
+        }
+
+        private unsafe MetadataReader GetMetadataReader(TModule module)
+        {
+            if (!TryGetMetadata(module, out var pointer, out var length))
+            {
+                return null;
+            }
+
+            try
+            {
+                return new MetadataReader(pointer, length);
+            }
+            catch (BadImageFormatException)
+            {
+                return null;
             }
         }
 
@@ -98,7 +118,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 if (resolver == null)
                 {
-                    var reader = GetModuleMetadata(module);
+                    var reader = GetMetadataReader(module);
                     if (reader == null)
                     {
                         return;

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/CSharpFunctionResolverTests.cs
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/CSharpFunctionResolverTests.cs
@@ -330,16 +330,16 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 
                 // Request to all modules.
                 resolver.EnableResolution(process, requestAll);
-                Assert.Equal(0, moduleA.GetMetadataCount);
-                Assert.Equal(0, moduleB.GetMetadataCount);
-                Assert.Equal(0, moduleC.GetMetadataCount);
+                Assert.Equal(0, moduleA.MetadataAccessCount);
+                Assert.Equal(0, moduleB.MetadataAccessCount);
+                Assert.Equal(0, moduleC.MetadataAccessCount);
 
                 // Load module A (available).
                 process.AddModule(moduleA);
                 resolver.OnModuleLoad(process, moduleA);
-                Assert.Equal(1, moduleA.GetMetadataCount);
-                Assert.Equal(0, moduleB.GetMetadataCount);
-                Assert.Equal(0, moduleC.GetMetadataCount);
+                Assert.Equal(1, moduleA.MetadataAccessCount);
+                Assert.Equal(0, moduleB.MetadataAccessCount);
+                Assert.Equal(0, moduleC.MetadataAccessCount);
                 VerifySignatures(requestAll, "A.F1()");
                 VerifySignatures(requestA);
                 VerifySignatures(requestB);
@@ -348,9 +348,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
                 // Load module B (missing).
                 process.AddModule(moduleB);
                 resolver.OnModuleLoad(process, moduleB);
-                Assert.Equal(1, moduleA.GetMetadataCount);
-                Assert.Equal(1, moduleB.GetMetadataCount);
-                Assert.Equal(0, moduleC.GetMetadataCount);
+                Assert.Equal(1, moduleA.MetadataAccessCount);
+                Assert.Equal(1, moduleB.MetadataAccessCount);
+                Assert.Equal(0, moduleC.MetadataAccessCount);
                 VerifySignatures(requestAll, "A.F1()");
                 VerifySignatures(requestA);
                 VerifySignatures(requestB);
@@ -359,9 +359,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
                 // Load module C (available).
                 process.AddModule(moduleC);
                 resolver.OnModuleLoad(process, moduleC);
-                Assert.Equal(1, moduleA.GetMetadataCount);
-                Assert.Equal(1, moduleB.GetMetadataCount);
-                Assert.Equal(1, moduleC.GetMetadataCount);
+                Assert.Equal(1, moduleA.MetadataAccessCount);
+                Assert.Equal(1, moduleB.MetadataAccessCount);
+                Assert.Equal(1, moduleC.MetadataAccessCount);
                 VerifySignatures(requestAll, "A.F1()", "C.F1()");
                 VerifySignatures(requestA);
                 VerifySignatures(requestB);
@@ -369,9 +369,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 
                 // Request to module A (available).
                 resolver.EnableResolution(process, requestA);
-                Assert.Equal(2, moduleA.GetMetadataCount);
-                Assert.Equal(1, moduleB.GetMetadataCount);
-                Assert.Equal(1, moduleC.GetMetadataCount);
+                Assert.Equal(2, moduleA.MetadataAccessCount);
+                Assert.Equal(1, moduleB.MetadataAccessCount);
+                Assert.Equal(1, moduleC.MetadataAccessCount);
                 VerifySignatures(requestAll, "A.F1()", "C.F1()");
                 VerifySignatures(requestA, "A.F2()");
                 VerifySignatures(requestB);
@@ -379,9 +379,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 
                 // Request to module B (missing).
                 resolver.EnableResolution(process, requestB);
-                Assert.Equal(2, moduleA.GetMetadataCount);
-                Assert.Equal(2, moduleB.GetMetadataCount);
-                Assert.Equal(1, moduleC.GetMetadataCount);
+                Assert.Equal(2, moduleA.MetadataAccessCount);
+                Assert.Equal(2, moduleB.MetadataAccessCount);
+                Assert.Equal(1, moduleC.MetadataAccessCount);
                 VerifySignatures(requestAll, "A.F1()", "C.F1()");
                 VerifySignatures(requestA, "A.F2()");
                 VerifySignatures(requestB);
@@ -389,9 +389,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 
                 // Request to module C (available).
                 resolver.EnableResolution(process, requestC);
-                Assert.Equal(2, moduleA.GetMetadataCount);
-                Assert.Equal(2, moduleB.GetMetadataCount);
-                Assert.Equal(2, moduleC.GetMetadataCount);
+                Assert.Equal(2, moduleA.MetadataAccessCount);
+                Assert.Equal(2, moduleB.MetadataAccessCount);
+                Assert.Equal(2, moduleC.MetadataAccessCount);
                 VerifySignatures(requestAll, "A.F1()", "C.F1()");
                 VerifySignatures(requestA, "A.F2()");
                 VerifySignatures(requestB);
@@ -450,6 +450,21 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
                 resolver.EnableResolution(process, request);
                 VerifySignatures(request);
             }
+        }
+
+        [Fact]
+        public void BadMetadata()
+        {
+            var source = "class A { static void F() {} }";
+            var compilation = CreateCompilation(source);
+
+            using var process = new Process(
+                new Module(compilation.EmitToArray()),
+                new Module(metadata: default), // emulates failure of the debugger to retrieve metadata
+                new Module(metadata: TestResources.MetadataTests.Invalid.IncorrectCustomAssemblyTableSize_TooManyMethodSpecs.ToImmutableArray()));
+
+            var resolver = Resolver.CSharpResolver;
+            Resolve(process, resolver, "F", "A.F()");
         }
 
         [Fact]

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/CSharpFunctionResolverTests.cs
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/CSharpFunctionResolverTests.cs
@@ -453,6 +453,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
         }
 
         [Fact]
+        [WorkItem(55475, "https://github.com/dotnet/roslyn/issues/55475")]
         public void BadMetadata()
         {
             var source = "class A { static void F() {} }";

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/FunctionResolverTestBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/FunctionResolverTestBase.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 
         private static string GetMethodSignature(Module module, int token)
         {
-            var reader = module.GetMetadataInternal();
+            var reader = module.GetMetadataReader();
             return GetMethodSignature(reader, MetadataTokens.MethodDefinitionHandle(token));
         }
 

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/Module.cs
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/Module.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
@@ -13,45 +11,46 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 {
     internal sealed class Module : IDisposable
     {
-        private readonly string _name;
-        private readonly PEReader _reader;
-        private int _getMetadataCount;
+        private readonly PEReader? _reader;
 
-        internal Module(ImmutableArray<byte> bytes, string name = null)
+        public readonly string? Name;
+        public int MetadataAccessCount { get; private set; }
+
+        internal Module(ImmutableArray<byte> metadata, string? name = null)
         {
-            _name = name;
-            _reader = bytes.IsDefault ? null : new PEReader(bytes);
+            Name = name;
+            _reader = metadata.IsDefault ? null : new PEReader(metadata);
         }
 
-        internal string Name => _name;
-
-        internal int GetMetadataCount => _getMetadataCount;
-
-        internal MetadataReader GetMetadata()
+        internal unsafe bool TryGetMetadata(out byte* pointer, out int length)
         {
-            _getMetadataCount++;
-            return GetMetadataInternal();
+            if (_reader == null)
+            {
+                pointer = null;
+                length = 0;
+                return false;
+            }
+
+            MetadataAccessCount++;
+
+            var block = _reader.GetMetadata();
+            pointer = block.Pointer;
+            length = block.Length;
+            return true;
         }
 
-        internal MetadataReader GetMetadataInternal()
+        internal unsafe MetadataReader? GetMetadataReader()
         {
             if (_reader == null)
             {
                 return null;
             }
-            unsafe
-            {
-                var block = _reader.GetMetadata();
-                return new MetadataReader(block.Pointer, block.Length);
-            }
+
+            var block = _reader.GetMetadata();
+            return new MetadataReader(block.Pointer, block.Length);
         }
 
         void IDisposable.Dispose()
-        {
-            if (_reader != null)
-            {
-                _reader.Dispose();
-            }
-        }
+            => _reader?.Dispose();
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/Resolver.cs
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/Resolver.cs
@@ -63,10 +63,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             return module.Name;
         }
 
-        internal override MetadataReader GetModuleMetadata(Module module)
-        {
-            return module.GetMetadata();
-        }
+        internal override unsafe bool TryGetMetadata(Module module, out byte* pointer, out int length)
+            => module.TryGetMetadata(out pointer, out length);
 
         internal override Request[] GetRequests(Process process)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/55475