### PR TITLE
Fix issue where we return diagnostics typescript diagnostics from the C# LSP server

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -400,13 +400,13 @@ namespace Roslyn.Test.Utilities
         private static RequestDispatcher CreateRequestDispatcher(TestWorkspace workspace)
         {
             var factory = workspace.ExportProvider.GetExportedValue<RequestDispatcherFactory>();
-            return factory.CreateRequestDispatcher();
+            return factory.CreateRequestDispatcher(ProtocolConstants.RoslynLspLanguages);
         }
 
         private static RequestExecutionQueue CreateRequestQueue(TestWorkspace workspace)
         {
             var registrationService = workspace.ExportProvider.GetExportedValue<ILspWorkspaceRegistrationService>();
-            return new RequestExecutionQueue(NoOpLspLogger.Instance, registrationService, serverName: "Tests", "TestClient");
+            return new RequestExecutionQueue(NoOpLspLogger.Instance, registrationService, ProtocolConstants.RoslynLspLanguages, serverName: "Tests", "TestClient");
         }
 
         private static string GetDocumentFilePathFromName(string documentName)

--- a/src/Features/LanguageServer/Protocol/AbstractRequestDispatcherFactory.cs
+++ b/src/Features/LanguageServer/Protocol/AbstractRequestDispatcherFactory.cs
@@ -15,21 +15,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer
     internal abstract class AbstractRequestDispatcherFactory
     {
         protected readonly ImmutableArray<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> _requestHandlerProviders;
-        protected readonly ImmutableArray<string> _languageNames;
 
-        protected AbstractRequestDispatcherFactory(IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders, ImmutableArray<string> languageNames)
+        protected AbstractRequestDispatcherFactory(IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders)
         {
             _requestHandlerProviders = requestHandlerProviders.ToImmutableArray();
-            _languageNames = languageNames;
         }
 
         /// <summary>
         /// Creates a new request dispatcher every time to ensure handlers are not shared
         /// and cleaned up appropriately on server restart.
         /// </summary>
-        public virtual RequestDispatcher CreateRequestDispatcher()
+        public virtual RequestDispatcher CreateRequestDispatcher(ImmutableArray<string> supportedLanguages)
         {
-            return new RequestDispatcher(_requestHandlerProviders, _languageNames);
+            return new RequestDispatcher(_requestHandlerProviders, supportedLanguages);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/AbstractRequestDispatcherFactory.cs
+++ b/src/Features/LanguageServer/Protocol/AbstractRequestDispatcherFactory.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer
     internal abstract class AbstractRequestDispatcherFactory
     {
         protected readonly ImmutableArray<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> _requestHandlerProviders;
-        protected readonly string? _languageName;
+        protected readonly ImmutableArray<string> _languageNames;
 
-        protected AbstractRequestDispatcherFactory(IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders, string? languageName = null)
+        protected AbstractRequestDispatcherFactory(IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders, ImmutableArray<string> languageNames)
         {
             _requestHandlerProviders = requestHandlerProviders.ToImmutableArray();
-            _languageName = languageName;
+            _languageNames = languageNames;
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// </summary>
         public virtual RequestDispatcher CreateRequestDispatcher()
         {
-            return new RequestDispatcher(_requestHandlerProviders, _languageName);
+            return new RequestDispatcher(_requestHandlerProviders, _languageNames);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using StreamJsonRpc;
@@ -41,6 +42,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 workspaceRegistrationService,
                 _listenerProvider,
                 logger,
+                ProtocolConstants.RoslynLspLanguages,
                 clientName: null,
                 userVisibleServerName: UserVisibleName,
                 telemetryServerTypeName: this.GetType().Name);

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandlerProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// Exports all the code action handlers together to ensure they
     /// share the same code actions cache state.
     /// </summary>
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentCodeActionName)]
     [ProvidesMethod(LSP.Methods.CodeActionResolveName)]
     [ProvidesCommand(CodeActionsHandler.RunCodeActionCommandName)]

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandlerProvider.cs
@@ -14,7 +14,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentCompletionName)]
     [ProvidesMethod(LSP.Methods.TextDocumentCompletionResolveName)]
     internal class CompletionHandlerProvider : AbstractRequestHandlerProvider

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
@@ -12,7 +12,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentDefinitionName)]
     internal class GoToDefinitionHandler : AbstractGoToDefinitionHandler
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Definitions/GoToTypeDefinitionHandler.cs
@@ -12,7 +12,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentTypeDefinitionName)]
     internal class GoToTypeDefinitionHandler : AbstractGoToDefinitionHandler
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagonsticHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagonsticHandlerProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(VSInternalMethods.DocumentPullDiagnosticName)]
     internal class DocumentPullDiagonsticHandlerProvider : AbstractRequestHandlerProvider
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandlerProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider(), Shared]
     [ProvidesMethod(VSInternalMethods.WorkspacePullDiagnosticName)]
     internal class WorkspacePullDiagnosticHandlerProvider : AbstractRequestHandlerProvider
     {

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
@@ -13,7 +13,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentDidChangeName)]
     internal class DidChangeHandler : AbstractStatelessRequestHandler<LSP.DidChangeTextDocumentParams, object?>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
