### PR TITLE
Ignore stale active statements.

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/ActiveStatementsMapTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/ActiveStatementsMapTests.cs
@@ -98,7 +98,7 @@ S5();
             var moduleId = Guid.NewGuid();
             var token = 0x06000001;
             ManagedActiveStatementDebugInfo CreateInfo(int startLine, int startColumn, int endLine, int endColumn, string fileName)
-                => new(new(new(moduleId, token++, version: 1), ilOffset: 0), fileName, new SourceSpan(startLine, startColumn, endLine, endColumn), ActiveStatementFlags.None);
+                => new(new(new(moduleId, token++, version: 1), ilOffset: 0), fileName, new SourceSpan(startLine, startColumn, endLine, endColumn), ActiveStatementFlags.MethodUpToDate);
 
             var debugInfos = ImmutableArray.Create(
                 CreateInfo(3, 0, 3, 4, "x"),

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -3615,6 +3615,7 @@ class C
 
             AssertEx.Equal(new[]
             {
+                $"0x06000002 v1 | AS {document.FilePath}: (3,41)-(3,42) δ=0",
                 $"0x06000003 v1 | AS {document.FilePath}: (7,14)-(7,18) δ=2",
             }, InspectNonRemappableRegions(debuggingSession.EditSession.NonRemappableRegions));
 

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -2947,8 +2947,8 @@ class C { int Y => 1; }
             var baseSpans = (await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(documentId), CancellationToken.None)).Single();
             AssertEx.Equal(new[]
             {
-                new ActiveStatementSpan(0, activeLineSpan11, ActiveStatementFlags.MethodUpToDate |ActiveStatementFlags.IsNonLeafFrame, unmappedDocumentId: null),
-                new ActiveStatementSpan(1, activeLineSpan12, ActiveStatementFlags.MethodUpToDate |ActiveStatementFlags.IsLeafFrame, unmappedDocumentId: null)
+                new ActiveStatementSpan(0, activeLineSpan11, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsNonLeafFrame, unmappedDocumentId: null),
+                new ActiveStatementSpan(1, activeLineSpan12, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsLeafFrame, unmappedDocumentId: null)
             }, baseSpans);
 
             // change the source (valid edit):

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -2846,17 +2846,17 @@ class C { int Y => 1; }
                     activeInstruction1,
                     documentPath,
                     activeLineSpan11.ToSourceSpan(),
-                    ActiveStatementFlags.IsNonLeafFrame),
+                    ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsNonLeafFrame),
                 new ManagedActiveStatementDebugInfo(
                     activeInstruction2,
                     documentPath,
                     activeLineSpan12.ToSourceSpan(),
-                    ActiveStatementFlags.IsLeafFrame));
+                    ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsLeafFrame));
 
             EnterBreakState(debuggingSession, activeStatements);
 
-            var activeStatementSpan11 = new ActiveStatementSpan(0, activeLineSpan11, ActiveStatementFlags.IsNonLeafFrame, unmappedDocumentId: null);
-            var activeStatementSpan12 = new ActiveStatementSpan(1, activeLineSpan12, ActiveStatementFlags.IsLeafFrame, unmappedDocumentId: null);
+            var activeStatementSpan11 = new ActiveStatementSpan(0, activeLineSpan11, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsNonLeafFrame, unmappedDocumentId: null);
+            var activeStatementSpan12 = new ActiveStatementSpan(1, activeLineSpan12, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsLeafFrame, unmappedDocumentId: null);
 
             var baseSpans = await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(document1.Id), CancellationToken.None);
             AssertEx.Equal(new[]
@@ -2935,20 +2935,20 @@ class C { int Y => 1; }
                     activeInstruction1,
                     documentFilePath,
                     activeLineSpan11.ToSourceSpan(),
-                    ActiveStatementFlags.IsNonLeafFrame),
+                    ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsNonLeafFrame),
                 new ManagedActiveStatementDebugInfo(
                     activeInstruction2,
                     documentFilePath,
                     activeLineSpan12.ToSourceSpan(),
-                    ActiveStatementFlags.IsLeafFrame));
+                    ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsLeafFrame));
 
             EnterBreakState(debuggingSession, activeStatements);
 
             var baseSpans = (await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(documentId), CancellationToken.None)).Single();
             AssertEx.Equal(new[]
             {
-                new ActiveStatementSpan(0, activeLineSpan11, ActiveStatementFlags.IsNonLeafFrame, unmappedDocumentId: null),
-                new ActiveStatementSpan(1, activeLineSpan12, ActiveStatementFlags.IsLeafFrame, unmappedDocumentId: null)
+                new ActiveStatementSpan(0, activeLineSpan11, ActiveStatementFlags.MethodUpToDate |ActiveStatementFlags.IsNonLeafFrame, unmappedDocumentId: null),
+                new ActiveStatementSpan(1, activeLineSpan12, ActiveStatementFlags.MethodUpToDate |ActiveStatementFlags.IsLeafFrame, unmappedDocumentId: null)
             }, baseSpans);
 
             // change the source (valid edit):
