### PR TITLE
Use string.Format when an interpolated string part is dynamic

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 isConstant = isConstant && current.Right.ConstantValue is not null;
                 var rightInterpolatedString = (BoundUnconvertedInterpolatedString)current.Right;
 
-                if (rightInterpolatedString.Parts.ContainsAwaitExpression())
+                if (!ValidateInterpolatedStringParts(rightInterpolatedString))
                 {
                     // Exception to case 3. Delegate to standard binding.
                     stack.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -204,12 +204,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool ValidateInterpolatedStringParts(BoundUnconvertedInterpolatedString unconvertedInterpolatedString)
+        private static bool ValidateInterpolatedStringParts(BoundUnconvertedInterpolatedString unconvertedInterpolatedString)
             => !unconvertedInterpolatedString.Parts.ContainsAwaitExpression()
-               && unconvertedInterpolatedString.Parts.All(p => p is not BoundStringInsert { Value: { Type: { TypeKind: TypeKind.Dynamic } } });
+               && unconvertedInterpolatedString.Parts.All(p => p is not BoundStringInsert { Value.Type.TypeKind: TypeKind.Dynamic });
 
         private static bool AllInterpolatedStringPartsAreStrings(ImmutableArray<BoundExpression> parts)
-            => parts.All(p => p is BoundLiteral or BoundStringInsert { Value: { Type: { SpecialType: SpecialType.System_String } }, Alignment: null, Format: null });
+            => parts.All(p => p is BoundLiteral or BoundStringInsert { Value.Type.SpecialType: SpecialType.System_String, Alignment: null, Format: null });
 
         private bool TryBindUnconvertedBinaryOperatorToDefaultInterpolatedStringHandler(BoundBinaryOperator binaryOperator, BindingDiagnosticBag diagnostics, [NotNullWhen(true)] out BoundBinaryOperator? convertedBinaryOperator)
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -2778,7 +2778,25 @@ Console.WriteLine(" + expression + @");
 
             var verifier = CompileAndVerifyWithCSharp(new[] { source, interpolatedStringBuilder }, expectedOutput: @"base1");
 
-            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+            verifier.VerifyIL("<top-level-statements-entry-point>", expression.Contains('+')
+? @"
+{
+  // Code size       34 (0x22)
+  .maxstack  3
+  .locals init (object V_0) //hole
+  IL_0000:  ldc.i4.1
+  IL_0001:  box        ""int""
+  IL_0006:  stloc.0
+  IL_0007:  ldstr      ""base""
+  IL_000c:  ldstr      ""{0}""
+  IL_0011:  ldloc.0
+  IL_0012:  call       ""string string.Format(string, object)""
+  IL_0017:  call       ""string string.Concat(string, string)""
+  IL_001c:  call       ""void System.Console.WriteLine(string)""
+  IL_0021:  ret
+}
+"
+: @"
 {
   // Code size       24 (0x18)
   .maxstack  2
@@ -2787,6 +2805,58 @@ Console.WriteLine(" + expression + @");
   IL_0001:  box        ""int""
   IL_0006:  stloc.0
   IL_0007:  ldstr      ""base{0}""
+  IL_000c:  ldloc.0
+  IL_000d:  call       ""string string.Format(string, object)""
+  IL_0012:  call       ""void System.Console.WriteLine(string)""
+  IL_0017:  ret
+}
+");
+        }
+
+        [Theory, WorkItem(55609, "https://github.com/dotnet/roslyn/issues/55609")]
+        [InlineData(@"$""{hole}base""")]
+        [InlineData(@"$""{hole}"" + $""base""")]
+        public void DynamicInHoles_UsesFormat2(string expression)
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+dynamic hole = 1;
+Console.WriteLine(" + expression + @");
+";
+
+            var interpolatedStringBuilder = GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false);
+
+            var verifier = CompileAndVerifyWithCSharp(new[] { source, interpolatedStringBuilder }, expectedOutput: @"1base");
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", expression.Contains('+')
+? @"
+{
+  // Code size       34 (0x22)
+  .maxstack  2
+  .locals init (object V_0) //hole
+  IL_0000:  ldc.i4.1
+  IL_0001:  box        ""int""
+  IL_0006:  stloc.0
+  IL_0007:  ldstr      ""{0}""
+  IL_000c:  ldloc.0
+  IL_000d:  call       ""string string.Format(string, object)""
+  IL_0012:  ldstr      ""base""
+  IL_0017:  call       ""string string.Concat(string, string)""
+  IL_001c:  call       ""void System.Console.WriteLine(string)""
+  IL_0021:  ret
+}
+"
+: @"
+{
+  // Code size       24 (0x18)
+  .maxstack  2
+  .locals init (object V_0) //hole
+  IL_0000:  ldc.i4.1
+  IL_0001:  box        ""int""
+  IL_0006:  stloc.0
+  IL_0007:  ldstr      ""{0}base""
   IL_000c:  ldloc.0
   IL_000d:  call       ""string string.Format(string, object)""
   IL_0012:  call       ""void System.Console.WriteLine(string)""


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/55609. Note that we don't attempt to warn/error for custom handlers, as we never warn/error when mixing dynamic and ref structs today. If that ever changes, we'll naturally start producing warnings here as well.

Relates to test plan https://github.com/dotnet/roslyn/issues/51499
