### PR TITLE
Change Inheritance Margin Header style

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml
@@ -219,13 +219,13 @@
                 <Style x:Key="HeaderMenuItemStyle" TargetType="{x:Type MenuItem}">
                     <Setter Property="AutomationProperties.Name" Value="{Binding AutomationName}"/>
                     <Setter Property="IsEnabled" Value="False"/>
-                    <Setter Property="Background" Value="{DynamicResource {x:Static vsui:EnvironmentColors.TitleBarInactiveBrushKey}}"/>
+                    <Setter Property="Background" Value="Transparent"/>
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="{x:Type MenuItem}">
                                 <StackPanel FlowDirection="LeftToRight" Orientation="Horizontal" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                                     <imaging:CrispImage Margin="4,1,4,1" Width="16" Height="16" Moniker="{Binding ImageMoniker}"/>
-                                    <TextBlock Text="{Binding DisplayContent}" Foreground="{DynamicResource {x:Static vsui:EnvironmentColors.TitleBarInactiveTextBrushKey}}" Margin="4,1,4,1"/>
+                                    <TextBlock Text="{Binding DisplayContent}" FontWeight="Bold" Foreground="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarTextActiveBrushKey}}" Margin="4,1,4,1"/>
                                 </StackPanel>
                             </ControlTemplate>
                         </Setter.Value>


### PR DESCRIPTION
As discussed with the UX, make the inheritance margin's header look like the Control Q search page.
Light theme:
![image](https://user-images.githubusercontent.com/24360909/128928644-f3cc90b5-47c7-4a28-bd2c-4aa2d14d78d5.png)
![image](https://user-images.githubusercontent.com/24360909/128928663-fd7da084-49e9-4b9e-9948-8da0e7285c96.png)

Black theme:
![image](https://user-images.githubusercontent.com/24360909/128928170-fcd29b2b-3a43-4665-809b-ded11a22b641.png)
![image](https://user-images.githubusercontent.com/24360909/128928582-235d832b-2f67-4f84-9e73-a85e2f5f514a.png)

Blue theme:
 
![image](https://user-images.githubusercontent.com/24360909/128928753-9a9f553f-419a-42cb-8086-f5ea7af683d3.png)
![image](https://user-images.githubusercontent.com/24360909/128928772-d20df374-f92e-44fe-bab8-14f6113a941d.png)
