### PR TITLE
Reduce array allocations when constructing options

### DIFF
--- a/src/Analyzers/Core/Analyzers/UseConditionalExpression/UseConditionalExpressionOptions.cs
+++ b/src/Analyzers/Core/Analyzers/UseConditionalExpression/UseConditionalExpressionOptions.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
         public static readonly PerLanguageOption2<int> ConditionalExpressionWrappingLength = new(
             nameof(UseConditionalExpressionOptions),
             nameof(ConditionalExpressionWrappingLength), defaultValue: 120,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ConditionalExpressionWrappingLength)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ConditionalExpressionWrappingLength)}"));
     }
 }

--- a/src/Analyzers/Core/Analyzers/ValidateFormatString/ValidateFormatStringOption.cs
+++ b/src/Analyzers/Core/Analyzers/ValidateFormatString/ValidateFormatStringOption.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
                 nameof(ValidateFormatStringOption),
                 nameof(ReportInvalidPlaceholdersInStringDotFormatCalls),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.WarnOnInvalidStringDotFormatCalls"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.WarnOnInvalidStringDotFormatCalls"));
     }
 }

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralOptions.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
     {
         public static PerLanguageOption2<bool> Enabled =
             new(nameof(SplitStringLiteralOptions), nameof(Enabled), defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SplitStringLiterals"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SplitStringLiterals"));
     }
 
     [ExportOptionProvider(LanguageNames.CSharp), Shared]

--- a/src/EditorFeatures/Core/Implementation/SplitComment/SplitCommentOptions.cs
+++ b/src/EditorFeatures/Core/Implementation/SplitComment/SplitCommentOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SplitComment
     {
         public static PerLanguageOption2<bool> Enabled =
            new PerLanguageOption2<bool>(nameof(SplitCommentOptions), nameof(Enabled), defaultValue: true,
-               storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SplitComments"));
+               storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SplitComments"));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestionsOptions.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestionsOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
     internal class SuggestionsOptions
     {
         public static Option2<bool?> Asynchronous =
-           new Option2<bool?>(nameof(SuggestionsOptions), nameof(Asynchronous), defaultValue: null,
-               storageLocations: new RoamingProfileStorageLocation("TextEditor.Specific.Suggestions.Asynchronous2"));
+           new(nameof(SuggestionsOptions), nameof(Asynchronous), defaultValue: null,
+               storageLocation: new RoamingProfileStorageLocation("TextEditor.Specific.Suggestions.Asynchronous2"));
     }
 }

--- a/src/EditorFeatures/Core/Options/ColorSchemeOptions.cs
+++ b/src/EditorFeatures/Core/Options/ColorSchemeOptions.cs
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.Editor.Options
         public static readonly Option2<SchemeName> ColorScheme = new(nameof(ColorSchemeOptions),
             nameof(ColorScheme),
             defaultValue: SchemeName.VisualStudio2019,
-            storageLocations: new RoamingProfileStorageLocation(ColorSchemeSettingKey));
+            storageLocation: new RoamingProfileStorageLocation(ColorSchemeSettingKey));
 
         public static readonly Option2<UseEnhancedColors> LegacyUseEnhancedColors = new(nameof(ColorSchemeOptions),
             nameof(LegacyUseEnhancedColors),
             defaultValue: UseEnhancedColors.Default,
-            storageLocations: new RoamingProfileStorageLocation("WindowManagement.Options.UseEnhancedColorsForManagedLanguages"));
+            storageLocation: new RoamingProfileStorageLocation("WindowManagement.Options.UseEnhancedColorsForManagedLanguages"));
 
         public enum UseEnhancedColors
         {

--- a/src/EditorFeatures/Core/Shared/Options/ComponentOnOffOptions.cs
+++ b/src/EditorFeatures/Core/Shared/Options/ComponentOnOffOptions.cs
@@ -19,17 +19,17 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
         private const string LocalRegistryPath = @"Roslyn\Internal\OnOff\Components\";
 
         public static readonly Option2<bool> Adornment = new(nameof(EditorComponentOnOffOptions), nameof(Adornment), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Adornment"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Adornment"));
 
         public static readonly Option2<bool> Tagger = new(nameof(EditorComponentOnOffOptions), nameof(Tagger), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Tagger"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Tagger"));
 
         public static readonly Option2<bool> CodeRefactorings = new(nameof(EditorComponentOnOffOptions), nameof(CodeRefactorings), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Code Refactorings"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Code Refactorings"));
 
         public static readonly Option2<bool> ShowCodeRefactoringsWhenQueriedForCodeFixes = new(
             nameof(EditorComponentOnOffOptions), nameof(ShowCodeRefactoringsWhenQueriedForCodeFixes), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(ShowCodeRefactoringsWhenQueriedForCodeFixes)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(ShowCodeRefactoringsWhenQueriedForCodeFixes)));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/EditorFeatures/Core/Shared/Options/FeatureOnOffOptions.cs
+++ b/src/EditorFeatures/Core/Shared/Options/FeatureOnOffOptions.cs
@@ -15,32 +15,32 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
     internal static class FeatureOnOffOptions
     {
         public static readonly PerLanguageOption2<bool> EndConstruct = new(nameof(FeatureOnOffOptions), nameof(EndConstruct), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.AutoEndInsert"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.AutoEndInsert"));
 
         // This value is only used by Visual Basic, and so is using the old serialization name that was used by VB.
         public static readonly PerLanguageOption2<bool> AutomaticInsertionOfAbstractOrInterfaceMembers = new(nameof(FeatureOnOffOptions), nameof(AutomaticInsertionOfAbstractOrInterfaceMembers), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.AutoRequiredMemberInsert"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.AutoRequiredMemberInsert"));
 
         public static readonly PerLanguageOption2<bool> LineSeparator = new(nameof(FeatureOnOffOptions), nameof(LineSeparator), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.DisplayLineSeparators" : "TextEditor.%LANGUAGE%.Specific.Line Separator"));
+            storageLocation: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.DisplayLineSeparators" : "TextEditor.%LANGUAGE%.Specific.Line Separator"));
 
         public static readonly PerLanguageOption2<bool> Outlining = new(nameof(FeatureOnOffOptions), nameof(Outlining), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Outlining"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Outlining"));
 
         public static readonly PerLanguageOption2<bool> KeywordHighlighting = new(nameof(FeatureOnOffOptions), nameof(KeywordHighlighting), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.EnableHighlightRelatedKeywords" : "TextEditor.%LANGUAGE%.Specific.Keyword Highlighting"));
+            storageLocation: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.EnableHighlightRelatedKeywords" : "TextEditor.%LANGUAGE%.Specific.Keyword Highlighting"));
 
         public static readonly PerLanguageOption2<bool> ReferenceHighlighting = new(nameof(FeatureOnOffOptions), nameof(ReferenceHighlighting), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.EnableHighlightReferences" : "TextEditor.%LANGUAGE%.Specific.Reference Highlighting"));
+            storageLocation: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.EnableHighlightReferences" : "TextEditor.%LANGUAGE%.Specific.Reference Highlighting"));
 
         public static readonly PerLanguageOption2<bool> AutoInsertBlockCommentStartString = new(nameof(FeatureOnOffOptions), nameof(AutoInsertBlockCommentStartString), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Insert Block Comment Start String"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Insert Block Comment Start String"));
 
         public static readonly PerLanguageOption2<bool> PrettyListing = new(nameof(FeatureOnOffOptions), nameof(PrettyListing), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PrettyListing"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PrettyListing"));
 
         public static readonly PerLanguageOption2<bool> RenameTrackingPreview = new(nameof(FeatureOnOffOptions), nameof(RenameTrackingPreview), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.RenameTrackingPreview" : "TextEditor.%LANGUAGE%.Specific.Rename Tracking Preview"));
+            storageLocation: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.RenameTrackingPreview" : "TextEditor.%LANGUAGE%.Specific.Rename Tracking Preview"));
 
         /// <summary>
         /// This option is currently used by Roslyn, but we might want to implement it in the
@@ -64,19 +64,19 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
 
         public static readonly Option2<bool> NavigateToDecompiledSources = new(
             nameof(FeatureOnOffOptions), nameof(NavigateToDecompiledSources), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.{nameof(NavigateToDecompiledSources)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.{nameof(NavigateToDecompiledSources)}"));
 
         public static readonly Option2<int> UseEnhancedColors = new(
             nameof(FeatureOnOffOptions), nameof(UseEnhancedColors), defaultValue: 1,
-            storageLocations: new RoamingProfileStorageLocation("WindowManagement.Options.UseEnhancedColorsForManagedLanguages"));
+            storageLocation: new RoamingProfileStorageLocation("WindowManagement.Options.UseEnhancedColorsForManagedLanguages"));
 
         public static readonly PerLanguageOption2<bool?> AddImportsOnPaste = new(
             nameof(FeatureOnOffOptions), nameof(AddImportsOnPaste), defaultValue: null,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(AddImportsOnPaste)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(AddImportsOnPaste)}"));
 
         public static readonly Option2<bool?> OfferRemoveUnusedReferences = new(
             nameof(FeatureOnOffOptions), nameof(OfferRemoveUnusedReferences), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.{nameof(OfferRemoveUnusedReferences)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.{nameof(OfferRemoveUnusedReferences)}"));
 
         public static readonly PerLanguageOption2<bool?> ShowInheritanceMargin =
             new(nameof(FeatureOnOffOptions),
@@ -86,11 +86,11 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
 
         public static readonly Option2<bool> AutomaticallyCompleteStatementOnSemicolon = new(
             nameof(FeatureOnOffOptions), nameof(AutomaticallyCompleteStatementOnSemicolon), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.{nameof(AutomaticallyCompleteStatementOnSemicolon)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.{nameof(AutomaticallyCompleteStatementOnSemicolon)}"));
 
         public static readonly Option2<bool> SkipAnalyzersForImplicitlyTriggeredBuilds = new(
             nameof(FeatureOnOffOptions), nameof(SkipAnalyzersForImplicitlyTriggeredBuilds), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.{nameof(SkipAnalyzersForImplicitlyTriggeredBuilds)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.{nameof(SkipAnalyzersForImplicitlyTriggeredBuilds)}"));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/EditorFeatures/Core/Shared/Options/InternalFeatureOnOffOptions.cs
+++ b/src/EditorFeatures/Core/Shared/Options/InternalFeatureOnOffOptions.cs
@@ -17,63 +17,63 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
         internal const string LocalRegistryPath = StorageOptions.LocalRegistryPath;
 
         public static readonly Option2<bool> BraceMatching = new(nameof(InternalFeatureOnOffOptions), nameof(BraceMatching), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Brace Matching"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Brace Matching"));
 
         public static readonly Option2<bool> Classification = new(nameof(InternalFeatureOnOffOptions), nameof(Classification), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Classification"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Classification"));
 
         public static readonly Option2<bool> SemanticColorizer = new(nameof(InternalFeatureOnOffOptions), nameof(SemanticColorizer), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Semantic Colorizer"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Semantic Colorizer"));
 
         public static readonly Option2<bool> SyntacticColorizer = new(nameof(InternalFeatureOnOffOptions), nameof(SyntacticColorizer), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Syntactic Colorizer"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Syntactic Colorizer"));
 
         public static readonly Option2<bool> AutomaticPairCompletion = new(nameof(InternalFeatureOnOffOptions), nameof(AutomaticPairCompletion), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Automatic Pair Completion"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Automatic Pair Completion"));
 
         public static readonly Option2<bool> AutomaticLineEnder = new(nameof(InternalFeatureOnOffOptions), nameof(AutomaticLineEnder), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Automatic Line Ender"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Automatic Line Ender"));
 
         public static readonly Option2<bool> SmartIndenter = new(nameof(InternalFeatureOnOffOptions), nameof(SmartIndenter), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Smart Indenter"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Smart Indenter"));
 
         public static readonly Option2<bool> CompletionSet = new(nameof(InternalFeatureOnOffOptions), nameof(CompletionSet), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Completion Set"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Completion Set"));
 
         public static readonly Option2<bool> KeywordHighlight = new(nameof(InternalFeatureOnOffOptions), nameof(KeywordHighlight), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Keyword Highlight"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Keyword Highlight"));
 
         public static readonly Option2<bool> QuickInfo = new(nameof(InternalFeatureOnOffOptions), nameof(QuickInfo), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Quick Info"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Quick Info"));
 
         public static readonly Option2<bool> Squiggles = new(nameof(InternalFeatureOnOffOptions), nameof(Squiggles), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Squiggles"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Squiggles"));
 
         public static readonly Option2<bool> FormatOnSave = new(nameof(InternalFeatureOnOffOptions), nameof(FormatOnSave), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "FormatOnSave"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "FormatOnSave"));
 
         public static readonly Option2<bool> RenameTracking = new(nameof(InternalFeatureOnOffOptions), nameof(RenameTracking), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Rename Tracking"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Rename Tracking"));
 
         public static readonly Option2<bool> EventHookup = new(nameof(InternalFeatureOnOffOptions), nameof(EventHookup), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Event Hookup"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Event Hookup"));
 
         /// Due to https://github.com/dotnet/roslyn/issues/5393, the name "Snippets" is unusable for serialization.
         /// (Summary: Some builds incorrectly set it without providing a way to clear it so it exists in many registries.)
         public static readonly Option2<bool> Snippets = new(nameof(InternalFeatureOnOffOptions), nameof(Snippets), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Snippets2"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Snippets2"));
 
         public static readonly Option2<bool> TodoComments = new(nameof(InternalFeatureOnOffOptions), nameof(TodoComments), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Todo Comments"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Todo Comments"));
 
         public static readonly Option2<bool> DesignerAttributes = new(nameof(InternalFeatureOnOffOptions), nameof(DesignerAttributes), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Designer Attribute"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Designer Attribute"));
 
         public static readonly Option2<bool> BackgroundAnalysisMemoryMonitor = new(nameof(InternalFeatureOnOffOptions), "FullSolutionAnalysisMemoryMonitor", defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Full Solution Analysis Memory Monitor"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Full Solution Analysis Memory Monitor"));
 
         public static readonly Option2<bool> ProjectReferenceConversion = new(nameof(InternalFeatureOnOffOptions), nameof(ProjectReferenceConversion), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Project Reference Conversion"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Project Reference Conversion"));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/Features/Core/Portable/BraceCompletion/BraceCompletionOptions.cs
