### PR TITLE
Check CS0103 when try to replace type cast by 'is' pattern

### DIFF
--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.UsePatternMatching;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -520,6 +521,31 @@ class TestFile
             M(file.i);
         }
     }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        [WorkItem(51340, "https://github.com/dotnet/roslyn/issues/51340")]
+        public async Task TestNoDiagnosticWhenCS0103Happens()
+        {
+            await TestDiagnosticMissingAsync(
+@"
+using System.Linq;
+class Bar
+{
+    private void Foo()
+    {
+        var objects = new SpecificThingType[100];
+        var d = from obj in objects
+                let aGenericThing = obj.Prop
+                where aGenericTh[||]ing is SpecificThingType
+                let specificThing = (SpecificThingType)aGenericThing
+                select (obj, specificThing);
+    }
+}
+class SpecificThingType
+{
+    public SpecificThingType Prop { get; }
 }");
         }
     }

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
     internal class CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer : AbstractBuiltInCodeStyleDiagnosticAnalyzer
     {
         private const string CS0165 = nameof(CS0165); // Use of unassigned local variable 's'
+        private const string CS0103 = nameof(CS0103); // Name of the variable doesn't live in context
         private static readonly SyntaxAnnotation s_referenceAnnotation = new SyntaxAnnotation();
 
         public static readonly CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer Instance = new CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer();
@@ -170,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             var currentNode = root.GetAnnotatedNodes(s_referenceAnnotation).Single();
             var diagnostics = updatedSemanticModel.GetDiagnostics(currentNode.Span, cancellationToken);
 
-            return diagnostics.Any(d => d.Id == CS0165);
+            return diagnostics.Any(d => d.Id == CS0165 || d.Id == CS0103);
         }
 
         public static SemanticModel ReplaceMatches(


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/51340
In code sample
```
using System.Linq;
class Bar
{
    private void Foo()
    {
        var objects = new SpecificThingType[100];
        var d = from obj in objects
                let aGenericThing = obj.Prop
                where aGenericTh[||]ing is SpecificThingType
                let specificThing = (SpecificThingType)aGenericThing
                select (obj, specificThing);
    }
}
class SpecificThingType
{
    public SpecificThingType Prop { get; }
}
```
When we search the potential match for `aGenericThing`,  `let specificThing = (SpecificThingType)aGenericThing` is included.
However, when the analyzer is trying to apply `aGenericThing is SpecificThingType Baz` in the WhereClause
it is unsafe to replace `(SpecificThingType)aGenericThing` with `Baz`.

So add an extra diagnostic check for CS0103