### PR TITLE
Set resources correctly on CopyRefAssembly

### DIFF
--- a/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
+++ b/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
@@ -23,9 +23,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         public string DestinationPath { get; set; }
 
         public CopyRefAssembly()
+            : base(ErrorString.ResourceManager)
         {
-            TaskResources = ErrorString.ResourceManager;
-
             // These required properties will all be assigned by MSBuild. Suppress warnings about leaving them with
             // their default values.
             SourcePath = null!;
@@ -86,9 +85,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
             catch (Exception e)
             {
-                var util = new TaskLoggingHelper(this);
-                util.LogErrorWithCodeFromResources("Compiler_UnexpectedException");
-                util.LogErrorFromException(e, showStackTrace: true, showDetail: true, file: null);
+                Log.LogErrorWithCodeFromResources("Compiler_UnexpectedException");
+                Log.LogErrorFromException(e, showStackTrace: true, showDetail: true, file: null);
                 return false;
             }
 

--- a/src/Compilers/Core/MSBuildTaskTests/CopyRefAssemblyTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CopyRefAssemblyTests.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.CodeAnalysis.BuildTasks;
+using Xunit;
+using Moq;
+using System.IO;
+using Roslyn.Test.Utilities;
+using Microsoft.CodeAnalysis.BuildTasks.UnitTests.TestUtilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
+{
+    public sealed class CopyRefAssemblyTests : IDisposable
+    {
+        public TempRoot TempRoot { get; } = new TempRoot();
+
+        public void Dispose()
+        {
+            TempRoot.Dispose();
+        }
+
+        [Fact]
+        public void SourceDoesNotExist()
+        {
+            var dir = TempRoot.CreateDirectory();
+            var engine = new MockEngine();
+            var task = new CopyRefAssembly()
+            {
+                BuildEngine = engine,
+                SourcePath = Path.Combine(dir.Path, "does_not_exist.dll")
+            };
+
+            Assert.False(task.Execute());
+            Assert.False(string.IsNullOrEmpty(engine.Log));
+        }
+
+        [Fact]
+        public void BadDestinationPath()
+        {
+            var dir = TempRoot.CreateDirectory();
+            var file = dir.CreateFile("example.dll");
+            File.WriteAllText(file.Path, "");
+            var engine = new MockEngine();
+            var task = new CopyRefAssembly()
+            {
+                BuildEngine = engine,
+                SourcePath = file.Path,
+                DestinationPath = null!,
+            };
+
+            Assert.False(task.Execute());
+            Assert.False(string.IsNullOrEmpty(engine.Log));
+        }
+
+        [Fact]
+        public void SourceNotAssemblyNoDestination()
+        {
+            var dir = TempRoot.CreateDirectory();
+            var file = dir.CreateFile("example.dll");
+            File.WriteAllText(file.Path, "test");
+            var dest = Path.Combine(dir.Path, "dest.dll");
+            var engine = new MockEngine();
+            var task = new CopyRefAssembly()
+            {
+                BuildEngine = engine,
+                SourcePath = file.Path,
+                DestinationPath = dest,
+            };
+
+            Assert.True(task.Execute());
+            Assert.True(string.IsNullOrEmpty(engine.Log));
+            Assert.Equal("test", File.ReadAllText(dest));
+        }
+
+        [Fact]
+        public void SourceNotAssemblyWithDestination()
+        {
+            var dir = TempRoot.CreateDirectory();
+            var source = dir.CreateFile("example.dll");
+            File.WriteAllText(source.Path, "test");
+            var dest = dir.CreateFile("dest.dll");
+            File.WriteAllText(dest.Path, "dest");
+            var engine = new MockEngine();
+            var task = new CopyRefAssembly()
+            {
+                BuildEngine = engine,
+                SourcePath = source.Path,
+                DestinationPath = dest.Path,
+            };
+
+            Assert.True(task.Execute());
+            Assert.False(string.IsNullOrEmpty(engine.Log));
+            Assert.Equal("test", File.ReadAllText(dest.Path));
+        }
+    }
+}


### PR DESCRIPTION
Similar to other tasks we fixed previously we need to ensure that
resources are set correctly when creating the `CopyRefAssembly` task.
The only correct way to do this is pass the `ResourceManager` through
the constructor.

Follow up of #52836
Related to https://github.com/dotnet/msbuild/issues/6253