@@ -12,7 +12,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentDidCloseName)]
     internal class DidCloseHandler : AbstractStatelessRequestHandler<LSP.DidCloseTextDocumentParams, object?>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
@@ -13,7 +13,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentDidOpenName)]
     internal class DidOpenHandler : AbstractStatelessRequestHandler<LSP.DidOpenTextDocumentParams, object?>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/ExportLspRequestHandlerProviderAttribute.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ExportLspRequestHandlerProviderAttribute.cs
@@ -33,9 +33,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     [AttributeUsage(AttributeTargets.Class), MetadataAttribute]
     internal class ExportRoslynLanguagesLspRequestHandlerProviderAttribute : ExportLspRequestHandlerProviderAttribute
     {
-        public static ImmutableArray<string> SupportedLanguages = ImmutableArray.Create(CodeAnalysis.LanguageNames.CSharp, CodeAnalysis.LanguageNames.VisualBasic, CodeAnalysis.LanguageNames.FSharp);
-
-        public ExportRoslynLanguagesLspRequestHandlerProviderAttribute() : base(SupportedLanguages.ToArray())
+        public ExportRoslynLanguagesLspRequestHandlerProviderAttribute() : base(ProtocolConstants.RoslynLspLanguages.ToArray())
         {
         }
     }

--- a/src/Features/LanguageServer/Protocol/Handler/ExportLspRequestHandlerProviderAttribute.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ExportLspRequestHandlerProviderAttribute.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
@@ -13,11 +15,28 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     [AttributeUsage(AttributeTargets.Class), MetadataAttribute]
     internal class ExportLspRequestHandlerProviderAttribute : ExportAttribute
     {
-        public string? LanguageName { get; }
+        /// <summary>
+        /// The document languages that this handler supports.
+        /// </summary>
+        public string[] LanguageNames { get; }
 
-        public ExportLspRequestHandlerProviderAttribute(string? languageName = null) : base(typeof(AbstractRequestHandlerProvider))
+        public ExportLspRequestHandlerProviderAttribute(params string[] languageNames) : base(typeof(AbstractRequestHandlerProvider))
         {
-            LanguageName = languageName;
+            LanguageNames = languageNames;
+        }
+    }
+
+    /// <summary>
+    /// Defines an easy to use subclass for ExportLspRequestHandlerProviderAttribute that contains
+    /// all the language names that the default Roslyn servers support.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class), MetadataAttribute]
+    internal class ExportRoslynLanguagesLspRequestHandlerProviderAttribute : ExportLspRequestHandlerProviderAttribute
+    {
+        public static ImmutableArray<string> SupportedLanguages = ImmutableArray.Create(CodeAnalysis.LanguageNames.CSharp, CodeAnalysis.LanguageNames.VisualBasic, CodeAnalysis.LanguageNames.FSharp);
+
+        public ExportRoslynLanguagesLspRequestHandlerProviderAttribute() : base(SupportedLanguages.ToArray())
+        {
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/FoldingRanges/FoldingRangesHandler.cs
@@ -16,7 +16,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(Methods.TextDocumentFoldingRangeName)]
     internal sealed class FoldingRangesHandler : AbstractStatelessRequestHandler<FoldingRangeParams, FoldingRange[]>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentHandler.cs
@@ -11,7 +11,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentFormattingName)]
     internal class FormatDocumentHandler : AbstractFormatDocumentHandlerBase<LSP.DocumentFormattingParams, LSP.TextEdit[]>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -18,7 +18,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(Methods.TextDocumentOnTypeFormattingName)]
     internal class FormatDocumentOnTypeHandler : AbstractStatelessRequestHandler<DocumentOnTypeFormattingParams, TextEdit[]>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentRangeHandler.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(Methods.TextDocumentRangeFormattingName)]
     internal class FormatDocumentRangeHandler : AbstractFormatDocumentHandlerBase<DocumentRangeFormattingParams, TextEdit[]>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Highlights/DocumentHighlightHandler.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(Methods.TextDocumentDocumentHighlightName)]
     internal class DocumentHighlightsHandler : AbstractStatelessRequestHandler<TextDocumentPositionParams, DocumentHighlight[]>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Hover/HoverHandler.cs
