### PR TITLE
Prefer symbol references in InlineRename

### DIFF
--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -2165,5 +2165,37 @@ class [|C|]
                 Await VerifyTagsAreCorrect(workspace, "BarGoo")
             End Using
         End Function
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Async Function RenameInComment(host As RenameTestHost) As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" LanguageVersion="preview">
+                            <Document>
+                                class [|$$MyClass|]
+                                {
+                                    /// <summary>
+                                    /// Initializes <see cref="MyClass"/>;
+                                    /// </summary>
+                                    MyClass() 
+                                    {
+                                    }
+                                }
+                            </Document>
+                        </Project>
+                    </Workspace>, host)
+
+                Dim session = StartSession(workspace)
+
+                session.ApplyReplacementText("Example", True)
+                session.RefreshRenameSessionWithOptionsChanged(RenameOptions.RenameInComments, True)
+
+                session.Commit()
+
+                Await VerifyTagsAreCorrect(workspace, "Example")
+            End Using
+        End Function
+
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
@@ -143,6 +143,10 @@ namespace Microsoft.CodeAnalysis.Rename
                     mergedReferencedSymbols.AddRange(result.ReferencedSymbols);
                 }
 
+                // Add string and comment locations to the merged hashset 
+                // after adding in reference symbols. This allows any references
+                // in comments to be resolved as proper references rather than
+                // comment resolutions. See https://github.com/dotnet/roslyn/issues/54294
                 mergedLocations.AddRange(strings.NullToEmpty());
                 mergedLocations.AddRange(comments.NullToEmpty());
 

--- a/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
@@ -132,9 +132,6 @@ namespace Microsoft.CodeAnalysis.Rename
                 using var _1 = ArrayBuilder<ISymbol>.GetInstance(out var mergedReferencedSymbols);
                 using var _2 = ArrayBuilder<ReferenceLocation>.GetInstance(out var mergedImplicitLocations);
 
-                mergedLocations.AddRange(strings.NullToEmpty());
-                mergedLocations.AddRange(comments.NullToEmpty());
-
                 var renameMethodGroupReferences = optionSet.RenameOverloads || !GetOverloadedSymbols(symbol).Any();
                 foreach (var result in overloadsResult.Concat(originalSymbolResult))
                 {
@@ -145,6 +142,9 @@ namespace Microsoft.CodeAnalysis.Rename
                     mergedImplicitLocations.AddRange(result.ImplicitLocations);
                     mergedReferencedSymbols.AddRange(result.ReferencedSymbols);
                 }
+
+                mergedLocations.AddRange(strings.NullToEmpty());
+                mergedLocations.AddRange(comments.NullToEmpty());
 
                 return new RenameLocations(
                     symbol, solution, optionSet,


### PR DESCRIPTION
When renaming in comments/strings, if a rename location is already found in symbol references we should prefer that usage. This changes the order we add to the renamelocations hash set to reflect that

Fixes #54294