@@ -3374,12 +3374,11 @@ class C
         /// 1) Break, edit F from version 1 to version 2, continue (change is applied), G is still running in its loop
         ///    Function remapping is produced for F v1 -> F v2.
         /// 2) Hot-reload edit F (without breaking) to version 3.
-        ///    Function remapping is produced for F v2 -> F v3 based on the last set of active statements calculated for F v2.
-        ///    Assume that the execution did not progress since the last resume.
-        ///    These active statements will likely not match the actual runtime active statements,
-        ///    however F v2 will never be remapped since it was hot-reloaded and not EnC'd.
-        ///    This remapping is needed for mapping from F v1 to F v3.
-        /// 3) Break. Update F to v4.
+        ///    Function remapping is not produced for F v2 -> F v3. If G ever returned to F it will be remapped from F v1 -> F v2,
+        ///    where F v2 is considered stale code. This is consistent with the semantic of Hot Reload: Hot Reloaded changes do not have 
+        ///    an effect until the method is called again. In this case the method is not called, it it returned into hence the stale
+        ///    version executes.
+        /// 3) Break and apply EnC edit. This edit is to F v3 (Hot Reload) of the method. We will produce remapping F v3 -> v4.
         /// </summary>
         [Fact, WorkItem(52100, "https://github.com/dotnet/roslyn/issues/52100")]
         public async Task BreakStateRemappingFollowedUpByRunStateUpdate()
@@ -3434,6 +3433,7 @@ class C
 
             AssertEx.Equal(new[]
             {
+                $"0x06000002 v1 | AS {document.FilePath}: (4,41)-(4,42) δ=0",
                 $"0x06000003 v1 | AS {document.FilePath}: (9,14)-(9,18) δ=1",
             }, InspectNonRemappableRegions(debuggingSession.EditSession.NonRemappableRegions));
 
@@ -3451,8 +3451,10 @@ class C
 
             CommitSolutionUpdate(debuggingSession);
 
+            // the regions remain unchanged
             AssertEx.Equal(new[]
             {
+                $"0x06000002 v1 | AS {document.FilePath}: (4,41)-(4,42) δ=0",
                 $"0x06000003 v1 | AS {document.FilePath}: (9,14)-(9,18) δ=1",
             }, InspectNonRemappableRegions(debuggingSession.EditSession.NonRemappableRegions));
 
@@ -3466,8 +3468,14 @@ class C
                 flags: new[]
                 {
                     ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsLeafFrame,    // G
-                    ActiveStatementFlags.IsNonLeafFrame,                                       // F - not up-to-date anymore
+                    ActiveStatementFlags.IsStale | ActiveStatementFlags.IsNonLeafFrame,        // F - not up-to-date anymore and since F v1 is followed by F v3 (hot-reload) it is now stale
                 }));
+
+            var spans = (await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(documentId), CancellationToken.None)).Single();
+            AssertEx.Equal(new[]
+            {
+                new ActiveStatementSpan(0, new LinePositionSpan(new(4,41), new(4,42)), ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsLeafFrame, unmappedDocumentId: null),
+            }, spans);
 
             solution = solution.WithDocumentText(documentId, SourceText.From(ActiveStatementsDescription.ClearTags(markedSourceV4), Encoding.UTF8));
 
@@ -3479,11 +3487,10 @@ class C
 
             CommitSolutionUpdate(debuggingSession);
 
