### PR TITLE
Avoid enumerator allocations for DiagnosticDescriptor.CustomTags

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryExpressionParenthesesTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryParentheses;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
@@ -44,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParent
         }
 
         internal override bool ShouldSkipMessageDescriptionVerification(DiagnosticDescriptor descriptor)
-            => descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary) && descriptor.DefaultSeverity == DiagnosticSeverity.Hidden;
+            => descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary) && descriptor.DefaultSeverity == DiagnosticSeverity.Hidden;
 
         private static DiagnosticDescription GetRemoveUnnecessaryParenthesesDiagnostic(string text, int line, int column)
             => TestHelpers.Diagnostic(IDEDiagnosticIds.RemoveUnnecessaryParenthesesDiagnosticId, text, startLocation: new LinePosition(line, column));

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryPatternParenthesesTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryPatternParenthesesTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryParentheses;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -43,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.RemoveUnnecessaryParent
         }
 
         internal override bool ShouldSkipMessageDescriptionVerification(DiagnosticDescriptor descriptor)
-            => descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary) && descriptor.DefaultSeverity == DiagnosticSeverity.Hidden;
+            => descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary) && descriptor.DefaultSeverity == DiagnosticSeverity.Hidden;
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryParentheses)]
         public async Task TestArithmeticRequiredForClarity2()

--- a/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/UseCoalesceExpressionCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/UseCoalesceExpressionCodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeStyle;
 
         protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
-            => !diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary);
+            => !diagnostic.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary);
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/UseCoalesceExpressionForNullableCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseCoalesceExpression/UseCoalesceExpressionForNullableCodeFixProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeStyle;
 
         protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
-            => !diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary);
+            => !diagnostic.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary);
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Analyzers/Core/CodeFixes/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeStyle;
 
         protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
-            => !diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary);
+            => !diagnostic.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary);
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Analyzers/Core/CodeFixes/UseNullPropagation/AbstractUseNullPropagationCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseNullPropagation/AbstractUseNullPropagationCodeFixProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeStyle;
 
         protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
-            => !diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary);
+            => !diagnostic.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary);
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Analyzers/Core/CodeFixes/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeStyle;
 
         protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
-            => !diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary);
+            => !diagnostic.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary);
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Analyzers/Core/CodeFixes/UseThrowExpression/UseThrowExpressionCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseThrowExpression/UseThrowExpressionCodeFixProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.UseThrowExpression
@@ -35,7 +36,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeStyle;
 
         protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
-            => !diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary);
+            => !diagnostic.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary);
 
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Analyzers/VisualBasic/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/RemoveUnnecessaryParentheses/RemoveUnnecessaryParenthesesTests.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.RemoveUnnecessaryP
         End Function
 
         Friend Overrides Function ShouldSkipMessageDescriptionVerification(descriptor As DiagnosticDescriptor) As Boolean
-            Return descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary) And descriptor.DefaultSeverity = DiagnosticSeverity.Hidden
+            Return descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary) And descriptor.DefaultSeverity = DiagnosticSeverity.Hidden
         End Function
 
         Private Shadows Async Function TestAsync(initial As String, expected As String,

--- a/src/Compilers/Core/Portable/CommandLine/SarifDiagnosticComparer.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifDiagnosticComparer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis
                 && x.Id == y.Id
                 && x.IsEnabledByDefault == y.IsEnabledByDefault
                 && x.Title!.Equals(y.Title)
-                && x.CustomTags.SequenceEqual(y.CustomTags));
+                && x.ImmutableCustomTags.SequenceEqual(y.ImmutableCustomTags));
         }
 
         public int GetHashCode(DiagnosticDescriptor obj)
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis
                 Hash.Combine(obj.Id!.GetHashCode(),
                 Hash.Combine(obj.IsEnabledByDefault.GetHashCode(),
                 Hash.Combine(obj.Title!.GetHashCode(),
-                Hash.CombineValues(obj.CustomTags))))))));
+                Hash.CombineValues(obj.ImmutableCustomTags))))))));
         }
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis
             // Currently, the following are always inherited from the descriptor and therefore will be
             // captured as rule metadata and need not be logged here. IsWarningAsError is also omitted
             // because it can be inferred from level vs. defaultLevel in the log.
