### PR TITLE
Move NonRemappableRegions, Capabilities to EditSession

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -102,6 +102,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             AssertEx.Equal(Array.Empty<SyntaxKind>(), unhandledKinds);
         }
 
+        private static async Task<DocumentAnalysisResults> AnalyzeDocumentAsync(Project oldProject, Document newDocument, ActiveStatementsMap activeStatementMap = null)
+        {
+            var analyzer = new CSharpEditAndContinueAnalyzer();
+            var baseActiveStatements = AsyncLazy.Create(ActiveStatementsMap.Empty);
+            var capabilities = AsyncLazy.Create(EditAndContinueTestHelpers.Net5RuntimeCapabilities);
+            return await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray<LinePositionSpan>.Empty, capabilities, CancellationToken.None);
+        }
+
         #endregion
 
         [Fact]
@@ -301,9 +309,7 @@ class C
                 }),
                 ActiveStatementsMap.Empty.InstructionMap);
 
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+            var result = await AnalyzeDocumentAsync(oldProject, newDocument, baseActiveStatements);
 
             Assert.True(result.HasChanges);
 
@@ -347,10 +353,7 @@ class C
             var documentId = oldDocument.Id;
             var newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2));
 
-            var baseActiveStatements = ActiveStatementsMap.Empty;
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newSolution.GetDocument(documentId), ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+            var result = await AnalyzeDocumentAsync(oldProject, newSolution.GetDocument(documentId));
 
             Assert.True(result.HasChanges);
             Assert.True(result.HasChangesAndErrors);
@@ -373,10 +376,8 @@ class C
             using var workspace = TestWorkspace.CreateCSharp(source, composition: s_composition);
             var oldProject = workspace.CurrentSolution.Projects.Single();
             var oldDocument = oldProject.Documents.Single();
-            var baseActiveStatements = ActiveStatementsMap.Empty;
-            var analyzer = new CSharpEditAndContinueAnalyzer();
 
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, oldDocument, ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+            var result = await AnalyzeDocumentAsync(oldProject, oldDocument);
 
             Assert.False(result.HasChanges);
             Assert.False(result.HasChangesAndErrors);
@@ -414,10 +415,7 @@ class C
 
             var newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2));
 
-            var baseActiveStatements = ActiveStatementsMap.Empty;
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newSolution.GetDocument(documentId), ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+            var result = await AnalyzeDocumentAsync(oldProject, newSolution.GetDocument(documentId));
 
             Assert.False(result.HasChanges);
             Assert.False(result.HasChangesAndErrors);
@@ -447,10 +445,7 @@ class C
             var oldDocument = oldProject.Documents.Single();
             var documentId = oldDocument.Id;
 
-            var baseActiveStatements = ActiveStatementsMap.Empty;
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, oldDocument, ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+            var result = await AnalyzeDocumentAsync(oldProject, oldDocument);
 
             Assert.False(result.HasChanges);
             Assert.False(result.HasChangesAndErrors);
@@ -498,10 +493,7 @@ class C
 
                 var newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2));
 
-                var baseActiveStatements = ActiveStatementsMap.Empty;
-                var analyzer = new CSharpEditAndContinueAnalyzer();
-
-                var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newSolution.GetDocument(documentId), ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+                var result = await AnalyzeDocumentAsync(oldProject, newSolution.GetDocument(documentId));
 
                 Assert.True(result.HasChanges);
                 Assert.True(result.HasChangesAndErrors);
@@ -531,10 +523,7 @@ class C
             var oldDocument = oldProject.Documents.Single();
             var documentId = oldDocument.Id;
 
-            var baseActiveStatements = ActiveStatementsMap.Empty;
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, oldDocument, ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+            var result = await AnalyzeDocumentAsync(oldProject, oldDocument);
 
             Assert.False(result.HasChanges);
             Assert.False(result.HasChangesAndErrors);
@@ -574,10 +563,7 @@ class C
 
             var newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2));
 
-            var baseActiveStatements = ActiveStatementsMap.Empty;
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newSolution.GetDocument(documentId), ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+            var result = await AnalyzeDocumentAsync(oldProject, newSolution.GetDocument(documentId));
 
             Assert.True(result.HasChanges);
 
@@ -617,10 +603,7 @@ class C
 
             var newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2));
 
-            var baseActiveStatements = ActiveStatementsMap.Empty;
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newSolution.GetDocument(documentId), ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+            var result = await AnalyzeDocumentAsync(oldProject, newSolution.GetDocument(documentId));
 
             Assert.True(result.HasChanges);
 
@@ -672,12 +655,9 @@ namespace N
             var changedDocuments = changes.GetChangedDocuments().Concat(changes.GetAddedDocuments());
 
             var result = new List<DocumentAnalysisResults>();
-            var baseActiveStatements = ActiveStatementsMap.Empty;
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
             foreach (var changedDocumentId in changedDocuments)
             {
-                result.Add(await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newProject.GetDocument(changedDocumentId), ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None));
+                result.Add(await AnalyzeDocumentAsync(oldProject, newProject.GetDocument(changedDocumentId)));
             }
 
             Assert.True(result.IsSingle());
@@ -724,12 +704,9 @@ class D
             var changedDocuments = changes.GetChangedDocuments().Concat(changes.GetAddedDocuments());
 
             var result = new List<DocumentAnalysisResults>();
-            var baseActiveStatements = ActiveStatementsMap.Empty;
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
             foreach (var changedDocumentId in changedDocuments)
             {
-                result.Add(await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newProject.GetDocument(changedDocumentId), ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None));
+                result.Add(await AnalyzeDocumentAsync(oldProject, newProject.GetDocument(changedDocumentId)));
             }
 
             Assert.True(result.IsSingle());
@@ -753,7 +730,8 @@ class D
 
             workspace.TryApplyChanges(newSolution);
 
-            var baseActiveStatements = ActiveStatementsMap.Empty;
+            var baseActiveStatements = AsyncLazy.Create(ActiveStatementsMap.Empty);
+            var capabilities = AsyncLazy.Create(EditAndContinueTestHelpers.Net5RuntimeCapabilities);
 
             var analyzer = new CSharpEditAndContinueAnalyzer(node =>
             {
@@ -763,7 +741,7 @@ class D
                 }
             });
 
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray<LinePositionSpan>.Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None);
+            var result = await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray<LinePositionSpan>.Empty, capabilities, CancellationToken.None);
 
             var expectedDiagnostic = outOfMemory ?
                 $"ENC0089: {string.Format(FeaturesResources.Modifying_source_file_0_requires_restarting_the_application_because_the_file_is_too_big, "src.cs")}" :
@@ -805,11 +783,7 @@ class C
             var newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2));
             var newDocument = newSolution.GetDocument(documentId);
 
