### PR TITLE
Show destination name

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
@@ -752,6 +752,105 @@ End Namespace
             Await TestMovementNewFileAsync(initialMarkup, expectedText1, expectedText2, newFileName, selection, newTypeName)
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function TestMoveFunctionWithRootNamespace() As Task
+            Dim initialMarkup = "
+Namespace TestNs
+    Public Class Class1
+        Public Shared Function Test[||]Func() As Integer
+            Return 0
+        End Function
+    End Class
+End Namespace"
+            Dim newTypeName = "Class1Helpers"
+            Dim newFileName = "Class1Helpers.vb"
+            Dim selection = ImmutableArray.Create("TestFunc")
+            Dim expectedText1 = "
+Namespace TestNs
+    Public Class Class1
+    End Class
+End Namespace"
+            ' if we cut out the root namespace, the returned namespace should still be the same
+            Dim expectedText2 = "Namespace TestNs
+    Module Class1Helpers
+        Public Function TestFunc() As Integer
+            Return 0
+        End Function
+    End Module
+End Namespace
+"
+
+            Dim test = New Test(newTypeName, selection, newFileName) With {.TestCode = initialMarkup}
+            test.FixedState.Sources.Add(expectedText1)
+            test.FixedState.Sources.Add((newFileName, expectedText2))
+            test.SolutionTransforms.Add(
+                Function(solution, projectId)
+                    Dim project = solution.GetProject(projectId)
+                    Dim compilationOptions = DirectCast(project.CompilationOptions, VisualBasicCompilationOptions)
+                    Return project.WithCompilationOptions(compilationOptions.WithRootNamespace("RootNs")).Solution
+                End Function)
+            Await test.RunAsync()
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function TestMoveFunctionWithRootNamespaceRefactorReferences() As Task
+            Dim initialMarkup1 = "
+Namespace TestNs
+    Public Class Class1
+        Public Shared Function Test[||]Func() As Integer
+            Return 0
+        End Function
+    End Class
+End Namespace"
+            Dim initialMarkup2 = "
+Imports RootNs.TestNs
+
+Public Class Class2
+    Public Shared Function TestFunc2() As Integer
+        Return Class1.TestFunc()
+    End Function
+End Class"
+            Dim newTypeName = "ExtraNs.Class1Helpers"
+            Dim newFileName = "Class1Helpers.vb"
+            Dim selection = ImmutableArray.Create("TestFunc")
+            Dim expectedText1 = "
+Namespace TestNs
+    Public Class Class1
+    End Class
+End Namespace"
+            Dim expectedText3 = "
+Imports RootNs.TestNs
+Imports RootNs.TestNs.ExtraNs
+
+Public Class Class2
+    Public Shared Function TestFunc2() As Integer
+        Return Class1Helpers.TestFunc()
+    End Function
+End Class"
+            Dim expectedText2 = "Namespace TestNs.ExtraNs
+    Module Class1Helpers
+        Public Function TestFunc() As Integer
+            Return 0
+        End Function
+    End Module
+End Namespace
+"
+
+            Dim test = New Test(newTypeName, selection, newFileName)
+            test.TestState.Sources.Add(initialMarkup1)
+            test.TestState.Sources.Add(initialMarkup2)
+            test.FixedState.Sources.Add(expectedText1)
+            test.FixedState.Sources.Add(expectedText3)
+            test.FixedState.Sources.Add((newFileName, expectedText2))
+            test.SolutionTransforms.Add(
+                Function(solution, projectId)
+                    Dim project = solution.GetProject(projectId)
+                    Dim compilationOptions = DirectCast(project.CompilationOptions, VisualBasicCompilationOptions)
+                    Return project.WithCompilationOptions(compilationOptions.WithRootNamespace("RootNs")).Solution
+                End Function)
+            Await test.RunAsync()
+        End Function
+
 #End Region
 #Region "SelectionTests"
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>

--- a/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialog.xaml
@@ -35,7 +35,6 @@
     <Grid Margin="11,6,11,11">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="25"/>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -53,30 +52,65 @@
                 Text="{Binding DestinationName, UpdateSourceTrigger=PropertyChanged}"
                 Margin="0 0 20 0"/>
 