-            Debug.Assert(diagnostic.CustomTags.SequenceEqual(diagnostic.Descriptor.CustomTags));
+            Debug.Assert(diagnostic.CustomTags.SequenceEqual(diagnostic.Descriptor.ImmutableCustomTags));
             Debug.Assert(diagnostic.Category == diagnostic.Descriptor.Category);
             Debug.Assert(diagnostic.DefaultSeverity == diagnostic.Descriptor.DefaultSeverity);
             Debug.Assert(diagnostic.IsEnabledByDefault == diagnostic.Descriptor.IsEnabledByDefault);

--- a/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
@@ -178,11 +178,11 @@ namespace Microsoft.CodeAnalysis
 
                     _writer.Write("isEnabledByDefault", descriptor.IsEnabledByDefault);
 
-                    if (descriptor.CustomTags.Any())
+                    if (descriptor.ImmutableCustomTags.Any())
                     {
                         _writer.WriteArrayStart("tags");
 
-                        foreach (string tag in descriptor.CustomTags)
+                        foreach (string tag in descriptor.ImmutableCustomTags)
                         {
                             _writer.Write(tag);
                         }

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis
                         _writer.Write("helpUri", descriptor.HelpLinkUri);
                     }
 
-                    if (!string.IsNullOrEmpty(descriptor.Category) || descriptor.CustomTags.Any())
+                    if (!string.IsNullOrEmpty(descriptor.Category) || descriptor.ImmutableCustomTags.Any())
                     {
                         _writer.WriteObjectStart("properties");
 
@@ -217,11 +217,11 @@ namespace Microsoft.CodeAnalysis
                             _writer.Write("category", descriptor.Category);
                         }
 
