### PR TITLE
Don't consider syntax trees changed if the compilation is the same

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -295,7 +295,7 @@ class C
         }
 
         [Fact]
-        public void Syntax_Receiver_Is_Not_Reused_Between_Invocations()
+        public void Syntax_Receiver_Is_Not_Reused_Between_Non_Cached_Invocations()
         {
             var source = @"
 class C 
@@ -333,6 +333,10 @@ class C
             Assert.Equal(1, testReceiver.Tag);
             Assert.Equal(21, testReceiver.VisitedNodes.Count);
             Assert.IsType<CompilationUnitSyntax>(testReceiver.VisitedNodes[0]);
+
+            // update the compilation. In v1 we always re-created the recevier, but in v2 we only re-create
+            // it if the compilation hase changed.
+            compilation = compilation.WithAssemblyName("modified");
 
             var previousReceiver = receiver;
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
@@ -1320,6 +1324,16 @@ class C
     string fieldC = null;
 }
 ";
+
+            var source2 = @"
+#pragma warning disable CS0414
+class C 
+{
+    string fieldD = null; 
+    string fieldE = null;
+    string fieldF = null;
+}
+";
             var parseOptions = TestOptions.RegularPreview;
             Compilation compilation = CreateCompilation(source1, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
@@ -1328,7 +1342,7 @@ class C
             var testGenerator = new PipelineCallbackGenerator(context =>
             {
                 var source = context.SyntaxProvider.CreateSyntaxProvider((c, _) => c is FieldDeclarationSyntax fds, (c, _) => ((FieldDeclarationSyntax)c.Node).Declaration.Variables[0].Identifier.ValueText);
-                source = source.WithComparer(new LambdaComparer<string>((a, b) => false));
+                source = source.WithComparer(new LambdaComparer<string>((a, b) => true));
                 context.RegisterSourceOutput(source, (spc, fieldName) =>
                 {
                     calledFor.Add(fieldName);
@@ -1339,11 +1353,13 @@ class C
             driver = driver.RunGenerators(compilation);
             Assert.Equal(new[] { "fieldA", "fieldB", "fieldC" }, calledFor);
 
-            // when we run it again, we get the same fields called for
-            // even though they were cached, because of our comparer
+            // make a change to the syntax tree
+            compilation = compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.First(), CSharpSyntaxTree.ParseText(source2, parseOptions));
+
+            // when we run it again, we get not output because the comparer has suppressed the modification
             calledFor.Clear();
             driver = driver.RunGenerators(compilation);
-            Assert.Equal(new[] { "fieldA", "fieldB", "fieldC" }, calledFor);
+            Assert.Empty(calledFor);
         }
 
         [Fact]
@@ -1397,6 +1413,16 @@ class C
     string fieldC = null;
 }
 ";
+
+            var source2 = @"
+#pragma warning disable CS0414
+class C 
+{
+    string fieldD = null; 
+    string fieldE = null;
+    string fieldF = null;
+}
+";
             var parseOptions = TestOptions.RegularPreview;
             Compilation compilation = CreateCompilation(source1, options: TestOptions.DebugDll, parseOptions: parseOptions);
             compilation.VerifyDiagnostics();
@@ -1419,7 +1445,7 @@ class C
                     noCompareCalledFor.Add(fieldName);
                 });
 
