### PR TITLE
Allow fully oblivious types to coexist with nullable-aware base types in partial classes

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         baseType = partBase;
                         baseTypeLocation = decl.NameLocation;
                     }
-                    else if ((object)partBase != null && !TypeSymbol.Equals(partBase, baseType, TypeCompareKind.ConsiderEverything2) && partBase.TypeKind != TypeKind.Error)
+                    else if ((object)partBase != null && !TypeSymbol.Equals(partBase, baseType, TypeCompareKind.ConsiderEverything) && partBase.TypeKind != TypeKind.Error)
                     {
                         // the parts do not agree
                         if (partBase.Equals(baseType, TypeCompareKind.ObliviousNullableModifierMatchesAny))


### PR DESCRIPTION
Fixes #45960

Some of the changes in the implementation are a bit weird here because we're adding some awareness of the difference between a top-level "non-annotated" base type and a top-level "oblivious" base type. This affects the test `PartialBaseTypeDifference_02`. If it is found that this doesn't make sense, we could simplify the change.