-            var analyzer = new CSharpEditAndContinueAnalyzer();
-
-            var capabilities = EditAndContinueCapabilities.None;
-
-            var result = await analyzer.AnalyzeDocumentAsync(oldProject, ActiveStatementsMap.Empty, newDocument, ImmutableArray<LinePositionSpan>.Empty, capabilities, CancellationToken.None);
+            var result = await AnalyzeDocumentAsync(oldProject, newDocument);
 
             Assert.Equal(RudeEditKind.NotSupportedByRuntime, result.RudeEditErrors.Single().Kind);
         }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
         private static async Task<DocumentAnalysisResults> AnalyzeDocumentAsync(Project oldProject, Document newDocument, ActiveStatementsMap activeStatementMap = null)
         {
             var analyzer = new CSharpEditAndContinueAnalyzer();
-            var baseActiveStatements = AsyncLazy.Create(activeStatementMap);
+            var baseActiveStatements = AsyncLazy.Create(activeStatementMap ?? ActiveStatementsMap.Empty);
             var capabilities = AsyncLazy.Create(EditAndContinueTestHelpers.Net5RuntimeCapabilities);
             return await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray<LinePositionSpan>.Empty, capabilities, CancellationToken.None);
         }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
         private static async Task<DocumentAnalysisResults> AnalyzeDocumentAsync(Project oldProject, Document newDocument, ActiveStatementsMap activeStatementMap = null)
         {
             var analyzer = new CSharpEditAndContinueAnalyzer();
-            var baseActiveStatements = AsyncLazy.Create(ActiveStatementsMap.Empty);
+            var baseActiveStatements = AsyncLazy.Create(activeStatementMap);
             var capabilities = AsyncLazy.Create(EditAndContinueTestHelpers.Net5RuntimeCapabilities);
             return await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray<LinePositionSpan>.Empty, capabilities, CancellationToken.None);
         }

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueCapabilitiesTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueCapabilitiesTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
+{
+    public class EditAndContinueCapabilitiesTests
+    {
+        [Fact]
+        public void ParseCapabilities()
+        {
+            var capabilities = ImmutableArray.Create("Baseline");
+
+            var service = EditAndContinueCapabilitiesParser.Parse(capabilities);
+
+            Assert.True(service.HasFlag(EditAndContinueCapabilities.Baseline));
+            Assert.False(service.HasFlag(EditAndContinueCapabilities.NewTypeDefinition));
+        }
+
+        [Fact]
+        public void ParseCapabilities_CaseSensitive()
+        {
+            var capabilities = ImmutableArray.Create("BaseLine");
+
+            var service = EditAndContinueCapabilitiesParser.Parse(capabilities);
+
+            Assert.False(service.HasFlag(EditAndContinueCapabilities.Baseline));
+        }
+
+        [Fact]
+        public void ParseCapabilities_IgnoreInvalid()
+        {
+            var capabilities = ImmutableArray.Create("Baseline", "Invalid", "NewTypeDefinition");
+
+            var service = EditAndContinueCapabilitiesParser.Parse(capabilities);
+
+            Assert.True(service.HasFlag(EditAndContinueCapabilities.Baseline));
+            Assert.True(service.HasFlag(EditAndContinueCapabilities.NewTypeDefinition));
+        }
+
+        [Fact]
+        public void ParseCapabilities_IgnoreInvalidNumeric()
+        {
+            var capabilities = ImmutableArray.Create("Baseline", "90", "NewTypeDefinition");
+
+            var service = EditAndContinueCapabilitiesParser.Parse(capabilities);
+
+            Assert.True(service.HasFlag(EditAndContinueCapabilities.Baseline));
+            Assert.True(service.HasFlag(EditAndContinueCapabilities.NewTypeDefinition));
+        }
+
+        [Fact]
+        public void ParseCapabilities_AllCapabilitiesParsed()
+        {
+            foreach (var name in Enum.GetNames(typeof(EditAndContinueCapabilities)))
+            {
+                var capabilities = ImmutableArray.Create(name);
+
+                var service = EditAndContinueCapabilitiesParser.Parse(capabilities);
+
+                var flag = (EditAndContinueCapabilities)Enum.Parse(typeof(EditAndContinueCapabilities), name);
+                Assert.True(service.HasFlag(flag), $"Capability '{name}' was not parsed correctly, so it's impossible for a runtime to enable it!");
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -1047,7 +1047,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         }
 
         [Fact]
-        public async Task BreakMode_ModuleDisallowsEditAndContinue()
+        public async Task ModuleDisallowsEditAndContinue()
         {
             var moduleId = Guid.NewGuid();
 
@@ -1114,7 +1114,7 @@ class C1
         }
 
         [Fact]
-        public async Task BreakMode_Encodings()
+        public async Task Encodings()
         {
             var source1 = "class C1 { void M() { System.Console.WriteLine(\"ã\"); } }";
 

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -363,6 +363,75 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             }
         }
 
+        private static EditAndContinueLogEntry Row(int rowNumber, TableIndex table, EditAndContinueOperation operation)
+            => new(MetadataTokens.Handle(table, rowNumber), operation);
+
+        private static unsafe void VerifyEncLogMetadata(ImmutableArray<byte> delta, params EditAndContinueLogEntry[] expectedRows)
+        {
+            fixed (byte* ptr = delta.ToArray())
+            {
+                var reader = new MetadataReader(ptr, delta.Length);
+                AssertEx.Equal(expectedRows, reader.GetEditAndContinueLogEntries(), itemInspector: EncLogRowToString);
+            }
+
+            static string EncLogRowToString(EditAndContinueLogEntry row)
+            {
+                TableIndex tableIndex;
+                MetadataTokens.TryGetTableIndex(row.Handle.Kind, out tableIndex);
+
+                return string.Format(
+                    "Row({0}, TableIndex.{1}, EditAndContinueOperation.{2})",
+                    MetadataTokens.GetRowNumber(row.Handle),
+                    tableIndex,
+                    row.Operation);
+            }
+        }
+
+        private static void GenerateSource(GeneratorExecutionContext context)
+        {
+            foreach (var syntaxTree in context.Compilation.SyntaxTrees)
+            {
+                var fileName = PathUtilities.GetFileName(syntaxTree.FilePath);
+
+                Generate(syntaxTree.GetText().ToString(), fileName);
+
+                if (context.AnalyzerConfigOptions.GetOptions(syntaxTree).TryGetValue("enc_generator_output", out var optionValue))
+                {
+                    context.AddSource("GeneratedFromOptions_" + fileName, $"class G {{ int X => {optionValue}; }}");
+                }
+            }
+
+            foreach (var additionalFile in context.AdditionalFiles)
+            {
+                Generate(additionalFile.GetText()!.ToString(), PathUtilities.GetFileName(additionalFile.Path));
+            }
+
+            void Generate(string source, string fileName)
+            {
+                var generatedSource = GetGeneratedCodeFromMarkedSource(source);
+                if (generatedSource != null)
+                {
+                    context.AddSource($"Generated_{fileName}", generatedSource);
+                }
+            }
+        }
+
+        private static string GetGeneratedCodeFromMarkedSource(string markedSource)
+        {
+            const string OpeningMarker = "/* GENERATE:";
+            const string ClosingMarker = "*/";
+
+            var index = markedSource.IndexOf(OpeningMarker);
+            if (index > 0)
+            {
+                index += OpeningMarker.Length;
+                var closing = markedSource.IndexOf(ClosingMarker, index);
+                return markedSource[index..closing].Trim();
+            }
+
+            return null;
+        }
+
         [Theory]
         [CombinatorialData]
         public async Task StartDebuggingSession_CapturingDocuments(bool captureAllDocuments)
@@ -485,64 +554,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         }
 
         [Fact]
-        public async Task RunMode_ProjectThatDoesNotSupportEnC()
-        {
-            using var _ = CreateWorkspace(out var solution, out var service, new[] { typeof(DummyLanguageService) });
-            var project = solution.AddProject("dummy_proj", "dummy_proj", DummyLanguageService.LanguageName);
-            var document = project.AddDocument("test", SourceText.From("dummy1"));
-            solution = document.Project.Solution;
-
-            await StartDebuggingSessionAsync(service, solution);
-
-            // no changes:
-            var document1 = solution.Projects.Single().Documents.Single();
-            var diagnostics = await service.GetDocumentDiagnosticsAsync(document1, s_noActiveSpans, CancellationToken.None);
-            Assert.Empty(diagnostics);
-
-            // change the source:
-            solution = solution.WithDocumentText(document1.Id, SourceText.From("dummy2"));
-            var document2 = solution.GetDocument(document1.Id);
-
-            diagnostics = await service.GetDocumentDiagnosticsAsync(document2, s_noActiveSpans, CancellationToken.None);
-            Assert.Empty(diagnostics);
-        }
-
-        [Fact]
-        public async Task RunMode_DesignTimeOnlyDocument()
-        {
-            var moduleFile = Temp.CreateFile().WriteAllBytes(TestResources.Basic.Members);
-
-            using var _ = CreateWorkspace(out var solution, out var service);
-            (solution, var document1) = AddDefaultTestProject(solution, "class C1 { void M() { System.Console.WriteLine(1); } }");
-
-            var documentInfo = CreateDesignTimeOnlyDocument(document1.Project.Id);
-            solution = solution.WithProjectOutputFilePath(document1.Project.Id, moduleFile.Path).AddDocument(documentInfo);
-
-            _mockCompilationOutputsProvider = _ => new CompilationOutputFiles(moduleFile.Path);
-
-            var debuggingSession = await StartDebuggingSessionAsync(service, solution);
-
-            // update a design-time-only source file:
-            solution = solution.WithDocumentText(documentInfo.Id, SourceText.From("class UpdatedC2 {}"));
-            var document2 = solution.GetDocument(documentInfo.Id);
-
-            // no updates:
-            var diagnostics = await service.GetDocumentDiagnosticsAsync(document2, s_noActiveSpans, CancellationToken.None);
-            Assert.Empty(diagnostics);
-
-            // validate solution update status and emit - changes made in design-time-only documents are ignored:
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
-            EndDebuggingSession(debuggingSession);
-
-            AssertEx.Equal(new[]
-            {
-                "Debugging_EncSession: SessionId=1|SessionCount=0|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=1"
-            }, _telemetryLog);
-        }
-
-        [Fact]
-        public async Task RunMode_ProjectNotBuilt()
+        public async Task ProjectNotBuilt()
         {
             using var _ = CreateWorkspace(out var solution, out var service);
             (solution, var document1) = AddDefaultTestProject(solution, "class C1 { void M() { System.Console.WriteLine(1); } }");
@@ -564,7 +576,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         }
 
         [Fact]
-        public async Task RunMode_DifferentDocumentWithSameContent()
+        public async Task DifferentDocumentWithSameContent()
         {
             var source = "class C1 { void M1() { System.Console.WriteLine(1); } }";
             var moduleFile = Temp.CreateFile().WriteAllBytes(TestResources.Basic.Members);
@@ -599,8 +611,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             }, _telemetryLog);
         }
 