+++ b/src/Features/Core/Portable/BraceCompletion/BraceCompletionOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.BraceCompletion
     {
         public static readonly PerLanguageOption2<bool> AutoFormattingOnCloseBrace = new(
             nameof(BraceCompletionOptions), nameof(AutoFormattingOnCloseBrace), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Close Brace"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Close Brace"));
 
         [ExportOptionProvider, Shared]
         internal class BraceCompletionOptionsProvider : IOptionProvider

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -16,33 +16,33 @@ namespace Microsoft.CodeAnalysis.Completion
         public static readonly PerLanguageOption2<bool> TriggerOnTyping = new(nameof(CompletionOptions), nameof(TriggerOnTyping), defaultValue: true);
 
         public static readonly PerLanguageOption2<bool> TriggerOnTypingLetters2 = new(nameof(CompletionOptions), nameof(TriggerOnTypingLetters), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerOnTypingLetters"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerOnTypingLetters"));
 
 #pragma warning disable RS0030 // Do not used banned APIs - Used by TypeScript through IVT, so we cannot change the field type.
         public static readonly PerLanguageOption<bool> TriggerOnTypingLetters = (PerLanguageOption<bool>)TriggerOnTypingLetters2!;
 #pragma warning restore RS0030 // Do not used banned APIs
 
         public static readonly PerLanguageOption2<bool?> TriggerOnDeletion = new(nameof(CompletionOptions), nameof(TriggerOnDeletion), defaultValue: null,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerOnDeletion"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerOnDeletion"));
 
         public static readonly PerLanguageOption2<EnterKeyRule> EnterKeyBehavior =
             new(nameof(CompletionOptions), nameof(EnterKeyBehavior), defaultValue: EnterKeyRule.Default,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.EnterKeyBehavior"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.EnterKeyBehavior"));
 
         public static readonly PerLanguageOption2<SnippetsRule> SnippetsBehavior =
             new(nameof(CompletionOptions), nameof(SnippetsBehavior), defaultValue: SnippetsRule.Default,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SnippetsBehavior"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SnippetsBehavior"));
 
         // Dev15 options
         public static readonly PerLanguageOption2<bool> ShowCompletionItemFilters = new(nameof(CompletionOptions), nameof(ShowCompletionItemFilters), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowCompletionItemFilters"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowCompletionItemFilters"));
 
         public static readonly PerLanguageOption2<bool> HighlightMatchingPortionsOfCompletionListItems = new(nameof(CompletionOptions), nameof(HighlightMatchingPortionsOfCompletionListItems), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.HighlightMatchingPortionsOfCompletionListItems"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.HighlightMatchingPortionsOfCompletionListItems"));
 
         public static readonly PerLanguageOption2<bool> BlockForCompletionItems2 = new(
             nameof(CompletionOptions), nameof(BlockForCompletionItems), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.BlockForCompletionItems"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.BlockForCompletionItems"));
 
 #pragma warning disable RS0030 // Do not used banned APIs - Used by TypeScript through IVT, so we cannot change the field type.
         public static readonly PerLanguageOption<bool> BlockForCompletionItems = (PerLanguageOption<bool>)BlockForCompletionItems2!;
@@ -50,23 +50,23 @@ namespace Microsoft.CodeAnalysis.Completion
 
         public static readonly PerLanguageOption2<bool> ShowNameSuggestions =
             new(nameof(CompletionOptions), nameof(ShowNameSuggestions), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowNameSuggestions"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowNameSuggestions"));
 
         //Dev16 options
 
         // Use tri-value so the default state can be used to turn on the feature with experimentation service.
         public static readonly PerLanguageOption2<bool?> ShowItemsFromUnimportedNamespaces =
             new(nameof(CompletionOptions), nameof(ShowItemsFromUnimportedNamespaces), defaultValue: null,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowItemsFromUnimportedNamespaces"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowItemsFromUnimportedNamespaces"));
 
         public static readonly PerLanguageOption2<bool> TriggerInArgumentLists =
             new(nameof(CompletionOptions), nameof(TriggerInArgumentLists), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerInArgumentLists"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerInArgumentLists"));
 
         // Use tri-value so the default state can be used to turn on the feature with experimentation service.
         public static readonly PerLanguageOption2<bool?> EnableArgumentCompletionSnippets =
             new(nameof(CompletionOptions), nameof(EnableArgumentCompletionSnippets), defaultValue: null,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.EnableArgumentCompletionSnippets"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.EnableArgumentCompletionSnippets"));
 
         // Test-only options
 
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Completion
         // It is intended for testing purposes only.
         public static readonly PerLanguageOption2<bool> ForceRoslynLSPCompletionExperiment =
             new(nameof(CompletionOptions), nameof(ForceRoslynLSPCompletionExperiment), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ForceRoslynLSPCompletionExperiment"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ForceRoslynLSPCompletionExperiment"));
 
         public static IEnumerable<PerLanguageOption2<bool>> GetDev15CompletionOptions()
         {

--- a/src/Features/Core/Portable/DocumentationComments/DocumentationCommentOptions.cs
+++ b/src/Features/Core/Portable/DocumentationComments/DocumentationCommentOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.DocumentationComments
     internal static class DocumentationCommentOptions
     {
         public static readonly PerLanguageOption2<bool> AutoXmlDocCommentGeneration = new(nameof(DocumentationCommentOptions), nameof(AutoXmlDocCommentGeneration), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.AutoComment" : "TextEditor.%LANGUAGE%.Specific.Automatic XML Doc Comment Generation"));
+            storageLocation: new RoamingProfileStorageLocation(language => language == LanguageNames.VisualBasic ? "TextEditor.%LANGUAGE%.Specific.AutoComment" : "TextEditor.%LANGUAGE%.Specific.Automatic XML Doc Comment Generation"));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeOptions.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/DateAndTimeOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.DateAndTime
                 nameof(DateAndTime),
                 nameof(ProvideDateAndTimeCompletions),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ProvideDateAndTimeCompletions"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ProvideDateAndTimeCompletions"));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegularExpressionsOptions.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegularExpressionsOptions.cs
@@ -18,28 +18,28 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
                 nameof(RegularExpressionsOptions),
                 nameof(ColorizeRegexPatterns),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ColorizeRegexPatterns"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ColorizeRegexPatterns"));
 
         public static PerLanguageOption2<bool> ReportInvalidRegexPatterns =
             new(
                 nameof(RegularExpressionsOptions),
                 nameof(ReportInvalidRegexPatterns),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ReportInvalidRegexPatterns"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ReportInvalidRegexPatterns"));
 
         public static PerLanguageOption2<bool> HighlightRelatedRegexComponentsUnderCursor =
             new(
                 nameof(RegularExpressionsOptions),
                 nameof(HighlightRelatedRegexComponentsUnderCursor),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.HighlightRelatedRegexComponentsUnderCursor"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.HighlightRelatedRegexComponentsUnderCursor"));
 
         public static PerLanguageOption2<bool> ProvideRegexCompletions =
             new(
                 nameof(RegularExpressionsOptions),
                 nameof(ProvideRegexCompletions),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ProvideRegexCompletions"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ProvideRegexCompletions"));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/Features/Core/Portable/ExtractMethod/ExtractMethodOptions.cs
+++ b/src/Features/Core/Portable/ExtractMethod/ExtractMethodOptions.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
     internal static class ExtractMethodOptions
     {
         public static readonly PerLanguageOption2<bool> AllowBestEffort = new(nameof(ExtractMethodOptions), nameof(AllowBestEffort), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Allow Best Effort"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Allow Best Effort"));
 
         public static readonly PerLanguageOption2<bool> DontPutOutOrRefOnStruct = new(nameof(ExtractMethodOptions), nameof(DontPutOutOrRefOnStruct), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Don't Put Out Or Ref On Strcut")); // NOTE: the spelling error is what we've shipped and thus should not change
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Don't Put Out Or Ref On Strcut")); // NOTE: the spelling error is what we've shipped and thus should not change
     }
 }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersOptions.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/GenerateConstructorFromMembersOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
         public static readonly PerLanguageOption2<bool> AddNullChecks = new(
             nameof(GenerateConstructorFromMembersOptions),
             nameof(AddNullChecks), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation(
+            storageLocation: new RoamingProfileStorageLocation(
                 $"TextEditor.%LANGUAGE%.Specific.{nameof(GenerateConstructorFromMembersOptions)}.{nameof(AddNullChecks)}"));
     }
 }

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersOptions.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersOptions.cs
@@ -11,13 +11,13 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         public static readonly PerLanguageOption2<bool> GenerateOperators = new(
             nameof(GenerateEqualsAndGetHashCodeFromMembersOptions),
             nameof(GenerateOperators), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation(
+            storageLocation: new RoamingProfileStorageLocation(
                 $"TextEditor.%LANGUAGE%.Specific.{nameof(GenerateEqualsAndGetHashCodeFromMembersOptions)}.{nameof(GenerateOperators)}"));
 
         public static readonly PerLanguageOption2<bool> ImplementIEquatable = new(
             nameof(GenerateEqualsAndGetHashCodeFromMembersOptions),
             nameof(ImplementIEquatable), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation(
+            storageLocation: new RoamingProfileStorageLocation(
                 $"TextEditor.%LANGUAGE%.Specific.{nameof(GenerateEqualsAndGetHashCodeFromMembersOptions)}.{nameof(ImplementIEquatable)}"));
     }
 }

--- a/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesOptions.cs
+++ b/src/Features/Core/Portable/GenerateOverrides/GenerateOverridesOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.GenerateOverrides
     {
         public static readonly Option2<bool> SelectAll = new(
             nameof(GenerateOverridesOptions), nameof(SelectAll), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.Specific.{nameof(GenerateOverridesOptions)}.{nameof(SelectAll)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.Specific.{nameof(GenerateOverridesOptions)}.{nameof(SelectAll)}"));
 
         [ExportOptionProvider, Shared]
         internal class GenerateOverridesOptionsProvider : IOptionProvider

--- a/src/Features/Core/Portable/ImplementType/ImplementTypeOptions.cs
+++ b/src/Features/Core/Portable/ImplementType/ImplementTypeOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.ImplementType
                 nameof(ImplementTypeOptions),
                 nameof(InsertionBehavior),
                 defaultValue: ImplementTypeInsertionBehavior.WithOtherMembersOfTheSameKind,
-                storageLocations: new RoamingProfileStorageLocation(
+                storageLocation: new RoamingProfileStorageLocation(
                     $"TextEditor.%LANGUAGE%.{nameof(ImplementTypeOptions)}.{nameof(InsertionBehavior)}"));
 
         public static readonly PerLanguageOption2<ImplementTypePropertyGenerationBehavior> PropertyGenerationBehavior =
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.ImplementType
                 nameof(ImplementTypeOptions),
                 nameof(PropertyGenerationBehavior),
                 defaultValue: ImplementTypePropertyGenerationBehavior.PreferThrowingProperties,
-                storageLocations: new RoamingProfileStorageLocation(
+                storageLocation: new RoamingProfileStorageLocation(
                     $"TextEditor.%LANGUAGE%.{nameof(ImplementTypeOptions)}.{nameof(PropertyGenerationBehavior)}"));
 
     }

--- a/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
@@ -17,13 +17,13 @@ namespace Microsoft.CodeAnalysis.InlineHints
             new(nameof(InlineHintsOptions),
                 nameof(DisplayAllHintsWhilePressingAltF1),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.Specific.DisplayAllHintsWhilePressingAltF1"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.Specific.DisplayAllHintsWhilePressingAltF1"));
 
         public static readonly PerLanguageOption2<bool> ColorHints =
             new(nameof(InlineHintsOptions),
                 nameof(ColorHints),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ColorHints"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ColorHints"));
 
         /// <summary>
         /// Non-persisted option used to switch to displaying everything while the user is holding ctrl-alt.