@@ -19,7 +19,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(Methods.TextDocumentHoverName)]
     internal class HoverHandler : AbstractStatelessRequestHandler<TextDocumentPositionParams, Hover?>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
@@ -22,7 +22,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.VSInternalMethods.OnAutoInsertName)]
     internal class OnAutoInsertHandler : AbstractStatelessRequestHandler<LSP.VSInternalDocumentOnAutoInsertParams, LSP.VSInternalDocumentOnAutoInsertResponseItem?>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
@@ -15,7 +15,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(VSMethods.GetProjectContextsName)]
     internal class GetTextDocumentWithContextHandler : AbstractStatelessRequestHandler<VSGetProjectContextsParams, VSProjectContextList?>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -18,7 +18,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentReferencesName)]
     internal class FindAllReferencesHandler : AbstractStatelessRequestHandler<LSP.ReferenceParams, LSP.VSInternalReferenceItem[]?>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
@@ -13,7 +13,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentImplementationName)]
     internal class FindImplementationsHandler : AbstractStatelessRequestHandler<LSP.TextDocumentPositionParams, LSP.Location[]>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Rename/RenameHandler.cs
@@ -16,7 +16,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentRenameName)]
     internal class RenameHandler : AbstractStatelessRequestHandler<LSP.RenameParams, WorkspaceEdit?>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
@@ -5,7 +5,7 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
@@ -51,6 +52,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     internal partial class RequestExecutionQueue
     {
         private readonly string _serverName;
+        private readonly ImmutableArray<string> _supportedLanguages;
 
         private readonly AsyncQueue<QueueItem> _queue;
         private readonly CancellationTokenSource _cancelSource;
@@ -80,11 +82,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public RequestExecutionQueue(
             ILspLogger logger,
             ILspWorkspaceRegistrationService workspaceRegistrationService,
+            ImmutableArray<string> supportedLanguages,
             string serverName,
             string serverTypeName)
         {
             _logger = logger;
             _workspaceRegistrationService = workspaceRegistrationService;
+            _supportedLanguages = supportedLanguages;
             _serverName = serverName;
 
             _queue = new AsyncQueue<QueueItem>();
@@ -293,6 +297,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 _workspaceRegistrationService,
                 _lspSolutionCache,
                 trackerToUse,
+                _supportedLanguages,
                 out workspace);
         }
     }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestHandlerProviderMetadataView.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestHandlerProviderMetadataView.cs
@@ -13,29 +13,36 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// </summary>
     internal class RequestHandlerProviderMetadataView
     {
-        public string? LanguageName { get; set; }
+        public string[] LanguageNames { get; set; }
 
         public string[] Methods { get; set; }
 
         public RequestHandlerProviderMetadataView(IDictionary<string, object> metadata)
         {
             var methodMetadata = metadata["Method"];
+            Methods = ConvertMetadataToArray(methodMetadata);
 
-            // When multiple of the same attribute are defined on a class, the metadata
-            // is aggregated into an array.  However, when just one of the same attribute is defined,
-            // the metadata is not aggregated and is just a string.
-            // MEF cannot construct the metadata object when it sees just the string type with AllowMultiple = true,
-            // so we override and construct it ourselves here.
-            if (methodMetadata is string[] methodNames)
+            var languageMetadata = metadata["LanguageNames"];
+            LanguageNames = ConvertMetadataToArray(languageMetadata);
+        }
+
+        /// <summary>
+        /// When multiple of the same attribute are defined on a class, the metadata
+        /// is aggregated into an array.  However, when just one of the same attribute is defined,
+        /// the metadata is not aggregated and is just a string.
+        /// MEF cannot construct the metadata object when it sees just the string type with AllowMultiple = true,
+        /// so we override and construct it ourselves here.
+        /// </summary>
+        private static string[] ConvertMetadataToArray(object metadata)
+        {
+            if (metadata is string[] arrayData)
             {
-                Methods = methodNames;
+                return arrayData;
             }
             else
             {
-                Methods = new string[] { (string)methodMetadata };
+                return new string[] { (string)metadata };
             }
-
-            LanguageName = metadata["LanguageName"] as string;
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandlerProvider.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(Methods.TextDocumentSemanticTokensFullName)]
     [ProvidesMethod(Methods.TextDocumentSemanticTokensFullDeltaName)]
     [ProvidesMethod(Methods.TextDocumentSemanticTokensRangeName)]

--- a/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
@@ -17,7 +17,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(LSP.Methods.TextDocumentSignatureHelpName)]
     internal class SignatureHelpHandler : AbstractStatelessRequestHandler<LSP.TextDocumentPositionParams, LSP.SignatureHelp?>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -21,7 +21,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(Methods.TextDocumentDocumentSymbolName)]
     internal class DocumentSymbolsHandler : AbstractStatelessRequestHandler<DocumentSymbolParams, object[]>
     {

--- a/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Symbols/WorkspaceSymbolsHandler.cs
@@ -18,7 +18,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 {
-    [ExportLspRequestHandlerProvider, Shared]
+    [ExportRoslynLanguagesLspRequestHandlerProvider, Shared]
     [ProvidesMethod(Methods.WorkspaceSymbolName)]
     internal class WorkspaceSymbolsHandler : AbstractStatelessRequestHandler<WorkspaceSymbolParams, SymbolInformation[]?>
     {

--- a/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
+++ b/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
@@ -54,11 +55,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             ILspWorkspaceRegistrationService workspaceRegistrationService,
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspLogger logger,
+            ImmutableArray<string> supportedLanguages,
             string? clientName,
             string userVisibleServerName,
             string telemetryServerTypeName)
         {
-            RequestDispatcher = requestDispatcherFactory.CreateRequestDispatcher();
+            RequestDispatcher = requestDispatcherFactory.CreateRequestDispatcher(supportedLanguages);
 
             _capabilitiesProvider = capabilitiesProvider;
             WorkspaceRegistrationService = workspaceRegistrationService;
@@ -73,7 +75,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             _userVisibleServerName = userVisibleServerName;
             TelemetryServerName = telemetryServerTypeName;
 
-            Queue = new RequestExecutionQueue(logger, workspaceRegistrationService, userVisibleServerName, TelemetryServerName);
+            Queue = new RequestExecutionQueue(logger, workspaceRegistrationService, supportedLanguages, userVisibleServerName, TelemetryServerName);
             Queue.RequestServerShutdown += RequestExecutionQueue_Errored;
         }
 

--- a/src/Features/LanguageServer/Protocol/ProtocolConstants.cs
+++ b/src/Features/LanguageServer/Protocol/ProtocolConstants.cs
@@ -2,10 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+
 namespace Microsoft.CodeAnalysis.LanguageServer
 {
     internal class ProtocolConstants
     {
         public const string RazorCSharp = "RazorCSharp";
+
+        public static ImmutableArray<string> RoslynLspLanguages = ImmutableArray.Create(LanguageNames.CSharp, LanguageNames.VisualBasic, LanguageNames.FSharp);
     }
 }

--- a/src/Features/LanguageServer/Protocol/RequestDispatcher.cs
+++ b/src/Features/LanguageServer/Protocol/RequestDispatcher.cs
@@ -17,7 +17,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.CodeAnalysis.LanguageServer
 {
     /// <summary>
-    /// Aggregates handlers for the specified language and dispatches LSP requests
+    /// Aggregates handlers for the specified languages and dispatches LSP requests
     /// to the appropriate handler for the request.
     /// </summary>
     internal class RequestDispatcher

--- a/src/Features/LanguageServer/Protocol/RequestDispatcher.cs
+++ b/src/Features/LanguageServer/Protocol/RequestDispatcher.cs
@@ -24,9 +24,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer
     {
         private readonly ImmutableDictionary<string, Lazy<IRequestHandler>> _requestHandlers;
 
-        public RequestDispatcher(ImmutableArray<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders, string? languageName = null)
+        public RequestDispatcher(ImmutableArray<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders, ImmutableArray<string> languageNames)
         {
-            _requestHandlers = CreateMethodToHandlerMap(requestHandlerProviders.Where(rh => rh.Metadata.LanguageName == languageName));
+            _requestHandlers = CreateMethodToHandlerMap(requestHandlerProviders.Where(rh => languageNames.All(languageName => rh.Metadata.LanguageNames.Contains(languageName))));
         }
 
         private static ImmutableDictionary<string, Lazy<IRequestHandler>> CreateMethodToHandlerMap(IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders)

--- a/src/Features/LanguageServer/Protocol/RequestDispatcherFactory.cs
+++ b/src/Features/LanguageServer/Protocol/RequestDispatcherFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public RequestDispatcherFactory([ImportMany] IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders)
-            : base(requestHandlerProviders)
+            : base(requestHandlerProviders, ExportRoslynLanguagesLspRequestHandlerProviderAttribute.SupportedLanguages)
         {
         }
     }

--- a/src/Features/LanguageServer/Protocol/RequestDispatcherFactory.cs
+++ b/src/Features/LanguageServer/Protocol/RequestDispatcherFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public RequestDispatcherFactory([ImportMany] IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders)
-            : base(requestHandlerProviders, ExportRoslynLanguagesLspRequestHandlerProviderAttribute.SupportedLanguages)
+            : base(requestHandlerProviders)
         {
         }
     }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
+using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +13,9 @@ using Microsoft.CodeAnalysis.Editor.Test;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Experiments;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
@@ -19,6 +23,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -399,6 +404,30 @@ class B {";
         }
 
         [Fact]
+        public async Task TestNoWorkspaceDiagnosticsForClosedFilesInProjectsWithIncorrectLanguage()
+        {
+            var csharpMarkup =
+@"class A {";
+            var typeScriptMarkup = "???";
+
+            var workspaceXml =
+@$"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj1"">
+        <Document FilePath=""C:\C.cs"">{csharpMarkup}</Document>
+    </Project>
+    <Project Language=""TypeScript"" CommonReferences=""true"" AssemblyName=""TypeScriptProj"">
+        <Document FilePath=""C:\T.ts"">{typeScriptMarkup}</Document>
+    </Project>
+</Workspace>";
+
+            using var testLspServer = CreateTestWorkspaceFromXml(workspaceXml, BackgroundAnalysisScope.FullSolution);
+
+            var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer);
+
+            Assert.True(results.All(r => r.TextDocument!.Uri.OriginalString == "C:\\C.cs"));
+        }
+
+        [Fact]
         public async Task TestWorkspaceDiagnosticsForRemovedDocument()
         {
             var markup1 =
@@ -663,9 +692,11 @@ class A {";
                 workspace.Options
                     .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, scope)
                     .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, scope)
+                    .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, InternalLanguageNames.TypeScript, scope)
                     .WithChangedOption(InternalDiagnosticsOptions.NormalDiagnosticMode, diagnosticMode)));
 