-                        if (descriptor.CustomTags.Any())
+                        if (descriptor.ImmutableCustomTags.Any())
                         {
                             _writer.WriteArrayStart("tags");
 
-                            foreach (string tag in descriptor.CustomTags)
+                            foreach (string tag in descriptor.ImmutableCustomTags)
                             {
                                 _writer.Write(tag);
                             }

--- a/src/Compilers/Core/Portable/Diagnostic/CustomObsoleteDiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CustomObsoleteDiagnosticInfo.cs
@@ -87,19 +87,11 @@ namespace Microsoft.CodeAnalysis
             ImmutableArray<string> customTags;
             if (diagnosticId is null)
             {
-                customTags = baseDescriptor.CustomTags.ToImmutableArray();
+                customTags = baseDescriptor.ImmutableCustomTags;
             }
             else
             {
-                var capacity = 1;
-                if (baseDescriptor.CustomTags is ICollection<string> { Count: int count })
-                {
-                    capacity += count;
-                }
-                var tagsBuilder = ArrayBuilder<string>.GetInstance(capacity);
-                tagsBuilder.AddRange(baseDescriptor.CustomTags);
-                tagsBuilder.Add(WellKnownDiagnosticTags.CustomObsolete);
-                customTags = tagsBuilder.ToImmutableAndFree();
+                customTags = baseDescriptor.ImmutableCustomTags.Add(WellKnownDiagnosticTags.CustomObsolete);
             }
 
             return new DiagnosticDescriptor(

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets custom tags for the diagnostic.
         /// </summary>
-        internal virtual IReadOnlyList<string> CustomTags { get { return (IReadOnlyList<string>)this.Descriptor.CustomTags; } }
+        internal virtual ImmutableArray<string> CustomTags { get { return this.Descriptor.ImmutableCustomTags; } }
 
         /// <summary>
         /// Gets property bag for the diagnostic. it will return <see cref="ImmutableDictionary{TKey, TValue}.Empty"/> 

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Utilities;
@@ -61,6 +62,15 @@ namespace Microsoft.CodeAnalysis
         /// Custom tags for the diagnostic.
         /// </summary>
         public IEnumerable<string> CustomTags { get; }
+
+        internal ImmutableArray<string> ImmutableCustomTags
+        {
+            get
+            {
+                Debug.Assert(CustomTags is ImmutableArray<string>);
+                return (ImmutableArray<string>)CustomTags;
+            }
+        }
 
         /// <summary>
         /// Create a DiagnosticDescriptor, which provides description about a <see cref="Diagnostic"/>.
@@ -139,6 +149,8 @@ namespace Microsoft.CodeAnalysis
             string? helpLinkUri,
             ImmutableArray<string> customTags)
         {
+            Debug.Assert(!customTags.IsDefault);
+
             if (string.IsNullOrWhiteSpace(id))
             {
                 throw new ArgumentException(CodeAnalysisResources.DiagnosticIdCantBeNullOrWhitespace, nameof(id));
@@ -247,7 +259,15 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal bool IsNotConfigurable()
         {
-            return AnalyzerManager.HasNotConfigurableTag(this.CustomTags);
+            return AnalyzerManager.HasNotConfigurableTag(ImmutableCustomTags);
+        }
+
+        /// <summary>
+        /// Returns true if diagnostic descriptor is a built-in compiler diagnostic or is not configurable.
+        /// </summary>
+        internal bool IsCompilerOrNotConfigurable()
+        {
+            return AnalyzerManager.HasCompilerOrNotConfigurableTag(ImmutableCustomTags);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Roslyn.Utilities;
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis
             get { return this.Info.AdditionalLocations; }
         }
 
-        internal override IReadOnlyList<string> CustomTags
+        internal override ImmutableArray<string> CustomTags
         {
             get
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1714,7 +1714,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             if (diagnostic.Id == AnalyzerExceptionDiagnosticId || diagnostic.Id == AnalyzerDriverExceptionDiagnosticId)
             {
-                foreach (var tag in diagnostic.Descriptor.CustomTags)
+                foreach (var tag in diagnostic.Descriptor.ImmutableCustomTags)
                 {
                     if (tag == WellKnownDiagnosticTags.AnalyzerException)
                     {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             foreach (var diag in supportedDiagnostics)
             {
-                if (HasNotConfigurableTag(diag.CustomTags))
+                if (diag.IsNotConfigurable())
                 {
                     if (diag.IsEnabledByDefault)
                     {
@@ -393,7 +393,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        internal static bool HasNotConfigurableTag(IEnumerable<string> customTags)
+        internal static bool HasCompilerOrNotConfigurableTag(ImmutableArray<string> customTags)
+        {
+            foreach (var customTag in customTags)
+            {
+                if (customTag is WellKnownDiagnosticTags.Compiler or WellKnownDiagnosticTags.NotConfigurable)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal static bool HasNotConfigurableTag(ImmutableArray<string> customTags)
         {
             foreach (var customTag in customTags)
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerOptionsExtensions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerOptionsExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             //  3. Non-configurable diagnostics
             if (analyzerOptions == null ||
                 !descriptor.IsEnabledByDefault ||
-                descriptor.CustomTags.Contains(tag => tag == WellKnownDiagnosticTags.Compiler || tag == WellKnownDiagnosticTags.NotConfigurable))
+                descriptor.IsCompilerOrNotConfigurable())
             {
                 severity = default;
                 return false;

--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             _effectiveSeverityOpt = includeEffectiveSeverity ? d.Severity : (DiagnosticSeverity?)null;
 
             DiagnosticWithInfo dinfo = null;
-            if (d.Code == 0 || d.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.CustomObsolete))
+            if (d.Code == 0 || d.Descriptor.ImmutableCustomTags.Contains(WellKnownDiagnosticTags.CustomObsolete))
             {
                 _code = d.Id;
                 _errorCodeType = typeof(string);

--- a/src/EditorFeatures/Core/Shared/Extensions/TelemetryExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/TelemetryExtensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
@@ -45,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
         public static string GetTelemetryDiagnosticID(this Diagnostic diagnostic)
         {
             // we log diagnostic id as it is if it is from us
-            if (diagnostic.Descriptor.CustomTags.Any(t => t == WellKnownDiagnosticTags.Telemetry))
+            if (diagnostic.Descriptor.ImmutableCustomTags().Any(t => t == WellKnownDiagnosticTags.Telemetry))
             {
                 return diagnostic.Id;
             }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -21,6 +21,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Remote.Testing;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -488,7 +489,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             static IEnumerable<Location> GetUnnecessaryLocations(Diagnostic diagnostic)
             {
-                if (diagnostic.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary))
+                if (diagnostic.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.Unnecessary))
                     yield return diagnostic.Location;
 
                 if (!diagnostic.Properties.TryGetValue(WellKnownDiagnosticTags.Unnecessary, out var additionalUnnecessaryLocationsString))

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CodeFixVerifierHelper.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CodeFixVerifierHelper.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using Xunit;
@@ -42,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         {
             foreach (var descriptor in analyzer.SupportedDiagnostics)
             {
-                if (descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable))
+                if (descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.NotConfigurable))
                 {
                     // The title only displayed for rule configuration
                     continue;
@@ -69,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             // Local function
             static bool ShouldSkipMessageDescriptionVerification(DiagnosticDescriptor descriptor)
             {
-                if (descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable))
+                if (descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.NotConfigurable))
                 {
                     if (!descriptor.IsEnabledByDefault || descriptor.DefaultSeverity == DiagnosticSeverity.Hidden)
                     {

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.CSharp.UseLocalFunction;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty;
@@ -51,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
         internal virtual bool ShouldSkipMessageDescriptionVerification(DiagnosticDescriptor descriptor)
         {
-            if (descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable))
+            if (descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.NotConfigurable))
             {
                 if (!descriptor.IsEnabledByDefault || descriptor.DefaultSeverity == DiagnosticSeverity.Hidden)
                 {
@@ -76,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
                 foreach (var descriptor in diagnosticAnalyzer.SupportedDiagnostics)
                 {
-                    if (descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable))
+                    if (descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.NotConfigurable))
                     {
                         // The title only displayed for rule configuration
                         continue;
@@ -230,7 +231,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         private static void AssertNoAnalyzerExceptionDiagnostics(IEnumerable<Diagnostic> diagnostics)
 #pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
         {
-            var analyzerExceptionDiagnostics = diagnostics.Where(diag => diag.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.AnalyzerException));
+            var analyzerExceptionDiagnostics = diagnostics.Where(diag => diag.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.AnalyzerException));
             AssertEx.Empty(analyzerExceptionDiagnostics, "Found analyzer exception diagnostics");
         }
 

--- a/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
@@ -69,21 +70,21 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             => HasCustomTag(diagnostic.CustomTags, WellKnownDiagnosticTags.NotConfigurable);
 
         public static bool IsNotConfigurableDiagnostic(Diagnostic diagnostic)
-            => HasCustomTag(diagnostic.Descriptor.CustomTags, WellKnownDiagnosticTags.NotConfigurable);
+            => HasCustomTag(diagnostic.Descriptor.ImmutableCustomTags(), WellKnownDiagnosticTags.NotConfigurable);
 
         public static bool IsCompilerDiagnostic(DiagnosticData diagnostic)
             => HasCustomTag(diagnostic.CustomTags, WellKnownDiagnosticTags.Compiler);
 
         public static bool IsCompilerDiagnostic(Diagnostic diagnostic)
-            => HasCustomTag(diagnostic.Descriptor.CustomTags, WellKnownDiagnosticTags.Compiler);
+            => HasCustomTag(diagnostic.Descriptor.ImmutableCustomTags(), WellKnownDiagnosticTags.Compiler);
 
         public static bool IsSynthesizedExternalSourceDiagnostic(DiagnosticData diagnostic)
             => HasCustomTag(diagnostic.CustomTags, SynthesizedExternalSourceDiagnosticTag);
 
         public static bool IsSynthesizedExternalSourceDiagnostic(Diagnostic diagnostic)
-            => HasCustomTag(diagnostic.Descriptor.CustomTags, SynthesizedExternalSourceDiagnosticTag);
+            => HasCustomTag(diagnostic.Descriptor.ImmutableCustomTags(), SynthesizedExternalSourceDiagnosticTag);
 
-        public static bool HasCustomTag(IEnumerable<string> customTags, string tagToFind)
-            => customTags != null && customTags.Any(c => CultureInfo.InvariantCulture.CompareInfo.Compare(c, tagToFind) == 0);
+        public static bool HasCustomTag(ImmutableArray<string> customTags, string tagToFind)
+            => customTags.Any(c => CultureInfo.InvariantCulture.CompareInfo.Compare(c, tagToFind) == 0);
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_BuildSynchronization.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
 using Roslyn.Utilities;
@@ -192,7 +193,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 descriptor.DefaultSeverity,
                 descriptor.IsEnabledByDefault,
                 diagnostic.WarningLevel,
-                descriptor.CustomTags.ToImmutableArray(),
+                descriptor.ImmutableCustomTags(),
                 diagnostic.Properties,
                 diagnostic.ProjectId,
                 diagnostic.DataLocation,

--- a/src/Tools/BuildActionTelemetryTable/BuildActionTelemetryTable.csproj
+++ b/src/Tools/BuildActionTelemetryTable/BuildActionTelemetryTable.csproj
@@ -26,6 +26,8 @@
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\Hash.cs" Link="Utilities\Hash.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\NullableAttributes.cs" Link="Utilities\NullableAttributes.cs" />
     <Compile Include="..\..\EditorFeatures\Core\Shared\Extensions\TelemetryExtensions.cs" Link="Utilities\TelemetryExtensions.cs" />
+    <Compile Include="..\..\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\CodeStyle\EditorConfigSeverityStrings.cs" Link="Utilities\EditorConfigSeverityStrings.cs" />
+    <Compile Include="..\..\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\Extensions\DiagnosticDescriptorExtensions.cs" Link="Utilities\DiagnosticDescriptorExtensions.cs" />
     <Compile Include="..\..\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\Utilities\Contract.cs" Link="Utilities\Contract.cs" />
   </ItemGroup>
 

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersCommandHandler.cs
@@ -323,7 +323,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
         private void UpdateSeverityMenuItemsEnabled()
         {
-            var configurable = !_tracker.SelectedDiagnosticItems.Any(item => item.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.NotConfigurable));
+            var configurable = !_tracker.SelectedDiagnosticItems.Any(item => item.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.NotConfigurable));
 
             _setSeverityDefaultMenuItem.Enabled = configurable;
             _setSeverityErrorMenuItem.Enabled = configurable;

--- a/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
@@ -479,7 +479,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
                     diagnostic.DefaultSeverity,
                     diagnostic.Descriptor.IsEnabledByDefault,
                     diagnostic.WarningLevel,
-                    diagnostic.Descriptor.CustomTags.AsImmutableOrEmpty(),
+                    diagnostic.Descriptor.ImmutableCustomTags(),
                     diagnostic.Properties,
                     document.Project.Id,
                     GetDataLocation(document, mappedFilePath),

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private static bool IsTelemetryCollectionAllowed(DiagnosticAnalyzer analyzer, ImmutableArray<DiagnosticDescriptor> descriptors)
             => analyzer.IsCompilerAnalyzer() ||
                analyzer is IBuiltInAnalyzer ||
-               descriptors.Length > 0 && descriptors[0].CustomTags.Any(t => t == WellKnownDiagnosticTags.Telemetry);
+               descriptors.Length > 0 && descriptors[0].ImmutableCustomTags().Any(t => t == WellKnownDiagnosticTags.Telemetry);
 
         /// <summary>
         /// Return true if the given <paramref name="analyzer"/> is suppressed for the given project.

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 diagnostic.DefaultSeverity,
                 diagnostic.Descriptor.IsEnabledByDefault,
                 diagnostic.WarningLevel,
-                diagnostic.Descriptor.CustomTags.AsImmutableOrEmpty(),
+                diagnostic.Descriptor.ImmutableCustomTags(),
                 (additionalProperties == null) ? diagnostic.Properties : diagnostic.Properties.AddRange(additionalProperties),
                 projectId,
                 location,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticDescriptorExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticDescriptorExtensions.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -18,6 +17,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         private const string SeveritySuffix = "severity";
 
         private const string DotnetAnalyzerDiagnosticSeverityKey = DotnetAnalyzerDiagnosticPrefix + "." + SeveritySuffix;
+
+        public static ImmutableArray<string> ImmutableCustomTags(this DiagnosticDescriptor descriptor)
+        {
+            Debug.Assert(descriptor.CustomTags is ImmutableArray<string>);
+            return (ImmutableArray<string>)descriptor.CustomTags;
+        }
 
         /// <summary>
         /// Gets project-level effective severity of the given <paramref name="descriptor"/> accounting for severity configurations from both the following sources:
@@ -61,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             //  2. Compiler diagnostics
             //  3. Non-configurable diagnostics
             if (!descriptor.IsEnabledByDefault ||
-                descriptor.CustomTags.Any(tag => tag == WellKnownDiagnosticTags.Compiler || tag == WellKnownDiagnosticTags.NotConfigurable))
+                descriptor.ImmutableCustomTags().Any(tag => tag == WellKnownDiagnosticTags.Compiler || tag == WellKnownDiagnosticTags.NotConfigurable))
             {
                 return false;
             }
@@ -103,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             //  2. Compiler diagnostics
             //  3. Non-configurable diagnostics
             if (!descriptor.IsEnabledByDefault ||
-                descriptor.CustomTags.Any(tag => tag == WellKnownDiagnosticTags.Compiler || tag == WellKnownDiagnosticTags.NotConfigurable))
+                descriptor.ImmutableCustomTags().Any(tag => tag == WellKnownDiagnosticTags.Compiler || tag == WellKnownDiagnosticTags.NotConfigurable))
             {
                 return ReportDiagnostic.Default;
             }
@@ -149,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             //  2. Compiler diagnostics
             //  3. Non-configurable diagnostics
             if (!descriptor.IsEnabledByDefault ||
-                descriptor.CustomTags.Any(tag => tag == WellKnownDiagnosticTags.Compiler || tag == WellKnownDiagnosticTags.NotConfigurable))
+                descriptor.ImmutableCustomTags().Any(tag => tag == WellKnownDiagnosticTags.Compiler || tag == WellKnownDiagnosticTags.NotConfigurable))
             {
                 severity = default;
                 return false;
@@ -177,6 +182,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static bool IsCompilationEnd(this DiagnosticDescriptor descriptor)
-            => descriptor.CustomTags.Contains(WellKnownDiagnosticTags.CompilationEnd);
+            => descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.CompilationEnd);
     }
 }


### PR DESCRIPTION
Eliminates 2.7GB (51%) of allocations occurring OOP during a period of time where high GC overhead causes code action delays. Nearly all of the benefit comes from changing this call:

https://github.com/dotnet/roslyn/blob/6ff82a995eebcb2e21c3bad5ac8163ce5fd05db8/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerOptionsExtensions.cs#L44

Fixes [AB#1371515](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1371515)