@@ -37,67 +37,67 @@ namespace Microsoft.CodeAnalysis.InlineHints
             new(nameof(InlineHintsOptions),
                 nameof(EnabledForParameters),
                 defaultValue: false,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints"));
 
         public static readonly PerLanguageOption2<bool> ForLiteralParameters =
             new(nameof(InlineHintsOptions),
                 nameof(ForLiteralParameters),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForLiteralParameters"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForLiteralParameters"));
 
         public static readonly PerLanguageOption2<bool> ForObjectCreationParameters =
             new(nameof(InlineHintsOptions),
                 nameof(ForObjectCreationParameters),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForObjectCreationParameters"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForObjectCreationParameters"));
 
         public static readonly PerLanguageOption2<bool> ForOtherParameters =
             new(nameof(InlineHintsOptions),
                 nameof(ForOtherParameters),
                 defaultValue: false,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForOtherParameters"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForOtherParameters"));
 
         public static readonly PerLanguageOption2<bool> ForIndexerParameters =
             new(nameof(InlineHintsOptions),
                 nameof(ForIndexerParameters),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForArrayIndexers"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.ForArrayIndexers"));
 
         public static readonly PerLanguageOption2<bool> SuppressForParametersThatDifferOnlyBySuffix =
             new(nameof(InlineHintsOptions),
                 nameof(SuppressForParametersThatDifferOnlyBySuffix),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.SuppressForParametersThatDifferOnlyBySuffix"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.SuppressForParametersThatDifferOnlyBySuffix"));
 
         public static readonly PerLanguageOption2<bool> SuppressForParametersThatMatchMethodIntent =
             new(nameof(InlineHintsOptions),
                 nameof(SuppressForParametersThatMatchMethodIntent),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.SuppressForParametersThatMatchMethodIntent"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineParameterNameHints.SuppressForParametersThatMatchMethodIntent"));
 
         public static readonly PerLanguageOption2<bool> EnabledForTypes =
             new(nameof(InlineHintsOptions),
                 nameof(EnabledForTypes),
                 defaultValue: false,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineTypeHints"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineTypeHints"));
 
         public static readonly PerLanguageOption2<bool> ForImplicitVariableTypes =
             new(nameof(InlineHintsOptions),
                 nameof(ForImplicitVariableTypes),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineTypeHints.ForImplicitVariableTypes"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineTypeHints.ForImplicitVariableTypes"));
 
         public static readonly PerLanguageOption2<bool> ForLambdaParameterTypes =
             new(nameof(InlineHintsOptions),
                 nameof(ForLambdaParameterTypes),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineTypeHints.ForLambdaParameterTypes"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineTypeHints.ForLambdaParameterTypes"));
 
         public static readonly PerLanguageOption2<bool> ForImplicitObjectCreation =
             new(nameof(InlineHintsOptions),
                 nameof(ForImplicitObjectCreation),
                 defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineTypeHints.ForImplicitObjectCreation"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.InlineTypeHints.ForImplicitObjectCreation"));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoOptions.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoOptions.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis.QuickInfo
     internal static class QuickInfoOptions
     {
         public static readonly PerLanguageOption2<bool> ShowRemarksInQuickInfo = new(nameof(QuickInfoOptions), nameof(ShowRemarksInQuickInfo), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowRemarks"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowRemarks"));
 
         public static readonly Option2<bool> IncludeNavigationHintsInQuickInfo = new(nameof(QuickInfoOptions), nameof(IncludeNavigationHintsInQuickInfo), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.Specific.IncludeNavigationHintsInQuickInfo"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.Specific.IncludeNavigationHintsInQuickInfo"));
     }
 }

--- a/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
+++ b/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Shared.Options
 #pragma warning disable RS0030 // Do not used banned APIs - to avoid a binary breaking API change.
         public static readonly PerLanguageOption<bool> RemoveDocumentDiagnosticsOnDocumentClose = new(
             "ServiceFeatureOnOffOptions", "RemoveDocumentDiagnosticsOnDocumentClose", defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.RemoveDocumentDiagnosticsOnDocumentClose"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.RemoveDocumentDiagnosticsOnDocumentClose"));
 #pragma warning restore RS0030 // Do not used banned APIs
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/InternalSolutionCrawlerOptions.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/InternalSolutionCrawlerOptions.cs
@@ -12,10 +12,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         private const string LocalRegistryPath = @"Roslyn\Internal\SolutionCrawler\";
 
         public static readonly Option2<bool> SolutionCrawler = new(nameof(InternalSolutionCrawlerOptions), "Solution Crawler", defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Solution Crawler"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Solution Crawler"));
 
         public static readonly Option2<bool> DirectDependencyPropagationOnly = new(nameof(InternalSolutionCrawlerOptions), "Project propagation only on direct dependency", defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Project propagation only on direct dependency"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Project propagation only on direct dependency"));
 
         public static readonly TimeSpan ActiveFileWorkerBackOffTimeSpan = TimeSpan.FromMilliseconds(100);
         public static readonly TimeSpan AllFilesWorkerBackOffTimeSpan = TimeSpan.FromMilliseconds(1500);

--- a/src/Features/Core/Portable/Structure/BlockStructureOptions.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureOptions.cs
@@ -10,36 +10,36 @@ namespace Microsoft.CodeAnalysis.Structure
     {
         public static readonly PerLanguageOption2<bool> ShowBlockStructureGuidesForCommentsAndPreprocessorRegions = new(
             nameof(BlockStructureOptions), nameof(ShowBlockStructureGuidesForCommentsAndPreprocessorRegions), defaultValue: false,
-             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowBlockStructureGuidesForCommentsAndPreprocessorRegions)}"));
+             storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowBlockStructureGuidesForCommentsAndPreprocessorRegions)}"));
 
         public static readonly PerLanguageOption2<bool> ShowBlockStructureGuidesForDeclarationLevelConstructs = new(
             nameof(BlockStructureOptions), nameof(ShowBlockStructureGuidesForDeclarationLevelConstructs), defaultValue: true,
-             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowBlockStructureGuidesForDeclarationLevelConstructs)}"));
+             storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowBlockStructureGuidesForDeclarationLevelConstructs)}"));
 
         public static readonly PerLanguageOption2<bool> ShowBlockStructureGuidesForCodeLevelConstructs = new(
             nameof(BlockStructureOptions), nameof(ShowBlockStructureGuidesForCodeLevelConstructs), defaultValue: true,
-             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowBlockStructureGuidesForCodeLevelConstructs)}"));
+             storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowBlockStructureGuidesForCodeLevelConstructs)}"));
 
         public static readonly PerLanguageOption2<bool> ShowOutliningForCommentsAndPreprocessorRegions = new(
             nameof(BlockStructureOptions), nameof(ShowOutliningForCommentsAndPreprocessorRegions), defaultValue: true,
-             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowOutliningForCommentsAndPreprocessorRegions)}"));
+             storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowOutliningForCommentsAndPreprocessorRegions)}"));
 
         public static readonly PerLanguageOption2<bool> ShowOutliningForDeclarationLevelConstructs = new(
             nameof(BlockStructureOptions), nameof(ShowOutliningForDeclarationLevelConstructs), defaultValue: true,
-             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowOutliningForDeclarationLevelConstructs)}"));
+             storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowOutliningForDeclarationLevelConstructs)}"));
 
         public static readonly PerLanguageOption2<bool> ShowOutliningForCodeLevelConstructs = new(
             nameof(BlockStructureOptions), nameof(ShowOutliningForCodeLevelConstructs), defaultValue: true,
-             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowOutliningForCodeLevelConstructs)}"));
+             storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ShowOutliningForCodeLevelConstructs)}"));
 
         public static readonly PerLanguageOption2<bool> CollapseRegionsWhenCollapsingToDefinitions = new(
             nameof(BlockStructureOptions), nameof(CollapseRegionsWhenCollapsingToDefinitions), defaultValue: false,
-             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(CollapseRegionsWhenCollapsingToDefinitions)}"));
+             storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(CollapseRegionsWhenCollapsingToDefinitions)}"));
 
         public static readonly PerLanguageOption2<int> MaximumBannerLength = new(
             nameof(BlockStructureOptions),
             nameof(MaximumBannerLength), defaultValue: 80,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(MaximumBannerLength)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(MaximumBannerLength)}"));
 
     }
 }

--- a/src/Features/LanguageServer/Protocol/LspOptions.cs
+++ b/src/Features/LanguageServer/Protocol/LspOptions.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Text;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.Providers;
@@ -22,7 +20,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         /// If there are more than this many items, we will set the isIncomplete flag on the returned completion list.
         /// </summary>
         public static readonly Option2<int> MaxCompletionListSize = new(nameof(LspOptions), nameof(MaxCompletionListSize), defaultValue: 1000,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(MaxCompletionListSize)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(MaxCompletionListSize)));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/VisualStudio/Core/Def/Implementation/Progression/ProgressionOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/ProgressionOptions.cs
@@ -14,6 +14,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
         public static readonly Option2<bool> SearchUsingNavigateToEngine = new(
             nameof(ProgressionOptions), nameof(SearchUsingNavigateToEngine), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "SearchUsingNavigateToEngine"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "SearchUsingNavigateToEngine"));
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/SourceGeneratedFileManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/SourceGeneratedFileManager.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         /// </summary>
         internal static readonly Option2<bool?> EnableOpeningInWorkspace =
             new(nameof(SourceGeneratedFileManager), nameof(EnableOpeningInWorkspace), defaultValue: null,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.Roslyn.Specific.EnableOpeningSourceGeneratedFilesInWorkspaceExperiment"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.Roslyn.Specific.EnableOpeningSourceGeneratedFilesInWorkspaceExperiment"));
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioNavigationOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioNavigationOptions.cs
@@ -9,6 +9,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     internal static class VisualStudioNavigationOptions
     {
         public static readonly PerLanguageOption2<bool> NavigateToObjectBrowser = new(nameof(VisualStudioNavigationOptions), nameof(NavigateToObjectBrowser), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.NavigateToObjectBrowser"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.NavigateToObjectBrowser"));
     }
 }

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/OptionPages/ForceLowMemoryMode_Options.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/OptionPages/ForceLowMemoryMode_Options.cs
@@ -10,10 +10,10 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow.OptionsPages
 {
     internal sealed partial class ForceLowMemoryMode
     {
-        public static readonly Option2<bool> Enabled = new Option2<bool>(nameof(ForceLowMemoryMode), nameof(Enabled), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(@"Roslyn\ForceLowMemoryMode\Enabled"));
+        public static readonly Option2<bool> Enabled = new(nameof(ForceLowMemoryMode), nameof(Enabled), defaultValue: false,
+            storageLocation: new LocalUserProfileStorageLocation(@"Roslyn\ForceLowMemoryMode\Enabled"));
 
-        public static readonly Option2<int> SizeInMegabytes = new Option2<int>(nameof(ForceLowMemoryMode), nameof(SizeInMegabytes), defaultValue: 500,
-            storageLocations: new LocalUserProfileStorageLocation(@"Roslyn\ForceLowMemoryMode\SizeInMegabytes"));
+        public static readonly Option2<int> SizeInMegabytes = new(nameof(ForceLowMemoryMode), nameof(SizeInMegabytes), defaultValue: 500,
+            storageLocation: new LocalUserProfileStorageLocation(@"Roslyn\ForceLowMemoryMode\SizeInMegabytes"));
     }
 }

--- a/src/Workspaces/Core/Portable/Classification/ReassignedVariableOptions.cs
+++ b/src/Workspaces/Core/Portable/Classification/ReassignedVariableOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Classification
     {
         public static PerLanguageOption2<bool> ClassifyReassignedVariables =
            new PerLanguageOption2<bool>(nameof(ClassificationOptions), nameof(ClassifyReassignedVariables), defaultValue: false,
-               storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ClassificationOptions)}.{nameof(ClassifyReassignedVariables)}"));
+               storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(ClassificationOptions)}.{nameof(ClassifyReassignedVariables)}"));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/Workspaces/Core/Portable/Diagnostics/InternalDiagnosticsOptions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/InternalDiagnosticsOptions.cs
@@ -11,27 +11,27 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private const string LocalRegistryPath = @"Roslyn\Internal\Diagnostics\";
 
         public static readonly Option2<bool> PreferLiveErrorsOnOpenedFiles = new(nameof(InternalDiagnosticsOptions), "Live errors will be preferred over errors from build on opened files from same analyzer", defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Live errors will be preferred over errors from build on opened files from same analyzer"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Live errors will be preferred over errors from build on opened files from same analyzer"));
 
         public static readonly Option2<bool> PreferBuildErrorsOverLiveErrors = new(nameof(InternalDiagnosticsOptions), "Errors from build will be preferred over live errors from same analyzer", defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Errors from build will be preferred over live errors from same analyzer"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Errors from build will be preferred over live errors from same analyzer"));
 
         public static readonly Option2<bool> PutCustomTypeInBingSearch = new(nameof(InternalDiagnosticsOptions), nameof(PutCustomTypeInBingSearch), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "PutCustomTypeInBingSearch"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "PutCustomTypeInBingSearch"));
 
         public static readonly Option2<bool> CrashOnAnalyzerException = new(nameof(InternalDiagnosticsOptions), nameof(CrashOnAnalyzerException), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "CrashOnAnalyzerException"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "CrashOnAnalyzerException"));
 
         public static readonly Option2<bool> ProcessHiddenDiagnostics = new(nameof(InternalDiagnosticsOptions), nameof(ProcessHiddenDiagnostics), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "Process Hidden Diagnostics"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "Process Hidden Diagnostics"));
 
         public static readonly Option2<DiagnosticMode> NormalDiagnosticMode = new(nameof(InternalDiagnosticsOptions), nameof(NormalDiagnosticMode), defaultValue: DiagnosticMode.Default,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "NormalDiagnosticMode"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "NormalDiagnosticMode"));
 
         public static readonly Option2<DiagnosticMode> RazorDiagnosticMode = new(nameof(InternalDiagnosticsOptions), nameof(RazorDiagnosticMode), defaultValue: DiagnosticMode.Pull,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "RazorDiagnosticMode"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "RazorDiagnosticMode"));
 
         public static readonly Option2<bool> EnableFileLoggingForDiagnostics = new(nameof(InternalDiagnosticsOptions), nameof(EnableFileLoggingForDiagnostics), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + "EnableFileLoggingForDiagnostics"));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "EnableFileLoggingForDiagnostics"));
     }
 }

--- a/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaOptions.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaOptions.cs
@@ -19,11 +19,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
 
         public static readonly Option<bool> ShowDebugInfo = new(
             "InternalFeatureOnOffOptions", nameof(ShowDebugInfo), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(ShowDebugInfo)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(ShowDebugInfo)));
 
         public static readonly Option<bool> RemoveRecommendationLimit = new(
             "InternalFeatureOnOffOptions", nameof(RemoveRecommendationLimit), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(RemoveRecommendationLimit)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(RemoveRecommendationLimit)));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/Workspaces/Core/Portable/Options/Option`1.cs
+++ b/src/Workspaces/Core/Portable/Options/Option`1.cs
@@ -38,17 +38,22 @@ namespace Microsoft.CodeAnalysis.Options
         }
 
         public Option(string feature, string name, T defaultValue)
