### PR TITLE
Prevent exception if their is no else block.

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/InvertIf/InvertMultiLineIfTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/InvertIf/InvertMultiLineIfTests.vb
@@ -709,5 +709,29 @@ end class",
     end sub
 end class")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInvertIf)>
+        Public Async Function InvertIfWithoutElse() As Task
+            Await TestInRegularAndScriptAsync(
+"class C
+    sub M(x as String)
+        [||]If x = ""a"" Then
+          ' Comment
+          x += 1
+        End If
+    end sub
+
+end class",
+"class C
+    sub M(x as String)
+        If x IsNot ""a"" Then
+            Return
+        End If
+        ' Comment
+        x += 1
+    end sub
+
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/InvertIf/VisualBasicInvertIfCodeRefactoringProvider.MultiLine.vb
+++ b/src/Features/VisualBasic/Portable/InvertIf/VisualBasicInvertIfCodeRefactoringProvider.MultiLine.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InvertIf
         End Function
 
         Private Shared Function HasComment(elseBlock As ElseBlockSyntax) As Boolean
-            Return elseBlock.GetLeadingTrivia().Any(Function(trivia) trivia.IsKind(SyntaxKind.CommentTrivia))
+        Return elseBlock IsNot Nothing AndAlso elseBlock.GetLeadingTrivia().Any(Function(trivia) trivia.IsKind(SyntaxKind.CommentTrivia))
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/InvertIf/VisualBasicInvertIfCodeRefactoringProvider.MultiLine.vb
+++ b/src/Features/VisualBasic/Portable/InvertIf/VisualBasicInvertIfCodeRefactoringProvider.MultiLine.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InvertIf
         End Function
 
         Private Shared Function HasComment(elseBlock As ElseBlockSyntax) As Boolean
-        Return elseBlock IsNot Nothing AndAlso elseBlock.GetLeadingTrivia().Any(Function(trivia) trivia.IsKind(SyntaxKind.CommentTrivia))
+            Return elseBlock IsNot Nothing AndAlso elseBlock.GetLeadingTrivia().Any(Function(trivia) trivia.IsKind(SyntaxKind.CommentTrivia))
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Previously would fail with `Null Reference Exception` , if the `ifBlock` didn't have and `elseBlock`
```vbnet
If condition Then
  Console.WriteLine("Statement")
End If
```