-            var analyzerReference = new TestAnalyzerReferenceByLanguage(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap());
+            var analyzerReference = new TestAnalyzerReferenceByLanguage(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap().Add(
+                InternalLanguageNames.TypeScript, ImmutableArray.Create<DiagnosticAnalyzer>(new MockTypescriptDiagnosticAnalyzer())));
             workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { analyzerReference }));
 
             var registrationService = workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>();
@@ -673,6 +704,26 @@ class A {";
 
             var diagnosticService = (DiagnosticService)workspace.ExportProvider.GetExportedValue<IDiagnosticService>();
             diagnosticService.Register(new TestHostDiagnosticUpdateSource(workspace));
+        }
+
+        protected override TestComposition Composition => base.Composition.AddParts(typeof(MockTypescriptDiagnosticAnalyzer));
+
+        [DiagnosticAnalyzer(InternalLanguageNames.TypeScript), PartNotDiscoverable]
+        private class MockTypescriptDiagnosticAnalyzer : DocumentDiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            "TS01", "TS error", "TS error", "Error", DiagnosticSeverity.Error, isEnabledByDefault: true);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeSemanticsAsync(Document document, CancellationToken cancellationToken)
+                => SpecializedTasks.EmptyImmutableArray<Diagnostic>();
+
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(ImmutableArray.Create(
+                    Diagnostic.Create(Descriptor, Location.Create(document.FilePath!, default, default))));
+            }
         }
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.LinkedDocuments.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.LinkedDocuments.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.DocumentChanges
             return testLspServer.ExecuteRequestAsync<Uri, Solution>(nameof(GetLSPSolutionHandler), uri, new ClientCapabilities(), null, CancellationToken.None);
         }
 
