### PR TITLE
Don't hold onto documents in 'Find' features

### DIFF
--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindBaseSymbolsCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindBaseSymbolsCommandHandler.cs
@@ -70,12 +70,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                     KeyValueLogMessage.Create(LogType.UserAction, m => m["type"] = "streaming"),
                     cancellationToken))
                 {
+                    var solution = document.Project.Solution;
                     try
                     {
                         var relevantSymbol = await FindUsagesHelpers.GetRelevantSymbolAndProjectAtPositionAsync(document, caretPosition, cancellationToken).ConfigureAwait(false);
 
                         var overriddenSymbol = relevantSymbol?.symbol.GetOverriddenMember();
-                        var solution = document.Project.Solution;
                         while (overriddenSymbol != null)
                         {
                             if (cancellationToken.IsCancellationRequested)
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                     }
                     finally
                     {
-                        await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                        await context.OnCompletedAsync(solution, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindBaseSymbolsCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindBaseSymbolsCommandHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                         var relevantSymbol = await FindUsagesHelpers.GetRelevantSymbolAndProjectAtPositionAsync(document, caretPosition, cancellationToken).ConfigureAwait(false);
 
                         var overriddenSymbol = relevantSymbol?.symbol.GetOverriddenMember();
-
+                        var solution = document.Project.Solution;
                         while (overriddenSymbol != null)
                         {
                             if (cancellationToken.IsCancellationRequested)
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                             }
 
                             var definitionItem = overriddenSymbol.ToNonClassifiedDefinitionItem(document.Project.Solution, true);
-                            await context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                            await context.OnDefinitionFoundAsync(solution, definitionItem, cancellationToken).ConfigureAwait(false);
 
                             // try getting the next one
                             overriddenSymbol = overriddenSymbol.GetOverriddenMember();

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindDerivedSymbolsCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindDerivedSymbolsCommandHandler.cs
@@ -100,13 +100,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                         if (candidateSymbolProjectPair?.symbol == null)
                             return;
 
-                        var candidates = await GatherSymbolsAsync(candidateSymbolProjectPair.Value.symbol,
-                            document.Project.Solution, cancellationToken).ConfigureAwait(false);
+                        var solution = document.Project.Solution;
+                        var candidates = await GatherSymbolsAsync(
+                            candidateSymbolProjectPair.Value.symbol, solution, cancellationToken).ConfigureAwait(false);
 
                         foreach (var candidate in candidates)
                         {
                             var definitionItem = candidate.ToNonClassifiedDefinitionItem(document.Project.Solution, true);
-                            await context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                            await context.OnDefinitionFoundAsync(solution, definitionItem, cancellationToken).ConfigureAwait(false);
                         }
                     }
                 }

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindDerivedSymbolsCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindDerivedSymbolsCommandHandler.cs
@@ -84,6 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
         private async Task FindDerivedSymbolsAsync(
             Document document, int caretPosition, IStreamingFindUsagesPresenter presenter)
         {
+            var solution = document.Project.Solution;
             try
             {
                 using var token = _asyncListener.BeginAsyncOperation(nameof(FindDerivedSymbolsAsync));
@@ -100,7 +101,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                         if (candidateSymbolProjectPair?.symbol == null)
                             return;
 
-                        var solution = document.Project.Solution;
                         var candidates = await GatherSymbolsAsync(
                             candidateSymbolProjectPair.Value.symbol, solution, cancellationToken).ConfigureAwait(false);
 
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                 }
                 finally
                 {
-                    await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                    await context.OnCompletedAsync(solution, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindExtensionMethodsCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindExtensionMethodsCommandHandler.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
 
                                     var definitionItem = reducedMethod.ToNonClassifiedDefinitionItem(solution, true);
 
-                                    await context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                                    await context.OnDefinitionFoundAsync(solution, definitionItem, cancellationToken).ConfigureAwait(false);
                                 }
                             }
                         }

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindExtensionMethodsCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindExtensionMethodsCommandHandler.cs
@@ -62,67 +62,65 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
         private async Task FindExtensionMethodsAsync(
             Document document, int caretPosition, IStreamingFindUsagesPresenter presenter)
         {
+            var solution = document.Project.Solution;
             try
             {
                 using var token = _asyncListener.BeginAsyncOperation(nameof(FindExtensionMethodsAsync));
 
                 var (context, cancellationToken) = presenter.StartSearch(EditorFeaturesResources.Navigating, supportsReferences: true);
 
-                using (Logger.LogBlock(
-                    FunctionId.CommandHandler_FindAllReference,
-                    KeyValueLogMessage.Create(LogType.UserAction, m => m["type"] = "streaming"),
-                    cancellationToken))
+                try
                 {
-                    var candidateSymbolProjectPair = await FindUsagesHelpers.GetRelevantSymbolAndProjectAtPositionAsync(document, caretPosition, cancellationToken).ConfigureAwait(false);
-
-                    var symbol = candidateSymbolProjectPair?.symbol as INamedTypeSymbol;
-
-                    // if we didn't get the right symbol, just abort
-                    if (symbol == null)
+                    using (Logger.LogBlock(
+                        FunctionId.CommandHandler_FindAllReference,
+                        KeyValueLogMessage.Create(LogType.UserAction, m => m["type"] = "streaming"),
+                        cancellationToken))
                     {
-                        await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
-                        return;
-                    }
+                        var candidateSymbolProjectPair = await FindUsagesHelpers.GetRelevantSymbolAndProjectAtPositionAsync(document, caretPosition, cancellationToken).ConfigureAwait(false);
 
-                    if (!document.Project.TryGetCompilation(out var compilation))
-                    {
-                        await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
-                        return;
-                    }
+                        var symbol = candidateSymbolProjectPair?.symbol as INamedTypeSymbol;
 
-                    var solution = document.Project.Solution;
+                        // if we didn't get the right symbol, just abort
+                        if (symbol == null)
+                            return;
 
-                    foreach (var type in compilation.Assembly.GlobalNamespace.GetAllTypes(cancellationToken))
-                    {
-                        if (!type.MightContainExtensionMethods)
-                            continue;
+                        if (!document.Project.TryGetCompilation(out var compilation))
+                            return;
 
-                        foreach (var extMethod in type.GetMembers().OfType<IMethodSymbol>().Where(method => method.IsExtensionMethod))
+                        foreach (var type in compilation.Assembly.GlobalNamespace.GetAllTypes(cancellationToken))
                         {
-                            if (cancellationToken.IsCancellationRequested)
-                                break;
+                            if (!type.MightContainExtensionMethods)
+                                continue;
 
-                            var reducedMethod = extMethod.ReduceExtensionMethod(symbol);
-                            if (reducedMethod != null)
+                            foreach (var extMethod in type.GetMembers().OfType<IMethodSymbol>().Where(method => method.IsExtensionMethod))
                             {
-                                var loc = extMethod.Locations.First();
+                                if (cancellationToken.IsCancellationRequested)
+                                    break;
 
-                                var sourceDefinition = await SymbolFinder.FindSourceDefinitionAsync(reducedMethod, solution, cancellationToken).ConfigureAwait(false);
-
-                                // And if our definition actually is from source, then let's re-figure out what project it came from
-                                if (sourceDefinition != null)
+                                var reducedMethod = extMethod.ReduceExtensionMethod(symbol);
+                                if (reducedMethod != null)
                                 {
-                                    var originatingProject = solution.GetProject(sourceDefinition.ContainingAssembly, cancellationToken);
+                                    var loc = extMethod.Locations.First();
 
-                                    var definitionItem = reducedMethod.ToNonClassifiedDefinitionItem(solution, true);
+                                    var sourceDefinition = await SymbolFinder.FindSourceDefinitionAsync(reducedMethod, solution, cancellationToken).ConfigureAwait(false);
 
-                                    await context.OnDefinitionFoundAsync(solution, definitionItem, cancellationToken).ConfigureAwait(false);
+                                    // And if our definition actually is from source, then let's re-figure out what project it came from
+                                    if (sourceDefinition != null)
+                                    {
+                                        var originatingProject = solution.GetProject(sourceDefinition.ContainingAssembly, cancellationToken);
+
+                                        var definitionItem = reducedMethod.ToNonClassifiedDefinitionItem(solution, true);
+
+                                        await context.OnDefinitionFoundAsync(solution, definitionItem, cancellationToken).ConfigureAwait(false);
+                                    }
                                 }
                             }
                         }
                     }
-
-                    await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    await context.OnCompletedAsync(solution, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindImplementingMembersCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindImplementingMembersCommandHandler.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                     continue;
 
                 var definitionItem = impl.ToNonClassifiedDefinitionItem(project.Solution, true);
-                await context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                await context.OnDefinitionFoundAsync(project.Solution, definitionItem, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindImplementingMembersCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindImplementingMembersCommandHandler.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                     }
                     finally
                     {
-                        await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                        await context.OnCompletedAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindMemberOverloadsCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindMemberOverloadsCommandHandler.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                     KeyValueLogMessage.Create(LogType.UserAction, m => m["type"] = "streaming"),
                     cancellationToken))
                 {
+                    var solution = document.Project.Solution;
                     try
                     {
                         var candidateSymbolProjectPair = await FindUsagesHelpers.GetRelevantSymbolAndProjectAtPositionAsync(document, caretPosition, cancellationToken).ConfigureAwait(false);
@@ -81,7 +82,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                         if (symbol == null || symbol.ContainingType == null)
                             return;
 
-                        var solution = document.Project.Solution;
                         foreach (var curSymbol in symbol.ContainingType.GetMembers()
                                                         .Where(m => m.Kind == symbol.Kind && m.Name == symbol.Name))
                         {
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                     }
                     finally
                     {
-                        await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                        await context.OnCompletedAsync(solution, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindMemberOverloadsCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindMemberOverloadsCommandHandler.cs
@@ -81,11 +81,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                         if (symbol == null || symbol.ContainingType == null)
                             return;
 
+                        var solution = document.Project.Solution;
                         foreach (var curSymbol in symbol.ContainingType.GetMembers()
                                                         .Where(m => m.Kind == symbol.Kind && m.Name == symbol.Name))
                         {
-                            var definitionItem = curSymbol.ToNonClassifiedDefinitionItem(document.Project.Solution, true);
-                            await context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                            var definitionItem = curSymbol.ToNonClassifiedDefinitionItem(solution, includeHiddenLocations: true);
+                            await context.OnDefinitionFoundAsync(solution, definitionItem, cancellationToken).ConfigureAwait(false);
                         }
                     }
                     finally

--- a/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindReferencesOfOverloadsCommandHandler.cs
+++ b/src/EditorFeatures/Core.Cocoa/NavigationCommandHandlers/FindReferencesOfOverloadsCommandHandler.cs
@@ -108,6 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                     KeyValueLogMessage.Create(LogType.UserAction, m => m["type"] = "streaming"),
                     cancellationToken))
                 {
+                    var solution = document.Project.Solution;
                     var symbolsToLookup = new List<ISymbol>();
 
                     foreach (var curSymbol in symbol.ContainingType.GetMembers()
@@ -122,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                         foreach (var sym in SymbolFinder.FindSimilarSymbols(curSymbol, compilation, cancellationToken))
                         {
                             // assumption here is, that FindSimilarSymbols returns symbols inside same project
-                            var symbolsToAdd = await GatherSymbolsAsync(sym, document.Project.Solution, cancellationToken).ConfigureAwait(false);
+                            var symbolsToAdd = await GatherSymbolsAsync(sym, solution, cancellationToken).ConfigureAwait(false);
                             symbolsToLookup.AddRange(symbolsToAdd);
                         }
                     }
@@ -137,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationCommandHandlers
                     // that means that a new search has started.  We don't care about telling the
                     // context it has completed.  In the latter case something wrong has happened
                     // and we don't want to run any more code in this particular context.
-                    await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                    await context.OnCompletedAsync(solution, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)

--- a/src/EditorFeatures/Core/CommandHandlers/AbstractGoToCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/AbstractGoToCommandHandler.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
                 return context.Message;
 
             await _streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                _threadingContext, document.Project.Solution.Workspace, context.SearchTitle, context.GetDefinitions(), cancellationToken).ConfigureAwait(false);
+                _threadingContext, document.Project.Solution, context.SearchTitle, context.GetDefinitions(), cancellationToken).ConfigureAwait(false);
             return null;
         }
     }

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptFindUsagesService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptFindUsagesService.cs
@@ -28,18 +28,20 @@ namespace Microsoft.CodeAnalysis.Editor.ExternalAccess.VSTypeScript
         }
 
         public Task FindReferencesAsync(Document document, int position, IFindUsagesContext context, CancellationToken cancellationToken)
-            => _underlyingService.FindReferencesAsync(document, position, new VSTypeScriptFindUsagesContext(context), cancellationToken);
+            => _underlyingService.FindReferencesAsync(document, position, new VSTypeScriptFindUsagesContext(document.Project.Solution, context), cancellationToken);
 
         public Task FindImplementationsAsync(Document document, int position, IFindUsagesContext context, CancellationToken cancellationToken)
-            => _underlyingService.FindImplementationsAsync(document, position, new VSTypeScriptFindUsagesContext(context), cancellationToken);
+            => _underlyingService.FindImplementationsAsync(document, position, new VSTypeScriptFindUsagesContext(document.Project.Solution, context), cancellationToken);
 
         private class VSTypeScriptFindUsagesContext : IVSTypeScriptFindUsagesContext
         {
+            private readonly Solution _solution;
             private readonly IFindUsagesContext _context;
             private readonly Dictionary<VSTypeScriptDefinitionItem, DefinitionItem> _definitionItemMap = new();
 
-            public VSTypeScriptFindUsagesContext(IFindUsagesContext context)
+            public VSTypeScriptFindUsagesContext(Solution solution, IFindUsagesContext context)
             {
+                _solution = solution;
                 _context = context;
             }
 
@@ -75,13 +77,13 @@ namespace Microsoft.CodeAnalysis.Editor.ExternalAccess.VSTypeScript
             public ValueTask OnDefinitionFoundAsync(VSTypeScriptDefinitionItem definition, CancellationToken cancellationToken)
             {
                 var item = GetOrCreateDefinitionItem(definition);
-                return _context.OnDefinitionFoundAsync(item, cancellationToken);
+                return _context.OnDefinitionFoundAsync(_solution, item, cancellationToken);
             }
 
             public ValueTask OnReferenceFoundAsync(VSTypeScriptSourceReferenceItem reference, CancellationToken cancellationToken)
             {
                 var item = GetOrCreateDefinitionItem(reference.Definition);
-                return _context.OnReferenceFoundAsync(new SourceReferenceItem(item, reference.SourceSpan, reference.SymbolUsageInfo), cancellationToken);
+                return _context.OnReferenceFoundAsync(_solution, new SourceReferenceItem(item, reference.SourceSpan, reference.SymbolUsageInfo), cancellationToken);
             }
         }
 

--- a/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
+++ b/src/EditorFeatures/Core/FindReferences/FindReferencesCommandHandler.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
                     }
                     finally
                     {
-                        await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                        await context.OnCompletedAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.DefinitionTrackingContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.DefinitionTrackingContext.cs
@@ -39,17 +39,17 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             public ValueTask SetSearchTitleAsync(string title, CancellationToken cancellationToken)
                 => _underlyingContext.SetSearchTitleAsync(title, cancellationToken);
 
-            public ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
-                => _underlyingContext.OnReferenceFoundAsync(reference, cancellationToken);
+            public ValueTask OnReferenceFoundAsync(Solution solution, SourceReferenceItem reference, CancellationToken cancellationToken)
+                => _underlyingContext.OnReferenceFoundAsync(solution, reference, cancellationToken);
 
-            public ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken)
+            public ValueTask OnDefinitionFoundAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken)
             {
                 lock (_gate)
                 {
                     _definitions.Add(definition);
                 }
 
-                return _underlyingContext.OnDefinitionFoundAsync(definition, cancellationToken);
+                return _underlyingContext.OnDefinitionFoundAsync(solution, definition, cancellationToken);
             }
 
             public ImmutableArray<DefinitionItem> GetDefinitions()

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
@@ -42,8 +42,10 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             {
                 var documentSpan = await ClassifiedSpansAndHighlightSpanFactory.GetClassifiedDocumentSpanAsync(
                     document, span, cancellationToken).ConfigureAwait(false);
-                await _context.OnReferenceFoundAsync(new SourceReferenceItem(
-                    _definition, documentSpan, SymbolUsageInfo.None), cancellationToken).ConfigureAwait(false);
+                await _context.OnReferenceFoundAsync(
+                    document.Project.Solution,
+                    new SourceReferenceItem(_definition, documentSpan, SymbolUsageInfo.None),
+                    cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -84,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             // Do nothing functions.  The streaming far service doesn't care about
             // any of these.
             public ValueTask OnStartedAsync(CancellationToken cancellationToken) => default;
-            public ValueTask OnCompletedAsync(CancellationToken cancellationToken) => default;
+            public ValueTask OnCompletedAsync(Solution solution, CancellationToken cancellationToken) => default;
             public ValueTask OnFindInDocumentStartedAsync(Document document, CancellationToken cancellationToken) => default;
             public ValueTask OnFindInDocumentCompletedAsync(Document document, CancellationToken cancellationToken) => default;
 
@@ -115,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             public async ValueTask OnDefinitionFoundAsync(SymbolGroup group, CancellationToken cancellationToken)
             {
                 var definitionItem = await GetDefinitionItemAsync(group, cancellationToken).ConfigureAwait(false);
-                await _context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                await _context.OnDefinitionFoundAsync(_solution, definitionItem, cancellationToken).ConfigureAwait(false);
             }
 
             public async ValueTask OnReferenceFoundAsync(SymbolGroup group, ISymbol definition, ReferenceLocation location, CancellationToken cancellationToken)
@@ -126,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                     cancellationToken).ConfigureAwait(false);
 
                 if (referenceItem != null)
-                    await _context.OnReferenceFoundAsync(referenceItem, cancellationToken).ConfigureAwait(false);
+                    await _context.OnReferenceFoundAsync(_solution, referenceItem, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindImplementations.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindImplementations.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 var definitionItem = await implementation.ToClassifiedDefinitionItemAsync(
                     solution, isPrimary: true, includeHiddenLocations: false, FindReferencesSearchOptions.Default, cancellationToken).ConfigureAwait(false);
 
-                await context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                await context.OnDefinitionFoundAsync(project.Solution, definitionItem, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService_FindReferences.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             foreach (var definition in thirdPartyDefinitions)
             {
                 // Don't need ConfigureAwait(true) here 
-                await context.OnDefinitionFoundAsync(definition, cancellationToken).ConfigureAwait(false);
+                await context.OnDefinitionFoundAsync(document.Project.Solution, definition, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 ImmutableArray.Create(TextTags.StringLiteral),
                 ImmutableArray.Create(new TaggedText(TextTags.Text, searchTitle)));
 
-            await context.OnDefinitionFoundAsync(definition, cancellationToken).ConfigureAwait(false);
+            await context.OnDefinitionFoundAsync(document.Project.Solution, definition, cancellationToken).ConfigureAwait(false);
 
             var progressAdapter = new FindLiteralsProgressAdapter(context, definition);
 

--- a/src/EditorFeatures/Core/FindUsages/FindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/FindUsagesContext.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
 
         public virtual ValueTask SetSearchTitleAsync(string title, CancellationToken cancellationToken) => default;
 
-        public virtual ValueTask OnCompletedAsync(CancellationToken cancellationToken) => default;
+        public virtual ValueTask OnCompletedAsync(Solution solution, CancellationToken cancellationToken) => default;
 
         public virtual ValueTask OnDefinitionFoundAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken) => default;
 

--- a/src/EditorFeatures/Core/FindUsages/FindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/FindUsagesContext.cs
@@ -21,9 +21,9 @@ namespace Microsoft.CodeAnalysis.FindUsages
 
         public virtual ValueTask OnCompletedAsync(CancellationToken cancellationToken) => default;
 
-        public virtual ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken) => default;
+        public virtual ValueTask OnDefinitionFoundAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken) => default;
 
-        public virtual ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken) => default;
+        public virtual ValueTask OnReferenceFoundAsync(Solution solution, SourceReferenceItem reference, CancellationToken cancellationToken) => default;
 
         protected virtual ValueTask ReportProgressAsync(int current, int maximum, CancellationToken cancellationToken) => default;
     }

