### PR TITLE
Remove synchronous blocking call of go-to-def.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Editor.GoToDefinition;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
@@ -26,6 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
             private readonly IThreadingContext _threadingContext;
             private readonly IStreamingFindUsagesPresenter _presenter;
             private readonly IUIThreadOperationExecutor _uiThreadOperationExecutor;
+            private readonly IAsynchronousOperationListener _listener;
 
             public NavigableSymbol(
                 ImmutableArray<DefinitionItem> definitions,
@@ -33,7 +35,8 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                 Document document,
                 IThreadingContext threadingContext,
                 IStreamingFindUsagesPresenter streamingPresenter,
-                IUIThreadOperationExecutor uiThreadOperationExecutor)
+                IUIThreadOperationExecutor uiThreadOperationExecutor,
+                IAsynchronousOperationListenerProvider listenerProvider)
             {
                 Contract.ThrowIfFalse(definitions.Length > 0);
 
@@ -43,6 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                 _threadingContext = threadingContext;
                 _presenter = streamingPresenter;
                 _uiThreadOperationExecutor = uiThreadOperationExecutor;
+                _listener = listenerProvider.GetListener(FeatureAttribute.NavigableSymbols);
             }
 
             public SnapshotSpan SymbolSpan { get; }
@@ -50,19 +54,36 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
             public IEnumerable<INavigableRelationship> Relationships =>
                 SpecializedCollections.SingletonEnumerable(PredefinedNavigableRelationships.Definition);
 
-            public void Navigate(INavigableRelationship relationship) =>
-                _uiThreadOperationExecutor.Execute(
-                    title: EditorFeaturesResources.Go_to_Definition,
-                    defaultDescription: EditorFeaturesResources.Navigating_to_definition,
-                    allowCancellation: true,
-                    showProgress: false,
-                    action: context => GoToDefinitionHelpers.TryGoToDefinition(
-                        _definitions,
-                        _document.Project.Solution,
-                        _definitions[0].NameDisplayParts.GetFullText(),
+            public void Navigate(INavigableRelationship relationship)
+            {
+                // Fire and forget.
+                _ = NavigateAsync();
+            }
+
+            private async Task NavigateAsync()
+            {
+                try
+                {
+                    using var token = _listener.BeginAsyncOperation(nameof(NavigateAsync));
+                    using var context = _uiThreadOperationExecutor.BeginExecute(
+                        title: EditorFeaturesResources.Go_to_Definition,
+                        defaultDescription: EditorFeaturesResources.Navigating_to_definition,
+                        allowCancellation: true,
+                        showProgress: false);
+                    await _presenter.TryNavigateToOrPresentItemsAsync(
                         _threadingContext,
-                        _presenter,
-                        context.UserCancellationToken));
+                        _document.Project.Solution.Workspace,
+                        _definitions[0].NameDisplayParts.GetFullText(),
+                        _definitions,
+                        context.UserCancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception ex) when (FatalError.ReportAndCatch(ex))
+                {
+                }
+            }
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Editor.GoToDefinition;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Language.Intellisense;
@@ -26,17 +27,19 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
             private readonly IThreadingContext _threadingContext;
             private readonly IStreamingFindUsagesPresenter _presenter;
             private readonly IUIThreadOperationExecutor _uiThreadOperationExecutor;
-
+            private readonly IAsynchronousOperationListenerProvider _listenerProvider;
             private bool _disposed;
 
             public NavigableSymbolSource(
                 IThreadingContext threadingContext,
                 IStreamingFindUsagesPresenter streamingPresenter,
-                IUIThreadOperationExecutor uiThreadOperationExecutor)
+                IUIThreadOperationExecutor uiThreadOperationExecutor,
+                IAsynchronousOperationListenerProvider listenerProvider)
             {
                 _threadingContext = threadingContext;
                 _presenter = streamingPresenter;
                 _uiThreadOperationExecutor = uiThreadOperationExecutor;
+                _listenerProvider = listenerProvider;
             }
 
             public void Dispose()
