### PR TITLE
Moving WinForms Editor Factory logic to WinForms

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,11 +32,11 @@
     <MicrosoftCodeAnalysisTestingVersion>1.1.0-beta1.21322.2</MicrosoftCodeAnalysisTestingVersion>
     <CodeStyleAnalyzerVersion>3.10.0</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>16.10.230</VisualStudioEditorPackagesVersion>
-    <VisualStudioEditorNewPackagesVersion>17.0.278-preview</VisualStudioEditorNewPackagesVersion>
+    <VisualStudioEditorNewPackagesVersion>17.0.344-preview</VisualStudioEditorNewPackagesVersion>
     <ILAsmPackageVersion>5.0.0-alpha1.19409.1</ILAsmPackageVersion>
     <ILDAsmPackageVersion>5.0.0-preview.1.20112.8</ILDAsmPackageVersion>
     <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.0.3094-g82ddffa096</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.0.0-previews-4-31608-029</MicrosoftVisualStudioShellPackagesVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.0.0-previews-4-31622-033</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftBuildPackagesVersion>16.5.0</MicrosoftBuildPackagesVersion>
     <!-- The version of Roslyn we build Source Generators against that are built in this
          repository. This must be lower than MicrosoftNetCompilersToolsetVersion,
@@ -110,8 +110,8 @@
     <MicrosoftNetSdkVersion>2.0.0-alpha-20170405-2</MicrosoftNetSdkVersion>
     <MicrosoftNuGetBuildTasksVersion>0.1.0</MicrosoftNuGetBuildTasksVersion>
     <MicrosoftPortableTargetsVersion>0.1.2-dev</MicrosoftPortableTargetsVersion>
-    <MicrosoftServiceHubClientVersion>3.0.2043-alpha</MicrosoftServiceHubClientVersion>
-    <MicrosoftServiceHubFrameworkVersion>3.0.2043-alpha</MicrosoftServiceHubFrameworkVersion>
+    <MicrosoftServiceHubClientVersion>3.0.2061</MicrosoftServiceHubClientVersion>
+    <MicrosoftServiceHubFrameworkVersion>3.0.2061</MicrosoftServiceHubFrameworkVersion>
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
     <MicrosoftVisualStudioCacheVersion>17.0.13-alpha</MicrosoftVisualStudioCacheVersion>
     <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.8.27812-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
@@ -158,7 +158,7 @@
     <MicrosoftVisualStudioShell150Version>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShell150Version>
     <MicrosoftVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioShellDesignVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellDesignVersion>
-    <MicrosoftVisualStudioTelemetryVersion>16.3.198</MicrosoftVisualStudioTelemetryVersion>
+    <MicrosoftVisualStudioTelemetryVersion>16.3.205</MicrosoftVisualStudioTelemetryVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>8.0.0.0-alpha</MicrosoftVisualStudioTemplateWizardInterfaceVersion>
     <MicrosoftVisualStudioTextDataVersion>$(VisualStudioEditorNewPackagesVersion)</MicrosoftVisualStudioTextDataVersion>
     <MicrosoftVisualStudioTextInternalVersion>$(VisualStudioEditorNewPackagesVersion)</MicrosoftVisualStudioTextInternalVersion>
@@ -166,12 +166,13 @@
     <MicrosoftVisualStudioTextUIVersion>$(VisualStudioEditorNewPackagesVersion)</MicrosoftVisualStudioTextUIVersion>
     <MicrosoftVisualStudioTextUIWpfVersion>$(VisualStudioEditorNewPackagesVersion)</MicrosoftVisualStudioTextUIWpfVersion>
     <MicrosoftVisualStudioTextUICocoaVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextUICocoaVersion>
