### PR TITLE
Allow the integration CI pipeline to specify a build pool

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -17,7 +17,10 @@ pr:
 jobs:
 - job: VS_Integration
   pool:
-    name: NetCorePublic-Pool
+    ${{ if eq(variables['poolName'], '') }}:
+      name: 'NetCorePublic-Pool'
+    ${{ if ne(variables['poolName'], '') }}:
+      name: $(poolName)
     queue: $(queueName)
   strategy:
     maxParallel: 4

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -17,10 +17,7 @@ pr:
 jobs:
 - job: VS_Integration
   pool:
-    ${{ if eq(variables.poolName, '') }}:
-      name: 'NetCorePublic-Pool'
-    ${{ if ne(variables.poolName, '') }}:
-      name: $(poolName)
+    name: $(poolName)
     queue: $(queueName)
   strategy:
     maxParallel: 4

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -17,9 +17,9 @@ pr:
 jobs:
 - job: VS_Integration
   pool:
-    ${{ if eq(variables['poolName'], '') }}:
+    ${{ if eq(variables.poolName, '') }}:
       name: 'NetCorePublic-Pool'
-    ${{ if ne(variables['poolName'], '') }}:
+    ${{ if ne(variables.poolName, '') }}:
       name: $(poolName)
     queue: $(queueName)
   strategy:


### PR DESCRIPTION
This would allow the scouting integration CI to specify both a separate build pool and queue name.