### PR TITLE
Bulk update project when several documents change

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.SolutionCreator.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -479,6 +480,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 foreach (var kv in documentChecksums)
                 {
+                    Debug.Assert(assetProvider.EnsureCacheEntryIfExists(kv.Item2.Info), "Expected the prior call to GetAssetsAsync to obtain all items for this loop.");
+
                     var info = await assetProvider.GetAssetAsync<DocumentInfo.DocumentAttributes>(kv.Item2.Info, _cancellationToken).ConfigureAwait(false);
                     map.Add(info.Id, kv.Item2);
                 }


### PR DESCRIPTION
When changing the active solution configuration, all the documents in the solution change making for a very slow incremental update. This change detects "large" changes within a project as those touching three or more documents in a single operation, and ensures the assets are synchronized in bulk for this case.

Total StreamJsonRpc time prior to this change is 18.4 seconds in response to a configuration change (3138 GetAssetsAsync operations). Total time after this change is 6.5 seconds (1201 GetAssetsAsync operations).

Fixes AB#1365014