-            // TODO: https://github.com/dotnet/roslyn/issues/52100
-            // this is incorrect. correct value is: 0x06000003 v1 | AS (9,14)-(9,18) δ=16
+            // Stale active statement region is gone.
             AssertEx.Equal(new[]
             {
-                $"0x06000003 v1 | AS {document.FilePath}: (9,14)-(9,18) δ=5"
+                $"0x06000002 v1 | AS {document.FilePath}: (4,41)-(4,42) δ=0",
             }, InspectNonRemappableRegions(debuggingSession.EditSession.NonRemappableRegions));
 
             ExitBreakState(debuggingSession);
@@ -3682,19 +3689,20 @@ class C
             var expectedSpanF1 = new LinePositionSpan(new LinePosition(7, 14), new LinePosition(7, 18));
             var expectedSpanG1 = new LinePositionSpan(new LinePosition(3, 41), new LinePosition(3, 42));
 
+            var activeInstructionG1 = new ManagedInstructionId(new ManagedMethodId(moduleId, 0x06000002, version: 1), ilOffset: 0);
+            var span = await debuggingSession.GetCurrentActiveStatementPositionAsync(solution, s_noActiveSpans, activeInstructionG1, CancellationToken.None);
+            Assert.Equal(expectedSpanG1, span);
+
+            // Active statement in F has been deleted:
             var activeInstructionF1 = new ManagedInstructionId(new ManagedMethodId(moduleId, 0x06000003, version: 1), ilOffset: 0);
-            var span = await debuggingSession.GetCurrentActiveStatementPositionAsync(solution, s_noActiveSpans, activeInstructionF1, CancellationToken.None);
-            Assert.Equal(expectedSpanF1, span);
+            span = await debuggingSession.GetCurrentActiveStatementPositionAsync(solution, s_noActiveSpans, activeInstructionF1, CancellationToken.None);
+            Assert.Null(span);
 
             var spans = (await debuggingSession.GetBaseActiveStatementSpansAsync(solution, ImmutableArray.Create(documentId), CancellationToken.None)).Single();
             AssertEx.Equal(new[]
             {
-                new ActiveStatementSpan(0, expectedSpanG1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsLeafFrame, unmappedDocumentId: null),
-
-                // TODO: https://github.com/dotnet/roslyn/issues/52100
-                // This is incorrect: the active statement shouldn't be reported since it has been deleted.
-                // We need the debugger to mark the method version as replaced by run-mode update.
-                new ActiveStatementSpan(1, expectedSpanF1, ActiveStatementFlags.IsNonLeafFrame, unmappedDocumentId: null)
+                new ActiveStatementSpan(0, expectedSpanG1, ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsLeafFrame, unmappedDocumentId: null)
+                // active statement in F has been deleted
             }, spans);
 
             ExitBreakState(debuggingSession);

--- a/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditSessionActiveStatementsTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                     new ManagedInstructionId(new ManagedMethodId(module: Guid.NewGuid(), token: 0x06000005, version: 1), ilOffset: 10),
                     documentName: null,
                     sourceSpan: default,
-                    ActiveStatementFlags.IsNonLeafFrame));
+                    ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsNonLeafFrame));
 
             // add an extra active statement from project not belonging to the solution, it should be ignored:
             activeStatements = activeStatements.Add(
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                     new ManagedInstructionId(new ManagedMethodId(module: module3, token: 0x06000005, version: 1), ilOffset: 10),
                     "NonRoslynDocument.mcpp",
                     new SourceSpan(1, 1, 1, 10),
-                    ActiveStatementFlags.IsNonLeafFrame));
+                    ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsNonLeafFrame));
 
             // Add an extra active statement from language that doesn't support Roslyn EnC should be ignored:
             // See https://github.com/dotnet/roslyn/issues/24408 for test scenario.
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                     new ManagedInstructionId(new ManagedMethodId(module: module4, token: 0x06000005, version: 1), ilOffset: 10),
                     "a.dummy",
                     new SourceSpan(2, 1, 2, 10),
-                    ActiveStatementFlags.IsNonLeafFrame));
+                    ActiveStatementFlags.MethodUpToDate | ActiveStatementFlags.IsNonLeafFrame));
 
             using var workspace = new TestWorkspace(composition: s_composition);
 
@@ -193,8 +193,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 $"2: {document2.FilePath}: (21,14)-(21,24) flags=[MethodUpToDate, IsNonLeafFrame] mvid=22222222-2222-2222-2222-222222222222 0x06000003 v1 IL_0001",   // [|Test1.M1()|] in F2
                 $"3: {document2.FilePath}: (8,20)-(8,25) flags=[MethodUpToDate, IsNonLeafFrame] mvid=22222222-2222-2222-2222-222222222222 0x06000004 v1 IL_0002",     // [|F2();|] in M2
                 $"4: {document2.FilePath}: (26,20)-(26,25) flags=[MethodUpToDate, IsNonLeafFrame] mvid=22222222-2222-2222-2222-222222222222 0x06000005 v1 IL_0003",   // [|M2();|] in Main
