### PR TITLE
Change preview pane to hide unusable options

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewEngine.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewEngine.cs
@@ -252,7 +252,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                 textView = _editorFactory.GetWpfTextView(adapter);
             }
 
+            UpdateTextViewOptions(textView);
+
             return textView;
+        }
+
+        private static void UpdateTextViewOptions(IWpfTextView textView)
+        {
+            // Do not show the IndentationCharacterMargin, which controls spaces vs. tabs etc.
+            textView.Options.SetOptionValue(DefaultTextViewHostOptions.IndentationCharacterMarginOptionId, false);
+
+            // Do not show LineEndingMargin, which determines EOL and EOF settings.
+            textView.Options.SetOptionValue(DefaultTextViewHostOptions.LineEndingMarginOptionId, false);
         }
 
         // When the dialog is first instantiated, the IVsTextView it contains may 


### PR DESCRIPTION
Hides the indentation and EOL settings at the bottom of the editor in the preview pane. These don't work correctly, and instead change the settings for another open document. 

![ea99e971-4226-4791-87e0-160ced525e80](https://user-images.githubusercontent.com/475144/130303166-57720953-a2f3-4869-b186-c8bce80a1ce1.gif)


Before: 

![image](https://user-images.githubusercontent.com/475144/130303013-b2053684-eefd-4e43-9f90-c180b91a4e69.png)


After: 

![image](https://user-images.githubusercontent.com/475144/130303020-a12c46d2-699d-424c-b874-06b736d27667.png)