-    <MicrosoftVisualStudioThreadingAnalyzersVersion>17.0.32-alpha</MicrosoftVisualStudioThreadingAnalyzersVersion>
-    <MicrosoftVisualStudioThreadingVersion>17.0.32-alpha</MicrosoftVisualStudioThreadingVersion>
+    <MicrosoftVisualStudioThreadingAnalyzersVersion>17.0.40-alpha</MicrosoftVisualStudioThreadingAnalyzersVersion>
+    <MicrosoftVisualStudioThreadingVersion>17.0.40-alpha</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioUtilitiesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>17.0.21-alpha</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioInteractiveWindowVersion>4.0.0-beta.21267.2</MicrosoftVisualStudioInteractiveWindowVersion>
     <MicrosoftVisualStudioVsInteractiveWindowVersion>4.0.0-beta.21267.2</MicrosoftVisualStudioVsInteractiveWindowVersion>
+    <MicrosoftVisualStudioWinFormsInterfacesVersion>17.0.0-previews-4-31622-033</MicrosoftVisualStudioWinFormsInterfacesVersion>
     <MicrosoftVisualStudioWorkspaceVSIntegrationVersion>16.3.43</MicrosoftVisualStudioWorkspaceVSIntegrationVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
@@ -245,7 +246,7 @@
       If you bump their versions, you must push your changes to a dev branch in dotnet/roslyn and
       create a test insertion in Visual Studio to validate.
     -->
-    <NewtonsoftJsonVersion>12.0.2</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <StreamJsonRpcVersion>2.8.21</StreamJsonRpcVersion>
     <!--
       When updating the S.C.I or S.R.M version please let the MSBuild team know in advance so they

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public bool RequiresLSPSolution => true;
 
         public TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.CodeAction request)