-                $"5: NonRoslynDocument.mcpp: (1,1)-(1,10) flags=[IsNonLeafFrame] mvid={module3} 0x06000005 v1 IL_000A",
-                $"6: a.dummy: (2,1)-(2,10) flags=[IsNonLeafFrame] mvid={module4} 0x06000005 v1 IL_000A"
+                $"5: NonRoslynDocument.mcpp: (1,1)-(1,10) flags=[MethodUpToDate, IsNonLeafFrame] mvid={module3} 0x06000005 v1 IL_000A",
+                $"6: a.dummy: (2,1)-(2,10) flags=[MethodUpToDate, IsNonLeafFrame] mvid={module4} 0x06000005 v1 IL_000A"
             }, statements.Select(InspectActiveStatementAndInstruction));
 
             // Active Statements per document
@@ -216,12 +216,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             AssertEx.Equal(new[]
             {
-                $"5: NonRoslynDocument.mcpp: (1,1)-(1,10) flags=[IsNonLeafFrame]",
+                $"5: NonRoslynDocument.mcpp: (1,1)-(1,10) flags=[MethodUpToDate, IsNonLeafFrame]",
             }, baseActiveStatementsMap.DocumentPathMap["NonRoslynDocument.mcpp"].Select(InspectActiveStatement));
 
             AssertEx.Equal(new[]
             {
-                $"6: a.dummy: (2,1)-(2,10) flags=[IsNonLeafFrame]",
+                $"6: a.dummy: (2,1)-(2,10) flags=[MethodUpToDate, IsNonLeafFrame]",
             }, baseActiveStatementsMap.DocumentPathMap["a.dummy"].Select(InspectActiveStatement));
 
             // Exception Regions
@@ -275,7 +275,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             {
                 $"0x06000004 v1 | AS {document2.FilePath}: (8,20)-(8,25) δ=1",
                 $"0x06000004 v1 | ER {document2.FilePath}: (14,8)-(16,9) δ=1",
-                $"0x06000004 v1 | ER {document2.FilePath}: (10,10)-(12,11) δ=1"
+                $"0x06000004 v1 | ER {document2.FilePath}: (10,10)-(12,11) δ=1",
+                $"0x06000003 v1 | AS {document2.FilePath}: (21,14)-(21,24) δ=0",
+                $"0x06000005 v1 | AS {document2.FilePath}: (26,20)-(26,25) δ=0"
             }, nonRemappableRegions.Select(r => $"{r.Method.GetDebuggerDisplay()} | {r.Region.GetDebuggerDisplay()}"));
 
             AssertEx.Equal(new[]
@@ -384,11 +386,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 out var nonRemappableRegions,
                 out var exceptionRegionUpdates);
 
