### PR TITLE
Add a preview option for ServiceHub Core host

### DIFF
--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -25,6 +25,12 @@
 "Title"="C#/VB LSP completion experience"
 "PreviewPaneChannels"="IntPreview,int.main"
 
+[$RootKey$\FeatureFlags\Roslyn\OOPCoreClr]
+"Description"="Run C#/VB out-of-process code analysis on .Net 6 ServiceHub host."
+"Value"=dword:00000000
+"Title"="Run C#/VB code analysis on .Net 6 (requires restart)"
+"PreviewPaneChannels"="IntPreview,int.main"
+
 // Corresponds to WellKnownExperimentNames.LspPullDiagnosticsFeatureFlag
 [$RootKey$\FeatureFlags\Lsp\PullDiagnostics]
 "Description"="Enables the LSP-powered diagnostics for managed .Net projects"


### PR DESCRIPTION
The feature flag is defined [here](https://github.com/dotnet/roslyn/blob/main/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs#L50)

![image](https://user-images.githubusercontent.com/788783/130149298-2b8eda12-7374-46d5-9061-d3558b7670bd.png)