-            => ((JToken)request.Data!).ToObject<CodeActionResolveData>().TextDocument;
+            => ((JToken)request.Data!).ToObject<CodeActionResolveData>()?.TextDocument;
 
         public async Task<LSP.CodeAction> HandleRequestAsync(LSP.CodeAction codeAction, RequestContext context, CancellationToken cancellationToken)
         {
@@ -57,6 +57,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             Contract.ThrowIfNull(document);
 
             var data = ((JToken)codeAction.Data!).ToObject<CodeActionResolveData>();
+            Contract.ThrowIfNull(data);
+
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
                 _codeActionsCache,
                 document,

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/RunCodeActionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/RunCodeActionHandler.cs
@@ -51,12 +51,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public override LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.ExecuteCommandParams request)
         {
             var runRequest = ((JToken)request.Arguments.Single()).ToObject<CodeActionResolveData>();
-            return runRequest.TextDocument;
+            return runRequest?.TextDocument;
         }
 
         public override async Task<object> HandleRequestAsync(LSP.ExecuteCommandParams request, RequestContext context, CancellationToken cancellationToken)
         {
             var runRequest = ((JToken)request.Arguments.Single()).ToObject<CodeActionResolveData>();
+            Contract.ThrowIfNull(runRequest);
+
             var document = context.Document;
 
             Contract.ThrowIfNull(document);

--- a/src/Features/Lsif/Generator/CompilerInvocation.cs
+++ b/src/Features/Lsif/Generator/CompilerInvocation.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Newtonsoft.Json;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 {
@@ -34,6 +35,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
         public static async Task<CompilerInvocation> CreateFromJsonAsync(string jsonContents)
         {
             var invocationInfo = JsonConvert.DeserializeObject<CompilerInvocationInfo>(jsonContents);
+            Contract.ThrowIfNull(invocationInfo);
 
             // We will use a Workspace to simplify the creation of the compilation, but will be careful not to return the Workspace instance from this class.
             // We will still provide the language services which are used by the generator itself, but we don't tie it to a Workspace object so we can

--- a/src/Features/Lsif/Generator/Writing/LsifConverter.cs
+++ b/src/Features/Lsif/Generator/Writing/LsifConverter.cs
@@ -16,12 +16,12 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
                    objectType == typeof(Uri);
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             switch (value)
             {

--- a/src/Tools/BuildValidator/Program.cs
+++ b/src/Tools/BuildValidator/Program.cs
@@ -330,9 +330,9 @@ namespace BuildValidator
             }
 
             var parseResult = JsonConvert.DeserializeAnonymousType(Encoding.UTF8.GetString(sourceLinkUTF8), new { documents = (Dictionary<string, string>?)null });
-            var sourceLinks = parseResult.documents.Select(makeSourceLink).ToImmutableArray();
+            var sourceLinks = parseResult?.documents.Select(makeSourceLink).ToImmutableArray();
 
-            if (sourceLinks.IsDefault)
+            if (!sourceLinks.HasValue || sourceLinks.Value.IsDefault)
             {
                 logger.LogInformation("Empty source link cdi found in pdb");
                 sourceLinks = ImmutableArray<SourceLinkEntry>.Empty;
@@ -344,7 +344,7 @@ namespace BuildValidator
                     logger.LogInformation($@"""{link.Prefix}"": ""{link.Replace}""");
                 }
             }
-            return sourceLinks;
+            return sourceLinks.Value;
 
             static SourceLinkEntry makeSourceLink(KeyValuePair<string, string> entry)
             {

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -108,7 +108,7 @@ namespace RunTests
         <HelixTargetQueues>" + _options.HelixQueueName + @"</HelixTargetQueues>
         <Creator>" + queuedBy + @"</Creator>
         <IncludeDotNetCli>true</IncludeDotNetCli>
-        <DotNetCliVersion>" + globalJson.sdk.version + @"</DotNetCliVersion>
+        <DotNetCliVersion>" + globalJson?.sdk.version + @"</DotNetCliVersion>
         <DotNetCliPackageType>sdk</DotNetCliPackageType>
         <EnableAzurePipelinesReporter>" + (isAzureDevOpsRun ? "true" : "false") + @"</EnableAzurePipelinesReporter>
     </PropertyGroup>

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -4,26 +4,16 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Runtime.Remoting.Contexts;
-using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.AddAccessibilityModifiers;
-using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.FileHeaders;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.Designer.Interfaces;
 using Microsoft.VisualStudio.Editor;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
@@ -113,32 +103,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             {
                 case "Form":
 
-                    // We must create the WinForms designer here
-                    var loaderName = GetWinFormsLoaderName(vsHierarchy);
-                    var designerService = (IVSMDDesignerService)Microsoft.VisualStudio.Shell.PackageUtilities.QueryService<SVSMDDesignerService>(_oleServiceProvider);
-                    var designerLoader = (IVSMDDesignerLoader)designerService.CreateDesignerLoader(loaderName);
-                    if (designerLoader is null)
+                    if (WinFormsEditorFactory.Instance.CreateEditorInstance(
+                        vsHierarchy,
+                        itemid,
+                        _oleServiceProvider,
+                        textBuffer,
+                        readOnlyStatus,
+                        out ppunkDocView,
+                        out pbstrEditorCaption,
+                        out pguidCmdUI) == VSConstants.E_FAIL)
                     {
                         goto case "Code";
-                    }
-
-                    try
-                    {
-                        designerLoader.Initialize(_oleServiceProvider, vsHierarchy, (int)itemid, (IVsTextLines)textBuffer);
-                        pbstrEditorCaption = designerLoader.GetEditorCaption((int)readOnlyStatus);
-
-                        var designer = designerService.CreateDesigner(_oleServiceProvider, designerLoader);
-                        ppunkDocView = Marshal.GetIUnknownForObject(designer.View);
-                        pguidCmdUI = designer.CommandGuid;
-                    }
-                    catch
-                    {
-                        // Only dispose the designer loader on failure to create a designer.
-                        // The IVSMDDesignerService.CreateDesigner() method in VS passes it into the DesignSurface that gets created
-                        // and is used to perform the actual load (and reloads -- which happen during normal designer operation).
-                        // http://index/?leftProject=Microsoft.VisualStudio.Design&leftSymbol=n8p1tszkfyz7&file=DesignerActivationService.cs&line=629
-                        designerLoader.Dispose();
-                        throw;
                     }
 
                     break;
@@ -205,36 +180,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         public bool ShouldDeferUntilIntellisenseIsReady(uint grfCreate, string pszMkDocument, string pszPhysicalView)
         {
             return "Form".Equals(pszPhysicalView, StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static string GetWinFormsLoaderName(IVsHierarchy vsHierarchy)
-        {
-            const string LoaderName = "Microsoft.VisualStudio.Design.Serialization.CodeDom.VSCodeDomDesignerLoader";
-            const string NewLoaderName = "Microsoft.VisualStudio.Design.Core.Serialization.CodeDom.VSCodeDomDesignerLoader";
-
-            // If this is a netcoreapp3.0 (or newer), we must create the newer WinForms designer.
-            // TODO: This check will eventually move into the WinForms designer itself.
-            if (!vsHierarchy.TryGetTargetFrameworkMoniker((uint)VSConstants.VSITEMID.Root, out var targetFrameworkMoniker) ||
-                string.IsNullOrWhiteSpace(targetFrameworkMoniker))
-            {
-                return LoaderName;
-            }
-
-            try
-            {
-                var frameworkName = new FrameworkName(targetFrameworkMoniker);
-                if (frameworkName.Identifier == ".NETCoreApp" && frameworkName.Version?.Major >= 3)
-                {
-                    return NewLoaderName;
-                }
-            }
-            catch
-            {
-                // Fall back to the old loader name if there are any failures
-                // while parsing the TFM.
-            }
-
-            return LoaderName;
         }
 
         public int MapLogicalView(ref Guid rguidLogicalView, out string? pbstrPhysicalView)

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/ProjectAssets/ProjectAssetsFileReader.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/ProjectAssets/ProjectAssetsFileReader.cs
@@ -40,7 +40,10 @@ namespace Microsoft.CodeAnalysis.UnusedReferences.ProjectAssets
             try
             {
                 var projectAssets = JsonConvert.DeserializeObject<ProjectAssetsFile>(projectAssetsFileContents);
-                return ProjectAssetsReader.AddDependencyHierarchies(projectReferences, projectAssets);
+
+                return projectAssets is null
+                    ? ImmutableArray<ReferenceInfo>.Empty
+                    : ProjectAssetsReader.AddDependencyHierarchies(projectReferences, projectAssets);
             }
             catch
             {

--- a/src/VisualStudio/Core/Def/Implementation/WinFormsEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/WinFormsEditorFactory.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.WinForms.Interfaces;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal class WinFormsEditorFactory
+    {
+        private static WinFormsEditorFactory? _instance;
+
+        private WinFormsEditorFactory()
+        {
+
+        }
+
+        public static WinFormsEditorFactory Instance
+            => _instance ??= new WinFormsEditorFactory();
+
+        public int CreateEditorInstance(
+            IVsHierarchy vsHierarchy,
+            uint itemid,
+            OLE.Interop.IServiceProvider oleServiceProvider,
+            IVsTextBuffer textBuffer,
+            READONLYSTATUS readOnlyStatus,
+            out IntPtr ppunkDocView,
+            out string pbstrEditorCaption,
+            out Guid pguidCmdUI)
+        {
+            ppunkDocView = IntPtr.Zero;
+            pbstrEditorCaption = string.Empty;
+            pguidCmdUI = Guid.Empty;
+
+            var winFormsEditorFactory = (IWinFormsEditorFactory)PackageUtilities.QueryService<IWinFormsEditorFactory>(oleServiceProvider);
+
+            if (winFormsEditorFactory is null)
+            {
+                return VSConstants.E_FAIL;
+            }
+
+            return winFormsEditorFactory.CreateEditorInstance(
+                vsHierarchy,
+                itemid,
+                oleServiceProvider,
+                textBuffer,
+                readOnlyStatus,
+                out ppunkDocView,
+                out pbstrEditorCaption,
+                out pguidCmdUI);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -152,6 +152,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.VsInteractiveWindow" Version="$(MicrosoftVisualStudioVsInteractiveWindowVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.WinForms.Interfaces" Version="$(MicrosoftVisualStudioWinFormsInterfacesVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="VsWebsite.Interop" Version="$(VsWebsiteInteropVersion)" />
     <PackageReference Include="NuGet.VisualStudio" Version="$(NuGetVisualStudioVersion)" />
@@ -188,8 +189,8 @@
       <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)64S')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" />
       
       <!-- Add registrations for 64-bit and 64-bit Server GC on .Net Core host -->
-      <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)Core64')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" SubFolder="$(ServiceHubCoreSubPath)"/>
-      <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)Core64S')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" SubFolder="$(ServiceHubCoreSubPath)"/>
+      <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)Core64')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" SubFolder="$(ServiceHubCoreSubPath)" />
+      <PkgDefBrokeredService Include="@(ServiceHubService->'%(Identity)Core64S')" Condition="'%(ServiceHubService.IsBrokered)' == 'true'" SubFolder="$(ServiceHubCoreSubPath)" />
 
       <PkgDefBrokeredService Include="@(InProcService)" ProfferingPackageId="$(RoslynPackageGuid)" />
     </ItemGroup>

--- a/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/LspDiagnosticsTests.cs
@@ -588,6 +588,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
                     Contract.ThrowIfTrue(_currentNumberOfCallbacks > _expectedNumberOfCallbacks, "received too many callbacks");
 
                     var diagnosticParams = input.ToObject<LSP.PublishDiagnosticParams>();
+                    Contract.ThrowIfNull(diagnosticParams);
+
                     Results.Add(diagnosticParams);
 
                     if (_currentNumberOfCallbacks == _expectedNumberOfCallbacks)

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/MockVsFileChangeEx.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/MockVsFileChangeEx.vb
@@ -172,6 +172,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             Return Task.CompletedTask
         End Function
 
+        Public Function UnadviseFileChangesAsync(cookies As IReadOnlyCollection(Of UInteger), Optional cancellationToken As CancellationToken = Nothing) As Task(Of String()) Implements IVsAsyncFileChangeEx.UnadviseFileChangesAsync
+            Throw New NotImplementedException()
+        End Function
+
+        Public Function UnadviseDirChangesAsync(cookies As IReadOnlyCollection(Of UInteger), Optional cancellationToken As CancellationToken = Nothing) As Task(Of String()) Implements IVsAsyncFileChangeEx.UnadviseDirChangesAsync
+            Throw New NotImplementedException()
+        End Function
+
         Public ReadOnly Property WatchedFileCount As Integer
             Get
                 SyncLock _lock

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionResolveHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Completion/CompletionResolveHandler.cs
@@ -51,10 +51,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 return completionItem;
             }
 
-            CompletionResolveData data;
+            CompletionResolveData? data;
             if (completionItem.Data is JToken token)
             {
                 data = token.ToObject<CompletionResolveData>();
+                Contract.ThrowIfNull(data);
             }
             else
             {

--- a/src/Workspaces/Remote/ServiceHub/Services/ServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ServiceBase.cs
@@ -100,6 +100,7 @@ namespace Microsoft.CodeAnalysis.Remote
             var reader = solutionInfo.CreateReader();
             var serializer = JsonSerializer.Create(new JsonSerializerSettings() { Converters = new[] { AggregateJsonConverter.Instance }, DateParseHandling = DateParseHandling.None });
             var pinnedSolutionInfo = serializer.Deserialize<PinnedSolutionInfo>(reader);
+            Contract.ThrowIfNull(pinnedSolutionInfo);
 
             return GetSolutionAsync(pinnedSolutionInfo, cancellationToken);
         }


### PR DESCRIPTION
Referencing a newly published `Microsoft.VisualStudio.WinForms.Interfaces` NuGet package from `azure-public/vs-impl` feed for type `IWinFormsEditorFactory`. Corresponding implementation of this type is proffered as a service from WinForms .NET Framework package.

Created an internal wrapper type `WinFormsEditorFactory` which calls `IWinFormsEditorFactory.CreateEditorInstance` so as to hide `IWinFormsEditorFactory` type in non-WinForms scenarios, such as editing a .cs file. Else it will cause RPS failures due to an extra dll load.

Corresponding change in WinForms Framework Designer (for reference): https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/343299

The new WinForms NuGet package depends upon a newer version of `Microsoft.VisualStudio.Interop` package version `17.0.0-previews-4-31622-033`. While updating that I had to update versions of few other dependent packages.

Made changes required for issues highlighted by nullability.