### PR TITLE
Microsoft.Net.Compilers.Toolset.props make available for outerbuild targets

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
@@ -52,6 +52,7 @@
       <_File Include="@(CoreClrCompilerBinRuntimesArtifact)" TargetDir="tasks/netcoreapp3.1/bincore/runtimes"/>
      
       <_File Include="$(MSBuildProjectDirectory)\build\**\*.*" Condition="'$(TargetFramework)' == 'net472'" TargetDir="build" />
+      <_File Include="$(MSBuildProjectDirectory)\buildMultiTargeting\**\*.*" Condition="'$(TargetFramework)' == 'net472'" TargetDir="buildMultiTargeting" />
      
       <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)" />
     </ItemGroup>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/buildMultiTargeting/Microsoft.Net.Compilers.Toolset.props
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/buildMultiTargeting/Microsoft.Net.Compilers.Toolset.props
@@ -1,0 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\build\$(MSBuildThisFile)" />
+</Project>


### PR DESCRIPTION
Microsoft.Net.Compilers.Toolset.props is only imported only on innerbuilds and is not available for outer build targets like pack.
This is required to make the package validation work with the compiler package.