@@ -45,35 +48,34 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
             public async Task<INavigableSymbol> GetNavigableSymbolAsync(SnapshotSpan triggerSpan, CancellationToken cancellationToken)
             {
                 if (_disposed)
-                {
                     return null;
-                }
 
                 var snapshot = triggerSpan.Snapshot;
                 var position = triggerSpan.Start;
                 var document = snapshot.GetOpenDocumentInCurrentContextWithChanges();
                 if (document == null)
-                {
                     return null;
-                }
 
                 var service = document.GetLanguageService<IGoToSymbolService>();
                 if (service == null)
-                {
                     return null;
-                }
 
                 var context = new GoToSymbolContext(document, position, cancellationToken);
 
                 await service.GetSymbolsAsync(context).ConfigureAwait(false);
 
                 if (!context.TryGetItems(WellKnownSymbolTypes.Definition, out var definitions))
-                {
                     return null;
-                }
 
                 var snapshotSpan = new SnapshotSpan(snapshot, context.Span.ToSpan());
-                return new NavigableSymbol(definitions.ToImmutableArray(), snapshotSpan, document, _threadingContext, _presenter, _uiThreadOperationExecutor);
+                return new NavigableSymbol(
+                    definitions.ToImmutableArray(),
+                    snapshotSpan,
+                    document,
+                    _threadingContext,
+                    _presenter,
+                    _uiThreadOperationExecutor,
+                    _listenerProvider);
             }
         }
     }

--- a/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -25,23 +26,26 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
         private readonly IUIThreadOperationExecutor _uiThreadOperationExecutor;
         private readonly IThreadingContext _threadingContext;
         private readonly IStreamingFindUsagesPresenter _streamingPresenter;
+        private readonly IAsynchronousOperationListenerProvider _listenerProvider;
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public NavigableSymbolService(
             IUIThreadOperationExecutor uiThreadOperationExecutor,
             IThreadingContext threadingContext,
-            IStreamingFindUsagesPresenter streamingPresenter)
+            IStreamingFindUsagesPresenter streamingPresenter,
+            IAsynchronousOperationListenerProvider listenerProvider)
         {
             _uiThreadOperationExecutor = uiThreadOperationExecutor;
             _threadingContext = threadingContext;
             _streamingPresenter = streamingPresenter;
+            _listenerProvider = listenerProvider;
         }
 
         public INavigableSymbolSource TryCreateNavigableSymbolSource(ITextView textView, ITextBuffer buffer)
         {
             return textView.GetOrCreatePerSubjectBufferProperty(buffer, s_key,
-                (v, b) => new NavigableSymbolSource(_threadingContext, _streamingPresenter, _uiThreadOperationExecutor));
+                (v, b) => new NavigableSymbolSource(_threadingContext, _streamingPresenter, _uiThreadOperationExecutor, _listenerProvider));
         }
     }
 }

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -113,18 +113,5 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
                 () => streamingPresenter.TryNavigateToOrPresentItemsAsync(
                     threadingContext, solution.Workspace, title, definitions, cancellationToken));
         }
-
-        public static bool TryGoToDefinition(
-            ImmutableArray<DefinitionItem> definitions,
-            Solution solution,
-            string title,
-            IThreadingContext threadingContext,
-            IStreamingFindUsagesPresenter streamingPresenter,
-            CancellationToken cancellationToken)
-        {
-            return threadingContext.JoinableTaskFactory.Run(() =>
-                streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                    threadingContext, solution.Workspace, title, definitions, cancellationToken));
-        }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         public const string KeywordHighlighting = nameof(KeywordHighlighting);
         public const string LightBulb = nameof(LightBulb);
         public const string LineSeparators = nameof(LineSeparators);
+        public const string NavigableSymbols = nameof(NavigableSymbols);
         public const string NavigateTo = nameof(NavigateTo);
         public const string NavigationBar = nameof(NavigationBar);
         public const string Outlining = nameof(Outlining);


### PR DESCRIPTION
Switches us to async processing behind a threaded-wait-dialog.  A general effort to remove lots of our existing sync utilities that block some calling thread when the underlying operations have all been modernized to be async.