-            : this(feature, name, defaultValue, storageLocations: Array.Empty<OptionStorageLocation>())
+            : this(feature, name, defaultValue, storageLocations: ImmutableArray<OptionStorageLocation>.Empty)
         {
         }
 
         public Option(string feature, string name, T defaultValue, params OptionStorageLocation[] storageLocations)
-            : this(feature, group: OptionGroup.Default, name, defaultValue, storageLocations)
+            : this(feature, group: OptionGroup.Default, name, defaultValue, storageLocations.ToImmutableArray())
         {
         }
 
-        internal Option(string feature, OptionGroup group, string name, T defaultValue, params OptionStorageLocation[] storageLocations)
-            : this(feature, group, name, defaultValue, storageLocations.ToImmutableArray())
+        internal Option(string feature, string name, T defaultValue, OptionStorageLocation storageLocation)
+            : this(feature, name, defaultValue, storageLocations: ImmutableArray.Create(storageLocation))
+        {
+        }
+
+        internal Option(string feature, string name, T defaultValue, ImmutableArray<OptionStorageLocation> storageLocations)
+            : this(feature, OptionGroup.Default, name, defaultValue, storageLocations)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
+++ b/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
@@ -31,17 +31,22 @@ namespace Microsoft.CodeAnalysis.Options
         public ImmutableArray<OptionStorageLocation> StorageLocations { get; }
 
         public PerLanguageOption(string feature, string name, T defaultValue)
-            : this(feature, name, defaultValue, storageLocations: Array.Empty<OptionStorageLocation>())
+            : this(feature, name, defaultValue, storageLocations: ImmutableArray<OptionStorageLocation>.Empty)
         {
         }
 
         public PerLanguageOption(string feature, string name, T defaultValue, params OptionStorageLocation[] storageLocations)
-            : this(feature, group: OptionGroup.Default, name, defaultValue, storageLocations)
+            : this(feature, group: OptionGroup.Default, name, defaultValue, storageLocations.ToImmutableArray())
         {
         }
 
-        internal PerLanguageOption(string feature, OptionGroup group, string name, T defaultValue, params OptionStorageLocation[] storageLocations)
-            : this(feature, group, name, defaultValue, storageLocations.ToImmutableArray())
+        internal PerLanguageOption(string feature, string name, T defaultValue, OptionStorageLocation storageLocation)
+            : this(feature, name, defaultValue, storageLocations: ImmutableArray.Create(storageLocation))
+        {
+        }
+
+        internal PerLanguageOption(string feature, string name, T defaultValue, ImmutableArray<OptionStorageLocation> storageLocations)
+            : this(feature, OptionGroup.Default, name, defaultValue, storageLocations)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Simplification/SimplificationOptions.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplificationOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Simplification
         /// </summary>
         [Obsolete("This option is no longer used")]
         public static Option<bool> PreferAliasToQualification { get; } = new Option<bool>(nameof(SimplificationOptions), nameof(PreferAliasToQualification), true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferAliasToQualification"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferAliasToQualification"));
 
         /// <summary>
         /// This option influences the name reduction of members of a module in VB. If set to true, the 
@@ -26,81 +26,83 @@ namespace Microsoft.CodeAnalysis.Simplification
         /// </summary>
         [Obsolete("This option is no longer used")]
         public static Option<bool> PreferOmittingModuleNamesInQualification { get; } = new Option<bool>(nameof(SimplificationOptions), nameof(PreferOmittingModuleNamesInQualification), true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferOmittingModuleNamesInQualification"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferOmittingModuleNamesInQualification"));
 
         /// <summary>
         /// This option says that if we should simplify the Generic Name which has the type argument inferred
         /// </summary>
         [Obsolete("This option is no longer used")]
         public static Option<bool> PreferImplicitTypeInference { get; } = new Option<bool>(nameof(SimplificationOptions), nameof(PreferImplicitTypeInference), true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferImplicitTypeInference"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferImplicitTypeInference"));
 
         /// <summary>
         /// This option says if we should simplify the Explicit Type in Local Declarations
         /// </summary>
         [Obsolete("This option is no longer used")]
         public static Option<bool> PreferImplicitTypeInLocalDeclaration { get; } = new Option<bool>(nameof(SimplificationOptions), nameof(PreferImplicitTypeInLocalDeclaration), true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferImplicitTypeInLocalDeclaration"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferImplicitTypeInLocalDeclaration"));
 
         /// <summary>
         /// This option says if we should simplify to NonGeneric Name rather than GenericName
         /// </summary>
         [Obsolete("This option is no longer used")]
         public static Option<bool> AllowSimplificationToGenericType { get; } = new Option<bool>(nameof(SimplificationOptions), nameof(AllowSimplificationToGenericType), false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.AllowSimplificationToGenericType"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.AllowSimplificationToGenericType"));
 
         /// <summary>
         /// This option says if we should simplify from Derived types to Base types in Static Member Accesses
         /// </summary>
         [Obsolete("This option is no longer used")]
         public static Option<bool> AllowSimplificationToBaseType { get; } = new Option<bool>(nameof(SimplificationOptions), nameof(AllowSimplificationToBaseType), true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.AllowSimplificationToBaseType"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.AllowSimplificationToBaseType"));
 
         /// <summary>
         /// This option says if we should simplify away the <see langword="this"/> or <see langword="Me"/> in member access expressions.
         /// </summary>
         [Obsolete("This option is no longer used")]
         public static PerLanguageOption<bool> QualifyMemberAccessWithThisOrMe { get; } = new PerLanguageOption<bool>(nameof(SimplificationOptions), nameof(QualifyMemberAccessWithThisOrMe), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyMemberAccessWithThisOrMe"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyMemberAccessWithThisOrMe"));
 
         /// <summary>
         /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in field access expressions.
         /// </summary>
         [Obsolete("This option is no longer used")]
         public static PerLanguageOption<bool> QualifyFieldAccess { get; } = new PerLanguageOption<bool>(nameof(SimplificationOptions), nameof(QualifyFieldAccess), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyFieldAccess"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyFieldAccess"));
 
         /// <summary>
         /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in property access expressions.
         /// </summary>
         [Obsolete("This option is no longer used")]
-        public static PerLanguageOption<bool> QualifyPropertyAccess { get; } = new PerLanguageOption<bool>(nameof(SimplificationOptions), nameof(QualifyPropertyAccess), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyPropertyAccess"));
+        public static PerLanguageOption<bool> QualifyPropertyAccess { get; } = new(nameof(SimplificationOptions), nameof(QualifyPropertyAccess), defaultValue: false,
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyPropertyAccess"));
 
         /// <summary>
         /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in method access expressions.
         /// </summary>
         [Obsolete("This option is no longer used")]
-        public static PerLanguageOption<bool> QualifyMethodAccess { get; } = new PerLanguageOption<bool>(nameof(SimplificationOptions), nameof(QualifyMethodAccess), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyMethodAccess"));
+        public static PerLanguageOption<bool> QualifyMethodAccess { get; } = new(nameof(SimplificationOptions), nameof(QualifyMethodAccess), defaultValue: false,
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyMethodAccess"));
 
         /// <summary>
         /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in event access expressions.
         /// </summary>
         [Obsolete("This option is no longer used")]
-        public static PerLanguageOption<bool> QualifyEventAccess { get; } = new PerLanguageOption<bool>(nameof(SimplificationOptions), nameof(QualifyEventAccess), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyEventAccess"));
+        public static PerLanguageOption<bool> QualifyEventAccess { get; } = new(nameof(SimplificationOptions), nameof(QualifyEventAccess), defaultValue: false,
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyEventAccess"));
 
         /// <summary>
         /// This option says if we should prefer keyword for Intrinsic Predefined Types in Declarations
         /// </summary>
         [Obsolete("This option is no longer used")]
-        public static PerLanguageOption<bool> PreferIntrinsicPredefinedTypeKeywordInDeclaration { get; } = new PerLanguageOption<bool>(nameof(SimplificationOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInDeclaration), defaultValue: true);
+        public static PerLanguageOption<bool> PreferIntrinsicPredefinedTypeKeywordInDeclaration { get; } = new(
+            nameof(SimplificationOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInDeclaration), defaultValue: true);
 
         /// <summary>
         /// This option says if we should prefer keyword for Intrinsic Predefined Types in Member Access Expression
         /// </summary>
         [Obsolete("This option is no longer used")]
-        public static PerLanguageOption<bool> PreferIntrinsicPredefinedTypeKeywordInMemberAccess { get; } = new PerLanguageOption<bool>(nameof(SimplificationOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInMemberAccess), defaultValue: true);
+        public static PerLanguageOption<bool> PreferIntrinsicPredefinedTypeKeywordInMemberAccess { get; } = new(
+            nameof(SimplificationOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInMemberAccess), defaultValue: true);
     }
 }

--- a/src/Workspaces/Core/Portable/SolutionCrawler/SolutionCrawlerOptions.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/SolutionCrawlerOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         /// </summary>
         public static readonly PerLanguageOption2<BackgroundAnalysisScope> BackgroundAnalysisScopeOption = new(
             nameof(SolutionCrawlerOptions), nameof(BackgroundAnalysisScopeOption), defaultValue: BackgroundAnalysisScope.Default,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.BackgroundAnalysisScopeOption"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.BackgroundAnalysisScopeOption"));
 
         /// <summary>
         /// Option to turn configure background analysis scope for the current solution.
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         [Obsolete("Currently used by F# - should move to the new option SolutionCrawlerOptions.BackgroundAnalysisScopeOption")]
         internal static readonly PerLanguageOption<bool?> ClosedFileDiagnostic = new(
             "ServiceFeaturesOnOff", "Closed File Diagnostic", defaultValue: null,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Closed File Diagnostic"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Closed File Diagnostic"));
 
         /// <summary>
         /// Enables forced <see cref="BackgroundAnalysisScope.Minimal"/> scope when low VM is detected to improve performance.

--- a/src/Workspaces/Core/Portable/Storage/StorageOptions.cs
+++ b/src/Workspaces/Core/Portable/Storage/StorageOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Storage
 
         public static readonly Option<StorageDatabase> Database = new(
             OptionName, nameof(Database), defaultValue: StorageDatabase.SQLite,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(Database)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(Database)));
 
         /// <summary>
         /// Option that can be set in certain scenarios (like tests) to indicate that the client expects the DB to

--- a/src/Workspaces/Core/Portable/SymbolSearch/SymbolSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/SymbolSearchOptions.cs
@@ -12,14 +12,14 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
         public static readonly Option2<bool> Enabled = new(
             nameof(SymbolSearchOptions), nameof(Enabled), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(Enabled)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(Enabled)));
 
         public static PerLanguageOption2<bool> SuggestForTypesInReferenceAssemblies =
             new(nameof(SymbolSearchOptions), nameof(SuggestForTypesInReferenceAssemblies), defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInReferenceAssemblies"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInReferenceAssemblies"));
 
         public static PerLanguageOption2<bool> SuggestForTypesInNuGetPackages =
             new(nameof(SymbolSearchOptions), nameof(SuggestForTypesInNuGetPackages), defaultValue: true,
-                storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInNuGetPackages"));
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInNuGetPackages"));
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/FileTextLoader.cs
+++ b/src/Workspaces/Core/Portable/Workspace/FileTextLoader.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis
         /// "[VS HIVE]\Roslyn\Internal\Performance\Text"
         /// </summary>
         internal static readonly Option<long> FileLengthThreshold = new(nameof(FileTextLoaderOptions), nameof(FileLengthThreshold), defaultValue: 100 * 1024 * 1024,
-            storageLocations: new LocalUserProfileStorageLocation(@"Roslyn\Internal\Performance\Text\FileLengthThreshold"));
+            storageLocation: new LocalUserProfileStorageLocation(@"Roslyn\Internal\Performance\Text\FileLengthThreshold"));
     }
 
     [ExportOptionProvider, Shared]

--- a/src/Workspaces/Core/Portable/Workspace/Host/Caching/CacheOptions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Caching/CacheOptions.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.Host
     internal static class CacheOptions
     {
         internal static readonly Option2<int> RecoverableTreeLengthThreshold = new(nameof(CacheOptions), "RecoverableTreeLengthThreshold", defaultValue: 4096,
-            storageLocations: new LocalUserProfileStorageLocation(@"Roslyn\Internal\Performance\Cache\RecoverableTreeLengthThreshold"));
+            storageLocation: new LocalUserProfileStorageLocation(@"Roslyn\Internal\Performance\Cache\RecoverableTreeLengthThreshold"));
     }
 }

--- a/src/Workspaces/Remote/Core/RemoteHostOptions.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostOptions.cs
@@ -28,24 +28,24 @@ namespace Microsoft.CodeAnalysis.Remote
         // Even if primary workspace is not updated, other OOP queries will work as expected. Updating primary workspace
         // on OOP should let latest data to be synced pre-emptively rather than on demand, and will kick off
         // incremental analyzer tasks.
-        public static readonly Option<int> SolutionChecksumMonitorBackOffTimeSpanInMS = new Option<int>(
+        public static readonly Option<int> SolutionChecksumMonitorBackOffTimeSpanInMS = new(
             FeatureName, nameof(SolutionChecksumMonitorBackOffTimeSpanInMS), defaultValue: 1000,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(SolutionChecksumMonitorBackOffTimeSpanInMS)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(SolutionChecksumMonitorBackOffTimeSpanInMS)));
 
         // use 64bit OOP
-        public static readonly Option2<bool> OOP64Bit = new Option2<bool>(
+        public static readonly Option2<bool> OOP64Bit = new(
             FeatureName, nameof(OOP64Bit), defaultValue: true,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OOP64Bit)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OOP64Bit)));
 
         // use Server GC for 64-bit OOP
