### PR TITLE
Convert tests to new test framework

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -11,164 +11,154 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ExtractClass;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ExtractClass;
 using Microsoft.CodeAnalysis.PullMemberUp;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractClass
 {
-    public class ExtractClassTests : AbstractCSharpCodeActionTest
+    [UseExportProvider]
+    public class ExtractClassTests
     {
-        private Task TestExtractClassAsync(
-            string input,
-            string? expected = null,
-            IEnumerable<(string name, bool makeAbstract)>? dialogSelection = null,
-            bool sameFile = false,
-            bool isClassDeclarationSelection = false,
-            TestParameters testParameters = default)
+        private class Test : CSharpCodeRefactoringVerifier<CSharpExtractClassCodeRefactoringProvider>.Test
         {
-            var service = new TestExtractClassOptionsService(dialogSelection, sameFile, isClassDeclarationSelection);
-            var parametersWithOptionsService = testParameters.WithFixProviderData(service);
+            public IEnumerable<(string name, bool makeAbstract)>? DialogSelection { get; set; }
+            public bool SameFile { get; set; }
+            public bool IsClassDeclarationSelection { get; set; }
+            public string FileName { get; set; } = "/0/Test1.cs";
+            public string WorkspaceKind { get; set; } = CodeAnalysis.WorkspaceKind.Host;
 
-            if (expected is null)
+            protected override IEnumerable<CodeRefactoringProvider> GetCodeRefactoringProviders()
             {
-                return TestMissingAsync(input, parametersWithOptionsService);
+                var service = new TestExtractClassOptionsService(DialogSelection, SameFile, IsClassDeclarationSelection)
+                {
+                    FileName = FileName
+                };
+
+                return SpecializedCollections.SingletonEnumerable(new CSharpExtractClassCodeRefactoringProvider(service));
             }
 
-            return TestInRegularAndScript1Async(
-                input,
-                expected,
-                parameters: parametersWithOptionsService);
+            protected override Workspace CreateWorkspaceImpl()
+            {
+                return TestWorkspace.Create(WorkspaceKind, LanguageNames.CSharp, this.CreateCompilationOptions(), this.CreateParseOptions());
+            }
         }
-
-        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
-           => new CSharpExtractClassCodeRefactoringProvider((IExtractClassOptionsService)parameters.fixProviderData);
 
         [Fact]
         public async Task TestSingleMethod()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     int [||]Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2,
+                    }
+                },
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestErrorBaseMethod()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+class ErrorBase
+{
+}
+
 class Test : ErrorBase
 {
     int [||]Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
-
-            await TestExtractClassAsync(input);
+}";
+            await new Test
+            {
+                TestCode = input,
+                FixedCode = input,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestMiscellaneousFiles()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     int [||]Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            TestParameters parameters = default;
-            await TestExtractClassAsync(input, testParameters: parameters.WithWorkspaceKind(WorkspaceKind.MiscellaneousFiles));
+            await new Test
+            {
+                TestCode = input,
+                FixedCode = input,
+                WorkspaceKind = WorkspaceKind.MiscellaneousFiles
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestPartialClass()
         {
-            var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var input1 = @"
 partial class Test
 {
     int [||]Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-        <Document FilePath=""Test.Other.cs"">
+}";
+            var input2 = @"
 partial class Test
 {
     int Method2()
     {
         return 5;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 partial class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""Test.Other.cs"">
+}";
+            var expected2 = @"
 partial class Test
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected3 = @"internal class MyBase
 {
     int Method()
     {
@@ -178,23 +168,36 @@ partial class Test
     {
         return 5;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(
-                input,
-                expected,
-                dialogSelection: MakeSelection("Method", "Method2"));
+            await new Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        input1,
+                        input2,
+                    }
+                },
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2,
+                        expected3,
+                    }
+                },
+                FileName = "/0/Test2.cs",
+                DialogSelection = MakeSelection("Method", "Method2")
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestInNamespace()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 namespace MyNamespace
 {
     class Test
@@ -204,23 +207,16 @@ namespace MyNamespace
             return 1 + 1;
         }
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 namespace MyNamespace
 {
     class Test : MyBase
     {
     }
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">namespace MyNamespace
+}";
+            var expected2 = @"namespace MyNamespace
 {
     internal class MyBase
     {
@@ -229,20 +225,26 @@ namespace MyNamespace
             return 1 + 1;
         }
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2,
+                    }
+                },
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestInNamespace_FileScopedNamespace1()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"" LanguageVersion=""10"">
-        <Document FilePath=""Test.cs"">
 namespace MyNamespace
 {
     class Test
@@ -252,23 +254,16 @@ namespace MyNamespace
             return 1 + 1;
         }
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"" LanguageVersion=""10"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 namespace MyNamespace
 {
     class Test : MyBase
     {
     }
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">namespace MyNamespace;
+}";
+            var expected2 = @"namespace MyNamespace;
 
 internal class MyBase
 {
@@ -276,24 +271,31 @@ internal class MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestAsync(
-                input, expected,
-                CSharpParseOptions.Default,
-                options: Option(CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped, NotificationOption2.Silent),
-                fixProviderData: new TestExtractClassOptionsService());
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2,
+                    }
+                },
+                LanguageVersion = LanguageVersion.CSharp10,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped, NotificationOption2.Silent }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestInNamespace_FileScopedNamespace2()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"" LanguageVersion=""9"">
-        <Document FilePath=""Test.cs"">
 namespace MyNamespace
 {
     class Test
@@ -303,23 +305,16 @@ namespace MyNamespace
             return 1 + 1;
         }
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"" LanguageVersion=""9"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 namespace MyNamespace
 {
     class Test : MyBase
     {
     }
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">namespace MyNamespace
+}";
+            var expected2 = @"namespace MyNamespace
 {
     internal class MyBase
     {
@@ -328,24 +323,31 @@ namespace MyNamespace
             return 1 + 1;
         }
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestAsync(
-                input, expected,
-                CSharpParseOptions.Default,
-                options: Option(CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped, NotificationOption2.Silent),
-                fixProviderData: new TestExtractClassOptionsService());
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                LanguageVersion = LanguageVersion.CSharp9,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped, NotificationOption2.Silent }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestInNamespace_FileScopedNamespace3()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"" LanguageVersion=""10"">
-        <Document FilePath=""Test.cs"">
 namespace MyNamespace
 {
     class Test
@@ -355,23 +357,16 @@ namespace MyNamespace
             return 1 + 1;
         }
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"" LanguageVersion=""10"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 namespace MyNamespace
 {
     class Test : MyBase
     {
     }
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">namespace MyNamespace
+}";
+            var expected2 = @"namespace MyNamespace
 {
     internal class MyBase
     {
@@ -380,166 +375,171 @@ namespace MyNamespace
             return 1 + 1;
         }
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestAsync(
-                input, expected,
-                CSharpParseOptions.Default,
-                options: Option(CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.BlockScoped, NotificationOption2.Silent),
-                fixProviderData: new TestExtractClassOptionsService());
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                LanguageVersion = LanguageVersion.CSharp10,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.BlockScoped, NotificationOption2.Silent }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestAccessibility()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 public class Test
 {
     int [||]Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 public class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">public class MyBase
+}";
+            var expected2 = @"public class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestEvent()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 using System;
 
 class Test
 {
-    private event EventHandler [||]Event1;    
-}
-        </Document>
-    </Project>
-</Workspace>";
+    private event EventHandler [||]Event1;
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 using System;
 
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"using System;
+
+internal class MyBase
 {
     private event EventHandler Event1;
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestProperty()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     int [||]MyProperty { get; set; }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int MyProperty { get; set; }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestField()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     int [||]MyField;
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int MyField;
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestFileHeader_FromExistingFile()
         {
-            var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">// this is my document header
+            var input = @"// this is my document header
 // that should be copied over
 
 class Test
@@ -548,22 +548,15 @@ class Test
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">// this is my document header
+            var expected1 = @"// this is my document header
 // that should be copied over
 
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">// this is my document header
+}";
+            var expected2 = @"// this is my document header
 // that should be copied over
 
 internal class MyBase
@@ -572,20 +565,26 @@ internal class MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestFileHeader_FromOption()
         {
-            var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">// this is my document header
+            var input = @"// this is my document header
 // that should be ignored
 
 class Test
@@ -594,22 +593,15 @@ class Test
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">// this is my document header
+            var expected1 = @"// this is my document header
 // that should be ignored
 
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">// this is my real document header
+}";
+            var expected2 = @"// this is my real document header
 
 internal class MyBase
 {
@@ -617,20 +609,30 @@ internal class MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, testParameters: new TestParameters(options: Option(CodeStyleOptions2.FileHeaderTemplate, "this is my real document header")));
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                Options =
+                {
+                    { CodeStyleOptions2.FileHeaderTemplate, "this is my real document header" }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestWithInterface()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 interface ITest 
 {
     int Method();
@@ -638,19 +640,13 @@ interface ITest
 
 class Test : ITest
 {
-    int [||]Method()
+    public int [||]Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 interface ITest 
 {
     int Method();
@@ -658,28 +654,33 @@ interface ITest
 
 class Test : MyBase, ITest
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
-    int Method()
+    public int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [ConditionalFact(AlwaysSkip = "https://github.com/dotnet/roslyn/issues/45977")]
         public async Task TestRegion()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     #region MyRegion
@@ -690,15 +691,9 @@ class Test
 
     void OtherMethiod() { }
     #endregion
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
 
@@ -706,9 +701,8 @@ class Test : MyBase
 
     void OtherMethiod() { }
     #endregion
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     #region MyRegion
     int Method()
@@ -716,117 +710,115 @@ class Test : MyBase
         return 1 + 1;
     }
     #endregion
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(
-                input,
-                expected,
-                dialogSelection: MakeSelection("Method"));
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                DialogSelection = MakeSelection("Method")
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestMakeAbstract_SingleMethod()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
-    int [||]Method()
+    public int [||]Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-    override int Method()
+    public override int Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal abstract class MyBase
+}";
+            var expected2 = @"internal abstract class MyBase
 {
-    private abstract global::System.Int32 Method();
-}</Document>
-    </Project>
-</Workspace>";
+    public abstract int Method();
+}";
 
-            await TestExtractClassAsync(
-                input,
-                expected,
-                dialogSelection: MakeAbstractSelection("Method"));
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                DialogSelection = MakeAbstractSelection("Method")
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestMakeAbstract_MultipleMethods()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
-    int [||]Method()
+    public int [||]Method()
     {
         return 1 + 1;
     }
 
-    int Method2() => 2;
-    int Method3() => 3;
-}
-        </Document>
-    </Project>
-</Workspace>";
+    public int Method2() => 2;
+    public int Method3() => 3;
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-    override int Method()
+    public override int Method()
     {
         return 1 + 1;
     }
 
-    override int Method2() => 2;
-    override int Method3() => 3;
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal abstract class MyBase
+    public override int Method2() => 2;
+    public override int Method3() => 3;
+}";
+            var expected2 = @"internal abstract class MyBase
 {
-    private abstract global::System.Int32 Method();
-    private abstract global::System.Int32 Method2();
-    private abstract global::System.Int32 Method3();
-}</Document>
-    </Project>
-</Workspace>";
+    public abstract int Method();
+    public abstract int Method2();
+    public abstract int Method3();
+}";
 
