### PR TITLE
Use Auto Prop analyzer bails out for all attributes

### DIFF
--- a/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -222,9 +222,14 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             }
 
             // Can't remove the field if it has attributes on it.
-            if (getterField.GetAttributes().Length > 0)
+            var attributes = getterField.GetAttributes();
+            var suppressMessageAttributeType = semanticModel.Compilation.SuppressMessageAttributeType();
+            foreach (var attribute in attributes)
             {
-                return;
+                if (attribute.AttributeClass != suppressMessageAttributeType)
+                {
+                    return;
+                }
             }
 
             if (!CanConvert(property))


### PR DESCRIPTION
Fixes #55529 

Check to see if any of the attributes are not suppression messages before deciding to bail out instead of returning no matter what.