-        public static readonly Option2<bool> OOPServerGC = new Option2<bool>(
+        public static readonly Option2<bool> OOPServerGC = new(
             FeatureName, nameof(OOPServerGC), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OOPServerGC)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OOPServerGC)));
 
         // use coreclr host for OOP
-        public static readonly Option2<bool> OOPCoreClr = new Option2<bool>(
+        public static readonly Option2<bool> OOPCoreClr = new(
             FeatureName, nameof(OOPCoreClr), defaultValue: false,
-            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OOPCoreClr)));
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OOPCoreClr)));
 
         public static bool IsServiceHubProcessServerGC(HostWorkspaceServices services)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpCodeStyleOptions.cs
@@ -20,14 +20,31 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
 
         internal static ImmutableArray<IOption2> AllOptions { get; }
 
-        private static Option2<T> CreateOption<T>(OptionGroup group, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
-            => CodeStyleHelpers.CreateOption(group, nameof(CSharpCodeStyleOptions), name, defaultValue, s_allOptionsBuilder, storageLocations);
+        private static Option2<T> CreateOption<T>(
+            OptionGroup group, string name, T defaultValue, OptionStorageLocation2 storageLocation)
+            => CodeStyleHelpers.CreateOption(
+                group, nameof(CSharpCodeStyleOptions), name, defaultValue,
+                s_allOptionsBuilder, storageLocation);
 
-        private static Option2<CodeStyleOption2<bool>> CreateOption(OptionGroup group, string name, CodeStyleOption2<bool> defaultValue, string editorconfigKeyName, string roamingProfileStorageKeyName)
-            => CreateOption(group, name, defaultValue, EditorConfigStorageLocation.ForBoolCodeStyleOption(editorconfigKeyName, defaultValue), new RoamingProfileStorageLocation(roamingProfileStorageKeyName));
+        private static Option2<T> CreateOption<T>(
+            OptionGroup group, string name, T defaultValue, OptionStorageLocation2 storageLocation1, OptionStorageLocation2 storageLocation2)
+            => CodeStyleHelpers.CreateOption(
+                group, nameof(CSharpCodeStyleOptions), name, defaultValue,
+                s_allOptionsBuilder, storageLocation1, storageLocation2);
 
-        private static Option2<CodeStyleOption2<string>> CreateOption(OptionGroup group, string name, CodeStyleOption2<string> defaultValue, string editorconfigKeyName, string roamingProfileStorageKeyName)
-            => CreateOption(group, name, defaultValue, EditorConfigStorageLocation.ForStringCodeStyleOption(editorconfigKeyName, defaultValue), new RoamingProfileStorageLocation(roamingProfileStorageKeyName));
+        private static Option2<CodeStyleOption2<bool>> CreateOption(
+            OptionGroup group, string name, CodeStyleOption2<bool> defaultValue, string editorconfigKeyName, string roamingProfileStorageKeyName)
+            => CreateOption(
+                group, name, defaultValue,
+                EditorConfigStorageLocation.ForBoolCodeStyleOption(editorconfigKeyName, defaultValue),
+                new RoamingProfileStorageLocation(roamingProfileStorageKeyName));
+
+        private static Option2<CodeStyleOption2<string>> CreateOption(
+            OptionGroup group, string name, CodeStyleOption2<string> defaultValue, string editorconfigKeyName, string roamingProfileStorageKeyName)
+            => CreateOption(
+                group, name, defaultValue,
+                EditorConfigStorageLocation.ForStringCodeStyleOption(editorconfigKeyName, defaultValue),
+                new RoamingProfileStorageLocation(roamingProfileStorageKeyName));
 
         public static readonly Option2<CodeStyleOption2<bool>> VarForBuiltInTypes = CreateOption(
             CSharpCodeStyleOptionGroups.VarPreferences, nameof(VarForBuiltInTypes),
@@ -138,12 +155,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
         => CreateOption(
             CSharpCodeStyleOptionGroups.ExpressionBodiedMembers, optionName,
             defaultValue,
-            storageLocations: new OptionStorageLocation2[] {
-                new EditorConfigStorageLocation<CodeStyleOption2<ExpressionBodyPreference>>(
-                    editorconfigKeyName,
-                    s => ParseExpressionBodyPreference(s, defaultValue),
-                    v => GetExpressionBodyPreferenceEditorConfigString(v, defaultValue)),
-                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{optionName}")});
+            new EditorConfigStorageLocation<CodeStyleOption2<ExpressionBodyPreference>>(
+                editorconfigKeyName,
+                s => ParseExpressionBodyPreference(s, defaultValue),
+                v => GetExpressionBodyPreferenceEditorConfigString(v, defaultValue)),
+            new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{optionName}"));
 
         public static readonly Option2<CodeStyleOption2<ExpressionBodyPreference>> PreferExpressionBodiedConstructors = CreatePreferExpressionBodyOption(
             nameof(PreferExpressionBodiedConstructors), defaultValue: NeverWithSilentEnforcement, "csharp_style_expression_bodied_constructors");
@@ -176,12 +192,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
         => CreateOption(
             CSharpCodeStyleOptionGroups.CodeBlockPreferences, optionName,
             defaultValue,
-            storageLocations: new OptionStorageLocation2[] {
-                new EditorConfigStorageLocation<CodeStyleOption2<PreferBracesPreference>>(
-                    editorconfigKeyName,
-                    s => ParsePreferBracesPreference(s, defaultValue),
-                    v => GetPreferBracesPreferenceEditorConfigString(v, defaultValue)),
-                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{optionName}")});
+            new EditorConfigStorageLocation<CodeStyleOption2<PreferBracesPreference>>(
+                editorconfigKeyName,
+                s => ParsePreferBracesPreference(s, defaultValue),
+                v => GetPreferBracesPreferenceEditorConfigString(v, defaultValue)),
+            new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{optionName}"));
+
         public static readonly Option2<CodeStyleOption2<PreferBracesPreference>> PreferBraces = CreatePreferBracesOption(
             nameof(PreferBraces), defaultValue: UseBracesWithSilentEnforcement, "csharp_prefer_braces");
 
@@ -235,12 +251,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
             => CreateOption(
                 CSharpCodeStyleOptionGroups.UsingDirectivePreferences, optionName,
                 defaultValue,
-                storageLocations: new OptionStorageLocation2[] {
-                    new EditorConfigStorageLocation<CodeStyleOption2<AddImportPlacement>>(
-                        editorconfigKeyName,
-                        s => ParseUsingDirectivesPlacement(s, defaultValue),
-                        v => GetUsingDirectivesPlacementEditorConfigString(v, defaultValue)),
-                    new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{optionName}")});
+                new EditorConfigStorageLocation<CodeStyleOption2<AddImportPlacement>>(
+                    editorconfigKeyName,
+                    s => ParseUsingDirectivesPlacement(s, defaultValue),
+                    v => GetUsingDirectivesPlacementEditorConfigString(v, defaultValue)),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{optionName}"));
+
         public static readonly Option2<CodeStyleOption2<AddImportPlacement>> PreferredUsingDirectivePlacement = CreateUsingDirectivePlacementOption(
             nameof(PreferredUsingDirectivePlacement), defaultValue: PreferOutsidePlacementWithSilentEnforcement, "csharp_using_directive_placement");
 
@@ -277,34 +293,30 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
         public static Option2<CodeStyleOption2<bool>> AllowEmbeddedStatementsOnSameLine { get; } = CreateOption(
             CSharpCodeStyleOptionGroups.NewLinePreferences, nameof(AllowEmbeddedStatementsOnSameLine),
             defaultValue: CodeStyleOptions2.TrueWithSilentEnforcement,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_allow_embedded_statements_on_same_line_experimental", CodeStyleOptions2.TrueWithSilentEnforcement),
-                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(AllowEmbeddedStatementsOnSameLine)}")});
+            EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_allow_embedded_statements_on_same_line_experimental", CodeStyleOptions2.TrueWithSilentEnforcement),
+            new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(AllowEmbeddedStatementsOnSameLine)}"));
 
         public static Option2<CodeStyleOption2<bool>> AllowBlankLinesBetweenConsecutiveBraces { get; } = CreateOption(
             CSharpCodeStyleOptionGroups.NewLinePreferences, nameof(AllowBlankLinesBetweenConsecutiveBraces),
             defaultValue: CodeStyleOptions2.TrueWithSilentEnforcement,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_allow_blank_lines_between_consecutive_braces_experimental", CodeStyleOptions2.TrueWithSilentEnforcement),
-                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(AllowBlankLinesBetweenConsecutiveBraces)}")});
+            EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_allow_blank_lines_between_consecutive_braces_experimental", CodeStyleOptions2.TrueWithSilentEnforcement),
+            new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(AllowBlankLinesBetweenConsecutiveBraces)}"));
 
         public static Option2<CodeStyleOption2<bool>> AllowBlankLineAfterColonInConstructorInitializer { get; } = CreateOption(
             CSharpCodeStyleOptionGroups.NewLinePreferences, nameof(AllowBlankLineAfterColonInConstructorInitializer),
             defaultValue: CodeStyleOptions2.TrueWithSilentEnforcement,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental", CodeStyleOptions2.TrueWithSilentEnforcement),
-                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(AllowBlankLineAfterColonInConstructorInitializer)}")});
+            EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental", CodeStyleOptions2.TrueWithSilentEnforcement),
+            new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(AllowBlankLineAfterColonInConstructorInitializer)}"));
 
         private static Option2<CodeStyleOption2<NamespaceDeclarationPreference>> CreateNamespaceDeclarationOption(string optionName, CodeStyleOption2<NamespaceDeclarationPreference> defaultValue, string editorconfigKeyName)
             => CreateOption(
                 CSharpCodeStyleOptionGroups.CodeBlockPreferences, optionName,
                 defaultValue,
-                storageLocations: new OptionStorageLocation2[] {
-                    new EditorConfigStorageLocation<CodeStyleOption2<NamespaceDeclarationPreference>>(
-                        editorconfigKeyName,
-                        s => ParseNamespaceDeclaration(s, defaultValue),
-                        v => GetNamespaceDeclarationEditorConfigString(v, defaultValue)),
-                    new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{optionName}")});
+                new EditorConfigStorageLocation<CodeStyleOption2<NamespaceDeclarationPreference>>(
+                    editorconfigKeyName,
+                    s => ParseNamespaceDeclaration(s, defaultValue),
+                    v => GetNamespaceDeclarationEditorConfigString(v, defaultValue)),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{optionName}"));
 
         public static readonly Option2<CodeStyleOption2<NamespaceDeclarationPreference>> NamespaceDeclarations = CreateNamespaceDeclarationOption(
             nameof(NamespaceDeclarations),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpFormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpFormattingOptions2.cs
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         // Maps to store mapping between special option kinds and the corresponding options.
         private static readonly ImmutableDictionary<Option2<bool>, SpacingWithinParenthesesOption>.Builder s_spacingWithinParenthesisOptionsMapBuilder
             = ImmutableDictionary.CreateBuilder<Option2<bool>, SpacingWithinParenthesesOption>();
-        private static readonly ImmutableDictionary<Option2<bool>, NewLineOption>.Builder s_newLineOptionsMapBuilder =
-           ImmutableDictionary.CreateBuilder<Option2<bool>, NewLineOption>();
+        private static readonly ImmutableDictionary<Option2<bool>, NewLineOption>.Builder s_newLineOptionsMapBuilder
+            = ImmutableDictionary.CreateBuilder<Option2<bool>, NewLineOption>();
 
         // Maps to store mapping between special option kinds and the corresponding editor config string representations.
         #region Editor Config maps
@@ -74,9 +74,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         private static ImmutableDictionary<Option2<bool>, SpacingWithinParenthesesOption> SpacingWithinParenthesisOptionsMap { get; }
         private static ImmutableDictionary<Option2<bool>, NewLineOption> NewLineOptionsMap { get; }
 
-        private static Option2<T> CreateOption<T>(OptionGroup group, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
+        private static Option2<T> CreateOption<T>(
+            OptionGroup group, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation1,
+            OptionStorageLocation2 storageLocation2)
         {
-            var option = new Option2<T>("CSharpFormattingOptions", group, name, defaultValue, storageLocations);
+            var option = new Option2<T>(
+                "CSharpFormattingOptions",
+                group, name, defaultValue,
+                ImmutableArray.Create(storageLocation1, storageLocation2));
+
             s_allOptionsBuilder.Add(option);
             return option;
         }
@@ -86,12 +93,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var option = CreateOption(
                 CSharpFormattingOptionGroups.Spacing, name,
                 defaultValue: false,
-                storageLocations: new OptionStorageLocation2[] {
-                    new EditorConfigStorageLocation<bool>(
-                        "csharp_space_between_parentheses",
-                        s => DetermineIfSpaceOptionIsSet(s, parenthesesOption),
-                        GetSpacingWithParenthesesEditorConfigString),
-                    new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{name}")});
+                new EditorConfigStorageLocation<bool>(
+                    "csharp_space_between_parentheses",
+                    s => DetermineIfSpaceOptionIsSet(s, parenthesesOption),
+                    GetSpacingWithParenthesesEditorConfigString),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{name}"));
 
             Debug.Assert(s_spacingWithinParenthesisOptionsEditorConfigMap.ContainsValue(parenthesesOption));
             s_spacingWithinParenthesisOptionsMapBuilder.Add(option, parenthesesOption);
@@ -104,12 +110,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var option = CreateOption(
                 CSharpFormattingOptionGroups.NewLine, name,
                 defaultValue: true,
-                storageLocations: new OptionStorageLocation2[] {
-                    new EditorConfigStorageLocation<bool>(
-                        "csharp_new_line_before_open_brace",
-                        value => DetermineIfNewLineOptionIsSet(value, newLineOption),
-                        GetNewLineOptionEditorConfigString),
-                    new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{name}")});
+                new EditorConfigStorageLocation<bool>(
+                    "csharp_new_line_before_open_brace",
+                    value => DetermineIfNewLineOptionIsSet(value, newLineOption),
+                    GetNewLineOptionEditorConfigString),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{name}"));
 
             Debug.Assert(s_newLineOptionsEditorConfigMap.ContainsValue(newLineOption));
             s_newLineOptionsMapBuilder.Add(option, newLineOption);
@@ -120,51 +125,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         public static Option2<bool> SpacingAfterMethodDeclarationName { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpacingAfterMethodDeclarationName),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_declaration_name_and_open_parenthesis"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAfterMethodDeclarationName")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_declaration_name_and_open_parenthesis"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAfterMethodDeclarationName"));
 
         public static Option2<bool> SpaceWithinMethodDeclarationParenthesis { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceWithinMethodDeclarationParenthesis),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_declaration_parameter_list_parentheses"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodDeclarationParenthesis")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_declaration_parameter_list_parentheses"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodDeclarationParenthesis"));
 
         public static Option2<bool> SpaceBetweenEmptyMethodDeclarationParentheses { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceBetweenEmptyMethodDeclarationParentheses),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_declaration_empty_parameter_list_parentheses"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodDeclarationParentheses")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_declaration_empty_parameter_list_parentheses"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodDeclarationParentheses"));
 
         public static Option2<bool> SpaceAfterMethodCallName { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceAfterMethodCallName),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_call_name_and_opening_parenthesis"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterMethodCallName")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_call_name_and_opening_parenthesis"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterMethodCallName"));
 
         public static Option2<bool> SpaceWithinMethodCallParentheses { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceWithinMethodCallParentheses),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_call_parameter_list_parentheses"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodCallParentheses")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_call_parameter_list_parentheses"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodCallParentheses"));
 
         public static Option2<bool> SpaceBetweenEmptyMethodCallParentheses { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceBetweenEmptyMethodCallParentheses),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_call_empty_parameter_list_parentheses"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodCallParentheses")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_call_empty_parameter_list_parentheses"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodCallParentheses"));
 
         public static Option2<bool> SpaceAfterControlFlowStatementKeyword { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceAfterControlFlowStatementKeyword),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_keywords_in_control_flow_statements"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterControlFlowStatementKeyword")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_after_keywords_in_control_flow_statements"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterControlFlowStatementKeyword"));
 
         public static Option2<bool> SpaceWithinExpressionParentheses { get; } = CreateSpaceWithinParenthesesOption(
             SpacingWithinParenthesesOption.Expressions, nameof(SpaceWithinExpressionParentheses));