-            await TestExtractClassAsync(
-                input,
-                expected,
-                dialogSelection: MakeAbstractSelection("Method", "Method2", "Method3"));
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                DialogSelection = MakeAbstractSelection("Method", "Method2", "Method3")
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestMultipleMethods()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     int [||]Method()
@@ -835,20 +827,13 @@ class Test
     }
 
     int Method2() => 1;
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
@@ -856,23 +841,27 @@ class Test : MyBase
     }
 
     int Method2() => 1;
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(
-                input,
-                expected,
-                dialogSelection: MakeSelection("Method", "Method2"));
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                DialogSelection = MakeSelection("Method", "Method2")
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestMultipleMethods_SomeSelected()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     int [||]Method()
@@ -881,44 +870,41 @@ class Test
     }
 
     int Method2() => 1;
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
     int Method()
     {
-        return Method2() + 1;
+        return {|CS0122:Method2|}() + 1;
     }
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
 
     int Method2() => 1;
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(
-                input,
-                expected,
-                dialogSelection: MakeSelection("Method2"));
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                DialogSelection = MakeSelection("Method2")
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestSelection_CompleteMethodAndComments()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     [|/// <summary>
@@ -928,20 +914,13 @@ class Test
     {
         return 1 + 1;
     }|]
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     /// <summary>
     /// this is a test method
@@ -950,20 +929,26 @@ class Test : MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestSelection_PartialMethodAndComments()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     [|/// <summary>
@@ -973,20 +958,13 @@ class Test
     {|]
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     /// <summary>
     /// this is a test method
@@ -995,20 +973,26 @@ class Test : MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestSelection_PartialMethodAndComments2()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     /// <summary>
@@ -1018,20 +1002,13 @@ class Test
     {|]
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     /// <summary>
     /// this is a test method
@@ -1040,20 +1017,26 @@ class Test : MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestSelection_PartialMethodAndComments3()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     /// <summary>
@@ -1063,20 +1046,13 @@ class Test
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     /// <summary>
     /// this is a test method
@@ -1085,20 +1061,26 @@ class Test : MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestAttributes()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 using System;
 
 class TestAttribute : Attribute { }
@@ -1113,24 +1095,17 @@ class Test
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 using System;
 
 class TestAttribute : Attribute { }
 
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     /// <summary>
     /// this is a test method
@@ -1140,20 +1115,26 @@ class Test : MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestAttributes2()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 using System;
 
 class TestAttribute : Attribute { }
@@ -1170,15 +1151,9 @@ class Test
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 using System;
 
 class TestAttribute : Attribute { }
@@ -1186,9 +1161,8 @@ class TestAttribute2 : Attribute { }
 
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     /// <summary>
     /// this is a test method
@@ -1199,20 +1173,26 @@ class Test : MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [ConditionalFact(AlwaysSkip = "https://github.com/dotnet/roslyn/issues/45987")]
         public async Task TestAttributes3()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 using System;
 
 class TestAttribute : Attribute { }
@@ -1229,24 +1209,20 @@ class Test
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 using System;
 
 class TestAttribute : Attribute { }
 
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"
+using System;
+
+internal class MyBase
 {
     /// <summary>
     /// this is a test method
@@ -1257,20 +1233,26 @@ class Test : MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [ConditionalFact(AlwaysSkip = "https://github.com/dotnet/roslyn/issues/45987")]
         public async Task TestAttributes4()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 using System;
 
 class TestAttribute : Attribute { }
@@ -1287,24 +1269,17 @@ class Test
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 using System;
 
 class TestAttribute : Attribute { }
 
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     /// <summary>
     /// this is a test method
@@ -1315,33 +1290,33 @@ class Test : MyBase
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                }
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestSameFile()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test
 {
     void Method[||]()
     {
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
             var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 internal class MyBase
 {
     void Method()
@@ -1351,176 +1326,176 @@ internal class MyBase
 
 class Test : MyBase
 {
-}
-        </Document>
-    </Project>
-</Workspace>";
-            await TestExtractClassAsync(input, expected, sameFile: true);
+}";
+
+            await new Test
+            {
+                TestCode = input,
+                FixedCode = expected,
+                SameFile = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class Test[||]
 {
     int Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration2()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class [||]Test
 {
     int Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration3()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 [||]class Test
 {
     int Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration4()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 class[||] Test
 {
     int Method()
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration_Comment()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 using System;
 
 /// <summary>
@@ -1532,15 +1507,9 @@ class Test|]
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 using System;
 
 /// <summary>
@@ -1548,28 +1517,34 @@ using System;
 /// </summary>
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration_Comment2()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 using System;
 
 /// <summary>
@@ -1581,15 +1556,9 @@ class Test|]
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 using System;
 
 /// <summary>
@@ -1597,28 +1566,34 @@ using System;
 /// </summary>
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration_Comment3()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 using System;
 
 /// <summary>
@@ -1630,15 +1605,9 @@ class|] Test
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 using System;
 
 /// <summary>
@@ -1646,28 +1615,34 @@ using System;
 /// </summary>
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration_Attribute()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 using System;
 
 public class MyAttribute : Attribute { }
@@ -1679,15 +1654,9 @@ class Test
     {
         return 1 + 1;
     }
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 using System;
 
 public class MyAttribute : Attribute { }
@@ -1695,98 +1664,107 @@ public class MyAttribute : Attribute { }
 [MyAttribute]
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">[MyAttribute]
+}";
+            var expected2 = @"[My]
 internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration_SelectWithMembers()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 [|class Test
 {
     int Method()
     {
         return 1 + 1;
     }
-}|]
-        </Document>
-    </Project>
-</Workspace>";
+}|]";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         [Fact]
         public async Task TestClassDeclaration_SelectWithMembers2()
         {
             var input = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
 [|class Test
 {
     int Method()
     {
         return 1 + 1;
     }|]
-}
-        </Document>
-    </Project>
-</Workspace>";
+}";
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"">
-        <Document FilePath=""Test.cs"">
+            var expected1 = @"
 class Test : MyBase
 {
-}
-        </Document>
-        <Document FilePath=""MyBase.cs"">internal class MyBase
+}";
+            var expected2 = @"internal class MyBase
 {
     int Method()
     {
         return 1 + 1;
     }
-}</Document>
-    </Project>
-</Workspace>";
+}";
 
-            await TestExtractClassAsync(input, expected, isClassDeclarationSelection: true);
+            await new Test
+            {
+                TestCode = input,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                IsClassDeclarationSelection = true,
+            }.RunAsync();
         }
 
         private static IEnumerable<(string name, bool makeAbstract)> MakeAbstractSelection(params string[] memberNames)

--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -762,7 +762,7 @@ namespace ConsoleApp185
             }.RunAsync();
         }
 
