### PR TITLE
Convert FileChangeWatcher to batch processing

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
@@ -260,7 +260,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
 
             // Modify the file and raise a mock file change
             File.WriteAllText(ruleSetFile.Path, ruleSetSource.Replace("Error", "Warning"));
-            environment.RaiseFileChange(ruleSetFile.Path);
+            await environment.RaiseFileChangeAsync(ruleSetFile.Path);
 
             var listenerProvider = environment.ExportProvider.GetExportedValue<AsynchronousOperationListenerProvider>();
             var waiter = listenerProvider.GetWaiter(FeatureAttribute.RuleSetEditor);

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -14,6 +14,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 Imports Microsoft.CodeAnalysis.FindSymbols
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.Composition
@@ -269,14 +270,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             End Function
         End Class
 
-        Friend Sub RaiseFileChange(path As String)
+        Friend Async Function RaiseFileChangeAsync(path As String) As Task
             ' Ensure we've pushed everything to the file change watcher
             Dim fileChangeProvider = ExportProvider.GetExportedValue(Of FileChangeWatcherProvider)
             Dim mockFileChangeService = DirectCast(ServiceProvider.GetService(GetType(SVsFileChangeEx)), MockVsFileChangeEx)
             fileChangeProvider.TrySetFileChangeService_TestOnly(mockFileChangeService)
-            fileChangeProvider.Watcher.WaitForQueue_TestOnly()
+            Await ExportProvider.GetExportedValue(Of AsynchronousOperationListenerProvider)().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync()
             mockFileChangeService.FireUpdate(path)
-        End Sub
+        End Function
 
         Private Class MockVsSmartOpenScope
             Implements IVsSmartOpenScope


### PR DESCRIPTION
* [x] Convert `FileChangeWatcher` from task chaining to a batching work queue
* [ ] Automatically merge work items where possible
* [ ] Use batch APIs to reduce the number of calls to change file watchers

Supersedes #55018