@@ -178,165 +176,143 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         public static Option2<bool> SpaceAfterCast { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceAfterCast),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_cast"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterCast")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_after_cast"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterCast"));
 
         public static Option2<bool> SpacesIgnoreAroundVariableDeclaration { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpacesIgnoreAroundVariableDeclaration),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                new EditorConfigStorageLocation<bool>(
-                    "csharp_space_around_declaration_statements",
-                    s => DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(s),
-                    v => v ? "ignore" : "false"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacesIgnoreAroundVariableDeclaration")});
+            new EditorConfigStorageLocation<bool>(
+                "csharp_space_around_declaration_statements",
+                s => DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(s),
+                v => v ? "ignore" : "false"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacesIgnoreAroundVariableDeclaration"));
 
         public static Option2<bool> SpaceBeforeOpenSquareBracket { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceBeforeOpenSquareBracket),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_open_square_brackets"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeOpenSquareBracket")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_before_open_square_brackets"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeOpenSquareBracket"));
 
         public static Option2<bool> SpaceBetweenEmptySquareBrackets { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceBetweenEmptySquareBrackets),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_empty_square_brackets"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptySquareBrackets")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_between_empty_square_brackets"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptySquareBrackets"));
 
         public static Option2<bool> SpaceWithinSquareBrackets { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceWithinSquareBrackets),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_square_brackets"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinSquareBrackets")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_between_square_brackets"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinSquareBrackets"));
 
         public static Option2<bool> SpaceAfterColonInBaseTypeDeclaration { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceAfterColonInBaseTypeDeclaration),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_colon_in_inheritance_clause"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterColonInBaseTypeDeclaration")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_after_colon_in_inheritance_clause"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterColonInBaseTypeDeclaration"));
 
         public static Option2<bool> SpaceAfterComma { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceAfterComma),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_comma"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterComma")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_after_comma"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterComma"));
 
         public static Option2<bool> SpaceAfterDot { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceAfterDot),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_dot"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterDot")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_after_dot"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterDot"));
 
         public static Option2<bool> SpaceAfterSemicolonsInForStatement { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceAfterSemicolonsInForStatement),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_semicolon_in_for_statement"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterSemicolonsInForStatement")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_after_semicolon_in_for_statement"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterSemicolonsInForStatement"));
 
         public static Option2<bool> SpaceBeforeColonInBaseTypeDeclaration { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceBeforeColonInBaseTypeDeclaration),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_colon_in_inheritance_clause"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeColonInBaseTypeDeclaration")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_before_colon_in_inheritance_clause"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeColonInBaseTypeDeclaration"));
 
         public static Option2<bool> SpaceBeforeComma { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceBeforeComma),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_comma"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeComma")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_before_comma"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeComma"));
 
         public static Option2<bool> SpaceBeforeDot { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceBeforeDot),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_dot"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeDot")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_before_dot"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeDot"));
 
         public static Option2<bool> SpaceBeforeSemicolonsInForStatement { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpaceBeforeSemicolonsInForStatement),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_semicolon_in_for_statement"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeSemicolonsInForStatement")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_space_before_semicolon_in_for_statement"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeSemicolonsInForStatement"));
 
         public static Option2<BinaryOperatorSpacingOptions> SpacingAroundBinaryOperator { get; } = CreateOption(
             CSharpFormattingOptionGroups.Spacing, nameof(SpacingAroundBinaryOperator),
             defaultValue: BinaryOperatorSpacingOptions.Single,
-            storageLocations: new OptionStorageLocation2[] {
-                new EditorConfigStorageLocation<BinaryOperatorSpacingOptions>(
-                    "csharp_space_around_binary_operators",
-                    s => ParseEditorConfigSpacingAroundBinaryOperator(s),
-                    GetSpacingAroundBinaryOperatorEditorConfigString),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAroundBinaryOperator")});
+            new EditorConfigStorageLocation<BinaryOperatorSpacingOptions>(
+                "csharp_space_around_binary_operators",
+                s => ParseEditorConfigSpacingAroundBinaryOperator(s),
+                GetSpacingAroundBinaryOperatorEditorConfigString),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAroundBinaryOperator"));
 
         public static Option2<bool> IndentBraces { get; } = CreateOption(
             CSharpFormattingOptionGroups.Indentation, nameof(IndentBraces),
             defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_indent_braces"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.OpenCloseBracesIndent")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_indent_braces"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.OpenCloseBracesIndent"));
 
         public static Option2<bool> IndentBlock { get; } = CreateOption(
             CSharpFormattingOptionGroups.Indentation, nameof(IndentBlock),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_indent_block_contents"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentBlock")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_indent_block_contents"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentBlock"));
 
         public static Option2<bool> IndentSwitchSection { get; } = CreateOption(
             CSharpFormattingOptionGroups.Indentation, nameof(IndentSwitchSection),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_indent_switch_labels"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchSection")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_indent_switch_labels"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchSection"));
 
         public static Option2<bool> IndentSwitchCaseSection { get; } = CreateOption(
             CSharpFormattingOptionGroups.Indentation, nameof(IndentSwitchCaseSection),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_indent_case_contents"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchCaseSection")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_indent_case_contents"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchCaseSection"));
 
         public static Option2<bool> IndentSwitchCaseSectionWhenBlock { get; } = CreateOption(
             CSharpFormattingOptionGroups.Indentation, nameof(IndentSwitchCaseSectionWhenBlock),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_indent_case_contents_when_block"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchCaseSectionWhenBlock")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_indent_case_contents_when_block"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchCaseSectionWhenBlock"));
 
         public static Option2<LabelPositionOptions> LabelPositioning { get; } = CreateOption(
             CSharpFormattingOptionGroups.Indentation, nameof(LabelPositioning),
             defaultValue: LabelPositionOptions.OneLess,
-            storageLocations: new OptionStorageLocation2[] {
-                new EditorConfigStorageLocation<LabelPositionOptions>(
-                    "csharp_indent_labels",
-                    s => ParseEditorConfigLabelPositioning(s),
-                    GetLabelPositionOptionEditorConfigString),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.LabelPositioning")});
+            new EditorConfigStorageLocation<LabelPositionOptions>(
+                "csharp_indent_labels",
+                s => ParseEditorConfigLabelPositioning(s),
+                GetLabelPositionOptionEditorConfigString),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.LabelPositioning"));
 
         public static Option2<bool> WrappingPreserveSingleLine { get; } = CreateOption(
             CSharpFormattingOptionGroups.Wrapping, nameof(WrappingPreserveSingleLine),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_preserve_single_line_blocks"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingPreserveSingleLine")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_preserve_single_line_blocks"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingPreserveSingleLine"));
 
         public static Option2<bool> WrappingKeepStatementsOnSingleLine { get; } = CreateOption(
             CSharpFormattingOptionGroups.Wrapping, nameof(WrappingKeepStatementsOnSingleLine),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_preserve_single_line_statements"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingKeepStatementsOnSingleLine")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_preserve_single_line_statements"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingKeepStatementsOnSingleLine"));
 
         public static Option2<bool> NewLinesForBracesInTypes { get; } = CreateNewLineForBracesOption(
             NewLineOption.Types, nameof(NewLinesForBracesInTypes));
