### PR TITLE
Completion: Suggest "await" after dot of awaitable expression

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -456,5 +456,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             return false;
         }
+
+        internal override bool IsDotAwaitKeywordContext(CancellationToken cancellationToken)
+        {
+            var tokenOnLeft = SyntaxTree.FindTokenOnLeftOfPosition(Position, cancellationToken);
+            var dotToken = tokenOnLeft.GetPreviousTokenIfTouchingWord(Position);
+            // TODO: someTask.$$. Middle of DotDotToken // see UnnamedSymbolCompletionProvider.GetDotAndExpressionStart
+            // TODO: Support corner cases like: someTask.$$ int i = 0; // see CSharpRecommendationServiceRunner.ShouldBeTreatedAsTypeInsteadOfExpression
+
+            // Don't support conditional access someTask?.$$ or c?.TaskReturning().$$ because there is no good completion until
+            // await? is supported by the language https://github.com/dotnet/csharplang/issues/35
+            if (dotToken.Parent is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.GetParentConditionalAccessExpression() is null)
+            {
+                var expr = memberAccess.Expression;
+                if (expr is not null)
+                {
+                    var symbol = SemanticModel.GetSymbolInfo(expr, cancellationToken).Symbol?.GetSymbolType();
+                    var isAwaitable = symbol?.IsAwaitableNonDynamic(SemanticModel, Position);
+                    if (isAwaitable == true)
+                    {
+                        var parentOfAwaitable = memberAccess.Parent;
+                        if (parentOfAwaitable is not AwaitExpressionSyntax)
+                        {
+                            // We have a awaitable type left of the dot, that is not yet awaited.
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ContextQuery/SyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ContextQuery/SyntaxContext.cs
@@ -144,6 +144,16 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
 
         internal abstract bool IsAwaitKeywordContext();
 
+        /// <summary>
+        /// Should <see langword="await"/> be offered, if left of the dot at position is an awaitable expression?
+        /// <code>
+        ///   someTask.$$ // Suggest await completion
+        ///   await someTask.$$ // Don't suggest await completion
+        /// </code>
+        /// </summary>
+        /// <returns><see langword="true"/>, if await should be suggested for the expression left of the dot.</returns>
+        internal abstract bool IsDotAwaitKeywordContext(CancellationToken cancellationToken);
+
         public ISet<INamedTypeSymbol> GetOuterTypes(CancellationToken cancellationToken)
         {
             if (_outerTypes == null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
@@ -187,6 +187,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
             Return False
         End Function
 
+        Friend Overrides Function IsDotAwaitKeywordContext(cancellationToken As CancellationToken) As Boolean
+            Return False
+        End Function
+
         Private Function ComputeEnclosingNamedType(cancellationToken As CancellationToken) As INamedTypeSymbol
             Dim enclosingSymbol = Me.SemanticModel.GetEnclosingSymbol(Me.TargetToken.SpanStart, cancellationToken)
             Dim container = TryCast(enclosingSymbol, INamedTypeSymbol)


### PR DESCRIPTION
Fixes #52289

```CS
someTask.aw$$ // this triggers completion which contains "await" and "awaitf".
// committed suggestions "await":
await someTask$$
// or "awaitf"
await someTask.ConfigureAwait(false)$$
```