+
+            <GroupBox>
+                <GroupBox.Style>
+                    <Style TargetType="GroupBox">
+                        <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+                    </Style>
+                </GroupBox.Style>
+                <GroupBox.Header>
+                    <StackPanel 
+                    Orientation="Horizontal"  
+                    Visibility="{Binding ShowMessage, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Margin="{StaticResource messageMargin}">
+                        <imaging:CrispImage 
+                            Name="MessageIcon"
+                            Moniker="{Binding Icon}" 
+                            Height="16"
+                            Width="16"
+                            VerticalAlignment="Top" />
+
+                        <vs:LiveTextBlock 
+                            x:Name="MessageText"
+                            Text="{Binding Message}"
+                            Margin="7, 0, 0, 0"
+                            Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+                    </StackPanel>
+                </GroupBox.Header>
+
+                <Grid 
+                    Margin="{StaticResource messageMargin}"
+                    HorizontalAlignment="Left"
+                    Visibility="{Binding ShowMessage, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <vs:LiveTextBlock 
+                        Grid.Column="0"
+                        HorizontalAlignment="Right"
+                        x:Name="Namespace"
+                        Text="{Binding PrependedNamespace}"
+                        TextTrimming="CharacterEllipsis"
+                        Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+
+                    <vs:LiveTextBlock 
+                        Grid.Column="1"
+                        x:Name="TypeName"
+                        Text="{Binding DestinationName}"
+                        Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+                </Grid>
+            </GroupBox>
         </StackPanel>
 
-        <StackPanel 
-            Grid.Row="1"
-            Orientation="Horizontal"  
-            Visibility="{Binding ShowMessage, Converter={StaticResource BooleanToVisibilityConverter}}"
-            Margin="{StaticResource messageMargin}">
-            <imaging:CrispImage Name="MessageIcon"
-                                    Moniker="{Binding Icon}" 
-                                    Height="16"
-                                    Width="16"
-                                    VerticalAlignment="Top" />
-
-            <vs:LiveTextBlock x:Name="MessageText"
-                           Text="{Binding Message}"
-                           Margin="7, 0, 0, 0"
-                           Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
-        </StackPanel>
+        
 
         <GroupBox 
             x:Uid="MemberSelectionGroupBox"
             x:Name="MemberSelectionGroupBox"
             Margin="0, 20, 0, 0"
-            Grid.Row="2"
+            Grid.Row="1"
             Header="{Binding ElementName=dialog, Path=SelectMembers}"
             BorderThickness="1">
             <GroupBox.Style>
@@ -87,7 +121,7 @@
 
             <ContentPresenter Content="{Binding ElementName=dialog, Path=MemberSelectionControl}" />
         </GroupBox>
-        <StackPanel Grid.Row="3"
+        <StackPanel Grid.Row="2"
                     HorizontalAlignment="Right" 
                     Margin="0, 11, 0, 0"
                     Orientation="Horizontal">

--- a/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialogViewModel.cs
@@ -20,8 +20,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembe
 
         private readonly ImmutableArray<string> _existingNames;
 