--- a/src/EditorFeatures/Core/FindUsages/SimpleFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/SimpleFindUsagesContext.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             }
         }
 
-        public override ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken)
+        public override ValueTask OnDefinitionFoundAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken)
         {
             lock (_gate)
             {
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             return default;
         }
 
-        public override ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
+        public override ValueTask OnReferenceFoundAsync(Solution solution, SourceReferenceItem reference, CancellationToken cancellationToken)
         {
             lock (_gate)
             {

--- a/src/EditorFeatures/Core/GoToBase/AbstractGoToBaseService.cs
+++ b/src/EditorFeatures/Core/GoToBase/AbstractGoToBaseService.cs
@@ -51,14 +51,14 @@ namespace Microsoft.CodeAnalysis.Editor.GoToBase
                     var definitionItem = await sourceDefinition.ToClassifiedDefinitionItemAsync(
                         solution, isPrimary: true, includeHiddenLocations: false, FindReferencesSearchOptions.Default, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                    await context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                    await context.OnDefinitionFoundAsync(solution, definitionItem, cancellationToken).ConfigureAwait(false);
                     found = true;
                 }
                 else if (baseSymbol.Locations.Any(l => l.IsInMetadata))
                 {
                     var definitionItem = baseSymbol.ToNonClassifiedDefinitionItem(
                         solution, includeHiddenLocations: true);
-                    await context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
+                    await context.OnDefinitionFoundAsync(solution, definitionItem, cancellationToken).ConfigureAwait(false);
                     found = true;
                 }
             }

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 
             return _threadingContext.JoinableTaskFactory.Run(() =>
                 _streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                    _threadingContext, solution.Workspace, title, definitions, cancellationToken));
+                    _threadingContext, solution, title, definitions, cancellationToken));
         }
 
         private static bool IsThirdPartyNavigationAllowed(ISymbol symbolToNavigateTo, int caretPosition, Document document, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 
             return threadingContext.JoinableTaskFactory.Run(
                 () => streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                    threadingContext, solution.Workspace, title, definitions, cancellationToken));