- [Fact]
+        [Fact]
         [WorkItem(55746, "https://github.com/dotnet/roslyn/issues/55746")]
         public async Task TestUsingsInsideNamespace_NoNamespace()
         {

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis.AddImports;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -774,6 +775,53 @@ public interface IClass
 
             await TestExtractInterfaceCommandCSharpAsync(markup, expectedSuccess: true, expectedInterfaceCode: expectedInterfaceCode);
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
+        public async Task ExtractInterface_CodeGen_ImportsInsideNamespace()
+        {
+            var markup = @"
+namespace N
+{
+    public class Class
+    {
+        $$public System.Diagnostics.BooleanSwitch M1(System.Globalization.Calendar x) { return null; }
+        public void M2(System.Collections.Generic.List<System.IO.BinaryWriter> x) { }
+        public void M3<T>() where T : System.Net.WebProxy { }
+    }
+}";
+
+            var expectedInterfaceCode = @"namespace N
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Net;
+
+    public interface IClass
+    {
+        BooleanSwitch M1(Calendar x);
+        void M2(List<BinaryWriter> x);
+        void M3<T>() where T : WebProxy;
+    }
+}";
+
+            using var testState = ExtractInterfaceTestState.Create(
+                markup, LanguageNames.CSharp,
+                parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp10),
+                options: new OptionsCollection(LanguageNames.CSharp)
+                {
+                    { CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, AddImportPlacement.InsideNamespace }
+                });
+
+            var result = await testState.ExtractViaCommandAsync();
+
+            var interfaceDocument = result.UpdatedSolution.GetRequiredDocument(result.NavigationDocumentId);
+            var interfaceCode = (await interfaceDocument.GetTextAsync()).ToString();
+
+            Assert.Equal(expectedInterfaceCode, interfaceCode);
+        }
+
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
         public async Task ExtractInterface_CodeGen_TypeParameters1()

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -340,18 +340,17 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
             SyntaxNode contextNode,
             INamespaceOrTypeSymbol namespaceOrTypeSymbol,
             Document document,
-            bool placeSystemNamespaceFirst,
             bool allowInHiddenRegions,
             CancellationToken cancellationToken)
         {
             var root = GetCompilationUnitSyntaxNode(contextNode, cancellationToken);
-            var newRoot = await AddImportWorkerAsync(document, root, contextNode, namespaceOrTypeSymbol, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+            var newRoot = await AddImportWorkerAsync(document, root, contextNode, namespaceOrTypeSymbol, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
             return document.WithSyntaxRoot(newRoot);
         }
 
         private async Task<CompilationUnitSyntax> AddImportWorkerAsync(
             Document document, CompilationUnitSyntax root, SyntaxNode contextNode, INamespaceOrTypeSymbol namespaceOrTypeSymbol,
-            bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken)
+            bool allowInHiddenRegions, CancellationToken cancellationToken)
         {
             var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
@@ -382,13 +381,13 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
             var addImportService = document.GetLanguageService<IAddImportsService>();
             var generator = SyntaxGenerator.GetGenerator(document);
             var newRoot = addImportService.AddImports(
-                semanticModel.Compilation, root, contextNode, newImports, generator, options, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+                semanticModel.Compilation, root, contextNode, newImports, generator, options, allowInHiddenRegions, cancellationToken);
             return (CompilationUnitSyntax)newRoot;
         }
 
         protected override async Task<Document> AddImportAsync(
             SyntaxNode contextNode, IReadOnlyList<string> namespaceParts,
-            Document document, bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken)
+            Document document, bool allowInHiddenRegions, CancellationToken cancellationToken)
         {
             var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var root = GetCompilationUnitSyntaxNode(contextNode, cancellationToken);
@@ -400,7 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
             var service = document.GetLanguageService<IAddImportsService>();
             var generator = SyntaxGenerator.GetGenerator(document);
             var newRoot = service.AddImport(
-                compilation, root, contextNode, usingDirective, generator, options, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+                compilation, root, contextNode, usingDirective, generator, options, allowInHiddenRegions, cancellationToken);
 
             return document.WithSyntaxRoot(newRoot);
         }

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -494,8 +494,6 @@ namespace Microsoft.CodeAnalysis.AddImport
             // We might have multiple different diagnostics covering the same span.  Have to
             // process them all as we might produce different fixes for each diagnostic.
 
-            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-
             // Normally we don't allow generation into a hidden region in the file.  However, if we have a
             // modern span mapper at our disposal, we do allow it as that host span mapper can handle mapping
             // our edit to their domain appropriate.