-        private readonly string _prependedNamespace;
-
         public MoveStaticMembersDialogViewModel(
             StaticMemberSelectionViewModel memberSelectionViewModel,
             string defaultType,
@@ -33,8 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembe
             _syntaxFacts = syntaxFacts ?? throw new ArgumentNullException(nameof(syntaxFacts));
             _destinationName = defaultType;
             _existingNames = existingNames;
-            _prependedNamespace = prependedNamespace;
-            _fullyQualifiedTypeName = string.Join(".", _prependedNamespace, _destinationName);
+            PrependedNamespace = string.IsNullOrEmpty(prependedNamespace) ? prependedNamespace : prependedNamespace + ".";
 
             PropertyChanged += MoveMembersToTypeDialogViewModel_PropertyChanged;
             OnDestinationUpdated();
@@ -53,14 +50,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembe
         public void OnDestinationUpdated()
         {
             // TODO change once we allow movement to existing types
-            FullyQualifiedTypeName = string.Join(".", _prependedNamespace, _destinationName);
-            var isNewType = !_existingNames.Contains(FullyQualifiedTypeName);
-            _isValidName = isNewType && IsValidType(FullyQualifiedTypeName);
+            var fullyQualifiedTypeName = PrependedNamespace + DestinationName;
+            var isNewType = !_existingNames.Contains(fullyQualifiedTypeName);
+            _isValidName = isNewType && IsValidType(fullyQualifiedTypeName);
 
             if (_isValidName)
             {
                 Icon = KnownMonikers.StatusInformation;
-                Message = string.Format(ServicesVSResources.New_type_name_colon_0, FullyQualifiedTypeName);
+                Message = ServicesVSResources.New_Type_Name_colon;
                 ShowMessage = true;
             }
             else
@@ -90,6 +87,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembe
 
             return true;
         }
+
+        public string PrependedNamespace { get; }
 
         private string _destinationName;
         public string DestinationName
@@ -123,13 +122,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembe
         public bool CanSubmit
         {
             get => _isValidName && MemberSelectionViewModel.CheckedMembers.Length > 0;
-        }
-
-        private string _fullyQualifiedTypeName;
-        public string FullyQualifiedTypeName
-        {
-            get => _fullyQualifiedTypeName;
-            private set => SetProperty(ref _fullyQualifiedTypeName, value);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/VisualStudioMoveStaticMembersOptionsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/VisualStudioMoveStaticMembersOptionsService.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembe
                 return new MoveStaticMembersOptions(
                     // TODO: generate unique file name based off of existing folder documents
                     viewModel.DestinationName + (document.Project.Language == LanguageNames.CSharp ? ".cs" : ".vb"),
-                    viewModel.FullyQualifiedTypeName,
+                    viewModel.PrependedNamespace + viewModel.DestinationName,
                     viewModel.MemberSelectionViewModel.CheckedMembers.SelectAsArray(vm => vm.Symbol));
             }
 

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1750,9 +1750,6 @@ Additional information: {1}</value>
   <data name="Inherited_interfaces" xml:space="preserve">
     <value>Inherited interfaces</value>
   </data>
-  <data name="A_new_type_will_be_created" xml:space="preserve">
-    <value>A new type will be created</value>
-  </data>
   <data name="Invalid_type_name" xml:space="preserve">
     <value>Invalid type name</value>
   </data>
@@ -1779,5 +1776,8 @@ Additional information: {1}</value>
   </data>
   <data name="Visual_Studio_Settings" xml:space="preserve">
     <value>Visual Studio Settings</value>
+  </data>
+  <data name="New_type_name_colon_0" xml:space="preserve">
+    <value>New type name: '{0}'</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1777,7 +1777,4 @@ Additional information: {1}</value>
   <data name="Visual_Studio_Settings" xml:space="preserve">
     <value>Visual Studio Settings</value>
   </data>
-  <data name="New_type_name_colon_0" xml:space="preserve">
-    <value>New type name: '{0}'</value>
-  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -752,11 +752,6 @@
         <target state="translated">Předvolby nových řádků (experimentální):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">Nový řádek (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Vytvoří se nový obor názvů.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">Typ a název se musí poskytnout.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">Předvolby nových řádků (experimentální):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -752,11 +752,6 @@
         <target state="translated">Einstellungen für neue Zeilen (experimentell):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">Zeilenumbruch (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Ein neuer Namespace wird erstellt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">Typ und Name müssen angegeben werden.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">Einstellungen für neue Zeilen (experimentell):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -752,11 +752,6 @@
         <target state="translated">Nuevas preferencias de línea (experimental):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">Nueva línea (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Se creará un espacio de nombres</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">Se debe proporcionar un tipo y un nombre.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">Nuevas preferencias de línea (experimental):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Un espace de noms va être créé</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">Vous devez fournir un type et un nom.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">Préférences de nouvelle ligne (expérimental) :</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -752,11 +752,6 @@
         <target state="translated">Préférences de nouvelle ligne (expérimental) :</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">Nouvelle ligne (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -752,11 +752,6 @@
         <target state="translated">Preferenze per nuova riga (sperimentale):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">Nuova riga (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Verrà creato un nuovo spazio dei nomi</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">È necessario specificare un tipo e un nome.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">Preferenze per nuova riga (sperimentale):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -12,11 +12,6 @@
         <target state="translated">新しい名前空間が作成されます</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">種類と名前を指定する必要があります。</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">改行設定 (試験段階):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -752,11 +752,6 @@
         <target state="translated">改行設定 (試験段階):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">改行 (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -12,11 +12,6 @@
         <target state="translated">새 네임스페이스가 만들어집니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">형식과 이름을 지정해야 합니다.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">새 줄 기본 설정(실험적):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -752,11 +752,6 @@
         <target state="translated">새 줄 기본 설정(실험적):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">줄 바꿈(\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Zostanie utworzona nowa przestrzeń nazw</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">Konieczne jest podanie typu i nazwy.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">Preferencje nowego wiersza (eksperymentalne):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -752,11 +752,6 @@
         <target state="translated">Preferencje nowego wiersza (eksperymentalne):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">Nowy wiersz (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Um namespace será criado</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">Um tipo e um nome precisam ser fornecidos.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">Preferências de nova linha (experimental):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -752,11 +752,6 @@
         <target state="translated">Preferências de nova linha (experimental):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">Nova linha (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -752,11 +752,6 @@
         <target state="translated">Предпочтения для новых строк (экспериментальная функция):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">Новая строка (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Будет создано пространство имен</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">Следует указать тип и имя.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">Предпочтения для новых строк (экспериментальная функция):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -752,11 +752,6 @@
         <target state="translated">Yeni satır tercihleri (deneysel):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">Yeni Satır (\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Yeni bir ad alanı oluşturulacak</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">Bir tür ve ad verilmesi gerekiyor.</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">Yeni satır tercihleri (deneysel):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -752,11 +752,6 @@
         <target state="translated">新行首选项(实验性):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">换行(\\n)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -12,11 +12,6 @@
         <target state="translated">将创建一个新的命名空间</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">必须提供类型和名称。</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">新行首选项(实验性):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -12,11 +12,6 @@
         <target state="translated">將會建立新的命名空間</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_new_type_will_be_created">
-        <source>A new type will be created</source>
-        <target state="new">A new type will be created</target>
-        <note />
-      </trans-unit>
       <trans-unit id="A_type_and_name_must_be_provided">
         <source>A type and name must be provided.</source>
         <target state="translated">必須提供類型與名稱。</target>
@@ -755,6 +750,11 @@
       <trans-unit id="New_line_preferences_experimental_colon">
         <source>New line preferences (experimental):</source>
         <target state="translated">新行喜好設定 (實驗性):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="New_type_name_colon_0">
+        <source>New type name: '{0}'</source>
+        <target state="new">New type name: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Newline_n">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -752,11 +752,6 @@
         <target state="translated">新行喜好設定 (實驗性):</target>
         <note />
       </trans-unit>
-      <trans-unit id="New_type_name_colon_0">
-        <source>New type name: '{0}'</source>
-        <target state="new">New type name: '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Newline_n">
         <source>Newline (\\n)</source>
         <target state="translated">新行 (\\n)</target>

--- a/src/VisualStudio/Core/Test/MoveStaticMembers/MoveStaticMembersViewModelTest.vb
+++ b/src/VisualStudio/Core/Test/MoveStaticMembers/MoveStaticMembersViewModelTest.vb
@@ -128,12 +128,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
     </Project>
 </Workspace>]]></Text>
             Dim viewModel = Await GetViewModelAsync(markUp)