-        [Shared, ExportLspRequestHandlerProvider, PartNotDiscoverable]
+        [Shared, ExportRoslynLanguagesLspRequestHandlerProvider, PartNotDiscoverable]
         [ProvidesMethod(GetLSPSolutionHandler.MethodName)]
         private class GetLspSolutionHandlerProvider : AbstractRequestHandlerProvider
         {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/FailingMutatingRequestHandler.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/FailingMutatingRequestHandler.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 {
-    [Shared, ExportLspRequestHandlerProvider, PartNotDiscoverable]
+    [Shared, ExportRoslynLanguagesLspRequestHandlerProvider, PartNotDiscoverable]
     [ProvidesMethod(FailingMutatingRequestHandler.MethodName)]
     internal class FailingMutatingRequestHandlerProvider : AbstractRequestHandlerProvider
     {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/FailingRequestHandler.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/FailingRequestHandler.cs
@@ -15,7 +15,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 {
-    [Shared, ExportLspRequestHandlerProvider, PartNotDiscoverable]
+    [Shared, ExportRoslynLanguagesLspRequestHandlerProvider, PartNotDiscoverable]
     [ProvidesMethod(FailingRequestHandler.MethodName)]
     internal class FailingRequestHandlerProvider : AbstractRequestHandlerProvider
     {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/MutatingRequestHandler.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/MutatingRequestHandler.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 {
-    [Shared, ExportLspRequestHandlerProvider, PartNotDiscoverable]
+    [Shared, ExportRoslynLanguagesLspRequestHandlerProvider, PartNotDiscoverable]
     [ProvidesMethod(MutatingRequestHandler.MethodName)]
     internal class MutatingRequestHandlerProvider : AbstractRequestHandlerProvider
     {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/NonLSPSolutionRequestHandlerProvider.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/NonLSPSolutionRequestHandlerProvider.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 {
-    [Shared, ExportLspRequestHandlerProvider, PartNotDiscoverable]
+    [Shared, ExportRoslynLanguagesLspRequestHandlerProvider, PartNotDiscoverable]
     [ProvidesMethod(NonLSPSolutionRequestHandler.MethodName)]
     internal class NonLSPSolutionRequestHandlerProvider : AbstractRequestHandlerProvider
     {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/NonMutatingRequestHandler.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/NonMutatingRequestHandler.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 {
-    [Shared, ExportLspRequestHandlerProvider, PartNotDiscoverable]
+    [Shared, ExportRoslynLanguagesLspRequestHandlerProvider, PartNotDiscoverable]
     [ProvidesMethod(NonMutatingRequestHandler.MethodName)]
     internal class NonMutatingRequestHandlerProvider : AbstractRequestHandlerProvider
     {

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AbstractInProcLanguageClient.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,6 +47,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         /// Gets the name of the language client (displayed to the user).
         /// </summary>
         public abstract string Name { get; }
+
+        /// <summary>
+        /// The set of languages that this LSP server supports and can return results for.
+        /// </summary>
+        protected abstract ImmutableArray<string> SupportedLanguages { get; }
 
         /// <summary>
         /// Unused, implementing <see cref="ILanguageClient"/>
@@ -205,6 +211,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
                 _listenerProvider,
                 logger,
                 _diagnosticService,
+                SupportedLanguages,
                 clientName: _diagnosticsClientName,
                 userVisibleServerName: this.Name,
                 telemetryServerTypeName: this.GetType().Name);

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/AlwaysActivateInProcLanguageClient.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor;
@@ -45,6 +46,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         {
             _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
         }
+
+        protected override ImmutableArray<string> SupportedLanguages => ProtocolConstants.RoslynLspLanguages;
 
         public override string Name => CSharpVisualBasicLanguageServerFactory.UserVisibleName;
 

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/LiveShareInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/LiveShareInProcLanguageClient.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor;
@@ -42,6 +43,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         {
             _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
         }
+
+        protected override ImmutableArray<string> SupportedLanguages => ProtocolConstants.RoslynLspLanguages;
 
         public override string Name => "Live Share C#/Visual Basic Language Server Client";
 

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorInProcLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorInProcLanguageClient.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor;
@@ -41,6 +42,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Lsp
         public const string ClientName = ProtocolConstants.RazorCSharp;
 
         private readonly DefaultCapabilitiesProvider _defaultCapabilitiesProvider;
+
+        protected override ImmutableArray<string> SupportedLanguages => ProtocolConstants.RoslynLspLanguages;
 
         /// <summary>
         /// Gets the name of the language client (displayed in yellow bars).

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioInProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/VisualStudioInProcLanguageServer.cs
@@ -44,9 +44,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspLogger logger,
             IDiagnosticService? diagnosticService,
+            ImmutableArray<string> supportedLanguages,
             string? clientName,
             string userVisibleServerName,
-            string telemetryServerTypeName) : base(requestDispatcherFactory, jsonRpc, capabilitiesProvider, workspaceRegistrationService, listenerProvider, logger, clientName, userVisibleServerName, telemetryServerTypeName)
+            string telemetryServerTypeName)
+            : base(requestDispatcherFactory, jsonRpc, capabilitiesProvider, workspaceRegistrationService, listenerProvider, logger, supportedLanguages, clientName, userVisibleServerName, telemetryServerTypeName)
         {
             _diagnosticService = diagnosticService;
             // Dedupe on DocumentId.  If we hear about the same document multiple times, we only need to process that id once.

--- a/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
@@ -415,6 +415,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
                     listenerProvider,
                     NoOpLspLogger.Instance,
                     mockDiagnosticService,
+                    ProtocolConstants.RoslynLspLanguages,
                     clientName: null,
                     userVisibleServerName: string.Empty,
                     telemetryServerTypeName: string.Empty);
@@ -603,6 +604,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
                 : base(null!, null!, null, null!, null!, null!, null!, null)
             {
             }
+
+            protected override ImmutableArray<string> SupportedLanguages => ProtocolConstants.RoslynLspLanguages;
 
             public override string Name => nameof(LspDiagnosticsTests);
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor;
@@ -42,6 +43,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             : base(xamlDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
         {
         }
+
+        protected override ImmutableArray<string> SupportedLanguages => ImmutableArray.Create(StringConstants.XamlLanguageName);
 
         /// <summary>
         /// Gets the name of the language client (displayed in yellow bars).

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClientDisableUX.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClientDisableUX.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor;
@@ -43,6 +44,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             : base(xamlDispatcherFactory, workspace, diagnosticService, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
         {
         }
+
+        protected override ImmutableArray<string> SupportedLanguages => ImmutableArray.Create(StringConstants.XamlLanguageName);
 
         /// <summary>
         /// Gets the name of the language client (displayed in yellow bars).

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlRequestDispatcherFactory.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlRequestDispatcherFactory.cs
@@ -33,15 +33,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
             [ImportMany] IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders,
             XamlProjectService projectService,
             [Import(AllowDefault = true)] IXamlLanguageServerFeedbackService? feedbackService)
-            : base(requestHandlerProviders, languageNames: ImmutableArray.Create(StringConstants.XamlLanguageName))
+            : base(requestHandlerProviders)
         {
             _projectService = projectService;
             _feedbackService = feedbackService;
         }
 
-        public override RequestDispatcher CreateRequestDispatcher()
+        public override RequestDispatcher CreateRequestDispatcher(ImmutableArray<string> supportedLanguages)
         {
-            return new XamlRequestDispatcher(_projectService, _requestHandlerProviders, _feedbackService, _languageNames);
+            return new XamlRequestDispatcher(_projectService, _requestHandlerProviders, _feedbackService, supportedLanguages);
         }
 
         private class XamlRequestDispatcher : RequestDispatcher

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlRequestDispatcherFactory.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlRequestDispatcherFactory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
             [ImportMany] IEnumerable<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders,
             XamlProjectService projectService,
             [Import(AllowDefault = true)] IXamlLanguageServerFeedbackService? feedbackService)
-            : base(requestHandlerProviders, languageName: StringConstants.XamlLanguageName)
+            : base(requestHandlerProviders, languageNames: ImmutableArray.Create(StringConstants.XamlLanguageName))
         {
             _projectService = projectService;
             _feedbackService = feedbackService;
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
 
         public override RequestDispatcher CreateRequestDispatcher()
         {
-            return new XamlRequestDispatcher(_projectService, _requestHandlerProviders, _feedbackService, _languageName);
+            return new XamlRequestDispatcher(_projectService, _requestHandlerProviders, _feedbackService, _languageNames);
         }
 
         private class XamlRequestDispatcher : RequestDispatcher
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
                 XamlProjectService projectService,
                 ImmutableArray<Lazy<AbstractRequestHandlerProvider, RequestHandlerProviderMetadataView>> requestHandlerProviders,
                 IXamlLanguageServerFeedbackService? feedbackService,
-                string? languageName = null) : base(requestHandlerProviders, languageName)
+                ImmutableArray<string> languageNames) : base(requestHandlerProviders, languageNames)
             {
                 _projectService = projectService;
                 _feedbackService = feedbackService;


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/54970

This has two commits, I recommend commit at a time for review.

1.  https://github.com/dotnet/roslyn/commit/7539332c45ee8cee9384ad262b501613fe24cc6e modifies our existing "languageName" field on exporting handlers (used to differentiate between normal roslyn handlers and XAML lsp handlers) to support multiple language names.  Previously, if languageName was null, it meant everything that wasn't XAML which was not entirely clear.  With this commit we now export all handlers explicitly for the appropriate languages.
2.  https://github.com/dotnet/roslyn/commit/f0b238dc8e262c0ee6bab210f553eec9823f22c6 builds on 1) and has the LSP servers explicitly define their supported languages, passes the supported languages in the `RequestContext` and makes workspace pull diagnostics verify that the projects it is reporting diagnostics for match the server's language.