-            // although the span has not changed the method has, so we need to add corresponding non-remappable regions
             AssertEx.Equal(new[]
             {
                 $"0x06000001 v1 | AS {document.FilePath}: (6,18)-(6,23) δ=0",
                 $"0x06000001 v1 | ER {document.FilePath}: (8,8)-(12,9) δ=0",
+                $"0x06000002 v1 | AS {document.FilePath}: (18,14)-(18,36) δ=0",
             }, nonRemappableRegions.OrderBy(r => r.Region.Span.Span.Start.Line).Select(r => $"{r.Method.GetDebuggerDisplay()} | {r.Region.GetDebuggerDisplay()}"));
 
             AssertEx.Equal(new[]
@@ -580,6 +582,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             // Note: Since no method have been remapped yet all the following spans are in their pre-remap locations: 
             AssertEx.Equal(new[]
             {
+                $"0x06000001 v2 | AS {document.FilePath}: (6,18)-(6,22) δ=0",
                 $"0x06000002 v2 | ER {document.FilePath}: (18,16)-(21,9) δ=-1",
                 $"0x06000002 v2 | AS {document.FilePath}: (20,18)-(20,22) δ=-1",
                 $"0x06000003 v1 | AS {document.FilePath}: (30,22)-(30,26) δ=-1", // AS:2 moved -1 in first edit, 0 in second

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatement.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatement.cs
@@ -45,6 +45,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             Flags = flags;
             FileSpan = span;
             InstructionId = instructionId;
+
+            // IsStale implies !IsMethodUpToDate
+            Debug.Assert(!IsStale || !IsMethodUpToDate);
         }
 
         public ActiveStatement WithSpan(LinePositionSpan span)
@@ -74,8 +77,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public bool IsNonLeaf
             => (Flags & ActiveStatementFlags.IsNonLeafFrame) != 0;
 
+        /// <summary>
+        /// True if the active statement is located in a version of the method that's not the latest version of the method.
+        /// </summary>
         public bool IsMethodUpToDate
             => (Flags & ActiveStatementFlags.MethodUpToDate) != 0;
+
+        /// <summary>
+        /// True if the active statement is located in a version of the method that precedes a later version that was created by Hot Reload update.
+        /// </summary>
+        public bool IsStale
+            => (Flags & ActiveStatementFlags.IsStale) != 0;
 
         private string GetDebuggerDisplay()
             => $"{Ordinal}: {Span}";

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
@@ -72,12 +72,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     continue;
                 }
 
+                if (!TryGetUpToDateSpan(debugInfo, remapping, out var baseSpan))
+                {
+                    continue;
+                }
+
                 if (!updatedSpansByDocumentPath.TryGetValue(documentName, out var documentInfos))
                 {
                     updatedSpansByDocumentPath.Add(documentName, documentInfos = ArrayBuilder<(ManagedActiveStatementDebugInfo, SourceFileSpan, int)>.GetInstance());
                 }
 
-                documentInfos.Add((debugInfo, new SourceFileSpan(documentName, GetUpToDateSpan(debugInfo, remapping)), ordinal++));
+                documentInfos.Add((debugInfo, new SourceFileSpan(documentName, baseSpan), ordinal++));
             }
 
             foreach (var (_, infos) in updatedSpansByDocumentPath)
@@ -113,13 +118,20 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return new ActiveStatementsMap(byDocumentPath, byInstruction.ToImmutableDictionary());
         }
 
-        private static LinePositionSpan GetUpToDateSpan(ManagedActiveStatementDebugInfo activeStatementInfo, ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> remapping)
+        private static bool TryGetUpToDateSpan(ManagedActiveStatementDebugInfo activeStatementInfo, ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>> remapping, out LinePositionSpan newSpan)
         {
-            var activeSpan = activeStatementInfo.SourceSpan.ToLinePositionSpan();
-
-            if ((activeStatementInfo.Flags & ActiveStatementFlags.MethodUpToDate) != 0)
+            // Drop stale active statements - their location in the current snapshot is unknown.
+            if (activeStatementInfo.Flags.HasFlag(ActiveStatementFlags.IsStale))
             {
-                return activeSpan;
+                newSpan = default;
+                return false;
+            }
+
+            var activeSpan = activeStatementInfo.SourceSpan.ToLinePositionSpan();
+            if (activeStatementInfo.Flags.HasFlag(ActiveStatementFlags.MethodUpToDate))
+            {
+                newSpan = activeSpan;
+                return true;
             }
 
             var instructionId = activeStatementInfo.ActiveInstruction;
@@ -131,15 +143,16 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 {
                     if (region.Span.Span.Contains(activeSpan) && activeStatementInfo.DocumentName == region.Span.Path)
                     {
-                        return activeSpan.AddLineDelta(region.LineDelta);
+                        newSpan = activeSpan.AddLineDelta(region.LineDelta);
+                        return true;
                     }
                 }
             }
 
-            // The active statement is in a method that's not up-to-date but the active span have not changed.
-            // We only add changed spans to non-remappable regions map, so we won't find unchanged span there.
-            // Return the original span.
-            return activeSpan;
+            // The active statement is in a method instance that was updated during Hot Reload session,
+            // at which point the location of the span was not known. 
+            newSpan = default;
+            return false;
         }
 
         public bool IsEmpty

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -942,13 +942,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         activeStatementsInUpdatedMethodsBuilder.Add(new ManagedActiveStatementUpdate(methodId, instructionId.ILOffset, newActiveStatement.Span.ToSourceSpan()));
                     }
 