-                var comparerSource = source.WithComparer(new LambdaComparer<string>((a, b) => false));
+                var comparerSource = source.WithComparer(new LambdaComparer<string>((a, b) => true));
                 context.RegisterSourceOutput(comparerSource, (spc, fieldName) =>
                 {
                     compareCalledFor.Add(fieldName);
@@ -1434,14 +1460,17 @@ class C
             Assert.Equal(new[] { "fieldA", "fieldB", "fieldC" }, noCompareCalledFor);
             Assert.Equal(new[] { "fieldA", "fieldB", "fieldC" }, compareCalledFor);
 
-            // now, when we re-run, both transforms will run, but only the comparare output will re-run
+            // make a change to the syntax tree
+            compilation = compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.First(), CSharpSyntaxTree.ParseText(source2, parseOptions));
+
+            // now, when we re-run, both transforms will run, but the compararer will supress the modified output
             syntaxCalledFor.Clear();
             noCompareCalledFor.Clear();
             compareCalledFor.Clear();
             driver = driver.RunGenerators(compilation);
-            Assert.Equal(new[] { "fieldA", "fieldB", "fieldC", "fieldA", "fieldB", "fieldC" }, syntaxCalledFor);
-            Assert.Empty(noCompareCalledFor);
-            Assert.Equal(new[] { "fieldA", "fieldB", "fieldC" }, compareCalledFor);
+            Assert.Equal(new[] { "fieldD", "fieldE", "fieldF", "fieldD", "fieldE", "fieldF" }, syntaxCalledFor);
+            Assert.Equal(new[] { "fieldD", "fieldE", "fieldF" }, noCompareCalledFor);
+            Assert.Empty(compareCalledFor);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/DriverStateTable.cs
@@ -60,42 +60,61 @@ namespace Microsoft.CodeAnalysis
                 // when we don't have a value for this node, we update all the syntax inputs at once
                 if (!_tableBuilder.ContainsKey(syntaxInputNode))
                 {
+                    // CONSIDER: when the compilation is the same as previous, the syntax trees must also be the same.
+                    // if we have a previous state table for a node, we can just short circuit knowing that it is up to date
+                    var compilationIsCached = GetLatestStateTableForNode(SharedInputNodes.Compilation).IsCached;
+
                     // get a builder for each input node
                     var builders = ArrayBuilder<ISyntaxInputBuilder>.GetInstance(_syntaxInputNodes.Length);
                     foreach (var node in _syntaxInputNodes)
                     {
-                        builders.Add(node.GetBuilder(_previousTable));
-                    }
-
-                    // update each tree for the builders, sharing the semantic model
-                    foreach ((var tree, var state) in GetLatestStateTableForNode(SharedInputNodes.SyntaxTrees))
-                    {
-                        var root = tree.GetRoot(_cancellationToken);
-                        var model = state != EntryState.Removed ? Compilation.GetSemanticModel(tree) : null;
-                        for (int i = 0; i < builders.Count; i++)
+                        if (compilationIsCached && _previousTable._tables.TryGetValue(node, out var previousStateTable))
                         {
-                            try
-                            {
-                                _cancellationToken.ThrowIfCancellationRequested();
-                                builders[i].VisitTree(root, state, model, _cancellationToken);
-                            }
-                            catch (UserFunctionException ufe)
-                            {
-                                // we're evaluating this node ahead of time, so we can't just throw the exception
-                                // instead we'll hold onto it, and throw the exception when a downstream node actually
-                                // attempts to read the value
-                                _syntaxExceptions[builders[i].SyntaxInputNode] = ufe;
-                                builders.RemoveAt(i);
-                                i--;
-                            }
+                            _tableBuilder.Add(node, previousStateTable);
+                        }
+                        else
+                        {
+                            builders.Add(node.GetBuilder(_previousTable));
                         }
                     }
 
-                    // save the updated inputs
-                    foreach (var builder in builders)
+                    if (builders.Count == 0)
                     {
-                        builder.SaveStateAndFree(_tableBuilder);
-                        Debug.Assert(_tableBuilder.ContainsKey(builder.SyntaxInputNode));
+                        // bring over the previously cached syntax tree inputs
+                        _tableBuilder[SharedInputNodes.SyntaxTrees] = _previousTable._tables[SharedInputNodes.SyntaxTrees];
+                    }
+                    else
+                    {
+                        // update each tree for the builders, sharing the semantic model
+                        foreach ((var tree, var state) in GetLatestStateTableForNode(SharedInputNodes.SyntaxTrees))
+                        {
+                            var root = tree.GetRoot(_cancellationToken);
+                            var model = state != EntryState.Removed ? Compilation.GetSemanticModel(tree) : null;
+                            for (int i = 0; i < builders.Count; i++)
+                            {
+                                try
+                                {
+                                    _cancellationToken.ThrowIfCancellationRequested();
+                                    builders[i].VisitTree(root, state, model, _cancellationToken);
+                                }
+                                catch (UserFunctionException ufe)
+                                {
+                                    // we're evaluating this node ahead of time, so we can't just throw the exception
+                                    // instead we'll hold onto it, and throw the exception when a downstream node actually
+                                    // attempts to read the value
+                                    _syntaxExceptions[builders[i].SyntaxInputNode] = ufe;
+                                    builders.RemoveAt(i);
+                                    i--;
+                                }
+                            }
+                        }
+
+                        // save the updated inputs
+                        foreach (var builder in builders)
+                        {
+                            builder.SaveStateAndFree(_tableBuilder);
+                            Debug.Assert(_tableBuilder.ContainsKey(builder.SyntaxInputNode));
+                        }
                     }
                     builders.Free();
                 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -329,6 +329,36 @@ namespace Microsoft.CodeAnalysis
                 _ => throw ExceptionUtilities.Unreachable
             };
 
+#if DEBUG
+            public override string ToString()
+            {
+                if (IsSingle)
+                {
+                    return $"{GetItem(0)}: {GetState(0)}";
+                }
+                else
+                {
+                    var sb = PooledStringBuilder.GetInstance();
+                    sb.Builder.Append("{");
+                    for (int i = 0; i < Count; i++)
+                    {
+                        sb.Builder.Append(" (");
+                        sb.Builder.Append(GetItem(i));
+                        sb.Builder.Append(':');
+                        sb.Builder.Append(GetState(i));
+                        sb.Builder.Append(')');
+                        if (i < Count - 1)
+                        {
+                            sb.Builder.Append(',');
+                        }
+                    }
+                    sb.Builder.Remove(sb.Builder.Length - 2, 1);
+                    sb.Builder.Append(" }");
+                    return sb.ToStringAndFree();
+                }
+            }
+#endif
+
             public sealed class Builder
             {
                 private readonly ArrayBuilder<T> _items = ArrayBuilder<T>.GetInstance();

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
@@ -85,11 +85,11 @@ namespace Microsoft.CodeAnalysis
                     foreach (var node in nodes)
                     {
                         var value = new GeneratorSyntaxContext(node, model);
-                        var transformed = ImmutableArray.Create(_owner._transformFunc(value, cancellationToken));
+                        var transformed = _owner._transformFunc(value, cancellationToken);
 
-                        if (state == EntryState.Added || !_transformTable.TryModifyEntries(transformed, _owner._comparer))
+                        if (state == EntryState.Added || !_transformTable.TryModifyEntry(transformed, _owner._comparer))
                         {
-                            _transformTable.AddEntries(transformed, EntryState.Added);
+                            _transformTable.AddEntry(transformed, EntryState.Added);
                         }
                     }
                 }


### PR DESCRIPTION
We can skip looking at syntax trees completely when the compilation is the same as one we've seen before. When all the syntax nodes successfully ran the previous iteration (i.e. no exceptions, no new generators have been added) we can just use their cached values directly. 