+                    threadingContext, solution, title, definitions, cancellationToken));
         }
 
         public static bool TryGoToDefinition(
@@ -127,23 +127,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 
             return threadingContext.JoinableTaskFactory.Run(() =>
                 streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                    threadingContext, solution.Workspace, title, definitions, cancellationToken));
-        }
-
-        public static bool TryGoToDefinition(
-            ImmutableArray<DefinitionItem> definitions,
-            Workspace workspace,
-            string title,
-            IThreadingContext threadingContext,
-            IStreamingFindUsagesPresenter streamingPresenter,
-            CancellationToken cancellationToken)
-        {
-            if (definitions.IsDefaultOrEmpty)
-                return false;
-
-            return threadingContext.JoinableTaskFactory.Run(() =>
-                streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                    threadingContext, workspace, title, definitions, cancellationToken));
+                    threadingContext, solution, title, definitions, cancellationToken));
         }
     }
 }

--- a/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
+++ b/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Editor.Host
                 }
                 finally
                 {
-                    await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                    await context.OnCompletedAsync(solution, cancellationToken).ConfigureAwait(false);
                 }
             }
 

--- a/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
+++ b/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.Host
         public static async Task<bool> TryNavigateToOrPresentItemsAsync(
             this IStreamingFindUsagesPresenter presenter,
             IThreadingContext threadingContext,
-            Workspace workspace,
+            Solution solution,
             string title,
             ImmutableArray<DefinitionItem> items,
             CancellationToken cancellationToken)
