### PR TITLE
Fix MatchFolderAndNamespace codefix for documents in project root

### DIFF
--- a/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
+++ b/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Xunit;
 using VerifyCS = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.CSharpCodeFixVerifier<
     Microsoft.CodeAnalysis.CSharp.Analyzers.MatchFolderAndNamespace.CSharpMatchFolderAndNamespaceDiagnosticAnalyzer,
@@ -29,7 +30,7 @@ build_property.RootNamespace = {DefaultNamespace}
         private static string CreateFolderPath(params string[] folders)
             => Path.Combine(Directory, Path.Combine(folders));
 
-        private static Task RunTestAsync(string fileName, string fileContents, string? directory = null, string? editorConfig = null, string? fixedCode = null)
+        private static Task RunTestAsync(string fileName, string fileContents, string? directory = null, string? editorConfig = null, string? fixedCode = null, string? defaultNamespace = null)
         {
             var filePath = Path.Combine(directory ?? Directory, fileName);
             fixedCode ??= fileContents;
@@ -37,11 +38,15 @@ build_property.RootNamespace = {DefaultNamespace}
             return RunTestAsync(
                 new[] { (filePath, fileContents) },
                 new[] { (filePath, fixedCode) },
-                editorConfig);
+                editorConfig,
+                defaultNamespace);
         }
 
-        private static Task RunTestAsync(IEnumerable<(string, string)> originalSources, IEnumerable<(string, string)>? fixedSources = null, string? editorconfig = null)
+        private static Task RunTestAsync(IEnumerable<(string, string)> originalSources, IEnumerable<(string, string)>? fixedSources = null, string? editorconfig = null, string? defaultNamespace = null)
         {
+            // When a namespace isn't provided we will fallback on our default
+            defaultNamespace ??= DefaultNamespace;
+
             var testState = new VerifyCS.Test
             {
                 EditorConfig = editorconfig ?? EditorConfig,
@@ -55,6 +60,16 @@ build_property.RootNamespace = {DefaultNamespace}
             fixedSources ??= Array.Empty<(string, string)>();
             foreach (var (fileName, content) in fixedSources)
                 testState.FixedState.Sources.Add((fileName, content));
+
+            // If empty string was provided as the namespace, then we will not set a default
+            if (defaultNamespace.Length > 0)
+            {
+                testState.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var project = solution.GetRequiredProject(projectId);
+                    return project.WithDefaultNamespace(defaultNamespace).Solution;
+                });
+            }
 
             return testState.RunAsync();
         }
@@ -239,7 +254,9 @@ build_property.ProjectDir = {Directory}
                 fileContents: code,
                 directory: folder,
                 fixedCode: fixedCode,
-                editorConfig: editorConfig);
+                editorConfig: editorConfig,
+                // passing empty string means that a default namespace isn't set on the test Project
+                defaultNamespace: string.Empty);
         }
 
         [Fact]
@@ -271,7 +288,9 @@ class Class1
                 fileContents: code,
                 directory: folder,
                 fixedCode: fixedCode,
-                editorConfig: editorConfig);
+                editorConfig: editorConfig,
+                // passing empty string means that a default namespace isn't set on the test Project
+                defaultNamespace: string.Empty);
         }
 
         [Fact]

--- a/src/Analyzers/Core/CodeFixes/MatchFolderAndNamespace/AbstractChangeNamespaceToMatchFolderCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/MatchFolderAndNamespace/AbstractChangeNamespaceToMatchFolderCodeFixProvider.cs
@@ -47,14 +47,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes.MatchFolderAndNamespace
             // to rewrite or move the complex logic. RenameDocumentAsync is designed to behave the same
             // as the intent of this analyzer/codefix pair.
             var targetFolders = PathMetadataUtilities.BuildFoldersFromNamespace(targetNamespace, document.Project.DefaultNamespace);
-            var documentWithNoFolders = document.WithFolders(Array.Empty<string>());
+            var documentWithInvalidFolders = document.WithFolders(document.Folders.Concat("Force-Namespace-Change"));
             var renameActionSet = await Renamer.RenameDocumentAsync(
-                documentWithNoFolders,
-                documentWithNoFolders.Name,
+                documentWithInvalidFolders,
+                documentWithInvalidFolders.Name,
                 newDocumentFolders: targetFolders,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            var newSolution = await renameActionSet.UpdateSolutionAsync(documentWithNoFolders.Project.Solution, cancellationToken).ConfigureAwait(false);
+            var newSolution = await renameActionSet.UpdateSolutionAsync(documentWithInvalidFolders.Project.Solution, cancellationToken).ConfigureAwait(false);
             Debug.Assert(newSolution != document.Project.Solution);
             return newSolution;
         }


### PR DESCRIPTION
Force the namespace to be updated by sending in an invalid namespace to the Rename service.