### PR TITLE
Fix typing in rename preview changes

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/AbstractRenameCommandHandler.cs
@@ -76,12 +76,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 actionIfInsideActiveSpan(_renameService.ActiveSession, containingSpan);
             }
-            else
+            else if (_renameService.ActiveSession.IsInOpenTextBuffer(singleSpan.Start))
             {
-                // It's in a read-only area, so let's commit the rename and then let the character go
-                // through
+                // It's in a read-only area that is open, so let's commit the rename 
+                // and then let the character go through
 
                 CommitIfActiveAndCallNextHandler(args, nextHandler);
+            }
+            else
+            {
+                nextHandler();
+                return;
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -888,6 +888,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             return false;
         }
 
+        internal bool IsInOpenTextBuffer(SnapshotPoint point)
+            => _openTextBuffers.ContainsKey(point.Snapshot.TextBuffer);
+
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 


### PR DESCRIPTION
When typing in preview changes, which is a readonly text buffer, the inline rename engine was defaulting to try and commit again. This results in extra modal dialogs being open that can't be closed. Fix by checking that the open buffers contains the area that is attempting to be edited before trying to commit. For the case of the preview pane, the open buffers are tracked differently.

Fixes #54876