### PR TITLE
Enforce non-mutating LSP requests to run in parallel.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -228,7 +228,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         // Non mutating are fire-and-forget because they are by definition readonly. Any errors
                         // will be sent back to the client but we can still capture errors in queue processing
                         // via NFW, though these errors don't put us into a bad state as far as the rest of the queue goes.
-                        _ = Task.Run(() => ExecuteCallbackAsync(work, context, _cancelSource.Token).ReportNonFatalErrorAsync(), _cancelSource.Token);
+                        // Furthermore we use Task.Run here to protect ourselves against synchronous execution of work
+                        // blocking the request queue for longer periods of time (it enforces parallelizabilty).
+                        _ = Task.Run(() => ExecuteCallbackAsync(work, context, _cancelSource.Token), _cancelSource.Token).ReportNonFatalErrorAsync();
                     }
                 }
             }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/LongRunningNonMutatingRequestHandler.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/LongRunningNonMutatingRequestHandler.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit.Sdk;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
+{
+    [Shared, ExportLspRequestHandlerProvider, PartNotDiscoverable]
+    [ProvidesMethod(LongRunningNonMutatingRequestHandler.MethodName)]
+    internal class LongRunningNonMutatingRequestHandlerProvider : AbstractRequestHandlerProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public LongRunningNonMutatingRequestHandlerProvider()
+        {
+        }
+
+        public override ImmutableArray<IRequestHandler> CreateRequestHandlers() => ImmutableArray.Create<IRequestHandler>(new LongRunningNonMutatingRequestHandler());
+    }
+
+    internal class LongRunningNonMutatingRequestHandler : IRequestHandler<TestRequest, TestResponse>
+    {
+        public const string MethodName = nameof(LongRunningNonMutatingRequestHandler);
+
+        public string Method => MethodName;
+
+        public bool MutatesSolutionState => false;
+
+        public bool RequiresLSPSolution => true;
+
+        public TextDocumentIdentifier GetTextDocumentIdentifier(TestRequest request) => null;
+
+        public Task<TestResponse> HandleRequestAsync(TestRequest request, RequestContext context, CancellationToken cancellationToken)
+        {
+            do
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return Task.FromResult(new TestResponse());
+                }
+
+                Thread.Sleep(100);
+            } while (true);
+
+            throw new XunitException("Somehow we got past an infinite delay without cancelling. This is unexpected");
+        }
+    }
+}

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/LongRunningNonMutatingRequestHandler.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/LongRunningNonMutatingRequestHandler.cs
@@ -16,7 +16,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 {
-    [Shared, ExportLspRequestHandlerProvider, PartNotDiscoverable]
+    [Shared, ExportRoslynLanguagesLspRequestHandlerProvider, PartNotDiscoverable]
     [ProvidesMethod(LongRunningNonMutatingRequestHandler.MethodName)]
     internal class LongRunningNonMutatingRequestHandlerProvider : AbstractRequestHandlerProvider
     {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -22,7 +22,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             .AddParts(typeof(NonMutatingRequestHandlerProvider))
             .AddParts(typeof(FailingRequestHandlerProvider))
             .AddParts(typeof(FailingMutatingRequestHandlerProvider))
-            .AddParts(typeof(NonLSPSolutionRequestHandlerProvider));
+            .AddParts(typeof(NonLSPSolutionRequestHandlerProvider))
+            .AddParts(typeof(LongRunningNonMutatingRequestHandlerProvider));
 
         [Fact]
         public async Task MutatingRequestsDontOverlap()
@@ -118,6 +119,32 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 
             Assert.Empty(responses.Where(r => r.StartTime == default));
             Assert.All(responses, r => Assert.True(r.EndTime > r.StartTime));
+        }
+
+        [Fact]
+        public async Task LongRunningSynchronousNonMutatingTaskDoesNotBlockQueue()
+        {
+            var requests = new[] {
+                new TestRequest(LongRunningNonMutatingRequestHandler.MethodName),
+                new TestRequest(MutatingRequestHandler.MethodName),
+                new TestRequest(NonMutatingRequestHandler.MethodName),
+            };
+
+            using var testLspServer = CreateTestLspServer("class C { }", out _);
+
+            // Cancel all requests if we hang for 5 seconds. This will result in a failed test run.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var waitables = StartTestRun(testLspServer, requests, cts.Token);
+
+            // Non-long running tasks should run and complete. If there's a test-failure for a "cancellation"
+            // at this point it means our long running task blocked the queue and prevented completion.
+            var responses = await Task.WhenAll(waitables.Skip(1));
+            Assert.Empty(responses.Where(r => r.StartTime == default));
+            Assert.All(responses, r => Assert.True(r.EndTime > r.StartTime));
+
+            // Our long-running waitable should still be running until cancelled.
+            var longRunningWaitable = waitables[0];
+            Assert.False(longRunningWaitable.IsCompleted);
         }
 
         [Fact]
@@ -235,14 +262,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             return responses;
         }
 
-        private static List<Task<TestResponse>> StartTestRun(TestLspServer testLspServer, TestRequest[] requests)
+        private static List<Task<TestResponse>> StartTestRun(TestLspServer testLspServer, TestRequest[] requests, CancellationToken cancellationToken = default)
         {
             var clientCapabilities = new LSP.ClientCapabilities();
 
             var waitables = new List<Task<TestResponse>>();
             foreach (var request in requests)
             {
-                waitables.Add(testLspServer.ExecuteRequestAsync<TestRequest, TestResponse>(request.MethodName, request, clientCapabilities, null, CancellationToken.None));
+                waitables.Add(testLspServer.ExecuteRequestAsync<TestRequest, TestResponse>(request.MethodName, request, clientCapabilities, null, cancellationToken));
             }
 
             return waitables;

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             using var testLspServer = CreateTestLspServer("class C { }", out _);
 
             // Cancel all requests if we hang for 5 seconds. This will result in a failed test run.
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
             var waitables = StartTestRun(testLspServer, requests, cts.Token);
 
             // Non-long running tasks should run and complete. If there's a test-failure for a "cancellation"


### PR DESCRIPTION
- As I was investigating a customer app's performance issues I was met met with C#'s [LSP request handler queue](https://github.com/dotnet/roslyn/blob/909e6dc8eda8ee5898b4e1339c512c44970bcff6/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs#L199). The queues responsibility is to [await mutating requests](https://github.com/dotnet/roslyn/blob/909e6dc8eda8ee5898b4e1339c512c44970bcff6/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs#L217) (ones that mutate solution state) and try and [parallelize non-mutating requests](https://github.com/dotnet/roslyn/blob/909e6dc8eda8ee5898b4e1339c512c44970bcff6/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs#L224-L227). When investigating I found that we weren't truly enforcing the parallelizability of the non-mutating requests which meant if an async operation ran synchronously it would block the entire execution of the queue. Turns out semantic tokens, completion and a few other requests exhibited this behavior. To work around this behavior we now `Task.Run` each work item to ensure they can each operate in parallel.
- Added tests to validate that long-running non-mutating requests don't block queue execution.

Fixes #55589