### PR TITLE
Prevent resetting the color when mouse is hovering over inheritance margin

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginTaggerProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginTaggerProvider.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Tagging;
-using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.InheritanceMargin;
 using Microsoft.CodeAnalysis.Internal.Log;

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml.cs
@@ -104,6 +104,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
 
         private void ContextMenu_OnClose(object sender, RoutedEventArgs e)
         {
+            // If mouse is still hovering. Don't reset the color. The context menu might be closed because user clicks within the margin
             if (!IsMouseOver)
             {
                 ResetBorderToInitialColor();

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml.cs
@@ -104,7 +104,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
 
         private void ContextMenu_OnClose(object sender, RoutedEventArgs e)
         {
-            ResetBorderToInitialColor();
+            if (!IsMouseOver)
+            {
+                ResetBorderToInitialColor();
+            }
             // Move the focus back to textView when the context menu is closed.
             // It ensures the focus won't be left at the margin
             ResetFocus();


### PR DESCRIPTION
Found this today:
Now:
![now](https://user-images.githubusercontent.com/24360909/129316021-546b7e84-323e-42e8-8b8b-9eab65cb2bb2.gif)

After:
![after](https://user-images.githubusercontent.com/24360909/129316045-bea273e1-45c1-404d-b5d9-62d71655b03b.gif)
