### PR TITLE
Split 'generate default constructor' in a codefix and coderefactoring

### DIFF
--- a/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string FixIncorrectExitContinue = nameof(FixIncorrectExitContinue);
         public const string FixReturnType = nameof(FixReturnType);
         public const string GenerateConstructor = nameof(GenerateConstructor);
+        public const string GenerateDefaultConstructors = nameof(GenerateDefaultConstructors);
         public const string GenerateEndConstruct = nameof(GenerateEndConstruct);
         public const string GenerateEnumMember = nameof(GenerateEnumMember);
         public const string GenerateEvent = nameof(GenerateEvent);

--- a/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -4,6 +4,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.GenerateDefaultConstructors;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
@@ -31,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateDefaultConstruc
                 TestCode = source,
                 FixedCode = fixedSource,
                 CodeActionIndex = index,
+                LanguageVersion = LanguageVersion.CSharp10,
             }.RunAsync();
 
             await TestCodeFixMissingAsync(source);
@@ -43,6 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateDefaultConstruc
                 TestCode = source.Replace("[||]", ""),
                 FixedCode = fixedSource,
                 CodeActionIndex = index,
+                LanguageVersion = LanguageVersion.CSharp10,
             }.RunAsync();
 
             await TestRefactoringMissingAsync(source);
@@ -165,8 +168,8 @@ class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestRefOutParams()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
@@ -174,6 +177,7 @@ class B
 {
     internal B(ref int x, out string s, params bool[] b)
     {
+        s = null;
     }
 }",
 @"class C : B
@@ -187,6 +191,7 @@ class B
 {
     internal B(ref int x, out string s, params bool[] b)
     {
+        s = null;
     }
 }");
         }
@@ -795,8 +800,8 @@ index: 2);
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors), CompilerTrait(CompilerFeature.Tuples)]
         public async Task Tuple()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
@@ -824,8 +829,8 @@ class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors), CompilerTrait(CompilerFeature.Tuples)]
         public async Task TupleWithNames()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
@@ -854,7 +859,7 @@ class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public async Task TestGenerateFromDerivedClass()
         {
-            await TestRefactoringAsync(
+            await TestCodeFixAsync(
 @"class Base
 {
     public Base(string value)
@@ -862,7 +867,7 @@ class B
     }
 }
 
-class [||]Derived : Base
+class [||]{|CS7036:Derived|} : Base
 {
 }",
 @"class Base
@@ -884,7 +889,7 @@ class Derived : Base
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public async Task TestGenerateFromDerivedClass2()
         {
-            await TestRefactoringAsync(
+            await TestCodeFixAsync(
 @"class Base
 {
     public Base(int a, string value = null)
@@ -892,7 +897,7 @@ class Derived : Base
     }
 }
 
-class [||]Derived : Base
+class [||]{|CS7036:Derived|} : Base
 {
 }",
 @"class Base
@@ -1265,14 +1270,14 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromPrivateProtectedConstructor2()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
 abstract class B
 {
-    private protected internal B(int x)
+    private protected internal {|CS0107:B|}(int x)
     {
     }
 }",
@@ -1285,7 +1290,7 @@ abstract class B
 
 abstract class B
 {
-    private protected internal B(int x)
+    private protected internal {|CS0107:B|}(int x)
     {
     }
 }");
@@ -1384,8 +1389,8 @@ sealed class Program : Base
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestRecord()
         {
-            await TestRefactoringAsync(
-@"record C : [||]B
+            await TestCodeFixAsync(
+@"record {|CS1729:C|} : [||]B
 {
 }
 

--- a/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.GenerateDefaultConstructors;
-using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.GenerateDefaultConstructors;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -607,23 +605,6 @@ class B
     }
 }");
         }
-
-//        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
-//        public async Task TestFixCount1()
-//        {
-//            await TestActionCountAsync(
-//@"class C : [||]B
-//{
-//}
-
-//class B
-//{
-//    public B(int x)
-//    {
-//    }
-//}",
-//count: 1);
-//        }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         [WorkItem(544070, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544070")]

--- a/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -194,8 +194,8 @@ class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestFix1()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS1729:C|} : [||]B
 {
 }
 
@@ -239,8 +239,8 @@ class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestFix2()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS1729:C|} : [||]B
 {
 }
 
@@ -331,8 +331,8 @@ index: 2);
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestFixAll1()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS1729:C|} : [||]B
 {
 }
 