@@ -68,6 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.Host
             // Can only navigate or present items on UI thread.
             await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
+            var workspace = solution.Workspace;
             // Ignore any definitions that we can't navigate to.
             var definitions = items.WhereAsArray(d => d.CanNavigateTo(workspace, cancellationToken));
 
@@ -111,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.Host
                 try
                 {
                     foreach (var definition in nonExternalItems)
-                        await context.OnDefinitionFoundAsync(definition, cancellationToken).ConfigureAwait(false);
+                        await context.OnDefinitionFoundAsync(solution, definition, cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/FindReferences/FindReferencesCommandHandlerTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
         {
             public readonly List<DefinitionItem> Result = new List<DefinitionItem>();
 
-            public override ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken)
+            public override ValueTask OnDefinitionFoundAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken)
             {
                 lock (Result)
                 {

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -98,11 +98,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
                 .ToImmutableArray();
             for (var i = 0; i < expectedTargets.Length; i++)
             {
-                VerifyInheritanceTarget(expectedTargets[i], sortedActualTargets[i]);
+                VerifyInheritanceTarget(testWorkspace.CurrentSolution, expectedTargets[i], sortedActualTargets[i]);
             }
         }
 
-        private static void VerifyInheritanceTarget(TestInheritanceTargetItem expectedTarget, InheritanceTargetItem actualTarget)
+        private static void VerifyInheritanceTarget(Solution solution, TestInheritanceTargetItem expectedTarget, InheritanceTargetItem actualTarget)
         {
             Assert.Equal(expectedTarget.TargetSymbolName, actualTarget.DefinitionItem.DisplayParts.JoinText());
             Assert.Equal(expectedTarget.RelationshipToMember, actualTarget.RelationToMember);
@@ -120,7 +120,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
                 for (var i = 0; i < actualDocumentSpans.Length; i++)
                 {
                     Assert.Equal(expectedDocumentSpans[i].SourceSpan, actualDocumentSpans[i].SourceSpan);
-                    Assert.Equal(expectedDocumentSpans[i].Document.FilePath, actualDocumentSpans[i].Document.FilePath);
+                    var document = solution.GetRequiredDocument(actualDocumentSpans[i].DocumentId);
+                    Assert.Equal(expectedDocumentSpans[i].Document.FilePath, document.FilePath);
                 }
             }
         }

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -67,8 +67,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                 For Each cursorDocument In workspace.Documents.Where(Function(d) d.CursorPosition.HasValue)
                     Dim cursorPosition = cursorDocument.CursorPosition.Value
 
-                    Dim startDocument = If(workspace.CurrentSolution.GetDocument(cursorDocument.Id),
-                                      Await workspace.CurrentSolution.GetSourceGeneratedDocumentAsync(cursorDocument.Id, CancellationToken.None))
+                    Dim solution = workspace.CurrentSolution
+                    Dim startDocument = If(solution.GetDocument(cursorDocument.Id),
+                                      Await solution.GetSourceGeneratedDocumentAsync(cursorDocument.Id, CancellationToken.None))
                     Assert.NotNull(startDocument)
 
                     Dim findRefsService = startDocument.GetLanguageService(Of IFindUsagesService)
@@ -81,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                             Select(Function(d) New FileNameAndSpans(
                                                    d.Name, d.AnnotatedSpans(DefinitionKey).ToList())).ToList()
 
-                    Dim actualDefinitions = GetFileNamesAndSpans(
+                    Dim actualDefinitions = GetFileNamesAndSpans(solution,
                         context.Definitions.Where(AddressOf context.ShouldShow).
                                             SelectMany(Function(d) d.SourceSpans))
 
@@ -93,7 +94,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                             Select(Function(d) New FileNameAndSpans(
                                                    d.Name, d.SelectedSpans.ToList())).ToList()
 
-                    Dim actualReferences = GetFileNamesAndSpans(
+                    Dim actualReferences = GetFileNamesAndSpans(solution,
                         context.References.Select(Function(r) r.SourceSpan))
 
                     Assert.Equal(expectedReferences, actualReferences)
@@ -106,7 +107,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                             Select(Function(d) New FileNameAndSpans(
                                                    d.Name, d.AnnotatedSpans(key).ToList())).ToList()
                         Dim valueUsageInfoField = key.Substring(ValueUsageInfoKey.Length)
-                        Dim actual = GetFileNamesAndSpans(
+                        Dim actual = GetFileNamesAndSpans(solution,
                             context.References.Where(Function(r) r.SymbolUsageInfo.ValueUsageInfoOpt?.ToString() = valueUsageInfoField).Select(Function(r) r.SourceSpan))
 
                         Assert.Equal(expected, actual)
@@ -120,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                             Select(Function(d) New FileNameAndSpans(
                                                    d.Name, d.AnnotatedSpans(key).ToList())).ToList()
                         Dim typeOrNamespaceUsageInfoFieldNames = key.Substring(TypeOrNamespaceUsageInfoKey.Length).Split(","c).Select(Function(s) s.Trim)
-                        Dim actual = GetFileNamesAndSpans(
+                        Dim actual = GetFileNamesAndSpans(solution,
                             context.References.Where(Function(r)
                                                          Return r.SymbolUsageInfo.TypeOrNamespaceUsageInfoOpt IsNot Nothing AndAlso
                                                                 r.SymbolUsageInfo.TypeOrNamespaceUsageInfoOpt.ToString().Split(","c).Select(Function(s) s.Trim).SetEquals(typeOrNamespaceUsageInfoFieldNames)
@@ -139,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                                 OrderBy(Function(d) d.Name).
                                                 Select(Function(d) New FileNameAndSpans(
                                                        d.Name, d.AnnotatedSpans(annotationKey).ToList())).ToList()
-                            Dim actual = GetFileNamesAndSpans(
+                            Dim actual = GetFileNamesAndSpans(solution,
                                 context.References.Where(Function(r)
                                                              Dim actualValue As String = Nothing
                                                              If r.AdditionalProperties.TryGetValue(propertyName, actualValue) Then
@@ -176,14 +177,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             Return additionalPropertiesMap
         End Function
 
-        Private Shared Function GetFileNamesAndSpans(items As IEnumerable(Of DocumentSpan)) As List(Of FileNameAndSpans)
-            Return items.Where(Function(i) i.Document IsNot Nothing).
-                         GroupBy(Function(i) i.Document).
+        Private Shared Function GetFileNamesAndSpans(solution As Solution, items As IEnumerable(Of SerializableDocumentSpan)) As List(Of FileNameAndSpans)
+            Return items.Where(Function(i) i.DocumentId IsNot Nothing).
+                         GroupBy(Function(i) solution.GetRequiredDocument(i.DocumentId)).
                          OrderBy(Function(g) g.Key.Name).
                          Select(Function(g) GetFileNameAndSpans(g)).ToList()
         End Function
 
-        Private Shared Function GetFileNameAndSpans(g As IGrouping(Of Document, DocumentSpan)) As FileNameAndSpans
+        Private Shared Function GetFileNameAndSpans(g As IGrouping(Of Document, SerializableDocumentSpan)) As FileNameAndSpans
             Return New FileNameAndSpans(
                 g.Key.Name,
                 g.Select(Function(i) i.SourceSpan).OrderBy(Function(s) s.Start).
@@ -232,7 +233,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                 Return definition.DisplayIfNoReferences
             End Function
 
-            Public Overrides Function OnDefinitionFoundAsync(definition As DefinitionItem, cancellationToken As CancellationToken) As ValueTask
+            Public Overrides Function OnDefinitionFoundAsync(solution As Solution, definition As DefinitionItem, cancellationToken As CancellationToken) As ValueTask
                 SyncLock gate
                     Me.Definitions.Add(definition)
                 End SyncLock
@@ -240,7 +241,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                 Return Nothing
             End Function
 
-            Public Overrides Function OnReferenceFoundAsync(reference As SourceReferenceItem, cancellationToken As CancellationToken) As ValueTask
+            Public Overrides Function OnReferenceFoundAsync(solution As Solution, reference As SourceReferenceItem, cancellationToken As CancellationToken) As ValueTask
                 SyncLock gate
                     References.Add(reference)
                 End SyncLock

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTestsBase.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTestsBase.vb
@@ -91,7 +91,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 
                             For Each location In items
                                 For Each docSpan In location.SourceSpans
-                                    actualLocations.Add(New FilePathAndSpan(docSpan.Document.FilePath, docSpan.SourceSpan))
+                                    actualLocations.Add(New FilePathAndSpan(solution.GetRequiredDocument(docSpan.DocumentId).FilePath, docSpan.SourceSpan))
                                 Next
                             Next
 

--- a/src/EditorFeatures/Test2/GoToHelpers/GoToHelpers.vb
+++ b/src/EditorFeatures/Test2/GoToHelpers/GoToHelpers.vb
@@ -22,7 +22,8 @@ Friend Class GoToHelpers
             Dim documentWithCursor = workspace.DocumentWithCursor
             Dim position = documentWithCursor.CursorPosition.Value
 
-            Dim document = workspace.CurrentSolution.GetDocument(documentWithCursor.Id)
+            Dim solution = workspace.CurrentSolution
+            Dim document = solution.GetDocument(documentWithCursor.Id)
 
             Dim context = New SimpleFindUsagesContext()
             Await testingMethod(document, position, context)
@@ -32,7 +33,7 @@ Friend Class GoToHelpers
             Else
                 Dim actualDefinitions = context.GetDefinitions().
                                                 SelectMany(Function(d) d.SourceSpans).
-                                                Select(Function(ss) New FilePathAndSpan(ss.Document.FilePath, ss.SourceSpan)).
+                                                Select(Function(ss) New FilePathAndSpan(solution.GetRequiredDocument(ss.DocumentId).FilePath, ss.SourceSpan)).
                                                 ToList()
                 actualDefinitions.Sort()
 

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DocumentLocationDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DocumentLocationDefinitionItem.cs
@@ -37,34 +37,33 @@ namespace Microsoft.CodeAnalysis.FindUsages
             {
             }
 
+            private DocumentSpan? TryGetDocumentSpan(Workspace workspace)
+            {
+                var currentSolution = workspace.CurrentSolution;
+                var document = currentSolution.GetDocument(SourceSpans[0].DocumentId);
+                return document != null ? new DocumentSpan(document, SourceSpans[0].SourceSpan) : null;
+            }
+
             public override bool CanNavigateTo(Workspace workspace, CancellationToken cancellationToken)
             {
                 if (Properties.ContainsKey(NonNavigable))
-                {
                     return false;
-                }
 
                 if (Properties.TryGetValue(MetadataSymbolKey, out var symbolKey))
-                {
                     return CanNavigateToMetadataSymbol(workspace, symbolKey);
-                }
 
-                return SourceSpans[0].CanNavigateTo(cancellationToken);
+                return TryGetDocumentSpan(workspace) is DocumentSpan span && span.CanNavigateTo(cancellationToken);
             }
 
             public override bool TryNavigateTo(Workspace workspace, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken)
             {
                 if (Properties.ContainsKey(NonNavigable))
-                {
                     return false;
-                }
 
                 if (Properties.TryGetValue(MetadataSymbolKey, out var symbolKey))
-                {
                     return TryNavigateToMetadataSymbol(workspace, symbolKey);
-                }
 
-                return SourceSpans[0].TryNavigateTo(showInPreviewTab, activateTab, cancellationToken);
+                return TryGetDocumentSpan(workspace) is DocumentSpan span && span.TryNavigateTo(showInPreviewTab, activateTab, cancellationToken);
             }
 
             private bool CanNavigateToMetadataSymbol(Workspace workspace, string symbolKey)

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// Additional locations to present in the UI.  A definition may have multiple locations 
         /// for cases like partial types/members.
         /// </summary>
-        public ImmutableArray<DocumentSpan> SourceSpans { get; }
+        public ImmutableArray<SerializableDocumentSpan> SourceSpans { get; }
 
         /// <summary>
         /// Whether or not this definition should be presented if we never found any references to
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
             DisplayParts = displayParts;
             NameDisplayParts = nameDisplayParts.IsDefaultOrEmpty ? displayParts : nameDisplayParts;
             OriginationParts = originationParts.NullToEmpty();
-            SourceSpans = sourceSpans.NullToEmpty();
+            SourceSpans = sourceSpans.NullToEmpty().SelectAsArray(ss => SerializableDocumentSpan.Dehydrate(ss));
             Properties = properties ?? ImmutableDictionary<string, string>.Empty;
             DisplayableProperties = displayableProperties ?? ImmutableDictionary<string, string>.Empty;
             DisplayIfNoReferences = displayIfNoReferences;

--- a/src/Features/Core/Portable/FindUsages/IFindUsagesContext.cs
+++ b/src/Features/Core/Portable/FindUsages/IFindUsagesContext.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// </summary>
         ValueTask SetSearchTitleAsync(string title, CancellationToken cancellationToken);
 
-        ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken);
-        ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken);
+        ValueTask OnDefinitionFoundAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken);
+        ValueTask OnReferenceFoundAsync(Solution solution, SourceReferenceItem reference, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
+++ b/src/Features/Core/Portable/FindUsages/IRemoteFindUsagesService.cs
@@ -108,14 +108,14 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 _idToDefinition.Add(id, rehydrated);
             }
 
-            await _context.OnDefinitionFoundAsync(rehydrated, cancellationToken).ConfigureAwait(false);
+            await _context.OnDefinitionFoundAsync(_solution, rehydrated, cancellationToken).ConfigureAwait(false);
         }
 
         public async ValueTask OnReferenceFoundAsync(SerializableSourceReferenceItem reference, CancellationToken cancellationToken)
         {
             var rehydrated = await reference.RehydrateAsync(_solution, GetDefinition(reference.DefinitionId), cancellationToken).ConfigureAwait(false);
 
-            await _context.OnReferenceFoundAsync(rehydrated, cancellationToken).ConfigureAwait(false);
+            await _context.OnReferenceFoundAsync(_solution, rehydrated, cancellationToken).ConfigureAwait(false);
         }
 
         private DefinitionItem GetDefinition(int definitionId)
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
                    item.DisplayParts,
                    item.NameDisplayParts,
                    item.OriginationParts,
-                   item.SourceSpans.SelectAsArray(ss => SerializableDocumentSpan.Dehydrate(ss)),
+                   item.SourceSpans,
                    item.Properties,
                    item.DisplayableProperties,
                    item.DisplayIfNoReferences);
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
 
         public static SerializableSourceReferenceItem Dehydrate(int definitionId, SourceReferenceItem item)
             => new(definitionId,
-                   SerializableDocumentSpan.Dehydrate(item.SourceSpan),
+                   item.SourceSpan,
                    item.SymbolUsageInfo,
                    item.AdditionalProperties);
 

--- a/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
+++ b/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// <summary>
         /// The location of the source item.
         /// </summary>
-        public DocumentSpan SourceSpan { get; }
+        public SerializableDocumentSpan SourceSpan { get; }
 
         /// <summary>
         /// If this reference is a location where the definition is written to.
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
             bool isWrittenTo)
         {
             Definition = definition;
-            SourceSpan = sourceSpan;
+            SourceSpan = SerializableDocumentSpan.Dehydrate(sourceSpan);
             SymbolUsageInfo = symbolUsageInfo;
             IsWrittenTo = isWrittenTo;
             AdditionalProperties = additionalProperties ?? ImmutableDictionary<string, string>.Empty;

--- a/src/Features/Core/Portable/ValueTracking/ValueTracker.FindReferencesProgress.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTracker.FindReferencesProgress.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.ValueTracking
 
             public ValueTask ItemCompletedAsync(CancellationToken _) => new();
 
-            public ValueTask OnCompletedAsync(CancellationToken _) => new();
+            public ValueTask OnCompletedAsync(Solution solution, CancellationToken _) => new();
 
             public ValueTask OnDefinitionFoundAsync(SymbolGroup symbolGroup, CancellationToken _) => new();
 

--- a/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
+++ b/src/Features/LanguageServer/Protocol/CustomProtocol/FindUsagesLSPContext.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
         }
 
         // After all definitions/references have been found, wait here until all results have been reported.
-        public override async ValueTask OnCompletedAsync(CancellationToken cancellationToken)
+        public override async ValueTask OnCompletedAsync(Solution solution, CancellationToken cancellationToken)
             => await _workQueue.WaitUntilCurrentBatchCompletesAsync().ConfigureAwait(false);
 
         public override async ValueTask OnDefinitionFoundAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken)

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindAllReferencesHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             // Finds the references for the symbol at the specific position in the document, reporting them via streaming to the LSP client.
             await findUsagesService.FindReferencesAsync(document, position, findUsagesContext, cancellationToken).ConfigureAwait(false);
-            await findUsagesContext.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+            await findUsagesContext.OnCompletedAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false);
 
             return progress.GetValues();
         }

--- a/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/References/FindImplementationsHandler.cs
@@ -46,18 +46,20 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var findUsagesContext = new SimpleFindUsagesContext();
             await FindImplementationsAsync(findUsagesService, document, position, findUsagesContext, cancellationToken).ConfigureAwait(false);
 
+            var solution = document.Project.Solution;
             foreach (var definition in findUsagesContext.GetDefinitions())
             {
                 var text = definition.GetClassifiedText();
                 foreach (var sourceSpan in definition.SourceSpans)
                 {
+                    var span = new DocumentSpan(solution.GetRequiredDocument(sourceSpan.DocumentId), sourceSpan.SourceSpan);
                     if (context.ClientCapabilities?.HasVisualStudioLspCapability() == true)
                     {
-                        locations.AddIfNotNull(await ProtocolConversions.DocumentSpanToLocationWithTextAsync(sourceSpan, text, cancellationToken).ConfigureAwait(false));
+                        locations.AddIfNotNull(await ProtocolConversions.DocumentSpanToLocationWithTextAsync(span, text, cancellationToken).ConfigureAwait(false));
                     }
                     else
                     {
-                        locations.AddIfNotNull(await ProtocolConversions.DocumentSpanToLocationAsync(sourceSpan, cancellationToken).ConfigureAwait(false));
+                        locations.AddIfNotNull(await ProtocolConversions.DocumentSpanToLocationAsync(span, cancellationToken).ConfigureAwait(false));
                     }
                 }
             }

--- a/src/Tools/ExternalAccess/Debugger/DebuggerFindReferencesService.cs
+++ b/src/Tools/ExternalAccess/Debugger/DebuggerFindReferencesService.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Debugger
             }
             finally
             {
-                await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                await context.OnCompletedAsync(project.Solution, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FindUsages/FSharpFindUsagesContext.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FindUsages/FSharpFindUsagesContext.cs
@@ -11,11 +11,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor.FindUsage
 {
     internal class FSharpFindUsagesContext : IFSharpFindUsagesContext
     {
+        private readonly Solution _solution;
         private readonly IFindUsagesContext _context;
         private readonly CancellationToken _cancellationToken;
 
-        public FSharpFindUsagesContext(IFindUsagesContext context, CancellationToken cancellationToken)
+        public FSharpFindUsagesContext(Solution solution, IFindUsagesContext context, CancellationToken cancellationToken)
         {
+            _solution = solution;
             _context = context;
             _cancellationToken = cancellationToken;
         }
@@ -24,12 +26,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor.FindUsage
 
         public Task OnDefinitionFoundAsync(FSharp.FindUsages.FSharpDefinitionItem definition)
         {
-            return _context.OnDefinitionFoundAsync(definition.RoslynDefinitionItem, _cancellationToken).AsTask();
+            return _context.OnDefinitionFoundAsync(_solution, definition.RoslynDefinitionItem, _cancellationToken).AsTask();
         }
 
         public Task OnReferenceFoundAsync(FSharp.FindUsages.FSharpSourceReferenceItem reference)
         {
-            return _context.OnReferenceFoundAsync(reference.RoslynSourceReferenceItem, _cancellationToken).AsTask();
+            return _context.OnReferenceFoundAsync(_solution, reference.RoslynSourceReferenceItem, _cancellationToken).AsTask();
         }
 
         public Task ReportMessageAsync(string message)

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FindUsages/FSharpFindUsagesService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FindUsages/FSharpFindUsagesService.cs
@@ -25,9 +25,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor.FindUsage
             => _service = service;
 
         public Task FindImplementationsAsync(Document document, int position, IFindUsagesContext context, CancellationToken cancellationToken)
-            => _service.FindImplementationsAsync(document, position, new FSharpFindUsagesContext(context, cancellationToken));
+            => _service.FindImplementationsAsync(document, position, new FSharpFindUsagesContext(document.Project.Solution, context, cancellationToken));
 
         public Task FindReferencesAsync(Document document, int position, IFindUsagesContext context, CancellationToken cancellationToken)
-            => _service.FindReferencesAsync(document, position, new FSharpFindUsagesContext(context, cancellationToken));
+            => _service.FindReferencesAsync(document, position, new FSharpFindUsagesContext(document.Project.Solution, context, cancellationToken));
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -303,14 +303,14 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 return default;
             }
 
-            public sealed override async ValueTask OnCompletedAsync(CancellationToken cancellationToken)
+            public sealed override async ValueTask OnCompletedAsync(Solution solution, CancellationToken cancellationToken)
             {
-                await OnCompletedAsyncWorkerAsync(cancellationToken).ConfigureAwait(false);
+                await OnCompletedAsyncWorkerAsync(solution, cancellationToken).ConfigureAwait(false);
 
                 _tableDataSink.IsStable = true;
             }
 
-            protected abstract Task OnCompletedAsyncWorkerAsync(CancellationToken cancellationToken);
+            protected abstract Task OnCompletedAsyncWorkerAsync(Solution solution, CancellationToken cancellationToken);
 
             public sealed override ValueTask OnDefinitionFoundAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken)
             {

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 => throw new InvalidOperationException();
 
             // Nothing to do on completion.
-            protected override Task OnCompletedAsyncWorkerAsync(CancellationToken cancellationToken)
+            protected override Task OnCompletedAsyncWorkerAsync(Solution solution, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 
             protected override async ValueTask OnDefinitionFoundWorkerAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/DocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/DocumentSpanEntry.cs
@@ -105,7 +105,11 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             public static DocumentSpanEntry? TryCreate(
                 AbstractTableDataSourceFindUsagesContext context,
                 RoslynDefinitionBucket definitionBucket,
-                DocumentSpan documentSpan,
+                Guid guid,
+                string projectName,
+                string? projectFlavor,
+                string? filePath,
+                TextSpan sourceSpan,
                 HighlightSpanKind spanKind,
                 MappedSpanResult mappedSpanResult,
                 ExcerptResult excerptResult,
@@ -113,8 +117,6 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 SymbolUsageInfo symbolUsageInfo,
                 ImmutableDictionary<string, string> customColumnsData)
             {
-                var document = documentSpan.Document;
-                var (guid, projectName, projectFlavor) = GetGuidAndProjectInfo(document);
                 var entry = new DocumentSpanEntry(
                     context, definitionBucket,
                     projectName, projectFlavor, guid,
@@ -126,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 // for the user. i.e. they're the same file/span.  Showing multiple entries for these
                 // is just noisy and gets worse and worse with shared projects and whatnot.  So, we
                 // collapse things down to only show a single entry for each unique file/span pair.
-                var winningEntry = definitionBucket.GetOrAddEntry(documentSpan, entry);
+                var winningEntry = definitionBucket.GetOrAddEntry(filePath, sourceSpan, entry);
 
                 // If we were the one that successfully added this entry to the bucket, then pass us
                 // back out to be put in the ui.

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/RoslynDefinitionBucket.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/RoslynDefinitionBucket.cs
@@ -114,9 +114,9 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 return null;
             }
 
-            public DocumentSpanEntry GetOrAddEntry(DocumentSpan documentSpan, DocumentSpanEntry entry)
+            public DocumentSpanEntry GetOrAddEntry(string? filePath, TextSpan sourceSpan, DocumentSpanEntry entry)
             {
-                var key = (documentSpan.Document.FilePath, documentSpan.SourceSpan);
+                var key = (filePath, sourceSpan);
                 lock (_locationToEntry)
                 {
                     return _locationToEntry.GetOrAdd(key, entry);

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMargin.xaml.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                         showProgress: false),
                     context => GoToDefinitionHelpers.TryGoToDefinition(
                         ImmutableArray.Create(viewModel.DefinitionItem),
-                        _workspace,
+                        _workspace.CurrentSolution,
                         string.Format(EditorFeaturesResources._0_declarations, viewModel.DisplayContent),
                         _threadingContext,
                         _streamingFindUsagesPresenter,

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -525,7 +525,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                 }
                 finally
                 {
-                    await context.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                    await context.OnCompletedAsync(project.Solution, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
             finally
             {
-                await _progress.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                await _progress.OnCompletedAsync(_solution, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/NoOpStreamingFindReferencesProgress.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/NoOpStreamingFindReferencesProgress.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public static Task ReportProgressAsync(int current, int maximum) => Task.CompletedTask;
 #pragma warning restore IDE0060 // Remove unused parameter
 
-        public ValueTask OnCompletedAsync(CancellationToken cancellationToken) => default;
+        public ValueTask OnCompletedAsync(Solution solution, CancellationToken cancellationToken) => default;
         public ValueTask OnStartedAsync(CancellationToken cancellationToken) => default;
         public ValueTask OnDefinitionFoundAsync(SymbolGroup group, CancellationToken cancellationToken) => default;
         public ValueTask OnReferenceFoundAsync(SymbolGroup group, ISymbol symbol, ReferenceLocation location, CancellationToken cancellationToken) => default;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/StreamingFindReferencesProgress.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/StreamingFindReferencesProgress.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             });
         }
 
-        public ValueTask OnCompletedAsync(CancellationToken cancellationToken)
+        public ValueTask OnCompletedAsync(Solution solution, CancellationToken cancellationToken)
         {
             _progress.OnCompleted();
             return default;

--- a/src/Workspaces/Core/Portable/FindSymbols/IStreamingFindReferencesProgress.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/IStreamingFindReferencesProgress.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         IStreamingProgressTracker ProgressTracker { get; }
 
         ValueTask OnStartedAsync(CancellationToken cancellationToken);
-        ValueTask OnCompletedAsync(CancellationToken cancellationToken);
+        ValueTask OnCompletedAsync(Solution solution, CancellationToken cancellationToken);
 
         ValueTask OnFindInDocumentStartedAsync(Document document, CancellationToken cancellationToken);
         ValueTask OnFindInDocumentCompletedAsync(Document document, CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/StreamingProgressCollector.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/StreamingProgressCollector.cs
@@ -54,8 +54,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
         }
 
-        public ValueTask OnStartedAsync(CancellationToken cancellationToken) => _underlyingProgress.OnStartedAsync(cancellationToken);
-        public ValueTask OnCompletedAsync(CancellationToken cancellationToken) => _underlyingProgress.OnCompletedAsync(cancellationToken);
+        public ValueTask OnStartedAsync(CancellationToken cancellationToken)
+            => _underlyingProgress.OnStartedAsync(cancellationToken);
+
+        public ValueTask OnCompletedAsync(Solution solution, CancellationToken cancellationToken)
+            => _underlyingProgress.OnCompletedAsync(solution, cancellationToken);
 
         public ValueTask OnFindInDocumentCompletedAsync(Document document, CancellationToken cancellationToken) => _underlyingProgress.OnFindInDocumentCompletedAsync(document, cancellationToken);
         public ValueTask OnFindInDocumentStartedAsync(Document document, CancellationToken cancellationToken) => _underlyingProgress.OnFindInDocumentStartedAsync(document, cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.FindReferencesServerCallback.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.FindReferencesServerCallback.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 => _progress.OnStartedAsync(cancellationToken);
 
             public ValueTask OnCompletedAsync(CancellationToken cancellationToken)
-                => _progress.OnCompletedAsync(cancellationToken);
+                => _progress.OnCompletedAsync(_solution, cancellationToken);
 
             public ValueTask OnFindInDocumentStartedAsync(DocumentId documentId, CancellationToken cancellationToken)
             {

--- a/src/Workspaces/Remote/ServiceHub/Services/FindUsages/RemoteFindUsagesService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/FindUsages/RemoteFindUsagesService.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Remote
             public ValueTask SetSearchTitleAsync(string title, CancellationToken cancellationToken)
                 => _callback.InvokeAsync((callback, cancellationToken) => callback.SetSearchTitleAsync(_callbackId, title, cancellationToken), cancellationToken);
 
-            public ValueTask OnDefinitionFoundAsync(DefinitionItem definition, CancellationToken cancellationToken)
+            public ValueTask OnDefinitionFoundAsync(Solution solution, DefinitionItem definition, CancellationToken cancellationToken)
             {
                 var id = GetOrAddDefinitionItemId(definition);
                 var dehydratedDefinition = SerializableDefinitionItem.Dehydrate(id, definition);
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 }
             }
 
-            public ValueTask OnReferenceFoundAsync(SourceReferenceItem reference, CancellationToken cancellationToken)
+            public ValueTask OnReferenceFoundAsync(Solution solution, SourceReferenceItem reference, CancellationToken cancellationToken)
             {
                 var definitionItem = GetOrAddDefinitionItemId(reference.Definition);
                 var dehydratedReference = SerializableSourceReferenceItem.Dehydrate(definitionItem, reference);

--- a/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (symbol == null)
                 {
                     await progressCallback.OnStartedAsync(cancellationToken).ConfigureAwait(false);
-                    await progressCallback.OnCompletedAsync(cancellationToken).ConfigureAwait(false);
+                    await progressCallback.OnCompletedAsync(solution, cancellationToken).ConfigureAwait(false);
                     return;
                 }
 
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Remote
             public ValueTask OnStartedAsync(CancellationToken cancellationToken)
                 => _callback.InvokeAsync((callback, cancellationToken) => callback.OnStartedAsync(_callbackId, cancellationToken), cancellationToken);
 
-            public ValueTask OnCompletedAsync(CancellationToken cancellationToken)
+            public ValueTask OnCompletedAsync(Solution solution, CancellationToken cancellationToken)
                 => _callback.InvokeAsync((callback, cancellationToken) => callback.OnCompletedAsync(_callbackId, cancellationToken), cancellationToken);
 
             public ValueTask OnFindInDocumentStartedAsync(Document document, CancellationToken cancellationToken)


### PR DESCRIPTION
Instead of using a Document+Span as the internal currency for locations, use a DocumentId+Span.

Note: features like FAR did not actually need the Document that was passed along after the initial creation of the entry in the UI.  