-            Dim nsPrefix = "New type name: 'TestNs."
 
             Assert.Equal(viewModel.DestinationName, "TestClassHelpers")
+            Assert.Equal("TestNs.", viewModel.PrependedNamespace)
 
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "TestClassHelpers'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             Assert.False(viewModel.MemberSelectionViewModel.CheckedMembers.IsEmpty)
             Assert.True(viewModel.CanSubmit)
@@ -145,7 +145,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
 
             viewModel.DestinationName = "ValidName"
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "ValidName'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             ' spaces are not allowed as types
             viewModel.DestinationName = "asd "
@@ -157,7 +157,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
             viewModel.DestinationName = "ConflictingClassName3"
             Assert.True(viewModel.CanSubmit)
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "ConflictingClassName3'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             viewModel.DestinationName = "ITestInterface"
             Assert.False(viewModel.CanSubmit)
@@ -167,13 +167,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
             viewModel.DestinationName = "NoNsClass"
             Assert.True(viewModel.CanSubmit)
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "NoNsClass'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             ' different namespace
             viewModel.DestinationName = "ConflictingClassName2"
             Assert.True(viewModel.CanSubmit)
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "ConflictingClassName2'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             viewModel.DestinationName = "TestClass"
             Assert.False(viewModel.CanSubmit)