@@ -388,7 +388,7 @@ index: 3);
             await TestRefactoringAsync(
 @"class C : [||]B
 {
-    public C(bool x)
+    public {|CS1729:C|}(bool x)
     {
     }
 }
@@ -409,7 +409,7 @@ class B
 }",
 @"class C : B
 {
-    public C(bool x)
+    public {|CS1729:C|}(bool x)
     {
     }
 
@@ -445,7 +445,7 @@ index: 2);
             await TestRefactoringAsync(
 @"class C : [||]B
 {
-    public C((bool, bool) x)
+    public {|CS1729:C|}((bool, bool) x)
     {
     }
 }
@@ -466,7 +466,7 @@ class B
 }",
 @"class C : B
 {
-    public C((bool, bool) x)
+    public {|CS1729:C|}((bool, bool) x)
     {
     }
 
@@ -610,7 +610,7 @@ class B
         [WorkItem(544070, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544070")]
         public async Task TestException1()
         {
-            await TestCodeFixAsync(
+            await TestRefactoringAsync(
 @"using System;
 class Program : Excep[||]tion
 {

--- a/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -27,6 +27,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateDefaultConstruc
     {
         private static async Task TestRefactoringAsync(string source, string fixedSource, int index = 0)
         {
+            await TestRefactoringOnlyAsync(source, fixedSource, index);
+            await TestCodeFixMissingAsync(source);
+        }
+
+        private static async Task TestRefactoringOnlyAsync(string source, string fixedSource, int index = 0)
+        {
             await new VerifyRefactoring.Test
             {
                 TestCode = source,
@@ -34,8 +40,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateDefaultConstruc
                 CodeActionIndex = index,
                 LanguageVersion = LanguageVersion.CSharp10,
             }.RunAsync();
-
-            await TestCodeFixMissingAsync(source);
         }
 
         private static async Task TestCodeFixAsync(string source, string fixedSource, int index = 0)
@@ -939,8 +943,8 @@ class Derived : Base
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromProtectedConstructor()
         {
-            await TestRefactoringAsync(
-@"abstract class C : [||]B
+            await TestCodeFixAsync(
+@"abstract class {|CS7036:C|} : [||]B
 {
 }
 
@@ -969,8 +973,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromProtectedConstructor2()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
@@ -999,8 +1003,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromProtectedConstructorCursorAtTypeOpening()
         {
-            await TestRefactoringAsync(
-@"class C : B
+            await TestRefactoringOnlyAsync(
+@"class {|CS7036:C|} : B
 {
 
 [||]
@@ -1032,8 +1036,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromProtectedConstructorCursorBetweenTypeMembers()
         {
-            await TestRefactoringAsync(
-@"class C : B
+            await TestRefactoringOnlyAsync(
+@"class {|CS7036:C|} : B
 {
     int X;
 [||]
@@ -1070,8 +1074,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorInAbstractClassFromPublicConstructor()
         {
-            await TestRefactoringAsync(
-@"abstract class C : [||]B
+            await TestCodeFixAsync(
+@"abstract class {|CS7036:C|} : [||]B
 {
 }
 
@@ -1100,8 +1104,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromPublicConstructor2()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
@@ -1190,8 +1194,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromProtectedInternalConstructor()
         {
-            await TestRefactoringAsync(
-@"abstract class C : [||]B
+            await TestCodeFixAsync(
+@"abstract class {|CS7036:C|} : [||]B
 {
 }
 
@@ -1220,8 +1224,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromProtectedInternalConstructor2()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 

--- a/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -62,8 +62,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateDefaultConstruc
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestProtectedBase()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
@@ -91,8 +91,8 @@ class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestPublicBase()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
@@ -120,8 +120,8 @@ class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestInternalBase()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
@@ -150,7 +150,7 @@ class B
         public async Task TestPrivateBase()
         {
             await TestRefactoringMissingAsync(
-@"class C : [||]B
+@"class {|CS1729:C|} : [||]B
 {
 }
 
@@ -285,8 +285,8 @@ index: 1);
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestRefactoring1()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS1729:C|} : [||]B
 {
 }
 
@@ -502,7 +502,7 @@ index: 2);
             await TestRefactoringMissingAsync(
 @"class C : [||]B
 {
-    public C(int x)
+    public {|CS7036:C|}(int x)
     {
     }
 }
@@ -1115,8 +1115,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromInternalConstructor()
         {
-            await TestRefactoringAsync(
-@"abstract class C : [||]B
+            await TestCodeFixAsync(
+@"abstract class {|CS7036:C|} : [||]B
 {
 }
 
@@ -1145,8 +1145,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromInternalConstructor2()
         {
-            await TestRefactoringAsync(
-@"class C : [||]B
+            await TestCodeFixAsync(
+@"class {|CS7036:C|} : [||]B
 {
 }
 
@@ -1235,8 +1235,8 @@ abstract class B
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestGenerateConstructorFromPrivateProtectedConstructor()
         {
-            await TestRefactoringAsync(
-@"abstract class C : [||]B
+            await TestCodeFixAsync(
+@"abstract class {|CS7036:C|} : [||]B
 {
 }
 

--- a/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -53,13 +53,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateDefaultConstruc
 
         private static async Task TestRefactoringMissingAsync(string source)
         {
-            await VerifyRefactoring.VerifyRefactoringAsync(source, source);
+            await new VerifyRefactoring.Test
+            {
+                TestCode = source,
+                FixedCode = source,
+                LanguageVersion = LanguageVersion.CSharp10,
+            }.RunAsync();
         }
 
         private static async Task TestCodeFixMissingAsync(string source)
         {
             source = source.Replace("[||]", "");
-            await VerifyCodeFix.VerifyCodeFixAsync(source, source);
+            await new VerifyCodeFix.Test
+            {
+                TestCode = source,
+                FixedCode = source,
+                LanguageVersion = LanguageVersion.CSharp10,
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]

--- a/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
@@ -225,7 +225,7 @@ End Class")
         Public Async Function TestNotOfferedOnUnresolvedBaseClassName() As Task
             Await TestRefactoringMissingAsync(
 "Class Derived
-    Inherits [||]Base
+    Inherits [||]{|BC30002:Base|}
 End Class")
         End Function
 
@@ -233,7 +233,7 @@ End Class")
         Public Async Function TestNotOfferedOnInheritsStatementForStructures() As Task
             Await TestRefactoringMissingAsync(
 "Structure Derived
-    Inherits [||]Base
+    {|BC30628:Inherits [||]Base|}
 End Structure")
         End Function
 
@@ -432,6 +432,7 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
 <Text>Class C
     Inherits B[||]
     Public Sub New(y As Integer)
+        mybase.new(y)
     End Sub
 End Class
 
@@ -442,9 +443,10 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf),
 <Text>Class C
     Inherits B
     Public Sub New(y As Integer)
+        mybase.new(y)
     End Sub
 
-    Friend Sub New(x As Integer)
+    Friend Sub {|BC30269:New|}(x As Integer)
         MyBase.New(x)
     End Sub
 End Class
@@ -613,7 +615,7 @@ End Class")
         <WorkItem(6541, "https://github.com/dotnet/Roslyn/issues/6541")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Async Function TestGenerateInDerivedType1() As Task
-            Await TestRefactoringAsync(
+            Await TestCodeFixAsync(
 "
 Public Class Base
     Public Sub New(a As String)
@@ -621,7 +623,7 @@ Public Class Base
     End Sub
 End Class
 
-Public Class [||]Derived
+Public Class [||]{|BC30387:Derived|}
     Inherits Base
 
 End Class",
@@ -644,7 +646,7 @@ End Class")
         <WorkItem(6541, "https://github.com/dotnet/Roslyn/issues/6541")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Async Function TestGenerateInDerivedType2() As Task
-            Await TestRefactoringAsync(
+            Await TestCodeFixAsync(
 "
 Public Class Base
     Public Sub New(a As Integer, Optional b As String = Nothing)
@@ -652,7 +654,7 @@ Public Class Base
     End Sub
 End Class
 
-Public Class [||]Derived
+Public Class [||]{|BC30387:Derived|}
     Inherits Base
 
 End Class",
@@ -678,6 +680,7 @@ End Class")
             Await TestRefactoringMissingAsync(
 "
 Public Enum [||]E
+    A
 End Enum")
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
@@ -240,7 +240,7 @@ End Structure")
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestNotOfferedForIncorrectlyParentedInheritsStatement() As Task
             Await TestRefactoringMissingAsync(
-"Inherits [||]Goo")
+"{|BC30683:Inherits [||]Goo|}")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
@@ -442,11 +442,11 @@ Class B
 End Class</Text>.Value.Replace(vbLf, vbCrLf),
 <Text>Class C
     Inherits B
-    Public Sub New(y As Integer)
+    Public Sub {|BC30269:New|}(y As Integer)
         mybase.new(y)
     End Sub
 
-    Friend Sub {|BC30269:New|}(x As Integer)
+    Friend Sub New(x As Integer)
         MyBase.New(x)
     End Sub
 End Class
@@ -584,7 +584,7 @@ index:=2)
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Async Function TestGenerateInDerivedType_InvalidClassStatement() As Task
-            Await TestRefactoringAsync(
+            Await TestCodeFixAsync(
 "
 Public Class Base
     Public Sub New(a As Integer, Optional b As String = Nothing)
@@ -592,7 +592,7 @@ Public Class Base
     End Sub
 End Class
 
-Public [||]Class ;;Derived
+Public [||]Class {|BC30203:|}{|BC30387:|}{|BC30037:;|}{|BC30037:;|}Derived
     Inherits Base
 
 End Class",
@@ -603,7 +603,7 @@ Public Class Base
     End Sub
 End Class
 
-Public Class ;;Derived
+Public Class {|BC30203:|}{|BC30037:;|}{|BC30037:;|}Derived
     Inherits Base
 
     Public Sub New(a As Integer, Optional b As String = Nothing)
@@ -687,8 +687,8 @@ End Enum")
         <WorkItem(25238, "https://github.com/dotnet/roslyn/issues/25238")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestGenerateConstructorFromFriendConstructor() As Task
-            Await TestRefactoringAsync(
-<Text>Class C
+            Await TestCodeFixAsync(
+<Text>Class {|BC30387:C|}
     Inherits B[||]
 End Class
 
@@ -713,8 +713,8 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         <WorkItem(25238, "https://github.com/dotnet/roslyn/issues/25238")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestGenerateConstructorFromFriendConstructor2() As Task
-            Await TestRefactoringAsync(
-<Text>MustInherit Class C
+            Await TestCodeFixAsync(
+<Text>MustInherit Class {|BC30387:C|}
     Inherits B[||]
 End Class
 
@@ -739,8 +739,8 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         <WorkItem(25238, "https://github.com/dotnet/roslyn/issues/25238")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestGenerateConstructorFromProtectedConstructor() As Task
-            Await TestRefactoringAsync(
-<Text>Class C
+            Await TestCodeFixAsync(
+<Text>Class {|BC30387:C|}
     Inherits B[||]
 End Class
 
@@ -765,8 +765,8 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         <WorkItem(25238, "https://github.com/dotnet/roslyn/issues/25238")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestGenerateConstructorFromProtectedConstructor2() As Task
-            Await TestRefactoringAsync(
-<Text>MustInherit Class C
+            Await TestCodeFixAsync(
+<Text>MustInherit Class {|BC30387:C|}
     Inherits B[||]
 End Class
 
@@ -791,8 +791,8 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         <WorkItem(25238, "https://github.com/dotnet/roslyn/issues/25238")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestGenerateConstructorFromProtectedFriendConstructor() As Task
-            Await TestRefactoringAsync(
-<Text>Class C
+            Await TestCodeFixAsync(
+<Text>Class {|BC30387:C|}
     Inherits B[||]
 End Class
 
@@ -817,8 +817,8 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         <WorkItem(25238, "https://github.com/dotnet/roslyn/issues/25238")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestGenerateConstructorFromProtectedFriendConstructor2() As Task
-            Await TestRefactoringAsync(
-<Text>MustInherit Class C
+            Await TestCodeFixAsync(
+<Text>MustInherit Class {|BC30387:C|}
     Inherits B[||]
 End Class
 
@@ -843,8 +843,8 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         <WorkItem(25238, "https://github.com/dotnet/roslyn/issues/25238")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestGenerateConstructorFromPublicConstructor() As Task
-            Await TestRefactoringAsync(
-<Text>Class C
+            Await TestCodeFixAsync(
+<Text>Class {|BC30387:C|}
     Inherits B[||]
 End Class
 
@@ -870,8 +870,8 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf))
         <WorkItem(25238, "https://github.com/dotnet/roslyn/issues/25238")>
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
         Public Async Function TestGenerateConstructorInAbstractClassFromPublicConstructor() As Task
-            Await TestRefactoringAsync(
-<Text>MustInherit Class C
+            Await TestCodeFixAsync(
+<Text>MustInherit Class {|BC30387:C|}
     Inherits B[||]
 End Class
 

--- a/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsCodeFixProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.CSharp.GenerateDefaultConstructors
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.GenerateDefaultConstructors), Shared]
     internal class CSharpGenerateDefaultConstructorsCodeFixProvider : AbstractGenerateDefaultConstructorCodeFixProvider
     {
         private const string CS1729 = nameof(CS1729); // 'B' does not contain a constructor that takes 0 arguments CSharpConsoleApp3   C:\Users\cyrusn\source\repos\CSharpConsoleApp3\CSharpConsoleApp3\Program.cs	1	Active

--- a/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsCodeFixProvider.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateDefaultConstructors
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     internal class CSharpGenerateDefaultConstructorsCodeFixProvider : AbstractGenerateDefaultConstructorCodeFixProvider
     {
+        private const string CS1729 = nameof(CS1729); // 'B' does not contain a constructor that takes 0 arguments CSharpConsoleApp3   C:\Users\cyrusn\source\repos\CSharpConsoleApp3\CSharpConsoleApp3\Program.cs	1	Active
         private const string CS7036 = nameof(CS7036); // There is no argument given that corresponds to the required formal parameter 's' of 'B.B(string)'
 
         [ImportingConstructor]
@@ -23,6 +24,6 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateDefaultConstructors
         }
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-            ImmutableArray.Create(CS7036);
+            ImmutableArray.Create(CS1729, CS7036);
     }
 }

--- a/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsCodeFixProvider.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.GenerateDefaultConstructors;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.CSharp.GenerateDefaultConstructors
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    internal class CSharpGenerateDefaultConstructorsCodeFixProvider : AbstractGenerateDefaultConstructorCodeFixProvider
+    {
+        private const string CS7036 = nameof(CS7036); // There is no argument given that corresponds to the required formal parameter 's' of 'B.B(string)'
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpGenerateDefaultConstructorsCodeFixProvider()
+        {
+        }
+
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(CS7036);
+    }
+}

--- a/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsService.cs
+++ b/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.GenerateDefaultConstructors;

--- a/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsService.cs
+++ b/src/Features/CSharp/Portable/GenerateDefaultConstructors/CSharpGenerateDefaultConstructorsService.cs
@@ -2,20 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors;
+using Microsoft.CodeAnalysis.GenerateDefaultConstructors;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateDefaultConstructors
+namespace Microsoft.CodeAnalysis.CSharp.GenerateDefaultConstructors
 {
     [ExportLanguageService(typeof(IGenerateDefaultConstructorsService), LanguageNames.CSharp), Shared]
     internal class CSharpGenerateDefaultConstructorsService : AbstractGenerateDefaultConstructorsService<CSharpGenerateDefaultConstructorsService>
@@ -28,14 +27,14 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateDefaultConstructo
 
         protected override bool TryInitializeState(
             SemanticDocument semanticDocument, TextSpan textSpan, CancellationToken cancellationToken,
-            out INamedTypeSymbol classType)
+            [NotNullWhen(true)] out INamedTypeSymbol? classType)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             // Offer the feature if we're on the header / between members of the class/struct,
             // or if we're on the first base-type of a class
 
-            var syntaxFacts = semanticDocument.Document.GetLanguageService<ISyntaxFactsService>();
+            var syntaxFacts = semanticDocument.Document.GetRequiredLanguageService<ISyntaxFactsService>();
             if (syntaxFacts.IsOnTypeHeader(semanticDocument.Root, textSpan.Start, out var typeDeclaration) ||
                 syntaxFacts.IsBetweenTypeMembers(semanticDocument.Text, semanticDocument.Root, textSpan.Start, out typeDeclaration))
             {
@@ -47,9 +46,10 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateDefaultConstructo
             var node = semanticDocument.Root.FindToken(textSpan.Start).GetAncestor<TypeSyntax>();
             if (node != null)
             {
-                if (node.Parent is BaseTypeSyntax && node.Parent.IsParentKind(SyntaxKind.BaseList, out BaseListSyntax baseList))
+                if (node.Parent is BaseTypeSyntax && node.Parent.IsParentKind(SyntaxKind.BaseList, out BaseListSyntax? baseList))
                 {
-                    if (baseList.Types.Count > 0 &&
+                    if (baseList.Parent != null &&
+                        baseList.Types.Count > 0 &&
                         baseList.Types[0].Type == node &&
                         baseList.IsParentKind(SyntaxKind.ClassDeclaration, SyntaxKind.RecordDeclaration))
                     {

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorCodeFixProvider.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorCodeFixProvider.cs
@@ -11,9 +11,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
-    internal abstract class AbstractGenerateDefaultConstructorCodeFixProvider
-        : CodeFixProvider
+    internal abstract class AbstractGenerateDefaultConstructorCodeFixProvider : CodeFixProvider
     {
+        public override FixAllProvider? GetFixAllProvider() => null;
+
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var cancellationToken = context.CancellationToken;

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorCodeFixProvider.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorCodeFixProvider.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
+{
+    internal abstract class AbstractGenerateDefaultConstructorCodeFixProvider
+        : CodeFixProvider
+    {
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var cancellationToken = context.CancellationToken;
+            var document = context.Document;
+            var diagnostic = context.Diagnostics.FirstOrDefault();
+            if (diagnostic == null)
+                return;
+
+            var node = diagnostic.Location.FindNode(cancellationToken);
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+
+            var typeDecl = node.AncestorsAndSelf().Where(n => syntaxFacts.IsTypeDeclaration(n)).FirstOrDefault();
+            if (typeDecl == null)
+                return;
+
+            var typeName = syntaxFacts.GetIdentifierOfTypeDeclaration(typeDecl);
+            var service = document.GetRequiredLanguageService<IGenerateDefaultConstructorsService>();
+            var actions = await service.GenerateDefaultConstructorsAsync(document, typeName.Span, cancellationToken).ConfigureAwait(false);
+            context.RegisterFixes(actions, diagnostic);
+        }
+    }
+}

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.AbstractCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.AbstractCodeAction.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -12,8 +10,9 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
+namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
     internal abstract partial class AbstractGenerateDefaultConstructorsService<TService>
     {
@@ -40,6 +39,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
 
             protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {
+                Contract.ThrowIfNull(_state.ClassType);
                 var result = await CodeGenerator.AddMemberDeclarationsAsync(
                     _document.Project.Solution,
                     _state.ClassType,
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
                     : default;
 
                 var classType = _state.ClassType;
+                Contract.ThrowIfNull(classType);
 
                 var accessibility = DetermineAccessibility(baseConstructor, classType);
                 return CodeGenerationSymbolFactory.CreateConstructorSymbol(

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.CodeAction.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
+using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
+namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
     internal abstract partial class AbstractGenerateDefaultConstructorsService<TService>
     {
@@ -25,6 +24,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
                 var parameters = constructor.Parameters.Select(p => p.Name);
                 var parameterString = string.Join(", ", parameters);
 
+                Contract.ThrowIfNull(state.ClassType);
                 return string.Format(FeaturesResources.Generate_constructor_0_1,
                     state.ClassType.Name, parameterString);
             }

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.CodeActionAll.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.CodeActionAll.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 
-namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
+namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
     internal abstract partial class AbstractGenerateDefaultConstructorsService<TService>
     {

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -12,13 +10,13 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
+namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
     internal abstract partial class AbstractGenerateDefaultConstructorsService<TService>
     {
         private class State
         {
-            public INamedTypeSymbol ClassType { get; private set; }
+            public INamedTypeSymbol? ClassType { get; private set; }
 
             public ImmutableArray<IMethodSymbol> UnimplementedConstructors { get; private set; }
 
@@ -26,7 +24,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
             {
             }
 
-            public static State Generate(
+            public static State? Generate(
                 TService service,
                 SemanticDocument document,
                 TextSpan textSpan,
@@ -66,7 +64,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
                 var classConstructors = ClassType.InstanceConstructors;
 
                 var destinationProvider = semanticDocument.Project.Solution.Workspace.Services.GetLanguageServices(ClassType.Language);
-                var syntaxFacts = destinationProvider.GetService<ISyntaxFactsService>();
+                var syntaxFacts = destinationProvider.GetRequiredService<ISyntaxFactsService>();
                 var isCaseSensitive = syntaxFacts.IsCaseSensitive;
 
                 UnimplementedConstructors =

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
@@ -62,15 +62,18 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 
                 // if this is for the refactoring, then don't offer this if the compiler is reporting an
                 // error here.  We'll let the code fix take care of that.
-                var fixesError = FixesError(classType, baseType);
-                if (forRefactoring == fixesError)
-                    return false;
+                var syntaxFacts = semanticDocument.Document.GetRequiredLanguageService<ISyntaxFactsService>();
+                if (syntaxFacts.IsOnTypeHeader(semanticDocument.Root, textSpan.Start, fullHeader: true, out _))
+                {
+                    var fixesError = FixesError(classType, baseType);
+                    if (forRefactoring == fixesError)
+                        return false;
+                }
 
                 var semanticFacts = semanticDocument.Document.GetLanguageService<ISemanticFactsService>();
                 var classConstructors = ClassType.InstanceConstructors;
 
                 var destinationProvider = semanticDocument.Project.Solution.Workspace.Services.GetLanguageServices(ClassType.Language);
-                var syntaxFacts = destinationProvider.GetRequiredService<ISyntaxFactsService>();
                 var isCaseSensitive = syntaxFacts.IsCaseSensitive;
 
                 UnimplementedConstructors =

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
@@ -86,8 +86,7 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
                 // See if the user didn't supply a constructor, and thus the compiler automatically generated
                 // one for them.   If so, also see if there's an accessible no-arg contructor in the base.
                 // If not, then the compiler will error and we want the code-fix to take over solving this problem.
-                if (classType.Constructors.Length == 1 &&
-                    classType.Constructors[0].IsImplicitlyDeclared)
+                if (classType.Constructors.Any(c => c.Parameters.Length == 0 && c.IsImplicitlyDeclared))
                 {
                     var baseNoArgConstructor = baseType.Constructors.FirstOrDefault(c => c.Parameters.Length == 0);
                     if (baseNoArgConstructor == null ||

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
                 {
                     var baseNoArgConstructor = baseType.Constructors.FirstOrDefault(c => c.Parameters.Length == 0);
                     if (baseNoArgConstructor == null ||
-                        !baseNoArgConstructor.IsAccessibleWithin(classType.ContainingAssembly))
+                        !baseNoArgConstructor.IsAccessibleWithin(classType))
                     {
                         // this code is in error, but we're the refactoring codepath.  Offer nothing
                         // and let the code fix provider handle it instead.

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
@@ -62,6 +62,8 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 
                 // if this is for the refactoring, then don't offer this if the compiler is reporting an
                 // error here.  We'll let the code fix take care of that.
+                //
+                // Similarly if this is for the codefix only offer if we do see that there's an error.
                 var syntaxFacts = semanticDocument.Document.GetRequiredLanguageService<ISyntaxFactsService>();
                 if (syntaxFacts.IsOnTypeHeader(semanticDocument.Root, textSpan.Start, fullHeader: true, out _))
                 {

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -12,7 +11,7 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
+namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
     internal abstract partial class AbstractGenerateDefaultConstructorsService<TService> : IGenerateDefaultConstructorsService
         where TService : AbstractGenerateDefaultConstructorsService<TService>
@@ -21,7 +20,9 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
         {
         }
 
-        protected abstract bool TryInitializeState(SemanticDocument document, TextSpan textSpan, CancellationToken cancellationToken, out INamedTypeSymbol classType);
+        protected abstract bool TryInitializeState(
+            SemanticDocument document, TextSpan textSpan, CancellationToken cancellationToken,
+            [NotNullWhen(true)] out INamedTypeSymbol? classType);
 
         public async Task<ImmutableArray<CodeAction>> GenerateDefaultConstructorsAsync(
             Document document,

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
         public async Task<ImmutableArray<CodeAction>> GenerateDefaultConstructorsAsync(
             Document document,
             TextSpan textSpan,
+            bool forRefactoring,
             CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.Refactoring_GenerateMember_GenerateDefaultConstructors, cancellationToken))
@@ -36,7 +37,7 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
                 using var _ = ArrayBuilder<CodeAction>.GetInstance(out var result);
                 if (textSpan.IsEmpty)
                 {
-                    var state = State.Generate((TService)this, semanticDocument, textSpan, cancellationToken);
+                    var state = State.Generate((TService)this, semanticDocument, textSpan, forRefactoring, cancellationToken);
                     if (state != null)
                     {
                         foreach (var constructor in state.UnimplementedConstructors)

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/GenerateDefaultConstructorsCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/GenerateDefaultConstructorsCodeRefactoringProvider.cs
@@ -6,7 +6,6 @@ using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/GenerateDefaultConstructorsCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/GenerateDefaultConstructorsCodeRefactoringProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
     /// <summary>
     /// This <see cref="CodeRefactoringProvider"/> gives users a way to generate constructors for
-    /// a derived type that delegate to a base type.  For all accessibly constructors in the base
+    /// a derived type that delegate to a base type.  For all accessible constructors in the base
     /// type, the user will be offered to create a constructor in the derived type with the same
     /// signature if they don't already have one.  This way, a user can override a type and easily
     /// create all the forwarding constructors.
@@ -39,17 +39,14 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
             // TODO: https://github.com/dotnet/roslyn/issues/5778
             // Not supported in REPL for now.
             if (document.Project.IsSubmission)
-            {
                 return;
-            }
 
             if (document.Project.Solution.Workspace.Kind == WorkspaceKind.MiscellaneousFiles)
-            {
                 return;
-            }
 
             var service = document.GetRequiredLanguageService<IGenerateDefaultConstructorsService>();
-            var actions = await service.GenerateDefaultConstructorsAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
+            var actions = await service.GenerateDefaultConstructorsAsync(
+                document, textSpan, forRefactoring: true, cancellationToken).ConfigureAwait(false);
             context.RegisterRefactorings(actions);
         }
     }

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/IGenerateDefaultConstructorsService.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/IGenerateDefaultConstructorsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +9,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
+namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
 {
     internal interface IGenerateDefaultConstructorsService : ILanguageService
     {

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/IGenerateDefaultConstructorsService.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/IGenerateDefaultConstructorsService.cs
@@ -14,6 +14,6 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
     internal interface IGenerateDefaultConstructorsService : ILanguageService
     {
         Task<ImmutableArray<CodeAction>> GenerateDefaultConstructorsAsync(
-            Document document, TextSpan textSpan, CancellationToken cancellationToken);
+            Document document, TextSpan textSpan, bool forRefactoring, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/VisualBasic/Portable/GenerateDefaultConstructors/VisualBasicGenerateDefaultConstructorsCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/GenerateDefaultConstructors/VisualBasicGenerateDefaultConstructorsCodeFixProvider.vb
@@ -1,0 +1,27 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.GenerateDefaultConstructors
+Imports Microsoft.CodeAnalysis.Host.Mef
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateDefaultConstructors
+    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicGenerateDefaultConstructorsCodeFixProvider
+        Inherits AbstractGenerateDefaultConstructorCodeFixProvider
+
+        Private Const BC30387 As String = NameOf(BC30387) ' Class 'C' must declare a 'Sub New' because its base class 'B' does not have an accessible 'Sub New' that can be called with no arguments.	
+        Private Const BC40056 As String = NameOf(BC40056) ' Namespace or type specified in the Imports 'TestProj' doesn't contain any public member or cannot be found. Make sure the namespace or the type is defined and contains at least one public member. Make sure the imported element name doesn't use any aliases.
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+
+        Public Overrides ReadOnly Property FixableDiagnosticIds As Immutable.ImmutableArray(Of String) =
+            ImmutableArray.Create(BC30387, BC40056)
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/GenerateDefaultConstructors/VisualBasicGenerateDefaultConstructorsCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/GenerateDefaultConstructors/VisualBasicGenerateDefaultConstructorsCodeFixProvider.vb
@@ -9,7 +9,7 @@ Imports Microsoft.CodeAnalysis.GenerateDefaultConstructors
 Imports Microsoft.CodeAnalysis.Host.Mef
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateDefaultConstructors
-    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
+    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.GenerateDefaultConstructors), [Shared]>
     Friend Class VisualBasicGenerateDefaultConstructorsCodeFixProvider
         Inherits AbstractGenerateDefaultConstructorCodeFixProvider
 

--- a/src/Features/VisualBasic/Portable/GenerateDefaultConstructors/VisualBasicGenerateDefaultConstructorsService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateDefaultConstructors/VisualBasicGenerateDefaultConstructorsService.vb
@@ -4,13 +4,13 @@
 
 Imports System.Composition
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
+Imports Microsoft.CodeAnalysis.GenerateDefaultConstructors
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
-Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateDefaultConstructors
+Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateDefaultConstructors
     <ExportLanguageService(GetType(IGenerateDefaultConstructorsService), LanguageNames.VisualBasic), [Shared]>
     Partial Friend Class VisualBasicGenerateDefaultConstructorsService
         Inherits AbstractGenerateDefaultConstructorsService(Of VisualBasicGenerateDefaultConstructorsService)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1425,6 +1425,14 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public SyntaxToken GetIdentifierOfParameter(SyntaxNode node)
             => ((ParameterSyntax)node).Identifier;
 
+        public SyntaxToken GetIdentifierOfTypeDeclaration(SyntaxNode node)
+            => node switch
+            {
+                BaseTypeDeclarationSyntax typeDecl => typeDecl.Identifier,
+                DelegateDeclarationSyntax delegateDecl => delegateDecl.Identifier,
+                _ => throw ExceptionUtilities.UnexpectedValue(node),
+            };
+
         public SyntaxToken GetIdentifierOfIdentifierName(SyntaxNode node)
             => ((IdentifierNameSyntax)node).Identifier;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -258,6 +258,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         SyntaxToken GetIdentifierOfGenericName(SyntaxNode? node);
         SyntaxToken GetIdentifierOfSimpleName(SyntaxNode node);
         SyntaxToken GetIdentifierOfParameter(SyntaxNode node);
+        SyntaxToken GetIdentifierOfTypeDeclaration(SyntaxNode node);
         SyntaxToken GetIdentifierOfVariableDeclarator(SyntaxNode node);
         SyntaxToken GetIdentifierOfIdentifierName(SyntaxNode node);
         SyntaxNode GetTypeOfVariableDeclarator(SyntaxNode node);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -1488,12 +1488,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
         Public Function GetIdentifierOfTypeDeclaration(node As SyntaxNode) As SyntaxToken Implements ISyntaxFacts.GetIdentifierOfTypeDeclaration
             Select Case node.Kind()
-                Case SyntaxKind.EnumBlock,
-                     SyntaxKind.StructureBlock,
-                     SyntaxKind.InterfaceBlock,
-                     SyntaxKind.ClassBlock,
-                     SyntaxKind.ModuleBlock
-                    Return DirectCast(node, TypeBlockSyntax).BlockStatement.Identifier
+                Case SyntaxKind.EnumStatement,
+                     SyntaxKind.StructureStatement,
+                     SyntaxKind.InterfaceStatement,
+                     SyntaxKind.ClassStatement,
+                     SyntaxKind.ModuleStatement
+                    Return DirectCast(node, TypeStatementSyntax).Identifier
 
                 Case SyntaxKind.DelegateSubStatement,
                      SyntaxKind.DelegateFunctionStatement

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -1486,6 +1486,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return DirectCast(node, ParameterSyntax).Identifier.Identifier
         End Function
 
+        Public Function GetIdentifierOfTypeDeclaration(node As SyntaxNode) As SyntaxToken Implements ISyntaxFacts.GetIdentifierOfTypeDeclaration
+            Select Case node.Kind()
+                Case SyntaxKind.EnumBlock,
+                     SyntaxKind.StructureBlock,
+                     SyntaxKind.InterfaceBlock,
+                     SyntaxKind.ClassBlock,
+                     SyntaxKind.ModuleBlock
+                    Return DirectCast(node, TypeBlockSyntax).BlockStatement.Identifier
+
+                Case SyntaxKind.DelegateSubStatement,
+                     SyntaxKind.DelegateFunctionStatement
+                    Return DirectCast(node, DelegateStatementSyntax).Identifier
+            End Select
+
+            Throw ExceptionUtilities.UnexpectedValue(node)
+        End Function
+
         Public Function GetIdentifierOfIdentifierName(node As SyntaxNode) As SyntaxToken Implements ISyntaxFacts.GetIdentifierOfIdentifierName
             Return DirectCast(node, IdentifierNameSyntax).Identifier
         End Function


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/55636

This split ensures that if we're fixing an error that the codeaction appears at the top of the action-list instead of in the middle of the refactorings.