@@ -550,7 +548,6 @@ namespace Microsoft.CodeAnalysis.AddImport
             ImmutableArray<PackageSource> packageSources,
             CancellationToken cancellationToken)
         {
-            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SymbolSearch;
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         protected abstract bool IsAddMethodContext(SyntaxNode node, SemanticModel semanticModel);
 
         protected abstract string GetDescription(IReadOnlyList<string> nameParts);
-        protected abstract (string description, bool hasExistingImport) GetDescription(Document document, INamespaceOrTypeSymbol symbol, SemanticModel semanticModel, SyntaxNode root, CancellationToken cancellationToken);
+        protected abstract (string description, bool hasExistingImport) GetDescription(Document document, OptionSet options, INamespaceOrTypeSymbol symbol, SemanticModel semanticModel, SyntaxNode root, CancellationToken cancellationToken);
 
         public async Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
             Document document, TextSpan span, string diagnosticId, int maxResults,

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -45,8 +45,8 @@ namespace Microsoft.CodeAnalysis.AddImport
         protected abstract ITypeSymbol GetQueryClauseInfo(SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken);
         protected abstract bool IsViableExtensionMethod(IMethodSymbol method, SyntaxNode expression, SemanticModel semanticModel, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken);
 
-        protected abstract Task<Document> AddImportAsync(SyntaxNode contextNode, INamespaceOrTypeSymbol symbol, Document document, bool specialCaseSystem, bool allowInHiddenRegions, CancellationToken cancellationToken);
-        protected abstract Task<Document> AddImportAsync(SyntaxNode contextNode, IReadOnlyList<string> nameSpaceParts, Document document, bool specialCaseSystem, bool allowInHiddenRegions, CancellationToken cancellationToken);
+        protected abstract Task<Document> AddImportAsync(SyntaxNode contextNode, INamespaceOrTypeSymbol symbol, Document document, bool allowInHiddenRegions, CancellationToken cancellationToken);
+        protected abstract Task<Document> AddImportAsync(SyntaxNode contextNode, IReadOnlyList<string> nameSpaceParts, Document document, bool allowInHiddenRegions, CancellationToken cancellationToken);
 
         protected abstract bool IsAddMethodContext(SyntaxNode node, SemanticModel semanticModel);
 
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
         public async Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
             Document document, TextSpan span, string diagnosticId, int maxResults,
-            bool placeSystemNamespaceFirst, bool allowInHiddenRegions,
+            bool allowInHiddenRegions,
             ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
         {
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 var result = await client.TryInvokeAsync<IRemoteMissingImportDiscoveryService, ImmutableArray<AddImportFixData>>(
                     document.Project.Solution,
                     (service, solutionInfo, callbackId, cancellationToken) =>
-                        service.GetFixesAsync(solutionInfo, callbackId, document.Id, span, diagnosticId, maxResults, placeSystemNamespaceFirst, allowInHiddenRegions, searchReferenceAssemblies, packageSources, cancellationToken),
+                        service.GetFixesAsync(solutionInfo, callbackId, document.Id, span, diagnosticId, maxResults, allowInHiddenRegions, searchReferenceAssemblies, packageSources, cancellationToken),
                     callbackTarget: symbolSearchService,
                     cancellationToken).ConfigureAwait(false);
 
@@ -74,14 +74,14 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             return await GetFixesInCurrentProcessAsync(
                 document, span, diagnosticId, maxResults,
-                placeSystemNamespaceFirst, allowInHiddenRegions,
+                allowInHiddenRegions,
                 symbolSearchService, searchReferenceAssemblies,
                 packageSources, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<ImmutableArray<AddImportFixData>> GetFixesInCurrentProcessAsync(
             Document document, TextSpan span, string diagnosticId, int maxResults,
-            bool placeSystemNamespaceFirst, bool allowInHiddenRegions,
+            bool allowInHiddenRegions,
             ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
         {
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                             {
                                 cancellationToken.ThrowIfCancellationRequested();
 
-                                var fixData = await reference.TryGetFixDataAsync(document, node, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+                                var fixData = await reference.TryGetFixDataAsync(document, node, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
                                 result.AddIfNotNull(fixData);
                             }
                         }
@@ -495,7 +495,6 @@ namespace Microsoft.CodeAnalysis.AddImport
             // process them all as we might produce different fixes for each diagnostic.
 
             var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var placeSystemNamespaceFirst = documentOptions.GetOption(GenerationOptions.PlaceSystemNamespaceFirst);
 
             // Normally we don't allow generation into a hidden region in the file.  However, if we have a
             // modern span mapper at our disposal, we do allow it as that host span mapper can handle mapping
@@ -508,7 +507,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             {
                 var fixes = await GetFixesAsync(
                     document, span, diagnostic.Id, maxResultsPerDiagnostic,
-                    placeSystemNamespaceFirst, allowInHiddenRegions,
+                    allowInHiddenRegions,
                     symbolSearchService, searchReferenceAssemblies,
                     packageSources, cancellationToken).ConfigureAwait(false);
 
@@ -552,7 +551,6 @@ namespace Microsoft.CodeAnalysis.AddImport
             CancellationToken cancellationToken)
         {
             var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var placeSystemNamespaceFirst = documentOptions.GetOption(GenerationOptions.PlaceSystemNamespaceFirst);
             var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// </summary>
         Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
             Document document, TextSpan span, string diagnosticId, int maxResults,
-            bool placeSystemNamespaceFirst, bool allowInHiddenRegions,
+            bool allowInHiddenRegions,
             ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
 
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
         /// <summary>
         /// Gets data for how to fix a particular <see cref="Diagnostic" /> id within the specified Document.
-        /// Similar to <see cref="GetFixesAsync(Document, TextSpan, string, int, bool, bool, ISymbolSearchService, bool, ImmutableArray{PackageSource}, CancellationToken)"/> 
+        /// Similar to <see cref="GetFixesAsync(Document, TextSpan, string, int, bool, ISymbolSearchService, bool, ImmutableArray{PackageSource}, CancellationToken)"/> 
         /// except it only returns fix data when there is a single using fix for a given span
         /// </summary>
         Task<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(

--- a/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
@@ -27,10 +27,10 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
 
             public override async Task<AddImportFixData> TryGetFixDataAsync(
-                Document document, SyntaxNode node, bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken)
+                Document document, SyntaxNode node, bool allowInHiddenRegions, CancellationToken cancellationToken)
             {
                 var textChanges = await GetTextChangesAsync(
-                    document, node, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+                    document, node, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
 
                 var title = $"{provider.GetDescription(SearchResult.NameParts)} ({string.Format(FeaturesResources.from_0, _referenceAssemblyWithType.AssemblyName)})";
                 var fullyQualifiedTypeName = string.Join(

--- a/src/Features/Core/Portable/AddImport/References/MetadataSymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/MetadataSymbolReference.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -40,10 +41,10 @@ namespace Microsoft.CodeAnalysis.AddImport
             protected override bool ShouldAddWithExistingImport(Document document) => true;
 
             protected override (string description, bool hasExistingImport) GetDescription(
-                Document document, SyntaxNode node,
+                Document document, OptionSet options, SyntaxNode node,
                 SemanticModel semanticModel, CancellationToken cancellationToken)
             {
-                var (description, hasExistingImport) = base.GetDescription(document, node, semanticModel, cancellationToken);
+                var (description, hasExistingImport) = base.GetDescription(document, options, node, semanticModel, cancellationToken);
                 if (description == null)
                 {
                     return (null, false);

--- a/src/Features/Core/Portable/AddImport/References/PackageReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/PackageReference.cs
@@ -32,10 +32,10 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
 
             public override async Task<AddImportFixData> TryGetFixDataAsync(
-                Document document, SyntaxNode node, bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken)
+                Document document, SyntaxNode node, bool allowInHiddenRegions, CancellationToken cancellationToken)
             {
                 var textChanges = await GetTextChangesAsync(
-                    document, node, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+                    document, node, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
 
                 return AddImportFixData.CreateForPackageSymbol(
                     textChanges, _source, _packageName, _versionOpt);

--- a/src/Features/Core/Portable/AddImport/References/ProjectSymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/ProjectSymbolReference.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -85,10 +86,10 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
 
             protected override (string description, bool hasExistingImport) GetDescription(
-                Document document, SyntaxNode node,
+                Document document, OptionSet options, SyntaxNode node,
                 SemanticModel semanticModel, CancellationToken cancellationToken)
             {
-                var (description, hasExistingImport) = base.GetDescription(document, node, semanticModel, cancellationToken);
+                var (description, hasExistingImport) = base.GetDescription(document, options, node, semanticModel, cancellationToken);
                 if (description == null)
                 {
                     return (null, false);

--- a/src/Features/Core/Portable/AddImport/References/Reference.cs
+++ b/src/Features/Core/Portable/AddImport/References/Reference.cs
@@ -101,10 +101,10 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
 
             public abstract Task<AddImportFixData> TryGetFixDataAsync(
-                Document document, SyntaxNode node, bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken);
+                Document document, SyntaxNode node, bool allowInHiddenRegions, CancellationToken cancellationToken);
 
             protected async Task<ImmutableArray<TextChange>> GetTextChangesAsync(
-                Document document, SyntaxNode node, bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken)
+                Document document, SyntaxNode node, bool allowInHiddenRegions, CancellationToken cancellationToken)
             {
                 var originalDocument = document;
 
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                     node, document, cancellationToken).ConfigureAwait(false);
 
                 var newDocument = await provider.AddImportAsync(
-                    node, SearchResult.NameParts, document, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+                    node, SearchResult.NameParts, document, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
 
                 var cleanedDocument = await CodeAction.CleanupDocumentAsync(
                     newDocument, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/AddImport/References/SymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/SymbolReference.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -80,8 +81,9 @@ namespace Microsoft.CodeAnalysis.AddImport
                 Document document, SyntaxNode node,
                 bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken)
             {
+                var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                var (description, hasExistingImport) = GetDescription(document, node, semanticModel, cancellationToken);
+                var (description, hasExistingImport) = GetDescription(document, options, node, semanticModel, cancellationToken);
                 if (description == null)
                 {
                     return null;
@@ -126,11 +128,11 @@ namespace Microsoft.CodeAnalysis.AddImport
             protected abstract CodeActionPriority GetPriority(Document document);
 
             protected virtual (string description, bool hasExistingImport) GetDescription(
-                Document document, SyntaxNode node,
+                Document document, OptionSet options, SyntaxNode node,
                 SemanticModel semanticModel, CancellationToken cancellationToken)
             {
                 return provider.GetDescription(
-                    document, SymbolResult.Symbol, semanticModel, node, cancellationToken);
+                    document, options, SymbolResult.Symbol, semanticModel, node, cancellationToken);
             }
         }
     }

--- a/src/Features/Core/Portable/AddImport/References/SymbolReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/SymbolReference.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             private async Task<ImmutableArray<TextChange>> GetTextChangesAsync(
                 Document document, SyntaxNode contextNode,
-                bool placeSystemNamespaceFirst, bool allowInHiddenRegions, bool hasExistingImport,
+                bool allowInHiddenRegions, bool hasExistingImport,
                 CancellationToken cancellationToken)
             {
                 // Defer to the language to add the actual import/using.
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
                 var updatedDocument = await provider.AddImportAsync(
                     newContextNode, SymbolResult.Symbol, newDocument,
-                    placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+                    allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
 
                 var cleanedDocument = await CodeAction.CleanupDocumentAsync(
                     updatedDocument, cancellationToken).ConfigureAwait(false);
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             public sealed override async Task<AddImportFixData> TryGetFixDataAsync(
                 Document document, SyntaxNode node,
-                bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken)
+                bool allowInHiddenRegions, CancellationToken cancellationToken)
             {
                 var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 }
 
                 var textChanges = await GetTextChangesAsync(
-                    document, node, placeSystemNamespaceFirst, allowInHiddenRegions, hasExistingImport, cancellationToken).ConfigureAwait(false);
+                    document, node, allowInHiddenRegions, hasExistingImport, cancellationToken).ConfigureAwait(false);
 
                 return GetFixData(
                     document, textChanges, description,

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
         ValueTask<ImmutableArray<AddImportFixData>> GetFixesAsync(
             PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId documentId, TextSpan span, string diagnosticId, int maxResults,
-            bool placeSystemNamespaceFirst, bool allowInHiddenRegions, bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
+            bool allowInHiddenRegions, bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(
             PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId id, TextSpan span, ImmutableArray<string> diagnosticIds,
             bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/AliasAmbiguousType/AbstractAliasAmbiguousTypeCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AliasAmbiguousType/AbstractAliasAmbiguousTypeCodeFixProvider.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.AliasAmbiguousType
                 var syntaxGenerator = document.GetRequiredLanguageService<SyntaxGenerator>();
                 var compilation = semanticModel.Compilation;
                 var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-                var placeSystemNamespaceFirst = optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, document.Project.Language);
                 var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
                 var codeActionsBuilder = ImmutableArray.CreateBuilder<CodeAction>(symbolInfo.CandidateSymbols.Length);
                 foreach (var symbol in symbolInfo.CandidateSymbols.Cast<ITypeSymbol>())
@@ -55,7 +54,7 @@ namespace Microsoft.CodeAnalysis.AliasAmbiguousType
                     codeActionsBuilder.Add(new MyCodeAction(codeActionPreviewText, c =>
                         {
                             var aliasDirective = syntaxGenerator.AliasImportDeclaration(typeName, symbol);
-                            var newRoot = addImportService.AddImport(compilation, root, diagnosticNode, aliasDirective, syntaxGenerator, optionSet, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+                            var newRoot = addImportService.AddImport(compilation, root, diagnosticNode, aliasDirective, syntaxGenerator, optionSet, allowInHiddenRegions, cancellationToken);
                             return Task.FromResult(document.WithSyntaxRoot(newRoot));
                         }));
                 }

--- a/src/Features/Core/Portable/AliasAmbiguousType/AbstractAliasAmbiguousTypeCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AliasAmbiguousType/AbstractAliasAmbiguousTypeCodeFixProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.AliasAmbiguousType
                     codeActionsBuilder.Add(new MyCodeAction(codeActionPreviewText, c =>
                         {
                             var aliasDirective = syntaxGenerator.AliasImportDeclaration(typeName, symbol);
-                            var newRoot = addImportService.AddImport(compilation, root, diagnosticNode, aliasDirective, syntaxGenerator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+                            var newRoot = addImportService.AddImport(compilation, root, diagnosticNode, aliasDirective, syntaxGenerator, optionSet, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
                             return Task.FromResult(document.WithSyntaxRoot(newRoot));
                         }));
                 }

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -606,7 +606,6 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             var namesToImport = GetAllNamespaceImportsForDeclaringDocument(oldNamespace, newNamespace);
 
             var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var placeSystemNamespaceFirst = optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, document.Project.Language);
             var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
 
             var documentWithAddedImports = await AddImportsInContainersAsync(
@@ -614,7 +613,6 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 addImportService,
                 containersToAddImports,
                 namesToImport,
-                placeSystemNamespaceFirst,
                 allowInHiddenRegions,
                 cancellationToken).ConfigureAwait(false);
 
@@ -651,7 +649,6 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                     .ConfigureAwait(false);
 
             var optionSet = await documentWithRefFixed.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var placeSystemNamespaceFirst = optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, documentWithRefFixed.Project.Language);
             var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
 
             var documentWithAdditionalImports = await AddImportsInContainersAsync(
@@ -659,7 +656,6 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 addImportService,
                 containers,
                 ImmutableArray.Create(newNamespace),
-                placeSystemNamespaceFirst,
                 allowInHiddenRegions,
                 cancellationToken).ConfigureAwait(false);
 
@@ -812,7 +808,6 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             IAddImportsService addImportService,
             ImmutableArray<SyntaxNode> containers,
             ImmutableArray<string> names,
-            bool placeSystemNamespaceFirst,
             bool allowInHiddenRegions,
             CancellationToken cancellationToken)
         {
@@ -838,7 +833,7 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
-                root = addImportService.AddImports(compilation, root, contextLocation, imports, generator, options, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+                root = addImportService.AddImports(compilation, root, contextLocation, imports, generator, options, allowInHiddenRegions, cancellationToken);
                 document = document.WithSyntaxRoot(root);
             }
 

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -732,8 +732,9 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                     }
                 }
 
+                var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
                 // Use a dummy import node to figure out which container the new import will be added to.
-                var container = addImportService.GetImportContainer(root, refNode, dummyImport);
+                var container = addImportService.GetImportContainer(root, refNode, dummyImport, options);
                 containers.Add(container);
             }
 
@@ -822,6 +823,8 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 containers = containers.Sort(SyntaxNodeSpanStartComparer.Instance);
             }
 
+            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+
             var imports = CreateImports(document, names, withFormatterAnnotation: true);
             foreach (var container in containers)
             {
@@ -835,7 +838,7 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
                 var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
-                root = addImportService.AddImports(compilation, root, contextLocation, imports, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+                root = addImportService.AddImports(compilation, root, contextLocation, imports, generator, options, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
                 document = document.WithSyntaxRoot(root);
             }
 

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -140,12 +140,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var addImportService = document.GetRequiredLanguageService<IAddImportsService>();
             var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
             var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var placeSystemNamespaceFirst = optionSet.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, document.Project.Language);
             var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
             var importNode = CreateImport(document, containingNamespace);
 
             var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var rootWithImport = addImportService.AddImport(compilation, root, addImportContextNode!, importNode, generator, optionSet, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+            var rootWithImport = addImportService.AddImport(compilation, root, addImportContextNode!, importNode, generator, optionSet, allowInHiddenRegions, cancellationToken);
             var documentWithImport = document.WithSyntaxRoot(rootWithImport);
             // This only formats the annotated import we just added, not the entire document.
             var formattedDocumentWithImport = await Formatter.FormatAsync(documentWithImport, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var importNode = CreateImport(document, containingNamespace);
 
             var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var rootWithImport = addImportService.AddImport(compilation, root, addImportContextNode!, importNode, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+            var rootWithImport = addImportService.AddImport(compilation, root, addImportContextNode!, importNode, generator, optionSet, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
             var documentWithImport = document.WithSyntaxRoot(rootWithImport);
             // This only formats the annotated import we just added, not the entire document.
             var formattedDocumentWithImport = await Formatter.FormatAsync(documentWithImport, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
@@ -337,6 +337,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
                 node.GetCurrentNode(newDestination),
                 sourceImports,
                 generator,
+                options.Options,
                 options.PlaceSystemNamespaceFirst,
                 destinationEditor.OriginalDocument.CanAddImportsInHiddenRegions(),
                 cancellationToken));

--- a/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
@@ -338,7 +338,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
                 sourceImports,
                 generator,
                 options.Options,
-                options.PlaceSystemNamespaceFirst,
                 destinationEditor.OriginalDocument.CanAddImportsInHiddenRegions(),
                 cancellationToken));
 

--- a/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
@@ -57,7 +57,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             CancellationToken cancellationToken)
         {
             var newDocumentId = DocumentId.CreateNewId(projectId, debugName: fileName);
-            var solutionWithInterfaceDocument = solution.AddDocument(newDocumentId, fileName, text: "", folders: folders);
+            var newDocumentPath = PathUtilities.CombinePaths(PathUtilities.GetDirectoryName(hintDocument.FilePath), fileName);
+
+            var solutionWithInterfaceDocument = solution.AddDocument(newDocumentId, fileName, text: "", folders: folders, filePath: newDocumentPath);
             var newDocument = solutionWithInterfaceDocument.GetRequiredDocument(newDocumentId);
             var newSemanticModel = await newDocument.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var options = new CodeGenerationOptions(

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -186,6 +187,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
 
         Protected Overrides Function GetDescription(
                 document As Document,
+                options As OptionSet,
                 symbol As INamespaceOrTypeSymbol,
                 semanticModel As SemanticModel,
                 root As SyntaxNode,
@@ -294,12 +296,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
                 placeSystemNamespaceFirst As Boolean, allowInHiddenRegions As Boolean,
                 importsStatement As ImportsStatementSyntax, cancellationToken As CancellationToken) As Task(Of Document)
 
+            Dim options = Await document.GetOptionsAsync(cancellationToken).ConfigureAwait(False)
             Dim compilation = Await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(False)
             Dim importService = document.GetLanguageService(Of IAddImportsService)
             Dim generator = SyntaxGenerator.GetGenerator(document)
 
             Dim root = Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
-            Dim newRoot = importService.AddImport(compilation, root, contextNode, importsStatement, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken)
+            Dim newRoot = importService.AddImport(compilation, root, contextNode, importsStatement, generator, options, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken)
             newRoot = newRoot.WithAdditionalAnnotations(CaseCorrector.Annotation, Formatter.Annotation)
             Dim newDocument = document.WithSyntaxRoot(newRoot)
 

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddImportFeatureService.vb
@@ -280,20 +280,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
                 contextNode As SyntaxNode,
                 symbol As INamespaceOrTypeSymbol,
                 document As Document,
-                placeSystemNamespaceFirst As Boolean,
                 allowInHiddenRegions As Boolean,
                 cancellationToken As CancellationToken) As Task(Of Document)
 
             Dim importsStatement = GetImportsStatement(symbol)
 
             Return Await AddImportAsync(
-                contextNode, document, placeSystemNamespaceFirst, allowInHiddenRegions,
+                contextNode, document, allowInHiddenRegions,
                 importsStatement, cancellationToken).ConfigureAwait(False)
         End Function
 
         Private Overloads Shared Async Function AddImportAsync(
                 contextNode As SyntaxNode, document As Document,
-                placeSystemNamespaceFirst As Boolean, allowInHiddenRegions As Boolean,
+                allowInHiddenRegions As Boolean,
                 importsStatement As ImportsStatementSyntax, cancellationToken As CancellationToken) As Task(Of Document)
 
             Dim options = Await document.GetOptionsAsync(cancellationToken).ConfigureAwait(False)
@@ -302,7 +301,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
             Dim generator = SyntaxGenerator.GetGenerator(document)
 
             Dim root = Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
-            Dim newRoot = importService.AddImport(compilation, root, contextNode, importsStatement, generator, options, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken)
+            Dim newRoot = importService.AddImport(compilation, root, contextNode, importsStatement, generator, options, allowInHiddenRegions, cancellationToken)
             newRoot = newRoot.WithAdditionalAnnotations(CaseCorrector.Annotation, Formatter.Annotation)
             Dim newDocument = document.WithSyntaxRoot(newRoot)
 
@@ -313,7 +312,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
                 contextNode As SyntaxNode,
                 nameSpaceParts As IReadOnlyList(Of String),
                 document As Document,
-                placeSystemNamespaceFirst As Boolean,
                 allowInHiddenRegions As Boolean,
                 cancellationToken As CancellationToken) As Task(Of Document)
             Dim nameSyntax = CreateNameSyntax(nameSpaceParts, nameSpaceParts.Count - 1)
@@ -321,7 +319,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImport
 
             Return AddImportAsync(
                 contextNode, document,
-                placeSystemNamespaceFirst, allowInHiddenRegions,
+                allowInHiddenRegions,
                 importsStatement, cancellationToken)
         End Function
 

--- a/src/VisualStudio/CSharp/Impl/Snippets/SnippetExpansionClient.cs
+++ b/src/VisualStudio/CSharp/Impl/Snippets/SnippetExpansionClient.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
 
         internal override Document AddImports(
             Document document, OptionSet options, int position, XElement snippetNode,
-            bool placeSystemNamespaceFirst, bool allowInHiddenRegions,
+            bool allowInHiddenRegions,
             CancellationToken cancellationToken)
         {
             var importsNode = snippetNode.Element(XName.Get("Imports", snippetNode.Name.NamespaceName));
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
             var addImportService = document.GetRequiredLanguageService<IAddImportsService>();
             var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
             var compilation = document.Project.GetRequiredCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var newRoot = addImportService.AddImports(compilation, root, contextLocation, newUsingDirectives, generator, options, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+            var newRoot = addImportService.AddImports(compilation, root, contextLocation, newUsingDirectives, generator, options, allowInHiddenRegions, cancellationToken);
 
             var newDocument = document.WithSyntaxRoot(newRoot);
 

--- a/src/VisualStudio/CSharp/Impl/Snippets/SnippetExpansionClient.cs
+++ b/src/VisualStudio/CSharp/Impl/Snippets/SnippetExpansionClient.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.CSharp.Snippets.SnippetFunctions;
@@ -111,7 +112,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
         }
 
         internal override Document AddImports(
-            Document document, int position, XElement snippetNode,
+            Document document, OptionSet options, int position, XElement snippetNode,
             bool placeSystemNamespaceFirst, bool allowInHiddenRegions,
             CancellationToken cancellationToken)
         {
@@ -141,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
             var addImportService = document.GetRequiredLanguageService<IAddImportsService>();
             var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
             var compilation = document.Project.GetRequiredCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var newRoot = addImportService.AddImports(compilation, root, contextLocation, newUsingDirectives, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+            var newRoot = addImportService.AddImports(compilation, root, contextLocation, newUsingDirectives, generator, options, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
 
             var newDocument = document.WithSyntaxRoot(newRoot);
 

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 
         public abstract int GetExpansionFunction(IXMLDOMNode xmlFunctionNode, string bstrFieldName, out IVsExpansionFunction? pFunc);
         protected abstract ITrackingSpan? InsertEmptyCommentAndGetEndPositionTrackingSpan();
-        internal abstract Document AddImports(Document document, OptionSet options, int position, XElement snippetNode, bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken);
+        internal abstract Document AddImports(Document document, OptionSet options, int position, XElement snippetNode, bool allowInHiddenRegions, CancellationToken cancellationToken);
         protected abstract string FallbackDefaultLiteral { get; }
 
         public int FormatSpan(IVsTextLines pBuffer, VsTextSpan[] tsInSurfaceBuffer)
@@ -1050,10 +1050,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             }
 
             var documentOptions = documentWithImports.GetOptionsAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var placeSystemNamespaceFirst = documentOptions.GetOption(GenerationOptions.PlaceSystemNamespaceFirst);
             var allowInHiddenRegions = documentWithImports.CanAddImportsInHiddenRegions();
 
-            documentWithImports = AddImports(documentWithImports, documentOptions, position, snippetNode, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+            documentWithImports = AddImports(documentWithImports, documentOptions, position, snippetNode, allowInHiddenRegions, cancellationToken);
             AddReferences(documentWithImports.Project, snippetNode);
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -25,6 +25,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Notification;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.SignatureHelp;
@@ -127,7 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
 
         public abstract int GetExpansionFunction(IXMLDOMNode xmlFunctionNode, string bstrFieldName, out IVsExpansionFunction? pFunc);
         protected abstract ITrackingSpan? InsertEmptyCommentAndGetEndPositionTrackingSpan();
-        internal abstract Document AddImports(Document document, int position, XElement snippetNode, bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken);
+        internal abstract Document AddImports(Document document, OptionSet options, int position, XElement snippetNode, bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken);
         protected abstract string FallbackDefaultLiteral { get; }
 
         public int FormatSpan(IVsTextLines pBuffer, VsTextSpan[] tsInSurfaceBuffer)
@@ -1052,7 +1053,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
             var placeSystemNamespaceFirst = documentOptions.GetOption(GenerationOptions.PlaceSystemNamespaceFirst);
             var allowInHiddenRegions = documentWithImports.CanAddImportsInHiddenRegions();
 
-            documentWithImports = AddImports(documentWithImports, position, snippetNode, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+            documentWithImports = AddImports(documentWithImports, documentOptions, position, snippetNode, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
             AddReferences(documentWithImports.Project, snippetNode);
         }
 

--- a/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
@@ -387,8 +387,11 @@ using G=   H.I;
                     editorAdaptersFactoryService:=Nothing,
                     workspace.ExportProvider.GetExports(Of ArgumentProvider, OrderableLanguageMetadata)().ToImmutableArray())
 
+                Dim document = workspace.CurrentSolution.Projects.Single().Documents.Single()
+                Dim options = Await document.GetOptionsAsync(CancellationToken.None).ConfigureAwait(false)
                 Dim updatedDocument = expansionClient.AddImports(
-                    workspace.CurrentSolution.Projects.Single().Documents.Single(),
+                    document,
+                    options,
                     If(position, 0),
                     snippetNode,
                     placeSystemNamespaceFirst,

--- a/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
@@ -6,6 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -389,12 +390,14 @@ using G=   H.I;
 
                 Dim document = workspace.CurrentSolution.Projects.Single().Documents.Single()
                 Dim options = Await document.GetOptionsAsync(CancellationToken.None).ConfigureAwait(false)
+
+                options = options.WithChangedOption(GenerationOptions.PlaceSystemNamespaceFirst, placeSystemNamespaceFirst)
+
                 Dim updatedDocument = expansionClient.AddImports(
                     document,
                     options,
                     If(position, 0),
                     snippetNode,
-                    placeSystemNamespaceFirst,
                     allowInHiddenRegions:=False,
                     CancellationToken.None)
 

--- a/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
@@ -209,7 +209,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
                 End Get
             End Property
 
-            Friend Overrides Function AddImports(document As Document, options As OptionSet, position As Integer, snippetNode As XElement, placeSystemNamespaceFirst As Boolean, allowInHiddenRegions As Boolean, cancellationToken As CancellationToken) As Document
+            Friend Overrides Function AddImports(document As Document, options As OptionSet, position As Integer, snippetNode As XElement, allowInHiddenRegions As Boolean, cancellationToken As CancellationToken) As Document
                 Return document
             End Function
         End Class

--- a/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
@@ -15,6 +15,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.VisualStudio.Editor
 Imports Microsoft.VisualStudio.Language.Intellisense
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
@@ -208,7 +209,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
                 End Get
             End Property
 
-            Friend Overrides Function AddImports(document As Document, position As Integer, snippetNode As XElement, placeSystemNamespaceFirst As Boolean, allowInHiddenRegions As Boolean, cancellationToken As CancellationToken) As Document
+            Friend Overrides Function AddImports(document As Document, options As OptionSet, position As Integer, snippetNode As XElement, placeSystemNamespaceFirst As Boolean, allowInHiddenRegions As Boolean, cancellationToken As CancellationToken) As Document
                 Return document
             End Function
         End Class

--- a/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
@@ -406,8 +406,11 @@ End Class</Test>
                     Nothing,
                     workspace.ExportProvider.GetExports(Of ArgumentProvider, OrderableLanguageMetadata)().ToImmutableArray())
 
+                Dim document = workspace.CurrentSolution.Projects.Single().Documents.Single()
+                Dim options = Await document.GetOptionsAsync(CancellationToken.None).ConfigureAwait(false)
                 Dim updatedDocument = expansionClient.AddImports(
-                    workspace.CurrentSolution.Projects.Single().Documents.Single(),
+                    document,
+                    options,
                     If(position, 0),
                     snippetNode,
                     placeSystemNamespaceFirst,

--- a/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
@@ -6,6 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -370,7 +371,7 @@ End Class</Test>
         Private Async Function TestSnippetAddImportsAsync(
                 markupCode As String,
                 namespacesToAdd As String(),
-                placeSystemNamespaceFirst As Boolean,
+                placeSystemNamespaceFirst As Boolean, 
                 expectedUpdatedCode As String) As Tasks.Task
 
             Dim originalCode As String = Nothing
@@ -408,12 +409,14 @@ End Class</Test>
 
                 Dim document = workspace.CurrentSolution.Projects.Single().Documents.Single()
                 Dim options = Await document.GetOptionsAsync(CancellationToken.None).ConfigureAwait(false)
+
+                options = options.WithChangedOption(GenerationOptions.PlaceSystemNamespaceFirst, placeSystemNamespaceFirst)
+
                 Dim updatedDocument = expansionClient.AddImports(
                     document,
                     options,
                     If(position, 0),
                     snippetNode,
-                    placeSystemNamespaceFirst,
                     allowInHiddenRegions:=False,
                     CancellationToken.None)
 

--- a/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
@@ -371,7 +371,7 @@ End Class</Test>
         Private Async Function TestSnippetAddImportsAsync(
                 markupCode As String,
                 namespacesToAdd As String(),
-                placeSystemNamespaceFirst As Boolean, 
+                placeSystemNamespaceFirst As Boolean,
                 expectedUpdatedCode As String) As Tasks.Task
 
             Dim originalCode As String = Nothing

--- a/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetExpansionClient.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetExpansionClient.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions
@@ -99,6 +100,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets
 
         Friend Overrides Function AddImports(
                 document As Document,
+                options As OptionSet,
                 position As Integer,
                 snippetNode As XElement,
                 placeSystemNamespaceFirst As Boolean,

--- a/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetExpansionClient.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetExpansionClient.vb
@@ -6,6 +6,7 @@ Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp
 Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
@@ -103,7 +104,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets
                 options As OptionSet,
                 position As Integer,
                 snippetNode As XElement,
-                placeSystemNamespaceFirst As Boolean,
                 allowInHiddenRegions As Boolean,
                 cancellationToken As CancellationToken) As Document
             Dim importsNode = snippetNode.Element(XName.Get("Imports", snippetNode.Name.NamespaceName))
@@ -126,6 +126,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets
             End If
 
             Dim root = document.GetSyntaxRootSynchronously(cancellationToken)
+
+            Dim placeSystemNamespaceFirst = options.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, document.Project.Language)
 
             Dim newRoot = CType(root, CompilationUnitSyntax).AddImportsStatements(newImportsStatements, placeSystemNamespaceFirst)
             Dim newDocument = document.WithSyntaxRoot(newRoot)

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -8,6 +8,9 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.AddImports;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
@@ -1205,6 +1208,41 @@ namespace N
         public static void M1(this int a){}
     }
 }", useSymbolAnnotations: true);
+        }
+
+        [Theory, MemberData(nameof(TestAllData))]
+        [WorkItem(55746, "https://github.com/dotnet/roslyn/issues/55746")]
+        public async Task TestAddImport_InsideNamespace(bool useSymbolAnnotations)
+        {
+            await TestAsync(
+@"namespace N
+{
+    class C
+    {
+        public System.Collections.Generic.List<int> F;
+    }
+}",
+
+@"namespace N
+{
+    using System.Collections.Generic;
+
+    class C
+    {
+        public System.Collections.Generic.List<int> F;
+    }
+}",
+
+@"namespace N
+{
+    using System.Collections.Generic;
+
+    class C
+    {
+        public List<int> F;
+    }
+}", useSymbolAnnotations,
+    optionsTransform: o => o.WithChangedOption(CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, new CodeStyleOption2<AddImportPlacement>(AddImportPlacement.InsideNamespace, NotificationOption2.Error)));
         }
 
         #endregion

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -1245,6 +1245,76 @@ namespace N
     optionsTransform: o => o.WithChangedOption(CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, new CodeStyleOption2<AddImportPlacement>(AddImportPlacement.InsideNamespace, NotificationOption2.Error)));
         }
 
+        [Theory, MemberData(nameof(TestAllData))]
+        [WorkItem(55746, "https://github.com/dotnet/roslyn/issues/55746")]
+        public async Task TestAddImport_InsideNamespace_NoNamespace(bool useSymbolAnnotations)
+        {
+            await TestAsync(
+@"class C
+{
+    public System.Collections.Generic.List<int> F;
+}",
+
+@"using System.Collections.Generic;
+
+class C
+{
+    public System.Collections.Generic.List<int> F;
+}",
+
+@"using System.Collections.Generic;
+
+class C
+{
+    public List<int> F;
+}", useSymbolAnnotations,
+    optionsTransform: o => o.WithChangedOption(CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, new CodeStyleOption2<AddImportPlacement>(AddImportPlacement.InsideNamespace, NotificationOption2.Error)));
+        }
+
+        [Theory, MemberData(nameof(TestAllData))]
+        [WorkItem(55746, "https://github.com/dotnet/roslyn/issues/55746")]
+        public async Task TestAddImport_InsideNamespace_MultipleNamespaces(bool useSymbolAnnotations)
+        {
+            await TestAsync(
+@"namespace N1
+{
+    namespace N2
+    {
+        class C
+        {
+            public System.Collections.Generic.List<int> F;
+        }
+    }
+}",
+
+@"namespace N1
+{
+    namespace N2
+    {
+        using System.Collections.Generic;
+
+        class C
+        {
+            public System.Collections.Generic.List<int> F;
+        }
+    }
+}",
+
+@"namespace N1
+{
+    namespace N2
+    {
+        using System.Collections.Generic;
+
+        class C
+        {
+            public List<int> F;
+        }
+    }
+}", useSymbolAnnotations,
+    optionsTransform: o => o.WithChangedOption(CSharpCodeStyleOptions.PreferredUsingDirectivePlacement, new CodeStyleOption2<AddImportPlacement>(AddImportPlacement.InsideNamespace, NotificationOption2.Error)));
+        }
+
         #endregion
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
@@ -59,12 +59,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public bool AddImports { get; }
 
         /// <summary>
-        /// True if, when adding a System import, the import should be placed above non-System
-        /// imports.  Defaults to true.  Only used if <see cref="AddImports"/> is true.
-        /// </summary>
-        public bool PlaceSystemNamespaceFirst { get; }
-
-        /// <summary>
         /// Contains additional imports to be automatically added.  This is useful for adding
         /// imports that are part of a list of statements.
         /// </summary>
@@ -143,7 +137,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             Location? afterThisLocation = null,
             Location? beforeThisLocation = null,
             bool addImports = true,
-            bool placeSystemNamespaceFirst = true,
             IEnumerable<INamespaceSymbol>? additionalImports = null,
             bool generateMembers = true,
             bool mergeNestedNamespaces = true,
@@ -165,7 +158,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             this.AfterThisLocation = afterThisLocation;
             this.BeforeThisLocation = beforeThisLocation;
             this.AddImports = addImports;
-            this.PlaceSystemNamespaceFirst = placeSystemNamespaceFirst;
             this.AdditionalImports = additionalImports ?? SpecializedCollections.EmptyEnumerable<INamespaceSymbol>();
             this.GenerateMembers = generateMembers;
             this.MergeNestedNamespaces = mergeNestedNamespaces;
@@ -197,7 +189,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             Optional<Location?> afterThisLocation = default,
             Optional<Location?> beforeThisLocation = default,
             Optional<bool> addImports = default,
-            Optional<bool> placeSystemNamespaceFirst = default,
             Optional<IEnumerable<INamespaceSymbol>> additionalImports = default,
             Optional<bool> generateMembers = default,
             Optional<bool> mergeNestedNamespaces = default,
@@ -215,7 +206,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             var newAfterThisLocation = afterThisLocation.HasValue ? afterThisLocation.Value : this.AfterThisLocation;
             var newBeforeThisLocation = beforeThisLocation.HasValue ? beforeThisLocation.Value : this.BeforeThisLocation;
             var newAddImports = addImports.HasValue ? addImports.Value : this.AddImports;
-            var newPlaceSystemNamespaceFirst = placeSystemNamespaceFirst.HasValue ? placeSystemNamespaceFirst.Value : this.PlaceSystemNamespaceFirst;
             var newAdditionalImports = additionalImports.HasValue ? additionalImports.Value : this.AdditionalImports;
             var newGenerateMembers = generateMembers.HasValue ? generateMembers.Value : this.GenerateMembers;
             var newMergeNestedNamespaces = mergeNestedNamespaces.HasValue ? mergeNestedNamespaces.Value : this.MergeNestedNamespaces;
@@ -234,7 +224,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 newAfterThisLocation,
                 newBeforeThisLocation,
                 newAddImports,
-                newPlaceSystemNamespaceFirst,
                 newAdditionalImports,
                 newGenerateMembers,
                 newMergeNestedNamespaces,

--- a/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
+++ b/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
@@ -58,14 +58,13 @@ namespace Microsoft.CodeAnalysis.Editing
             // into) B and C not A and D.
             var nodes = root.DescendantNodesAndSelf(overlapsWithSpan).Where(overlapsWithSpan);
 
-            var placeSystemNamespaceFirst = options.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, document.Project.Language);
             var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
 
             if (strategy == Strategy.AddImportsFromSymbolAnnotations)
-                return await AddImportDirectivesFromSymbolAnnotationsAsync(document, options, nodes, addImportsService, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+                return await AddImportDirectivesFromSymbolAnnotationsAsync(document, options, nodes, addImportsService, generator, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
 
             if (strategy == Strategy.AddImportsFromSyntaxes)
-                return await AddImportDirectivesFromSyntaxesAsync(document, options, nodes, addImportsService, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+                return await AddImportDirectivesFromSyntaxesAsync(document, options, nodes, addImportsService, generator, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
 
             throw ExceptionUtilities.UnexpectedValue(strategy);
         }
@@ -112,7 +111,6 @@ namespace Microsoft.CodeAnalysis.Editing
             IEnumerable<SyntaxNode> syntaxNodes,
             IAddImportsService addImportsService,
             SyntaxGenerator generator,
-            bool placeSystemNamespaceFirst,
             bool allowInHiddenRegions,
             CancellationToken cancellationToken)
         {
@@ -163,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Editing
 
             root = addImportsService.AddImports(
                 model.Compilation, root, context, importsToAdd, generator, options,
-                placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+                allowInHiddenRegions, cancellationToken);
 
             return document.WithSyntaxRoot(root);
         }
@@ -174,7 +172,6 @@ namespace Microsoft.CodeAnalysis.Editing
             IEnumerable<SyntaxNode> syntaxNodes,
             IAddImportsService addImportsService,
             SyntaxGenerator generator,
-            bool placeSystemNamespaceFirst,
             bool allowInHiddenRegions,
             CancellationToken cancellationToken)
         {
@@ -243,7 +240,7 @@ namespace Microsoft.CodeAnalysis.Editing
 
             root = addImportsService.AddImports(
                 model.Compilation, root, context, importsToAdd, generator, options,
-                placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+                allowInHiddenRegions, cancellationToken);
             return document.WithSyntaxRoot(root);
         }
 

--- a/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
+++ b/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
@@ -62,10 +62,10 @@ namespace Microsoft.CodeAnalysis.Editing
             var allowInHiddenRegions = document.CanAddImportsInHiddenRegions();
 
             if (strategy == Strategy.AddImportsFromSymbolAnnotations)
-                return await AddImportDirectivesFromSymbolAnnotationsAsync(document, nodes, addImportsService, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+                return await AddImportDirectivesFromSymbolAnnotationsAsync(document, options, nodes, addImportsService, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
 
             if (strategy == Strategy.AddImportsFromSyntaxes)
-                return await AddImportDirectivesFromSyntaxesAsync(document, nodes, addImportsService, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
+                return await AddImportDirectivesFromSyntaxesAsync(document, options, nodes, addImportsService, generator, placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken).ConfigureAwait(false);
 
             throw ExceptionUtilities.UnexpectedValue(strategy);
         }
@@ -108,6 +108,7 @@ namespace Microsoft.CodeAnalysis.Editing
 
         private async Task<Document> AddImportDirectivesFromSyntaxesAsync(
             Document document,
+            OptionSet options,
             IEnumerable<SyntaxNode> syntaxNodes,
             IAddImportsService addImportsService,
             SyntaxGenerator generator,
@@ -161,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editing
             var context = first.GetCommonRoot(last);
 
             root = addImportsService.AddImports(
-                model.Compilation, root, context, importsToAdd, generator,
+                model.Compilation, root, context, importsToAdd, generator, options,
                 placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
 
             return document.WithSyntaxRoot(root);
@@ -169,6 +170,7 @@ namespace Microsoft.CodeAnalysis.Editing
 
         private async Task<Document> AddImportDirectivesFromSymbolAnnotationsAsync(
             Document document,
+            OptionSet options,
             IEnumerable<SyntaxNode> syntaxNodes,
             IAddImportsService addImportsService,
             SyntaxGenerator generator,
@@ -230,7 +232,7 @@ namespace Microsoft.CodeAnalysis.Editing
             var context = first.GetCommonRoot(last);
 
             // Find the namespace/compilation-unit we'll be adding all these imports to.
-            var importContainer = addImportsService.GetImportContainer(root, context, importToSyntax.First().Value);
+            var importContainer = addImportsService.GetImportContainer(root, context, importToSyntax.First().Value, options);
 
             // Now remove any imports we think can cause conflicts in that container.
             var safeImportsToAdd = GetSafeToAddImports(importToSyntax.Keys.ToImmutableArray(), importContainer, model, cancellationToken);
@@ -240,7 +242,7 @@ namespace Microsoft.CodeAnalysis.Editing
                 return document;
 
             root = addImportsService.AddImports(
-                model.Compilation, root, context, importsToAdd, generator,
+                model.Compilation, root, context, importsToAdd, generator, options,
                 placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
             return document.WithSyntaxRoot(root);
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Remote
             TextSpan span,
             string diagnosticId,
             int maxResults,
-            bool placeSystemNamespaceFirst,
             bool allowInHiddenRegions,
             bool searchReferenceAssemblies,
             ImmutableArray<PackageSource> packageSources,
@@ -55,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var result = await service.GetFixesAsync(
                     document, span, diagnosticId, maxResults,
-                    placeSystemNamespaceFirst, allowInHiddenRegions,
+                    allowInHiddenRegions,
                     symbolSearchService, searchReferenceAssemblies,
                     packageSources, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/EditorConfig/EditorConfigStorageLocation`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/EditorConfig/EditorConfigStorageLocation`1.cs
@@ -95,7 +95,6 @@ namespace Microsoft.CodeAnalysis.Options
         {
             var editorConfigStringForValue = _getEditorConfigStringForValue(value, optionSet);
             RoslynDebug.Assert(!RoslynString.IsNullOrEmpty(editorConfigStringForValue));
-            Debug.Assert(editorConfigStringForValue.All(ch => !(char.IsWhiteSpace(ch) || char.IsUpper(ch))));
             return editorConfigStringForValue;
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpAddImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpAddImportsService.cs
@@ -8,11 +8,18 @@ using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.AddImports;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Roslyn.Utilities;
+
+#if CODE_STYLE
+using OptionSet = Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions;
+#else
+using Microsoft.CodeAnalysis.Options;
+#endif
 
 namespace Microsoft.CodeAnalysis.CSharp.AddImports
 {
@@ -24,6 +31,11 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImports
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpAddImportsService()
         {
+        }
+
+        protected override bool PlaceImportsInsideNamespaces(OptionSet options)
+        {
+            return options.GetOption(CSharpCodeStyleOptions.PreferredUsingDirectivePlacement).Value == AddImportPlacement.InsideNamespace;
         }
 
         // C# doesn't have global imports.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AbstractAddImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/AbstractAddImportsService.cs
@@ -128,11 +128,12 @@ namespace Microsoft.CodeAnalysis.AddImports
             IEnumerable<SyntaxNode> newImports,
             SyntaxGenerator generator,
             OptionSet options,
-            bool placeSystemNamespaceFirst,
             bool allowInHiddenRegions,
             CancellationToken cancellationToken)
         {
             contextLocation ??= root;
+
+            var placeSystemNamespaceFirst = options.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, compilation.Language);
 
             var globalImports = GetGlobalImports(compilation, generator);
             var containers = GetAllContainers(root, contextLocation);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/IAddImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/IAddImportsService.cs
@@ -8,6 +8,12 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host;
 using Roslyn.Utilities;
 
+#if CODE_STYLE
+using OptionSet = Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions;
+#else
+using Microsoft.CodeAnalysis.Options;
+#endif
+
 namespace Microsoft.CodeAnalysis.AddImports
 {
     internal interface IAddImportsService : ILanguageService
@@ -23,11 +29,11 @@ namespace Microsoft.CodeAnalysis.AddImports
         /// Given a context location in a provided syntax tree, returns the appropriate container
         /// that <paramref name="import"/> should be added to.
         /// </summary>
-        SyntaxNode GetImportContainer(SyntaxNode root, SyntaxNode? contextLocation, SyntaxNode import);
+        SyntaxNode GetImportContainer(SyntaxNode root, SyntaxNode? contextLocation, SyntaxNode import, OptionSet options);
 
         SyntaxNode AddImports(
             Compilation compilation, SyntaxNode root, SyntaxNode? contextLocation,
-            IEnumerable<SyntaxNode> newImports, SyntaxGenerator generator,
+            IEnumerable<SyntaxNode> newImports, SyntaxGenerator generator, OptionSet options,
             bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken);
     }
 
@@ -35,11 +41,11 @@ namespace Microsoft.CodeAnalysis.AddImports
     {
         public static SyntaxNode AddImport(
             this IAddImportsService service, Compilation compilation, SyntaxNode root,
-            SyntaxNode contextLocation, SyntaxNode newImport, SyntaxGenerator generator,
+            SyntaxNode contextLocation, SyntaxNode newImport, SyntaxGenerator generator, OptionSet options,
             bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken)
         {
             return service.AddImports(compilation, root, contextLocation,
-                SpecializedCollections.SingletonEnumerable(newImport), generator,
+                SpecializedCollections.SingletonEnumerable(newImport), generator, options,
                 placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/IAddImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/AddImports/IAddImportsService.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.AddImports
         SyntaxNode AddImports(
             Compilation compilation, SyntaxNode root, SyntaxNode? contextLocation,
             IEnumerable<SyntaxNode> newImports, SyntaxGenerator generator, OptionSet options,
-            bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken);
+            bool allowInHiddenRegions, CancellationToken cancellationToken);
     }
 
     internal static class IAddImportServiceExtensions
@@ -42,11 +42,11 @@ namespace Microsoft.CodeAnalysis.AddImports
         public static SyntaxNode AddImport(
             this IAddImportsService service, Compilation compilation, SyntaxNode root,
             SyntaxNode contextLocation, SyntaxNode newImport, SyntaxGenerator generator, OptionSet options,
-            bool placeSystemNamespaceFirst, bool allowInHiddenRegions, CancellationToken cancellationToken)
+            bool allowInHiddenRegions, CancellationToken cancellationToken)
         {
             return service.AddImports(compilation, root, contextLocation,
                 SpecializedCollections.SingletonEnumerable(newImport), generator, options,
-                placeSystemNamespaceFirst, allowInHiddenRegions, cancellationToken);
+                allowInHiddenRegions, cancellationToken);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicAddImportsService.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicAddImportsService.vb
@@ -12,6 +12,12 @@ Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
 
+#If CODE_STYLE Then
+Imports OptionSet = Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions
+#Else
+Imports Microsoft.CodeAnalysis.Options
+#End If
+
 Namespace Microsoft.CodeAnalysis.VisualBasic.AddImports
     <ExportLanguageService(GetType(IAddImportsService), LanguageNames.VisualBasic), [Shared]>
     Friend Class VisualBasicAddImportsService
@@ -55,6 +61,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddImports
             Return usingOrAlias.ImportsClauses.OfType(Of SimpleImportsClauseSyntax).
                                                Where(Function(c) c.Alias IsNot Nothing).
                                                FirstOrDefault()?.Alias
+        End Function
+
+        Protected Overrides Function PlaceImportsInsideNamespaces(options As OptionSet) As Boolean
+            ' Visual Basic doesn't support imports inside namespaces
+            Return False
         End Function
 
         Protected Overrides Function IsStaticUsing(usingOrAlias As ImportsStatementSyntax) As Boolean


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/55746
Fixes https://github.com/dotnet/roslyn/issues/39786

This also fixes anything that uses the AddImports service, so they all support using directive placement options, and fixes anything that uses the `MemberPuller` to respect that, plus the "System Usings First" setting.