@@ -183,7 +183,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
             viewModel.DestinationName = "ExtraNamespace.ValidName"
             Assert.True(viewModel.CanSubmit)
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "ExtraNamespace.ValidName'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             viewModel.DestinationName = "ExtraNs.ConflictingNsClassName"
             Assert.False(viewModel.CanSubmit)
@@ -339,12 +339,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
     </Project>
 </Workspace>]]></Text>
             Dim viewModel = Await GetViewModelAsync(markUp)
-            Dim nsPrefix = "New type name: 'TestNs."
 
             Assert.Equal(viewModel.DestinationName, "TestClassHelpers")
+            Assert.Equal("TestNs.", viewModel.PrependedNamespace)
 
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "TestClassHelpers'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             Assert.False(viewModel.MemberSelectionViewModel.CheckedMembers.IsEmpty)
             Assert.True(viewModel.CanSubmit)
@@ -356,7 +356,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
 
             viewModel.DestinationName = "ValidName"
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "ValidName'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             ' spaces are not allowed as types
             viewModel.DestinationName = "asd "
@@ -368,7 +368,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
             viewModel.DestinationName = "ConflictingClassName3"
             Assert.True(viewModel.CanSubmit)
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "ConflictingClassName3'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             viewModel.DestinationName = "ITestInterface"
             Assert.False(viewModel.CanSubmit)
@@ -378,13 +378,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
             viewModel.DestinationName = "NoNsClass"
             Assert.True(viewModel.CanSubmit)
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "NoNsClass'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             ' different namespace
             viewModel.DestinationName = "ConflictingClassName2"
             Assert.True(viewModel.CanSubmit)
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "ConflictingClassName2'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             viewModel.DestinationName = "TestClass"
             Assert.False(viewModel.CanSubmit)
@@ -394,9 +394,50 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
             viewModel.DestinationName = "ExtraNamespace.ValidName"
             Assert.True(viewModel.CanSubmit)
             Assert.True(viewModel.ShowMessage)
-            Assert.Equal(nsPrefix + "ExtraNamespace.ValidName'", viewModel.Message)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
 
             viewModel.DestinationName = "ExtraNs.ConflictingNsClassName"
+            Assert.False(viewModel.CanSubmit)
+            Assert.True(viewModel.ShowMessage)
+            Assert.Equal(ServicesVSResources.Invalid_type_name, viewModel.Message)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function VBTestRootNamespace() As Task
+            Dim markUp = <Text><![CDATA[
+<Workspace>
+    <Project Language="Visual Basic" AssemblyName="VBAssembly1" CommonReferences="true">
+        <CompilationOptions RootNamespace="RootNs"/>
+        <Document>
+            Namespace TestNs
+                Public Class TestClass
+                    Public Shared Function Bar$$bar() As Integer
+                        Return 12345;
+                    End Function
+                End Class
+            End Namespace
+        </Document>
+        <Document>
+            Namespace TestNs
+                Public Class ConflictingClassName
+                End Class
+            End Namespace
+        </Document>
+    </Project>
+</Workspace>]]></Text>
+
+            Dim viewModel = Await GetViewModelAsync(markUp)
+
+            Assert.Equal(viewModel.DestinationName, "TestClassHelpers")
+            Assert.Equal("RootNs.TestNs.", viewModel.PrependedNamespace)
+
+            Assert.True(viewModel.ShowMessage)
+            Assert.Equal(ServicesVSResources.New_Type_Name_colon, viewModel.Message)
+
+            Assert.False(viewModel.MemberSelectionViewModel.CheckedMembers.IsEmpty)
+            Assert.True(viewModel.CanSubmit)
+
+            viewModel.DestinationName = "ConflictingClassName"
             Assert.False(viewModel.CanSubmit)
             Assert.True(viewModel.ShowMessage)
             Assert.Equal(ServicesVSResources.Invalid_type_name, viewModel.Message)


### PR DESCRIPTION
Should be merged after #55581, as there is a test that depends on reference refactoring. Adds a destination name preview containing the fully qualified namespace, and fixes an error regarding the root namespace in VB.

Also slightly rewrites testing framework to so that ViewModel tests use options service code to get the view model

Here is a demo of the current UI (using a VB file with a root namespace of `ClassLibrary2`

https://user-images.githubusercontent.com/43689321/129640408-bd58ff49-86d6-4280-bb54-1a4e895d754a.mp4

