### PR TITLE
Clear dependency information from unused references after analysis

### DIFF
--- a/src/Features/Core/Portable/UnusedReferences/ReferenceInfo.cs
+++ b/src/Features/Core/Portable/UnusedReferences/ReferenceInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.Serialization;
 
@@ -54,5 +55,8 @@ namespace Microsoft.CodeAnalysis.UnusedReferences
 
         public ReferenceInfo WithItemSpecification(string itemSpecification)
             => new(ReferenceType, itemSpecification, TreatAsUsed, CompilationAssemblies, Dependencies);
+
+        public ReferenceInfo WithDependencies(IEnumerable<ReferenceInfo>? dependencies)
+            => new(ReferenceType, ItemSpecification, TreatAsUsed, CompilationAssemblies, dependencies.AsImmutableOrEmpty());
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/UnusedReferences/UnusedReferenceAnalysisService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/UnusedReferences/UnusedReferenceAnalysisService.cs
@@ -42,8 +42,14 @@ namespace Microsoft.CodeAnalysis.UnusedReferences
                 return result.Value;
             }
 
+            // Read specified references with dependency information from the project assets file.
             var references = await ProjectAssetsFileReader.ReadReferencesAsync(projectReferences, projectAssetsFilePath).ConfigureAwait(false);
-            return await UnusedReferencesRemover.GetUnusedReferencesAsync(solution, projectFilePath, references, cancellationToken).ConfigureAwait(false);
+
+            // Determine unused references
+            var unusedReferences = await UnusedReferencesRemover.GetUnusedReferencesAsync(solution, projectFilePath, references, cancellationToken).ConfigureAwait(false);
+
+            // Remove dependency information before returning.
+            return unusedReferences.SelectAsArray(reference => reference.WithDependencies(null));
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/UnusedReferences/RemoteUnusedReferenceAnalysisService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/UnusedReferences/RemoteUnusedReferenceAnalysisService.cs
@@ -29,9 +29,14 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
 
+                // Read specified references with dependency information from the project assets file.
                 var references = await ProjectAssetsFileReader.ReadReferencesAsync(projectReferences, projectAssetsFilePath).ConfigureAwait(false);
 
-                return await UnusedReferencesRemover.GetUnusedReferencesAsync(solution, projectFilePath, references, cancellationToken).ConfigureAwait(false);
+                // Determine unused references
+                var unusedReferences = await UnusedReferencesRemover.GetUnusedReferencesAsync(solution, projectFilePath, references, cancellationToken).ConfigureAwait(false);
+
+                // Remove dependency information before returning.
+                return unusedReferences.SelectAsArray(reference => reference.WithDependencies(null));
             }, cancellationToken);
         }
     }


### PR DESCRIPTION
Resolves #55869

We will no longer be serializing the reference dependencies when returning results from OOP.