-        [Fact]
-        public async Task BreakMode_ProjectThatDoesNotSupportEnC()
+        [Theory]
+        [CombinatorialData]
+        public async Task ProjectThatDoesNotSupportEnC(bool breakMode)
         {
             using var _ = CreateWorkspace(out var solution, out var service, new[] { typeof(DummyLanguageService) });
             var project = solution.AddProject("dummy_proj", "dummy_proj", DummyLanguageService.LanguageName);
@@ -608,12 +621,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             solution = document.Project.Solution;
 
             var debuggingSession = await StartDebuggingSessionAsync(service, solution);
-            EnterBreakState(debuggingSession);
+            if (breakMode)
+            {
+                EnterBreakState(debuggingSession);
+            }
+
+            // no changes:
+            var document1 = solution.Projects.Single().Documents.Single();
+            var diagnostics = await service.GetDocumentDiagnosticsAsync(document1, s_noActiveSpans, CancellationToken.None);
+            Assert.Empty(diagnostics);
 
             // change the source:
-            var document1 = solution.Projects.Single().Documents.Single();
             solution = solution.WithDocumentText(document1.Id, SourceText.From("dummy2"));
-            var document2 = solution.GetDocument(document1.Id);
 
             // validate solution update status and emit:
             Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
@@ -622,10 +641,48 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             Assert.Empty(updates.Updates);
             Assert.Empty(emitDiagnostics);
+
+            var document2 = solution.GetDocument(document1.Id);
+            diagnostics = await service.GetDocumentDiagnosticsAsync(document2, s_noActiveSpans, CancellationToken.None);
+            Assert.Empty(diagnostics);
         }
 
         [Fact]