+                    Debug.Assert(!oldActiveStatement.IsStale);
+
                     // Adds a region with specified PDB spans.
                     void AddNonRemappableRegion(SourceFileSpan oldSpan, SourceFileSpan newSpan, bool isExceptionRegion)
                     {
                         // it is a rude edit to change the path of the region span:
                         Debug.Assert(oldSpan.Path == newSpan.Path);
 
-                        if (newActiveStatement.IsMethodUpToDate)
+                        // The up-to-date flag is copied when new active statement is created from the corresponding old one.
+                        Debug.Assert(oldActiveStatement.IsMethodUpToDate == newActiveStatement.IsMethodUpToDate);
+
+                        if (oldActiveStatement.IsMethodUpToDate)
                         {
                             // Start tracking non-remappable regions for active statements in methods that were up-to-date 
                             // when break state was entered and now being updated (regardless of whether the active span changed or not).
@@ -957,15 +962,22 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 var lineDelta = oldSpan.Span.GetLineDelta(newSpan: newSpan.Span);
                                 nonRemappableRegionsBuilder.Add((methodId, new NonRemappableRegion(oldSpan, lineDelta, isExceptionRegion)));
                             }
-
-                            // If the method has been up-to-date and it is not updated now then either the active statement span has not changed,
-                            // or the entire method containing it moved. In neither case do we need to start tracking non-remapable region
-                            // for the active statement since movement of whole method bodies (if any) is handled only on PDB level without 
-                            // triggering any remapping on the IL level.
+                            else if (!isExceptionRegion)
+                            {
+                                // If the method has been up-to-date and it is not updated now then either the active statement span has not changed,
+                                // or the entire method containing it moved. In neither case do we need to start tracking non-remapable region
+                                // for the active statement since movement of whole method bodies (if any) is handled only on PDB level without 
+                                // triggering any remapping on the IL level.
+                                //
+                                // That said, we still add a non-remappable region for this active statement, so that we know in future sessions
+                                // that this active statement existed and its span has not changed. We don't report these regions to the debugger,
+                                // but we use them to map active statement spans to the baseline snapshots of following edit sessions.
+                                nonRemappableRegionsBuilder.Add((methodId, new NonRemappableRegion(oldSpan, lineDelta: 0, isExceptionRegion: false)));
+                            }
                         }
                         else if (oldSpan.Span != newSpan.Span)
                         {
-                            // The method is not up-to-date hence we maintain non-remapable span map for it that needs to be updated.
+                            // The method is not up-to-date hence we might have a previous non-remappable span mapping that needs to be brought forward to the new snapshot.
                             changedNonRemappableSpans[(methodId, oldSpan)] = newSpan;
                         }
                     }
@@ -994,17 +1006,20 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
             }
 
+            // Update previously calculated non-remappable region mappings.
+            // These map to the old snapshot and we need them to map to the new snapshot, which will be the baseline for the next session.
             if (unremappedActiveMethods.Count > 0)
             {
                 foreach (var (methodInstance, regionsInMethod) in previousNonRemappableRegions)
                 {
+                    // Skip non-remappable regions that belong to method instances that are from a different module.
                     if (methodInstance.Module != moduleId)
                     {
                         continue;
                     }
 
-                    // Skip non-remappable regions that belong to method instances that are from a different module 
-                    // or no longer active (all active statements in these method instances have been remapped to newer versions).
+                    // Skip no longer active methods - all active statements in these method instances have been remapped to newer versions.
+                    // New active statement can't appear in a stale method instance since such instance can't be invoked.
                     if (!unremappedActiveMethods.Contains(methodInstance.Method))
                     {
                         continue;


### PR DESCRIPTION
Stale active statements are located in a version of a method that has been replaced by a new version during Hot Reload update. According to Hot Reload semantics the new version of the method is not executed until the method is invoked again. Therefore, a stack frame that returns into the old version will not be remapped to the Hot Reload version. It will instead continue executing the old version and the corresponding active statement will be marked as stale if a break mode is entered afterwards. Roslyn ignores these stale active statements since we do not know their location in the current snapshot of the code. Ignoring these active statements also results in non-remappable region mapping for that active statement maintained on the edit session to not carry over to the next edit session. This is desirable as we do not know how to bring the mapping over to the snapshot that follows Hot Reload update (since the update does not produce active statement mapping).

Fixes https://github.com/dotnet/roslyn/issues/52100

TODO: The debugger currently does not set the flag.