@@ -368,49 +344,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         public static Option2<bool> NewLineForElse { get; } = CreateOption(
             CSharpFormattingOptionGroups.NewLine, nameof(NewLineForElse),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_else"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForElse")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_else"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForElse"));
 
         public static Option2<bool> NewLineForCatch { get; } = CreateOption(
             CSharpFormattingOptionGroups.NewLine, nameof(NewLineForCatch),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_catch"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForCatch")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_catch"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForCatch"));
 
         public static Option2<bool> NewLineForFinally { get; } = CreateOption(
             CSharpFormattingOptionGroups.NewLine, nameof(NewLineForFinally),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_finally"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForFinally")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_finally"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForFinally"));
 
         public static Option2<bool> NewLineForMembersInObjectInit { get; } = CreateOption(
             CSharpFormattingOptionGroups.NewLine, nameof(NewLineForMembersInObjectInit),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_members_in_object_initializers"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInObjectInit")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_members_in_object_initializers"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInObjectInit"));
 
         public static Option2<bool> NewLineForMembersInAnonymousTypes { get; } = CreateOption(
             CSharpFormattingOptionGroups.NewLine, nameof(NewLineForMembersInAnonymousTypes),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_members_in_anonymous_types"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInAnonymousTypes")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_members_in_anonymous_types"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInAnonymousTypes"));
 
         public static Option2<bool> NewLineForClausesInQuery { get; } = CreateOption(
             CSharpFormattingOptionGroups.NewLine, nameof(NewLineForClausesInQuery),
             defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_between_query_expression_clauses"),
-                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForClausesInQuery")});
+            EditorConfigStorageLocation.ForBoolOption("csharp_new_line_between_query_expression_clauses"),
+            new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForClausesInQuery"));
 
         static CSharpFormattingOptions2()
         {
             // Note that the static constructor executes after all the static field initializers for the options have executed,
             // and each field initializer adds the created option to the following builders.
+
             AllOptions = s_allOptionsBuilder.ToImmutable();
             SpacingWithinParenthesisOptionsMap = s_spacingWithinParenthesisOptionsMapBuilder.ToImmutable();
             NewLineOptionsMap = s_newLineOptionsMapBuilder.ToImmutable();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleHelpers.cs
@@ -118,7 +118,34 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             string name,
             T defaultValue,
             ImmutableArray<IOption2>.Builder optionsBuilder,
-            params OptionStorageLocation2[] storageLocations)
+            OptionStorageLocation2 storageLocation)
+        {
+            var option = new Option2<T>(feature, group, name, defaultValue, ImmutableArray.Create(storageLocation));
+            optionsBuilder.Add(option);
+            return option;
+        }
+
+        public static Option2<T> CreateOption<T>(
+            OptionGroup group,
+            string feature,
+            string name,
+            T defaultValue,
+            ImmutableArray<IOption2>.Builder optionsBuilder,
+            OptionStorageLocation2 storageLocation1,
+            OptionStorageLocation2 storageLocation2)
+        {
+            var option = new Option2<T>(feature, group, name, defaultValue, ImmutableArray.Create(storageLocation1, storageLocation2));
+            optionsBuilder.Add(option);
+            return option;
+        }
+
+        public static Option2<T> CreateOption<T>(
+            OptionGroup group,
+            string feature,
+            string name,
+            T defaultValue,
+            ImmutableArray<IOption2>.Builder optionsBuilder,
+            ImmutableArray<OptionStorageLocation2> storageLocations)
         {
             var option = new Option2<T>(feature, group, name, defaultValue, storageLocations);
             optionsBuilder.Add(option);
@@ -148,12 +175,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                 name,
                 defaultValue,
                 optionsBuilder,
-                storageLocations: new OptionStorageLocation2[]{
-                    new EditorConfigStorageLocation<CodeStyleOption2<UnusedValuePreference>>(
-                        editorConfigName,
-                        s => ParseUnusedExpressionAssignmentPreference(s, defaultValue),
-                        o => GetUnusedExpressionAssignmentPreferenceEditorConfigString(o, defaultValue)),
-                    new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{name}Preference")});
+                new EditorConfigStorageLocation<CodeStyleOption2<UnusedValuePreference>>(
+                    editorConfigName,
+                    s => ParseUnusedExpressionAssignmentPreference(s, defaultValue),
+                    o => GetUnusedExpressionAssignmentPreferenceEditorConfigString(o, defaultValue)),
+                new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{name}Preference"));
 
         private static Optional<CodeStyleOption2<UnusedValuePreference>> ParseUnusedExpressionAssignmentPreference(
             string optionString,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOptions2.cs
@@ -16,22 +16,55 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
         internal static ImmutableArray<IOption2> AllOptions { get; }
 
-        private static PerLanguageOption2<T> CreateOption<T>(OptionGroup group, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
+        private static PerLanguageOption2<T> CreateOption<T>(
+            OptionGroup group, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation)
         {
-            var option = new PerLanguageOption2<T>("CodeStyleOptions", group, name, defaultValue, storageLocations);
+            var option = new PerLanguageOption2<T>(
+                "CodeStyleOptions",
+                group, name, defaultValue,
+                ImmutableArray.Create(storageLocation));
+
             s_allOptionsBuilder.Add(option);
             return option;
         }
 
-        private static Option2<T> CreateCommonOption<T>(OptionGroup group, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
+        private static PerLanguageOption2<T> CreateOption<T>(
+            OptionGroup group, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation1, OptionStorageLocation2 storageLocation2)
         {
-            var option = new Option2<T>("CodeStyleOptions", group, name, defaultValue, storageLocations);
+            var option = new PerLanguageOption2<T>(
+                "CodeStyleOptions",
+                group, name, defaultValue,
+                ImmutableArray.Create(storageLocation1, storageLocation2));
+
             s_allOptionsBuilder.Add(option);
             return option;
         }
 
-        private static PerLanguageOption2<CodeStyleOption2<bool>> CreateOption(OptionGroup group, string name, CodeStyleOption2<bool> defaultValue, string editorconfigKeyName, string roamingProfileStorageKeyName)
-            => CreateOption(group, name, defaultValue, EditorConfigStorageLocation.ForBoolCodeStyleOption(editorconfigKeyName, defaultValue), new RoamingProfileStorageLocation(roamingProfileStorageKeyName));
+        private static Option2<T> CreateCommonOption<T>(OptionGroup group, string name, T defaultValue, OptionStorageLocation2 storageLocation)
+        {
+            var option = new Option2<T>(
+                "CodeStyleOptions",
+                group, name, defaultValue,
+                ImmutableArray.Create(storageLocation));
+
+            s_allOptionsBuilder.Add(option);
+            return option;
+        }
+
+        private static Option2<T> CreateCommonOption<T>(
+            OptionGroup group, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation1, OptionStorageLocation2 storageLocation2)
+        {
+            var option = new Option2<T>(
+                "CodeStyleOptions",
+                group, name, defaultValue,
+                ImmutableArray.Create(storageLocation1, storageLocation2));
+
+            s_allOptionsBuilder.Add(option);
+            return option;
+        }
 
         /// <remarks>
         /// When user preferences are not yet set for a style, we fall back to the default value.
@@ -42,6 +75,14 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         internal static readonly CodeStyleOption2<bool> FalseWithSilentEnforcement = new(value: false, notification: NotificationOption2.Silent);
         internal static readonly CodeStyleOption2<bool> TrueWithSuggestionEnforcement = new(value: true, notification: NotificationOption2.Suggestion);
         internal static readonly CodeStyleOption2<bool> FalseWithSuggestionEnforcement = new(value: false, notification: NotificationOption2.Suggestion);
+
+        private static PerLanguageOption2<CodeStyleOption2<bool>> CreateOption(
+            OptionGroup group, string name, CodeStyleOption2<bool> defaultValue,
+            string editorconfigKeyName, string roamingProfileStorageKeyName)
+            => CreateOption(
+                group, name, defaultValue,
+                EditorConfigStorageLocation.ForBoolCodeStyleOption(editorconfigKeyName, defaultValue),
+                new RoamingProfileStorageLocation(roamingProfileStorageKeyName));
 
         private static PerLanguageOption2<CodeStyleOption2<bool>> CreateQualifyAccessOption(string optionName, string editorconfigKeyName)
             => CreateOption(
@@ -109,12 +150,12 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         internal static readonly PerLanguageOption2<bool> PreferObjectInitializer_FadeOutCode = new(
             "CodeStyleOptions", nameof(PreferObjectInitializer_FadeOutCode),
             defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferObjectInitializer_FadeOutCode"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferObjectInitializer_FadeOutCode"));
 
         internal static readonly PerLanguageOption2<bool> PreferCollectionInitializer_FadeOutCode = new(
             "CodeStyleOptions", nameof(PreferCollectionInitializer_FadeOutCode),
             defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCollectionInitializer_FadeOutCode"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCollectionInitializer_FadeOutCode"));
 
         internal static readonly PerLanguageOption2<CodeStyleOption2<bool>> PreferSimplifiedBooleanExpressions = CreateOption(
             CodeStyleOptionGroups.ExpressionLevelPreferences, nameof(PreferSimplifiedBooleanExpressions),
@@ -127,11 +168,10 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                 CodeStyleOptionGroups.ExpressionLevelPreferences,
                 nameof(OperatorPlacementWhenWrapping),
                 defaultValue: OperatorPlacementWhenWrappingPreference.BeginningOfLine,
-                storageLocations:
-                    new EditorConfigStorageLocation<OperatorPlacementWhenWrappingPreference>(
-                        "dotnet_style_operator_placement_when_wrapping",
-                        OperatorPlacementUtilities.Parse,
-                        OperatorPlacementUtilities.GetEditorConfigString));
+                new EditorConfigStorageLocation<OperatorPlacementWhenWrappingPreference>(
+                    "dotnet_style_operator_placement_when_wrapping",
+                    OperatorPlacementUtilities.Parse,
+                    OperatorPlacementUtilities.GetEditorConfigString));
 
         internal static readonly PerLanguageOption2<CodeStyleOption2<bool>> PreferCoalesceExpression = CreateOption(
             CodeStyleOptionGroups.ExpressionLevelPreferences, nameof(PreferCoalesceExpression),
@@ -209,12 +249,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             CodeStyleOptionGroups.Parameter,
             nameof(UnusedParameters),
             defaultValue: s_preferAllMethodsUnusedParametersPreference,
-            storageLocations: new OptionStorageLocation2[]{
-                new EditorConfigStorageLocation<CodeStyleOption2<UnusedParametersPreference>>(
-                        "dotnet_code_quality_unused_parameters",
-                        s => ParseUnusedParametersPreference(s, s_preferAllMethodsUnusedParametersPreference),
-                        o => GetUnusedParametersPreferenceEditorConfigString(o, s_preferAllMethodsUnusedParametersPreference)),
-                new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(UnusedParameters)}Preference") });
+            new EditorConfigStorageLocation<CodeStyleOption2<UnusedParametersPreference>>(
+                    "dotnet_code_quality_unused_parameters",
+                    s => ParseUnusedParametersPreference(s, s_preferAllMethodsUnusedParametersPreference),
+                    o => GetUnusedParametersPreferenceEditorConfigString(o, s_preferAllMethodsUnusedParametersPreference)),
+            new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(UnusedParameters)}Preference"));
 
         private static readonly CodeStyleOption2<AccessibilityModifiersRequired> s_requireAccessibilityModifiersDefault =
             new(AccessibilityModifiersRequired.ForNonInterfaceMembers, NotificationOption2.Silent);
@@ -223,12 +262,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             CreateOption(
                 CodeStyleOptionGroups.Modifier, nameof(RequireAccessibilityModifiers),
                 defaultValue: s_requireAccessibilityModifiersDefault,
-                storageLocations: new OptionStorageLocation2[]{
-                    new EditorConfigStorageLocation<CodeStyleOption2<AccessibilityModifiersRequired>>(
-                        "dotnet_style_require_accessibility_modifiers",
-                        s => ParseAccessibilityModifiersRequired(s, s_requireAccessibilityModifiersDefault),
-                        v => GetAccessibilityModifiersRequiredEditorConfigString(v, s_requireAccessibilityModifiersDefault)),
-                    new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.RequireAccessibilityModifiers")});
+                new EditorConfigStorageLocation<CodeStyleOption2<AccessibilityModifiersRequired>>(
+                    "dotnet_style_require_accessibility_modifiers",
+                    s => ParseAccessibilityModifiersRequired(s, s_requireAccessibilityModifiersDefault),
+                    v => GetAccessibilityModifiersRequiredEditorConfigString(v, s_requireAccessibilityModifiersDefault)),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.RequireAccessibilityModifiers"));
 
         internal static readonly PerLanguageOption2<CodeStyleOption2<bool>> PreferReadonly = CreateOption(
             CodeStyleOptionGroups.Field, nameof(PreferReadonly),
@@ -245,9 +283,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             CodeStyleOptionGroups.Suppressions,
             nameof(RemoveUnnecessarySuppressionExclusions),
             defaultValue: "",
-            storageLocations: new OptionStorageLocation2[]{
-                EditorConfigStorageLocation.ForStringOption("dotnet_remove_unnecessary_suppression_exclusions", emptyStringRepresentation: "none"),
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.RemoveUnnecessarySuppressionExclusions") });
+            EditorConfigStorageLocation.ForStringOption("dotnet_remove_unnecessary_suppression_exclusions", emptyStringRepresentation: "none"),
+            new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.RemoveUnnecessarySuppressionExclusions"));
 
         private static readonly BidirectionalMap<string, AccessibilityModifiersRequired> s_accessibilityModifiersRequiredMap =
             new(new[]
@@ -295,12 +332,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         {
             return CreateOption(
                 CodeStyleOptionGroups.Parentheses, fieldName, defaultValue,
-                storageLocations: new OptionStorageLocation2[]{
-                    new EditorConfigStorageLocation<CodeStyleOption2<ParenthesesPreference>>(
-                        styleName,
-                        s => ParseParenthesesPreference(s, defaultValue),
-                        v => GetParenthesesPreferenceEditorConfigString(v, defaultValue)),
-                    new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{fieldName}Preference")});
+                new EditorConfigStorageLocation<CodeStyleOption2<ParenthesesPreference>>(
+                    styleName,
+                    s => ParseParenthesesPreference(s, defaultValue),
+                    v => GetParenthesesPreferenceEditorConfigString(v, defaultValue)),
+                new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{fieldName}Preference"));
         }
 
         internal static readonly PerLanguageOption2<CodeStyleOption2<ParenthesesPreference>> ArithmeticBinaryParentheses =
@@ -345,8 +381,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             CodeStyleOptionGroups.ExpressionLevelPreferences,
             nameof(PreferSystemHashCode),
             defaultValue: TrueWithSuggestionEnforcement,
-            storageLocations: new OptionStorageLocation2[]{
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferSystemHashCode") });
+            new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferSystemHashCode"));
 
         public static readonly PerLanguageOption2<CodeStyleOption2<bool>> PreferNamespaceAndFolderMatchStructure = CreateOption(
             CodeStyleOptionGroups.ExpressionLevelPreferences, nameof(PreferNamespaceAndFolderMatchStructure),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Editing/GenerationOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Editing/GenerationOptions.cs
@@ -13,15 +13,13 @@ namespace Microsoft.CodeAnalysis.Editing
         public static readonly PerLanguageOption2<bool> PlaceSystemNamespaceFirst = new(nameof(GenerationOptions),
             CodeStyleOptionGroups.Usings,
             nameof(PlaceSystemNamespaceFirst), defaultValue: true,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("dotnet_sort_system_directives_first"),
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PlaceSystemNamespaceFirst")});
+            EditorConfigStorageLocation.ForBoolOption("dotnet_sort_system_directives_first"),
+            new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PlaceSystemNamespaceFirst"));
 
         public static readonly PerLanguageOption2<bool> SeparateImportDirectiveGroups = new(
             nameof(GenerationOptions), CodeStyleOptionGroups.Usings, nameof(SeparateImportDirectiveGroups), defaultValue: false,
-            storageLocations: new OptionStorageLocation2[] {
-                EditorConfigStorageLocation.ForBoolOption("dotnet_separate_import_directive_groups"),
-                new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(SeparateImportDirectiveGroups)}")});
+            EditorConfigStorageLocation.ForBoolOption("dotnet_separate_import_directive_groups"),
+            new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(SeparateImportDirectiveGroups)}"));
 
         public static readonly ImmutableArray<IOption2> AllOptions = ImmutableArray.Create<IOption2>(
             PlaceSystemNamespaceFirst,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Fading/FadingOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Fading/FadingOptions.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.Fading
     {
         public static readonly PerLanguageOption2<bool> FadeOutUnusedImports = new(
             nameof(FadingOptions), nameof(FadeOutUnusedImports), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(FadeOutUnusedImports)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(FadeOutUnusedImports)}"));
 
         public static readonly PerLanguageOption2<bool> FadeOutUnreachableCode = new(
             nameof(FadingOptions), nameof(FadeOutUnreachableCode), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(FadeOutUnreachableCode)}"));
+            storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{nameof(FadeOutUnreachableCode)}"));
 
         public static readonly ImmutableArray<IOption2> AllOptions = ImmutableArray.Create<IOption2>(
             FadeOutUnusedImports,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
@@ -19,16 +19,36 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         internal static ImmutableArray<IOption2> AllOptions { get; }
 
-        private static PerLanguageOption2<T> CreatePerLanguageOption<T>(OptionGroup group, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
+        private static PerLanguageOption2<T> CreatePerLanguageOption<T>(
+            OptionGroup group, string name, T defaultValue)
         {
-            var option = new PerLanguageOption2<T>(nameof(FormattingOptions), group, name, defaultValue, storageLocations);
+            var option = new PerLanguageOption2<T>(nameof(FormattingOptions), group, name, defaultValue);
             s_allOptionsBuilder.Add(option);
             return option;
         }
 
-        private static Option2<T> CreateOption<T>(OptionGroup group, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
+        private static PerLanguageOption2<T> CreatePerLanguageOption<T>(
+            OptionGroup group, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation)
         {
-            var option = new Option2<T>(nameof(FormattingOptions), group, name, defaultValue, storageLocations);
+            var option = new PerLanguageOption2<T>(nameof(FormattingOptions), group, name, defaultValue, storageLocation);
+            s_allOptionsBuilder.Add(option);
+            return option;
+        }
+
+        private static Option2<T> CreateOption<T>(
+            OptionGroup group, string name, T defaultValue)
+        {
+            var option = new Option2<T>(nameof(FormattingOptions), group, name, defaultValue);
+            s_allOptionsBuilder.Add(option);
+            return option;
+        }
+
+        private static Option2<T> CreateOption<T>(
+            OptionGroup group, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation)
+        {
+            var option = new Option2<T>(nameof(FormattingOptions), group, name, defaultValue, storageLocation);
             s_allOptionsBuilder.Add(option);
             return option;
         }
@@ -36,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         public static PerLanguageOption2<bool> UseTabs { get; } = CreatePerLanguageOption(
             FormattingOptionGroups.IndentationAndSpacing, nameof(UseTabs),
             defaultValue: false,
-            storageLocations: new EditorConfigStorageLocation<bool>(
+            storageLocation: new EditorConfigStorageLocation<bool>(
                 "indent_style",
                 s => s == "tab",
                 isSet => isSet ? "tab" : "space"));
@@ -45,13 +65,13 @@ namespace Microsoft.CodeAnalysis.Formatting
         public static PerLanguageOption2<int> TabSize { get; } = CreatePerLanguageOption(
             FormattingOptionGroups.IndentationAndSpacing, nameof(TabSize),
             defaultValue: 4,
-            storageLocations: EditorConfigStorageLocation.ForInt32Option("tab_width"));
+            storageLocation: EditorConfigStorageLocation.ForInt32Option("tab_width"));
 
         // This is also serialized by the Visual Studio-specific LanguageSettingsPersister
         public static PerLanguageOption2<int> IndentationSize { get; } = CreatePerLanguageOption(
             FormattingOptionGroups.IndentationAndSpacing, nameof(IndentationSize),
             defaultValue: 4,
-            storageLocations: EditorConfigStorageLocation.ForInt32Option("indent_size"));
+            storageLocation: EditorConfigStorageLocation.ForInt32Option("indent_size"));
 
         // This is also serialized by the Visual Studio-specific LanguageSettingsPersister
         public static PerLanguageOption2<FormattingOptions.IndentStyle> SmartIndent { get; } = CreatePerLanguageOption(
@@ -61,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         public static PerLanguageOption2<string> NewLine { get; } = CreatePerLanguageOption(
             FormattingOptionGroups.NewLine, nameof(NewLine),
             defaultValue: Environment.NewLine,
-            storageLocations: new EditorConfigStorageLocation<string>(
+            storageLocation: new EditorConfigStorageLocation<string>(
                 "end_of_line",
                 ParseEditorConfigEndOfLine,
                 GetEndOfLineEditorConfigString));
@@ -69,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         internal static Option2<bool> InsertFinalNewLine { get; } = CreateOption(
             FormattingOptionGroups.NewLine, nameof(InsertFinalNewLine),
             defaultValue: false,
-            storageLocations: EditorConfigStorageLocation.ForBoolOption("insert_final_newline"));
+            storageLocation: EditorConfigStorageLocation.ForBoolOption("insert_final_newline"));
 
         /// <summary>
         /// Default value of 120 was picked based on the amount of code in a github.com diff at 1080p.
@@ -102,19 +122,19 @@ namespace Microsoft.CodeAnalysis.Formatting
         internal static Option2<bool> AllowDisjointSpanMerging { get; } = CreateOption(OptionGroup.Default, nameof(AllowDisjointSpanMerging), defaultValue: false);
 
         internal static readonly PerLanguageOption2<bool> AutoFormattingOnReturn = CreatePerLanguageOption(OptionGroup.Default, nameof(AutoFormattingOnReturn), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Return"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Return"));
 
         public static readonly PerLanguageOption2<bool> AutoFormattingOnTyping = CreatePerLanguageOption(
             OptionGroup.Default, nameof(AutoFormattingOnTyping), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Typing"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Typing"));
 
         public static readonly PerLanguageOption2<bool> AutoFormattingOnSemicolon = CreatePerLanguageOption(
             OptionGroup.Default, nameof(AutoFormattingOnSemicolon), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Semicolon"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Semicolon"));
 
         public static readonly PerLanguageOption2<bool> FormatOnPaste = CreatePerLanguageOption(
             OptionGroup.Default, nameof(FormatOnPaste), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.FormatOnPaste"));
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.FormatOnPaste"));
 
         static FormattingOptions2()
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionIdOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionIdOptions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         {
             var name = Enum.GetName(typeof(FunctionId), id) ?? throw ExceptionUtilities.UnexpectedValue(id);
 
-            return new Option2<bool>(nameof(FunctionIdOptions), name, defaultValue: false,
-                storageLocations: new LocalUserProfileStorageLocation(@"Roslyn\Internal\Performance\FunctionId\" + name));
+            return new(nameof(FunctionIdOptions), name, defaultValue: false,
+                storageLocation: new LocalUserProfileStorageLocation(@"Roslyn\Internal\Performance\FunctionId\" + name));
         }
 
         public static Option2<bool> GetOption(FunctionId id)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyleOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyleOptions.cs
@@ -18,12 +18,11 @@ namespace Microsoft.CodeAnalysis.Simplification
         /// This option describes the naming rules that should be applied to specified categories of symbols, 
         /// and the level to which those rules should be enforced.
         /// </summary>
-        internal static PerLanguageOption2<NamingStylePreferences> NamingPreferences { get; } = new PerLanguageOption2<NamingStylePreferences>(FeatureName, nameof(NamingPreferences), defaultValue: NamingStylePreferences.Default,
-            storageLocations: new OptionStorageLocation2[] {
-                new NamingStylePreferenceEditorConfigStorageLocation(),
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.NamingPreferences5"),
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.NamingPreferences")
-            });
+        internal static PerLanguageOption2<NamingStylePreferences> NamingPreferences { get; } = new PerLanguageOption2<NamingStylePreferences>(
+            FeatureName, nameof(NamingPreferences), defaultValue: NamingStylePreferences.Default,
+            new NamingStylePreferenceEditorConfigStorageLocation(),
+            new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.NamingPreferences5"),
+            new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.NamingPreferences"));
 
         public static OptionKey2 GetNamingPreferencesOptionKey(string language)
             => new(NamingPreferences, language);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/Option2`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/Option2`1.cs
@@ -49,17 +49,27 @@ namespace Microsoft.CodeAnalysis.Options
         public ImmutableArray<OptionStorageLocation2> StorageLocations { get; }
 
         public Option2(string feature, string name, T defaultValue)
-            : this(feature, name, defaultValue, storageLocations: Array.Empty<OptionStorageLocation2>())
+            : this(feature, name, defaultValue, storageLocations: ImmutableArray<OptionStorageLocation2>.Empty)
         {
         }
 
-        public Option2(string feature, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
+        public Option2(string feature, string name, T defaultValue, OptionStorageLocation2 storageLocation)
+            : this(feature, group: OptionGroup.Default, name, defaultValue, ImmutableArray.Create(storageLocation))
+        {
+        }
+
+        public Option2(string feature, string name, T defaultValue, ImmutableArray<OptionStorageLocation2> storageLocations)
             : this(feature, group: OptionGroup.Default, name, defaultValue, storageLocations)
         {
         }
 
-        internal Option2(string feature, OptionGroup group, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
-            : this(feature, group, name, defaultValue, storageLocations.ToImmutableArray())
+        internal Option2(string feature, OptionGroup group, string name, T defaultValue)
+            : this(feature, group, name, defaultValue, ImmutableArray<OptionStorageLocation2>.Empty)
+        {
+        }
+
+        internal Option2(string feature, OptionGroup group, string name, T defaultValue, OptionStorageLocation2 storageLocation)
+            : this(feature, group, name, defaultValue, ImmutableArray.Create(storageLocation))
         {
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/PerLanguageOption2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/PerLanguageOption2.cs
@@ -50,21 +50,56 @@ namespace Microsoft.CodeAnalysis.Options
         public ImmutableArray<OptionStorageLocation2> StorageLocations { get; }
 
         public PerLanguageOption2(string feature, string name, T defaultValue)
-            : this(feature, name, defaultValue, storageLocations: Array.Empty<OptionStorageLocation2>())
+            : this(feature, name, defaultValue, storageLocations: ImmutableArray<OptionStorageLocation2>.Empty)
         {
         }
 
-        public PerLanguageOption2(string feature, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
+        public PerLanguageOption2(
+            string feature, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation)
+            : this(feature, group: OptionGroup.Default, name, defaultValue, ImmutableArray.Create(storageLocation))
+        {
+        }
+
+        public PerLanguageOption2(
+            string feature, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation1,
+            OptionStorageLocation2 storageLocation2,
+            OptionStorageLocation2 storageLocation3)
+            : this(feature, group: OptionGroup.Default, name, defaultValue,
+                  ImmutableArray.Create(storageLocation1, storageLocation2, storageLocation3))
+        {
+        }
+
+        public PerLanguageOption2(
+            string feature, string name, T defaultValue,
+            ImmutableArray<OptionStorageLocation2> storageLocations)
             : this(feature, group: OptionGroup.Default, name, defaultValue, storageLocations)
         {
         }
 
-        internal PerLanguageOption2(string feature, OptionGroup group, string name, T defaultValue, params OptionStorageLocation2[] storageLocations)
-            : this(feature, group, name, defaultValue, storageLocations.ToImmutableArray())
+        internal PerLanguageOption2(string feature, OptionGroup group, string name, T defaultValue)
+            : this(feature, group, name, defaultValue, ImmutableArray<OptionStorageLocation2>.Empty)
         {
         }
 
-        internal PerLanguageOption2(string feature, OptionGroup group, string name, T defaultValue, ImmutableArray<OptionStorageLocation2> storageLocations)
+        internal PerLanguageOption2(
+            string feature, OptionGroup group, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation)
+            : this(feature, group, name, defaultValue, ImmutableArray.Create(storageLocation))
+        {
+        }
+
+        internal PerLanguageOption2(
+            string feature, OptionGroup group, string name, T defaultValue,
+            OptionStorageLocation2 storageLocation1, OptionStorageLocation2 storageLocation2)
+            : this(feature, group, name, defaultValue, ImmutableArray.Create(storageLocation1, storageLocation2))
+        {
+        }
+
+        internal PerLanguageOption2(
+            string feature, OptionGroup group, string name, T defaultValue,
+            ImmutableArray<OptionStorageLocation2> storageLocations)
         {
             if (string.IsNullOrWhiteSpace(feature))
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/CodeStyle/VisualBasicCodeStyleOptions.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/CodeStyle/VisualBasicCodeStyleOptions.vb
@@ -14,8 +14,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeStyle
             AllOptions = s_allOptionsBuilder.ToImmutable()
         End Sub
 
-        Private Shared Function CreateOption(Of T)(group As OptionGroup, name As String, defaultValue As T, ParamArray storageLocations As OptionStorageLocation2()) As [Option2](Of T)
-            Return CodeStyleHelpers.CreateOption(group, NameOf(VisualBasicCodeStyleOptions), name, defaultValue, s_allOptionsBuilder, storageLocations)
+        Private Shared Function CreateOption(Of T)(group As OptionGroup, name As String, defaultValue As T, storageLocation As OptionStorageLocation2) As [Option2](Of T)
+            Return CodeStyleHelpers.CreateOption(group, NameOf(VisualBasicCodeStyleOptions), name, defaultValue, s_allOptionsBuilder, storageLocation)
+        End Function
+
+        Private Shared Function CreateOption(Of T)(group As OptionGroup, name As String, defaultValue As T, storageLocation1 As OptionStorageLocation2, storageLocation2 As OptionStorageLocation2) As [Option2](Of T)
+            Return CodeStyleHelpers.CreateOption(group, NameOf(VisualBasicCodeStyleOptions), name, defaultValue, s_allOptionsBuilder, storageLocation1, storageLocation2)
         End Function
 
         Private Shared Function CreateOption(group As OptionGroup, name As String, defaultValue As CodeStyleOption2(Of Boolean), editorconfigKeyName As String, roamingProfileStorageKeyName As String) As [Option2](Of CodeStyleOption2(Of Boolean))
@@ -23,7 +27,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeStyle
         End Function
 
         Private Shared Function CreateOption(group As OptionGroup, name As String, defaultValue As CodeStyleOption2(Of String), editorconfigKeyName As String, roamingProfileStorageKeyName As String) As [Option2](Of CodeStyleOption2(Of String))
-            Return CreateOption(group, name, defaultValue, EditorConfigStorageLocation.ForStringCodeStyleOption(editorconfigKeyName, defaultValue), New RoamingProfileStorageLocation(roamingProfileStorageKeyName))
+            Return CreateOption(
+                group, name, defaultValue,
+                EditorConfigStorageLocation.ForStringCodeStyleOption(editorconfigKeyName, defaultValue),
+                New RoamingProfileStorageLocation(roamingProfileStorageKeyName))
         End Function
 
         Public Shared ReadOnly Property AllOptions As ImmutableArray(Of IOption2)


### PR DESCRIPTION
Most `Option<T>`, `PerLanguageOption<T>`, `Option2<T>` and `PerLanguageOption2<T>` instances are constructred by calling a constructor that takes a params array. This array is them immediately converted to an immutable array, resulting in two array allocations and a copy. This change audits each option creation and changes the code to pass an immutable array, avoiding an extra allocation and array copy per option.