-        public async Task BreakMode_DesignTimeOnlyDocument_Dynamic()
+        public async Task DesignTimeOnlyDocument()
+        {
+            var moduleFile = Temp.CreateFile().WriteAllBytes(TestResources.Basic.Members);
+
+            using var _ = CreateWorkspace(out var solution, out var service);
+            (solution, var document1) = AddDefaultTestProject(solution, "class C1 { void M() { System.Console.WriteLine(1); } }");
+
+            var documentInfo = CreateDesignTimeOnlyDocument(document1.Project.Id);
+            solution = solution.WithProjectOutputFilePath(document1.Project.Id, moduleFile.Path).AddDocument(documentInfo);
+
+            _mockCompilationOutputsProvider = _ => new CompilationOutputFiles(moduleFile.Path);
+
+            var debuggingSession = await StartDebuggingSessionAsync(service, solution);
+
+            // update a design-time-only source file:
+            solution = solution.WithDocumentText(documentInfo.Id, SourceText.From("class UpdatedC2 {}"));
+            var document2 = solution.GetDocument(documentInfo.Id);
+
+            // no updates:
+            var diagnostics = await service.GetDocumentDiagnosticsAsync(document2, s_noActiveSpans, CancellationToken.None);
+            Assert.Empty(diagnostics);
+
+            // validate solution update status and emit - changes made in design-time-only documents are ignored:
+            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
+
+            EndDebuggingSession(debuggingSession);
+
+            AssertEx.Equal(new[]
+            {
+                "Debugging_EncSession: SessionId=1|SessionCount=0|EmptySessionCount=0|HotReloadSessionCount=0|EmptyHotReloadSessionCount=1"
+            }, _telemetryLog);
+        }
+
+        [Fact]
+        public async Task DesignTimeOnlyDocument_Dynamic()
         {
             using var _ = CreateWorkspace(out var solution, out var service);
 
@@ -663,7 +720,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task BreakMode_DesignTimeOnlyDocument_Wpf(bool delayLoad)
+        public async Task DesignTimeOnlyDocument_Wpf(bool delayLoad)
         {
             var sourceA = "class A { public void M() { } }";
             var sourceB = "class B { public void M() { } }";
@@ -807,7 +864,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         }
 
         [Fact]
-        public async Task BreakMode_ErrorReadingPdbFile()
+        public async Task ErrorReadingPdbFile()
         {
             var source1 = "class C1 { void M() { System.Console.WriteLine(1); } }";
 
@@ -862,7 +919,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         }
 
         [Fact]
-        public async Task BreakMode_ErrorReadingSourceFile()
+        public async Task ErrorReadingSourceFile()
         {
             var source1 = "class C1 { void M() { System.Console.WriteLine(1); } }";
 
@@ -1164,7 +1221,7 @@ class C1
         }
 
         [Fact]
-        public async Task BreakMode_RudeEdits_SourceGenerators()
+        public async Task RudeEdits_SourceGenerators()
         {
             var sourceV1 = @"
 /* GENERATE: class G { int X1 => 1; } */
@@ -1305,7 +1362,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_RudeEdits_DocumentWithoutSequencePoints()
+        public async Task RudeEdits_DocumentWithoutSequencePoints()
         {
             var source1 = "abstract class C { public abstract void M(); }";
             var dir = Temp.CreateDirectory();
@@ -1351,7 +1408,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_RudeEdits_DelayLoadedModule()
+        public async Task RudeEdits_DelayLoadedModule()
         {
             var source1 = "class C { public void M() { } }";
             var dir = Temp.CreateDirectory();
@@ -1412,7 +1469,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_SyntaxError()
+        public async Task SyntaxError()
         {
             var moduleId = Guid.NewGuid();
 
@@ -1454,7 +1511,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_SemanticError()
+        public async Task SemanticError()
         {
             var sourceV1 = "class C1 { void M() { System.Console.WriteLine(1); } }";
 
@@ -1502,7 +1559,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_FileStatus_CompilationError()
+        public async Task FileStatus_CompilationError()
         {
             using var _ = CreateWorkspace(out var solution, out var service);
 
@@ -1537,7 +1594,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_EmitError()
+        public async Task ValidSignificantChange_EmitError()
         {
             var sourceV1 = "class C1 { void M() { System.Console.WriteLine(1); } }";
 
@@ -1592,7 +1649,7 @@ class C { int Y => 2; }
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task BreakMode_ValidSignificantChange_ApplyBeforeFileWatcherEvent(bool saveDocument)
+        public async Task ValidSignificantChange_ApplyBeforeFileWatcherEvent(bool saveDocument)
         {
             // Scenarios tested:
             //
@@ -1677,7 +1734,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_FileUpdateNotObservedBeforeDebuggingSessionStart()
+        public async Task ValidSignificantChange_FileUpdateNotObservedBeforeDebuggingSessionStart()
         {
             // workspace:     --V0--------------V2-------|--------V3------------------V1--------------|
             // file system:   --V0---------V1-----V2-----|------------------------------V1------------|
@@ -1751,7 +1808,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_AddedFileNotObservedBeforeDebuggingSessionStart()
+        public async Task ValidSignificantChange_AddedFileNotObservedBeforeDebuggingSessionStart()
         {
             // workspace:     ------|----V0---------------|----------
             // file system:   --V0--|---------------------|----------
@@ -1820,7 +1877,7 @@ class C { int Y => 2; }
 
         [Theory]
         [CombinatorialData]
-        public async Task BreakMode_ValidSignificantChange_DocumentOutOfSync(bool delayLoad)
+        public async Task ValidSignificantChange_DocumentOutOfSync(bool delayLoad)
         {
             var sourceOnDisk = "class C1 { void M() { System.Console.WriteLine(1); } }";
 
@@ -2009,7 +2066,7 @@ class C { int Y => 2; }
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task BreakMode_ValidSignificantChange_EmitSuccessful_UpdateDeferred(bool commitUpdate)
+        public async Task ValidSignificantChange_EmitSuccessful_UpdateDeferred(bool commitUpdate)
         {
             var dir = Temp.CreateDirectory();
 
@@ -2117,7 +2174,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_PartialTypes()
+        public async Task ValidSignificantChange_PartialTypes()
         {
             var sourceA1 = @"
 partial class C { int X = 1; void F() { X = 1; } }
@@ -2178,77 +2235,8 @@ partial class E { int B = 2; public E(int a, int b) { A = a; B = new System.Func
             EndDebuggingSession(debuggingSession);
         }
 
-        private static EditAndContinueLogEntry Row(int rowNumber, TableIndex table, EditAndContinueOperation operation)
-            => new(MetadataTokens.Handle(table, rowNumber), operation);
-
-        private static unsafe void VerifyEncLogMetadata(ImmutableArray<byte> delta, params EditAndContinueLogEntry[] expectedRows)
-        {
-            fixed (byte* ptr = delta.ToArray())
-            {
-                var reader = new MetadataReader(ptr, delta.Length);
-                AssertEx.Equal(expectedRows, reader.GetEditAndContinueLogEntries(), itemInspector: EncLogRowToString);
-            }
-
-            static string EncLogRowToString(EditAndContinueLogEntry row)
-            {
-                TableIndex tableIndex;
-                MetadataTokens.TryGetTableIndex(row.Handle.Kind, out tableIndex);
-
-                return string.Format(
-                    "Row({0}, TableIndex.{1}, EditAndContinueOperation.{2})",
-                    MetadataTokens.GetRowNumber(row.Handle),
-                    tableIndex,
-                    row.Operation);
-            }
-        }
-
-        private static void GenerateSource(GeneratorExecutionContext context)
-        {
-            foreach (var syntaxTree in context.Compilation.SyntaxTrees)
-            {
-                var fileName = PathUtilities.GetFileName(syntaxTree.FilePath);
-
-                Generate(syntaxTree.GetText().ToString(), fileName);
-
-                if (context.AnalyzerConfigOptions.GetOptions(syntaxTree).TryGetValue("enc_generator_output", out var optionValue))
-                {
-                    context.AddSource("GeneratedFromOptions_" + fileName, $"class G {{ int X => {optionValue}; }}");
-                }
-            }
-
-            foreach (var additionalFile in context.AdditionalFiles)
-            {
-                Generate(additionalFile.GetText()!.ToString(), PathUtilities.GetFileName(additionalFile.Path));
-            }
-
-            void Generate(string source, string fileName)
-            {
-                var generatedSource = GetGeneratedCodeFromMarkedSource(source);
-                if (generatedSource != null)
-                {
-                    context.AddSource($"Generated_{fileName}", generatedSource);
-                }
-            }
-        }
-
-        private static string GetGeneratedCodeFromMarkedSource(string markedSource)
-        {
-            const string OpeningMarker = "/* GENERATE:";
-            const string ClosingMarker = "*/";
-
-            var index = markedSource.IndexOf(OpeningMarker);
-            if (index > 0)
-            {
-                index += OpeningMarker.Length;
-                var closing = markedSource.IndexOf(ClosingMarker, index);
-                return markedSource[index..closing].Trim();
-            }
-
-            return null;
-        }
-
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_SourceGenerators_DocumentUpdate_GeneratedDocumentUpdate()
+        public async Task ValidSignificantChange_SourceGenerators_DocumentUpdate_GeneratedDocumentUpdate()
         {
             var sourceV1 = @"
 /* GENERATE: class G { int X => 1; } */
@@ -2294,7 +2282,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_SourceGenerators_DocumentUpdate_GeneratedDocumentUpdate_LineChanges()
+        public async Task ValidSignificantChange_SourceGenerators_DocumentUpdate_GeneratedDocumentUpdate_LineChanges()
         {
             var sourceV1 = @"
 /* GENERATE:
@@ -2356,7 +2344,7 @@ class G
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_SourceGenerators_DocumentUpdate_GeneratedDocumentInsert()
+        public async Task ValidSignificantChange_SourceGenerators_DocumentUpdate_GeneratedDocumentInsert()
         {
             var sourceV1 = @"
 partial class C { int X = 1; }
@@ -2400,7 +2388,7 @@ partial class C { int X = 1; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_SourceGenerators_AdditionalDocumentUpdate()
+        public async Task ValidSignificantChange_SourceGenerators_AdditionalDocumentUpdate()
         {
             var source = @"
 class C { int Y => 1; }
@@ -2447,7 +2435,7 @@ class C { int Y => 1; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_SourceGenerators_AnalyzerConfigUpdate()
+        public async Task ValidSignificantChange_SourceGenerators_AnalyzerConfigUpdate()
         {
             var source = @"
 class C { int Y => 1; }
@@ -2490,7 +2478,7 @@ class C { int Y => 1; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_SourceGenerators_DocumentRemove()
+        public async Task ValidSignificantChange_SourceGenerators_DocumentRemove()
         {
             var source1 = "";
 
@@ -2683,7 +2671,7 @@ class C { int Y => 1; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_BaselineCreationFailed_NoStream()
+        public async Task ValidSignificantChange_BaselineCreationFailed_NoStream()
         {
             using var _ = CreateWorkspace(out var solution, out var service);
             (solution, var document1) = AddDefaultTestProject(solution, "class C1 { void M() { System.Console.WriteLine(1); } }");
@@ -2708,7 +2696,7 @@ class C { int Y => 1; }
         }
 
         [Fact]
-        public async Task BreakMode_ValidSignificantChange_BaselineCreationFailed_AssemblyReadError()
+        public async Task ValidSignificantChange_BaselineCreationFailed_AssemblyReadError()
         {
             var sourceV1 = "class C1 { void M() { System.Console.WriteLine(1); } }";
             var compilationV1 = CSharpTestBase.CreateCompilationWithMscorlib40(sourceV1, options: TestOptions.DebugDll, assemblyName: "lib");

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -1574,7 +1574,7 @@ class C { int Y => 2; }
             Assert.Throws<InvalidOperationException>(() => debuggingSession.DiscardSolutionUpdate());
 
             // no change in non-remappable regions since we didn't have any active statements:
-            Assert.Empty(debuggingSession.NonRemappableRegions);
+            Assert.Empty(debuggingSession.EditSession.NonRemappableRegions);
 
             // solution update status after discarding an update (still has update ready):
             Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
@@ -1944,7 +1944,7 @@ class C { int Y => 2; }
                 Assert.Null(debuggingSession.GetTestAccessor().GetPendingSolutionUpdate());
 
                 // no change in non-remappable regions since we didn't have any active statements:
-                Assert.Empty(debuggingSession.NonRemappableRegions);
+                Assert.Empty(debuggingSession.EditSession.NonRemappableRegions);
 
                 var baselineReaders = debuggingSession.GetTestAccessor().GetBaselineModuleReaders();
                 Assert.Equal(2, baselineReaders.Length);
@@ -2080,7 +2080,7 @@ class C { int Y => 2; }
                 Assert.Null(debuggingSession.GetTestAccessor().GetPendingSolutionUpdate());
 
                 // no change in non-remappable regions since we didn't have any active statements:
-                Assert.Empty(debuggingSession.NonRemappableRegions);
+                Assert.Empty(debuggingSession.EditSession.NonRemappableRegions);
 
                 // verify that baseline is added:
                 Assert.Same(newBaseline, debuggingSession.GetTestAccessor().GetProjectEmitBaseline(document2.Project.Id));
@@ -2612,7 +2612,7 @@ class C { int Y => 1; }
             Assert.Null(debuggingSession.GetTestAccessor().GetPendingSolutionUpdate());
 
             // no change in non-remappable regions since we didn't have any active statements:
-            Assert.Empty(debuggingSession.NonRemappableRegions);
+            Assert.Empty(debuggingSession.EditSession.NonRemappableRegions);
 
             // verify that baseline is added for both modules:
             Assert.Same(newBaselineA1, debuggingSession.GetTestAccessor().GetProjectEmitBaseline(projectA.Id));
@@ -2662,7 +2662,7 @@ class C { int Y => 1; }
             Assert.Null(debuggingSession.GetTestAccessor().GetPendingSolutionUpdate());
 
             // no change in non-remappable regions since we didn't have any active statements:
-            Assert.Empty(debuggingSession.NonRemappableRegions);
+            Assert.Empty(debuggingSession.EditSession.NonRemappableRegions);
 
             // module readers tracked:
             baselineReaders = debuggingSession.GetTestAccessor().GetBaselineModuleReaders();
@@ -3292,7 +3292,7 @@ class C
             AssertEx.Equal(new[]
             {
                 $"0x06000003 v1 | AS {document.FilePath}: (9,14)-(9,18) δ=1",
-            }, InspectNonRemappableRegions(debuggingSession.NonRemappableRegions));
+            }, InspectNonRemappableRegions(debuggingSession.EditSession.NonRemappableRegions));
 
             ExitBreakState();
 
@@ -3311,7 +3311,7 @@ class C
             AssertEx.Equal(new[]
             {
                 $"0x06000003 v1 | AS {document.FilePath}: (9,14)-(9,18) δ=1",
-            }, InspectNonRemappableRegions(debuggingSession.NonRemappableRegions));
+            }, InspectNonRemappableRegions(debuggingSession.EditSession.NonRemappableRegions));
 
             // EnC update F v3 -> v4
 
@@ -3341,7 +3341,7 @@ class C
             AssertEx.Equal(new[]
             {
                 $"0x06000003 v1 | AS {document.FilePath}: (9,14)-(9,18) δ=5"
-            }, InspectNonRemappableRegions(debuggingSession.NonRemappableRegions));
+            }, InspectNonRemappableRegions(debuggingSession.EditSession.NonRemappableRegions));
 
             ExitBreakState();
         }
@@ -3466,7 +3466,7 @@ class C
             AssertEx.Equal(new[]
             {
                 $"0x06000003 v1 | AS {document.FilePath}: (7,14)-(7,18) δ=2",
-            }, InspectNonRemappableRegions(debuggingSession.NonRemappableRegions));
+            }, InspectNonRemappableRegions(debuggingSession.EditSession.NonRemappableRegions));
 
             ExitBreakState();
         }

--- a/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
@@ -60,8 +60,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 EditAndContinueWorkspaceServiceTests.SetDocumentsState(debuggingSession, solution, initialState);
             }
 
-            debuggingSession.GetTestAccessor().SetNonRemappableRegions(nonRemappableRegions ?? ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>.Empty);
-            debuggingSession.RestartEditSession(inBreakState: true, out _);
+            debuggingSession.RestartEditSession(nonRemappableRegions ?? ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>.Empty, inBreakState: true, out _);
             return debuggingSession.EditSession;
         }
 

--- a/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         {
             var mockDebuggerService = new MockManagedEditAndContinueDebuggerService()
             {
-                GetActiveStatementsImpl = () => activeStatements
+                GetActiveStatementsImpl = () => activeStatements,
             };
 
             var mockCompilationOutputsProvider = new Func<Project, CompilationOutputs>(_ => new MockCompilationOutputs(Guid.NewGuid()));
@@ -50,7 +50,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 new DebuggingSessionId(1),
                 solution,
                 mockDebuggerService,
-                EditAndContinueTestHelpers.Net5RuntimeCapabilities,
                 mockCompilationOutputsProvider,
                 SpecializedCollections.EmptyEnumerable<KeyValuePair<DocumentId, CommittedSolution.DocumentState>>(),
                 reportDiagnostics: true);

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -111,6 +111,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             var testAccessor = Analyzer.GetTestAccessor();
             var allEdits = new List<SemanticEditInfo>();
+            var lazyCapabilities = AsyncLazy.Create(capabilities ?? Net5RuntimeCapabilities);
 
             for (var documentIndex = 0; documentIndex < documentCount; documentIndex++)
             {
@@ -135,7 +136,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 Contract.ThrowIfNull(oldModel);
                 Contract.ThrowIfNull(newModel);
 
-                var result = Analyzer.AnalyzeDocumentAsync(oldProject, expectedResult.ActiveStatements.OldStatementsMap, newDocument, newActiveStatementSpans, capabilities ?? Net5RuntimeCapabilities, CancellationToken.None).Result;
+                var lazyOldActiveStatementMap = AsyncLazy.Create(expectedResult.ActiveStatements.OldStatementsMap);
+                var result = Analyzer.AnalyzeDocumentAsync(oldProject, lazyOldActiveStatementMap, newDocument, newActiveStatementSpans, lazyCapabilities, CancellationToken.None).Result;
                 var oldText = oldDocument.GetTextSynchronously(default);
                 var newText = newDocument.GetTextSynchronously(default);
 

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -23,16 +23,16 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 {
     internal abstract class EditAndContinueTestHelpers
     {
-        public static readonly EditAndContinueCapabilities BaselineCapabilities = EditAndContinueCapabilities.Baseline;
+        public const EditAndContinueCapabilities BaselineCapabilities = EditAndContinueCapabilities.Baseline;
 
-        public static readonly EditAndContinueCapabilities Net5RuntimeCapabilities =
+        public const EditAndContinueCapabilities Net5RuntimeCapabilities =
             EditAndContinueCapabilities.Baseline |
             EditAndContinueCapabilities.AddInstanceFieldToExistingType |
             EditAndContinueCapabilities.AddStaticFieldToExistingType |
             EditAndContinueCapabilities.AddMethodToExistingType |
             EditAndContinueCapabilities.NewTypeDefinition;
 
-        public static readonly EditAndContinueCapabilities Net6RuntimeCapabilities =
+        public const EditAndContinueCapabilities Net6RuntimeCapabilities =
             Net5RuntimeCapabilities |
             EditAndContinueCapabilities.ChangeCustomAttributes |
             EditAndContinueCapabilities.UpdateParameters;

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/MockManagedEditAndContinueDebuggerService.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/MockManagedEditAndContinueDebuggerService.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public Func<Guid, ManagedEditAndContinueAvailability>? IsEditAndContinueAvailable;
         public Dictionary<Guid, ManagedEditAndContinueAvailability>? LoadedModules;
         public Func<ImmutableArray<ManagedActiveStatementDebugInfo>>? GetActiveStatementsImpl;
+        public Func<ImmutableArray<string>>? GetCapabilitiesImpl;
 
         public Task<ImmutableArray<ManagedActiveStatementDebugInfo>> GetActiveStatementsAsync(CancellationToken cancellationToken)
             => Task.FromResult(GetActiveStatementsImpl?.Invoke() ?? ImmutableArray<ManagedActiveStatementDebugInfo>.Empty);
@@ -36,7 +37,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         }
 
         public Task<ImmutableArray<string>> GetCapabilitiesAsync(CancellationToken cancellationToken)
-            => Task.FromResult(ImmutableArray.Create("Baseline", "AddDefinitionToExistingType", "NewTypeDefinition"));
+            => Task.FromResult(GetCapabilitiesImpl?.Invoke() ?? ImmutableArray.Create("Baseline", "AddDefinitionToExistingType", "NewTypeDefinition"));
 
         public Task PrepareModuleForUpdateAsync(Guid mvid, CancellationToken cancellationToken)
             => Task.CompletedTask;

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
@@ -109,6 +109,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
 
             AssertEx.Equal(Array.Empty(Of SyntaxKind)(), unhandledKinds)
         End Sub
+
+        Private Shared Async Function AnalyzeDocumentAsync(oldProject As Project, newDocument As Document, Optional activeStatementMap As ActiveStatementsMap = Nothing) As Task(Of DocumentAnalysisResults)
+            Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
+            Dim baseActiveStatements = AsyncLazy.Create(If(activeStatementMap, ActiveStatementsMap.Empty))
+            Dim capabilities = AsyncLazy.Create(EditAndContinueTestHelpers.Net5RuntimeCapabilities)
+            Return Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray(Of LinePositionSpan).Empty, capabilities, CancellationToken.None)
+        End Function
 #End Region
 
         <Fact>
@@ -477,9 +484,7 @@ End Class
                     }),
                     ActiveStatementsMap.Empty.InstructionMap)
 
-                Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
-
-                Dim result = Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newDocument, ImmutableArray(Of LinePositionSpan).Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None)
+                Dim result = Await AnalyzeDocumentAsync(oldProject, newDocument, baseActiveStatements)
 
                 Assert.True(result.HasChanges)
                 Dim syntaxMap = result.SemanticEdits(0).SyntaxMap
@@ -507,9 +512,8 @@ End Class
             Using workspace = TestWorkspace.CreateVisualBasic(source, composition:=s_composition)
                 Dim oldProject = workspace.CurrentSolution.Projects.Single()
                 Dim oldDocument = oldProject.Documents.Single()
-                Dim baseActiveStatements = ActiveStatementsMap.Empty
-                Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
-                Dim result = Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, oldDocument, ImmutableArray(Of LinePositionSpan).Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None)
+
+                Dim result = Await AnalyzeDocumentAsync(oldProject, oldDocument)
 
                 Assert.False(result.HasChanges)
                 Assert.False(result.HasChangesAndErrors)
@@ -540,10 +544,8 @@ End Class
                 Dim documentId = oldDocument.Id
                 Dim oldSolution = workspace.CurrentSolution
                 Dim newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2))
-                Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
 
-                Dim baseActiveStatements = ActiveStatementsMap.Empty
-                Dim result = Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newSolution.GetDocument(documentId), ImmutableArray(Of LinePositionSpan).Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None)
+                Dim result = Await AnalyzeDocumentAsync(oldProject, newSolution.GetDocument(documentId))
 
                 Assert.False(result.HasChanges)
                 Assert.False(result.HasChangesAndErrors)
@@ -565,9 +567,8 @@ End Class
             Using workspace = TestWorkspace.CreateVisualBasic(source, composition:=s_composition)
                 Dim oldProject = workspace.CurrentSolution.Projects.Single()
                 Dim oldDocument = oldProject.Documents.Single()
-                Dim baseActiveStatements = ActiveStatementsMap.Empty
-                Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
-                Dim result = Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, oldDocument, ImmutableArray(Of LinePositionSpan).Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None)
+
+                Dim result = Await AnalyzeDocumentAsync(oldProject, oldDocument)
 
                 Assert.False(result.HasChanges)
                 Assert.False(result.HasChangesAndErrors)
@@ -600,10 +601,8 @@ End Class
                 Dim documentId = oldDocument.Id
                 Dim oldSolution = workspace.CurrentSolution
                 Dim newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2))
-                Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
 
-                Dim baseActiveStatements = ActiveStatementsMap.Empty
-                Dim result = Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newSolution.GetDocument(documentId), ImmutableArray(Of LinePositionSpan).Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None)
+                Dim result = Await AnalyzeDocumentAsync(oldProject, newSolution.GetDocument(documentId))
 
                 ' no declaration errors (error in method body is only reported when emitting)
                 Assert.False(result.HasChangesAndErrors)
@@ -633,10 +632,7 @@ End Class
                 Dim oldProject = oldSolution.Projects.Single()
                 Dim documentId = oldProject.Documents.Single().Id
                 Dim newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2))
-                Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
-
-                Dim baseActiveStatements = ActiveStatementsMap.Empty
-                Dim result = Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newSolution.GetDocument(documentId), ImmutableArray(Of LinePositionSpan).Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None)
+                Dim result = Await AnalyzeDocumentAsync(oldProject, newSolution.GetDocument(documentId))
 
                 Assert.True(result.HasChanges)
 
@@ -680,10 +676,8 @@ End Class
                 Dim changedDocuments = changes.GetChangedDocuments().Concat(changes.GetAddedDocuments())
 
                 Dim result = New List(Of DocumentAnalysisResults)()
-                Dim baseActiveStatements = ActiveStatementsMap.Empty
-                Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
                 For Each changedDocumentId In changedDocuments
-                    result.Add(Await analyzer.AnalyzeDocumentAsync(oldProject, baseActiveStatements, newProject.GetDocument(changedDocumentId), ImmutableArray(Of LinePositionSpan).Empty, EditAndContinueTestHelpers.Net5RuntimeCapabilities, CancellationToken.None))
+                    result.Add(Await AnalyzeDocumentAsync(oldProject, newProject.GetDocument(changedDocumentId)))
                 Next
 
                 Assert.True(result.IsSingle())

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -63,41 +62,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private readonly ReaderWriterLockSlim _baselineAccessLock = new();
         private bool _isDisposed;
 
-        // Maps active statement instructions reported by the debugger to their latest spans that might not yet have been applied
-        // (remapping not triggered yet). Consumed by the next edit session and updated when changes are committed at the end of the edit session.
-        //
-        // Consider a function F containing a call to function G. While G is being executed, F is updated a couple of times (in two edit sessions)
-        // before the thread returns from G and is remapped to the latest version of F. At the start of the second edit session,
-        // the active instruction reported by the debugger is still at the original location since function F has not been remapped yet (G has not returned yet).
-        //
-        // '>' indicates an active statement instruction for non-leaf frame reported by the debugger.
-        // v1 - before first edit, G executing
-        // v2 - after first edit, G still executing
-        // v3 - after second edit and G returned
-        //
-        // F v1:        F v2:       F v3:
-        // 0: nop       0: nop      0: nop
-        // 1> G()       1> nop      1: nop
-        // 2: nop       2: G()      2: nop
-        // 3: nop       3: nop      3> G()
-        //
-        // When entering a break state we query the debugger for current active statements.
-        // The returned statements reflect the current state of the threads in the runtime.
-        // When a change is successfully applied we remember changes in active statement spans.
-        // These changes are passed to the next edit session.
-        // We use them to map the spans for active statements returned by the debugger.
-        //
-        // In the above case the sequence of events is
-        // 1st break: get active statements returns (F, v=1, il=1, span1) the active statement is up-to-date
-        // 1st apply: detected span change for active statement (F, v=1, il=1): span1->span2
-        // 2nd break: previously updated statements contains (F, v=1, il=1)->span2
-        //            get active statements returns (F, v=1, il=1, span1) which is mapped to (F, v=1, il=1, span2) using previously updated statements
-        // 2nd apply: detected span change for active statement (F, v=1, il=1): span2->span3
-        // 3rd break: previously updated statements contains (F, v=1, il=1)->span3
-        //            get active statements returns (F, v=3, il=3, span3) the active statement is up-to-date
-        //
-        internal ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> NonRemappableRegions { get; private set; }
-
         internal EditSession EditSession { get; private set; }
 
         private readonly HashSet<Guid> _modulesPreparedForUpdate = new();
@@ -113,11 +77,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal readonly CommittedSolution LastCommittedSolution;
 
         internal readonly IManagedEditAndContinueDebuggerService DebuggerService;
-
-        /// <summary>
-        /// Gets the capabilities of the runtime with respect to applying code changes.
-        /// </summary>
-        internal readonly EditAndContinueCapabilities Capabilities;
 
         /// <summary>
         /// True if the diagnostics produced by the session should be reported to the diagnotic analyzer.
@@ -151,11 +110,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             _reportTelemetry = ReportTelemetry;
 
             Id = id;
-            Capabilities = capabilities;
             DebuggerService = debuggerService;
             LastCommittedSolution = new CommittedSolution(this, solution, initialDocumentStates);
-            NonRemappableRegions = ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>.Empty;
-            EditSession = new EditSession(this, _editSessionTelemetry, inBreakState: false);
+            EditSession = new EditSession(this, nonRemappableRegions: ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>.Empty, _editSessionTelemetry, capabilities, inBreakState: false);
             ReportDiagnostics = reportDiagnostics;
         }
 
@@ -227,14 +184,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         public void BreakStateEntered(out ImmutableArray<DocumentId> documentsToReanalyze)
-            => RestartEditSession(inBreakState: true, out documentsToReanalyze);
+            => RestartEditSession(nonRemappableRegions: null, inBreakState: true, out documentsToReanalyze);
 
-        internal void RestartEditSession(bool inBreakState, out ImmutableArray<DocumentId> documentsToReanalyze)
+        internal void RestartEditSession(ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>? nonRemappableRegions, bool inBreakState, out ImmutableArray<DocumentId> documentsToReanalyze)
         {
             ThrowIfDisposed();
 
             EndEditSession(out documentsToReanalyze);
-            EditSession = new EditSession(this, EditSession.Telemetry, inBreakState);
+            EditSession = new EditSession(this, nonRemappableRegions ?? EditSession.NonRemappableRegions, EditSession.Telemetry, EditSession.Capabilities, inBreakState);
         }
 
         private ImmutableArray<IDisposable> GetBaselineModuleReaders()
@@ -254,33 +211,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 return _modulesPreparedForUpdate.Add(mvid);
             }
-        }
-
-        private void CommitSolutionUpdate(PendingSolutionUpdate update)
-        {
-            // Save new non-remappable regions for the next edit session.
-            // If no edits were made the pending list will be empty and we need to keep the previous regions.
-
-            var nonRemappableRegions = GroupToImmutableDictionary(
-                from moduleRegions in update.NonRemappableRegions
-                from region in moduleRegions.Regions
-                group region.Region by new ManagedMethodId(moduleRegions.ModuleId, region.Method));
-
-            if (nonRemappableRegions.Count > 0)
-            {
-                NonRemappableRegions = nonRemappableRegions;
-            }
-
-            // update baselines:
-            lock (_projectEmitBaselinesGuard)
-            {
-                foreach (var (projectId, baseline) in update.EmitBaselines)
-                {
-                    _projectEmitBaselines[projectId] = baseline;
-                }
-            }
-
-            LastCommittedSolution.CommitSolution(update.Solution);
         }
 
         /// <summary>
@@ -509,7 +439,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     return ImmutableArray<Diagnostic>.Empty;
                 }
 
-                var analysis = await EditSession.Analyses.GetDocumentAnalysisAsync(LastCommittedSolution, oldDocument, document, activeStatementSpanProvider, Capabilities, cancellationToken).ConfigureAwait(false);
+                var analysis = await EditSession.Analyses.GetDocumentAnalysisAsync(LastCommittedSolution, oldDocument, document, activeStatementSpanProvider, EditSession.Capabilities, cancellationToken).ConfigureAwait(false);
                 if (analysis.HasChanges)
                 {
                     // Once we detected a change in a document let the debugger know that the corresponding loaded module
@@ -607,10 +537,31 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ThrowIfDisposed();
 
             var pendingUpdate = RetrievePendingUpdate();
-            CommitSolutionUpdate(pendingUpdate);
 
-            // restart edit session with no active statements (switching to run mode):
-            RestartEditSession(inBreakState: false, out documentsToReanalyze);
+            // Save new non-remappable regions for the next edit session.
+            // If no edits were made the pending list will be empty and we need to keep the previous regions.
+
+            var newNonRemappableRegions = GroupToImmutableDictionary(
+                from moduleRegions in pendingUpdate.NonRemappableRegions
+                from region in moduleRegions.Regions
+                group region.Region by new ManagedMethodId(moduleRegions.ModuleId, region.Method));
+
+            if (newNonRemappableRegions.IsEmpty)
+                newNonRemappableRegions = null;
+
+            // update baselines:
+            lock (_projectEmitBaselinesGuard)
+            {
+                foreach (var (projectId, baseline) in pendingUpdate.EmitBaselines)
+                {
+                    _projectEmitBaselines[projectId] = baseline;
+                }
+            }
+
+            LastCommittedSolution.CommitSolution(pendingUpdate.Solution);
+
+            // Restart edit session with no active statements (switching to run mode).
+            RestartEditSession(newNonRemappableRegions, inBreakState: false, out documentsToReanalyze);
         }
 
         public void DiscardSolutionUpdate()
@@ -681,7 +632,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             baseActiveStatements,
                             newDocument,
                             newActiveStatementSpans: ImmutableArray<LinePositionSpan>.Empty,
-                            Capabilities,
+                            EditSession.Capabilities,
                             cancellationToken).ConfigureAwait(false);
 
                         // Document content did not change or unable to determine active statement spans in a document with syntax errors:
@@ -802,7 +753,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         continue;
                     }
 
-                    var analysis = await EditSession.Analyses.GetDocumentAnalysisAsync(LastCommittedSolution, oldUnmappedDocument, newUnmappedDocument, activeStatementSpanProvider, Capabilities, cancellationToken).ConfigureAwait(false);
+                    var analysis = await EditSession.Analyses.GetDocumentAnalysisAsync(LastCommittedSolution, oldUnmappedDocument, newUnmappedDocument, activeStatementSpanProvider, EditSession.Capabilities, cancellationToken).ConfigureAwait(false);
 
                     // Document content did not change or unable to determine active statement spans in a document with syntax errors:
                     if (!analysis.ActiveStatements.IsDefault)
@@ -866,7 +817,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     return null;
                 }
 
-                var analysis = await EditSession.Analyses.GetDocumentAnalysisAsync(LastCommittedSolution, oldDocument, newDocument, activeStatementSpanProvider, Capabilities, cancellationToken).ConfigureAwait(false);
+                var analysis = await EditSession.Analyses.GetDocumentAnalysisAsync(LastCommittedSolution, oldDocument, newDocument, activeStatementSpanProvider, EditSession.Capabilities, cancellationToken).ConfigureAwait(false);
                 if (!analysis.HasChanges)
                 {
                     // Document content did not change:
@@ -1114,9 +1065,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             public TestAccessor(DebuggingSession instance)
                 => _instance = instance;
-
-            public void SetNonRemappableRegions(ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> nonRemappableRegions)
-                => _instance.NonRemappableRegions = nonRemappableRegions;
 
             public ImmutableHashSet<Guid> GetModulesPreparedForUpdate()
             {

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilities.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueCapabilities.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
@@ -48,5 +49,34 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// Whether the runtime supports updating the Param table, and hence related edits (eg parameter renames)
         /// </summary>
         UpdateParameters = 1 << 6,
+    }
+
+    internal static class EditAndContinueCapabilitiesParser
+    {
+        public static EditAndContinueCapabilities Parse(ImmutableArray<string> capabilities)
+        {
+            var caps = EditAndContinueCapabilities.None;
+
+            foreach (var capability in capabilities)
+            {
+                caps |= capability switch
+                {
+                    "Baseline" => EditAndContinueCapabilities.Baseline,
+                    "AddMethodToExistingType" => EditAndContinueCapabilities.AddMethodToExistingType,
+                    "AddStaticFieldToExistingType" => EditAndContinueCapabilities.AddStaticFieldToExistingType,
+                    "AddInstanceFieldToExistingType" => EditAndContinueCapabilities.AddInstanceFieldToExistingType,
+                    "NewTypeDefinition" => EditAndContinueCapabilities.NewTypeDefinition,
+                    "ChangeCustomAttributes" => EditAndContinueCapabilities.ChangeCustomAttributes,
+                    "UpdateParameters" => EditAndContinueCapabilities.UpdateParameters,
+
+                    // To make it eaiser for  runtimes to specify more broad capabilities
+                    "AddDefinitionToExistingType" => EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.AddStaticFieldToExistingType | EditAndContinueCapabilities.AddInstanceFieldToExistingType,
+
+                    _ => EditAndContinueCapabilities.None
+                };
+            }
+
+            return caps;
+        }
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -28,7 +28,45 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal readonly DebuggingSession DebuggingSession;
         internal readonly EditSessionTelemetry Telemetry;
 
-        private readonly ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> _nonRemappableRegions;
+        // Maps active statement instructions reported by the debugger to their latest spans that might not yet have been applied
+        // (remapping not triggered yet). Consumed by the next edit session and updated when changes are committed at the end of the edit session.
+        //
+        // Consider a function F containing a call to function G. While G is being executed, F is updated a couple of times (in two edit sessions)
+        // before the thread returns from G and is remapped to the latest version of F. At the start of the second edit session,
+        // the active instruction reported by the debugger is still at the original location since function F has not been remapped yet (G has not returned yet).
+        //
+        // '>' indicates an active statement instruction for non-leaf frame reported by the debugger.
+        // v1 - before first edit, G executing
+        // v2 - after first edit, G still executing
+        // v3 - after second edit and G returned
+        //
+        // F v1:        F v2:       F v3:
+        // 0: nop       0: nop      0: nop
+        // 1> G()       1> nop      1: nop
+        // 2: nop       2: G()      2: nop
+        // 3: nop       3: nop      3> G()
+        //
+        // When entering a break state we query the debugger for current active statements.
+        // The returned statements reflect the current state of the threads in the runtime.
+        // When a change is successfully applied we remember changes in active statement spans.
+        // These changes are passed to the next edit session.
+        // We use them to map the spans for active statements returned by the debugger.
+        //
+        // In the above case the sequence of events is
+        // 1st break: get active statements returns (F, v=1, il=1, span1) the active statement is up-to-date
+        // 1st apply: detected span change for active statement (F, v=1, il=1): span1->span2
+        // 2nd break: previously updated statements contains (F, v=1, il=1)->span2
+        //            get active statements returns (F, v=1, il=1, span1) which is mapped to (F, v=1, il=1, span2) using previously updated statements
+        // 2nd apply: detected span change for active statement (F, v=1, il=1): span2->span3
+        // 3rd break: previously updated statements contains (F, v=1, il=1)->span3
+        //            get active statements returns (F, v=3, il=3, span3) the active statement is up-to-date
+        //
+        internal readonly ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> NonRemappableRegions;
+
+        /// <summary>
+        /// Gets the capabilities of the runtime with respect to applying code changes.
+        /// </summary>
+        internal readonly EditAndContinueCapabilities Capabilities;
 
         /// <summary>
         /// Lazily calculated map of base active statements.
@@ -40,6 +78,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         internal readonly EditAndContinueDocumentAnalysesCache Analyses;
 
+        /// <summary>
+        /// True for Edit and Continue edit sessions - when the application is in break state.
+        /// False for Hot Reload edit sessions - when the application is running.
+        /// </summary>
         internal readonly bool InBreakState;
 
         /// <summary>
@@ -50,13 +92,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private readonly HashSet<DocumentId> _documentsWithReportedDiagnostics = new();
         private readonly object _documentsWithReportedDiagnosticsGuard = new();
 
-        internal EditSession(DebuggingSession debuggingSession, EditSessionTelemetry telemetry, bool inBreakState)
+        internal EditSession(
+            DebuggingSession debuggingSession,
+            ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> nonRemappableRegions,
+            EditSessionTelemetry telemetry,
+            EditAndContinueCapabilities capabilities,
+            bool inBreakState)
         {
             DebuggingSession = debuggingSession;
+            NonRemappableRegions = nonRemappableRegions;
             Telemetry = telemetry;
-
-            _nonRemappableRegions = debuggingSession.NonRemappableRegions;
-
+            Capabilities = capabilities;
             InBreakState = inBreakState;
 
             BaseActiveStatements = inBreakState ?
@@ -93,7 +139,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 // Last committed solution reflects the state of the source that is in sync with the binaries that are loaded in the debuggee.
                 var debugInfos = await DebuggingSession.DebuggerService.GetActiveStatementsAsync(cancellationToken).ConfigureAwait(false);
-                return ActiveStatementsMap.Create(debugInfos, _nonRemappableRegions);
+                return ActiveStatementsMap.Create(debugInfos, NonRemappableRegions);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {
@@ -291,7 +337,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
             }
 
-            var analyses = await Analyses.GetDocumentAnalysesAsync(DebuggingSession.LastCommittedSolution, documents, newDocumentActiveStatementSpanProvider, DebuggingSession.Capabilities, cancellationToken).ConfigureAwait(false);
+            var analyses = await Analyses.GetDocumentAnalysesAsync(DebuggingSession.LastCommittedSolution, documents, newDocumentActiveStatementSpanProvider, Capabilities, cancellationToken).ConfigureAwait(false);
             return (analyses, documentDiagnostics.ToImmutable());
         }
 
@@ -777,7 +823,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             mvid,
                             oldActiveStatementsMap,
                             updatedMethodTokens,
-                            _nonRemappableRegions,
+                            NonRemappableRegions,
                             projectChanges.ActiveStatementChanges,
                             out var activeStatementsInUpdatedMethods,
                             out var moduleNonRemappableRegions,

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -139,7 +139,16 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             try
             {
                 var capabilities = await DebuggingSession.DebuggerService.GetCapabilitiesAsync(cancellationToken).ConfigureAwait(false);
-                return EditAndContinueCapabilitiesParser.Parse(capabilities);
+                var result = EditAndContinueCapabilitiesParser.Parse(capabilities);
+
+                // For now, runtimes aren't returning capabilities, we just fall back to a known set.
+                // https://github.com/dotnet/roslyn/issues/54386
+                if (result == EditAndContinueCapabilities.None)
+                {
+                    result = EditAndContinueCapabilities.Baseline | EditAndContinueCapabilities.AddMethodToExistingType | EditAndContinueCapabilities.AddStaticFieldToExistingType | EditAndContinueCapabilities.AddInstanceFieldToExistingType | EditAndContinueCapabilities.NewTypeDefinition;
+                }
+
+                return result;
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueAnalyzer.cs
@@ -7,11 +7,20 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
     internal interface IEditAndContinueAnalyzer : ILanguageService
     {
-        Task<DocumentAnalysisResults> AnalyzeDocumentAsync(Project baseProject, ActiveStatementsMap baseActiveStatements, Document document, ImmutableArray<LinePositionSpan> newActiveStatementSpans, EditAndContinueCapabilities capabilities, CancellationToken cancellationToken);
+        Task<DocumentAnalysisResults> AnalyzeDocumentAsync(
+            Project baseProject,
+            AsyncLazy<ActiveStatementsMap> lazyBaseActiveStatements,
+            Document document,
+            ImmutableArray<LinePositionSpan> newActiveStatementSpans,
+            AsyncLazy<EditAndContinueCapabilities> lazyCapabilities,
+            CancellationToken cancellationToken);
+
         ActiveStatementExceptionRegions GetExceptionRegions(SyntaxNode syntaxRoot, TextSpan unmappedActiveStatementSpan, bool isNonLeaf, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
@@ -15,6 +15,9 @@ namespace Roslyn.Utilities
     {
         public static AsyncLazy<T> Create<T>(Func<CancellationToken, Task<T>> asynchronousComputeFunction, bool cacheResult)
             => new(asynchronousComputeFunction, cacheResult);
+
+        public static AsyncLazy<T> Create<T>(T value)
+            => new(value);
     }
 
     /// <summary>


### PR DESCRIPTION
Removes mutable NonRemappableRegions from DebuggingSession.

Makes capabilities lazy - they are only needed when analyzing documents with changes, but not before such document is analyzed.

Allows capabilities to change during debugging session - they are still immutable within edit session. When the debugger attaches to a new process it can now restart edit session with new capabilities and active statements.

Debugger follow-up: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1371922