### PR TITLE
Track duplicate hintNames as they are added

### DIFF
--- a/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
+++ b/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
@@ -73,6 +73,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override CommonMessageProvider MessageProvider => CSharp.MessageProvider.Instance;
 
-        internal override AdditionalSourcesCollection CreateSourcesCollection() => new AdditionalSourcesCollection(".cs");
+        internal override string SourceExtension => ".cs";
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
@@ -137,6 +137,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             Assert.Contains(hintName2, exception.Message);
         }
 
+        [Fact]
+        public void Hint_Name_Must_Be_Unique_When_Combining_Soruces()
+        {
+            AdditionalSourcesCollection asc = new AdditionalSourcesCollection(".cs");
+            asc.Add("hintName1", SourceText.From("", Encoding.UTF8));
+            asc.Add("hintName2", SourceText.From("", Encoding.UTF8));
+
+            AdditionalSourcesCollection asc2 = new AdditionalSourcesCollection(".cs");
+            asc2.Add("hintName3", SourceText.From("", Encoding.UTF8));
+            asc2.Add("hintName1", SourceText.From("", Encoding.UTF8));
+
+            var exception = Assert.Throws<ArgumentException>("hintName", () => asc.CopyTo(asc2));
+            Assert.Contains("hintName1", exception.Message);
+        }
+
         [Theory]
         [InlineData("file.cs", "file.cs")]
         [InlineData("file", "file")]

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -456,7 +456,7 @@ class C { }
                 );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/54185: the addition happens later so the exceptions don't occur directly at add-time. we should decide if this subtle behavior change is acceptable")]
+        [Fact]
         public void Generator_HintName_MustBe_Unique()
         {
             var source = @"
@@ -483,6 +483,47 @@ class C { }
             outputCompilation.VerifyDiagnostics();
             generatorDiagnostics.Verify();
             Assert.Equal(2, outputCompilation.SyntaxTrees.Count());
+        }
+
+        [Fact]
+        public void Generator_HintName_MustBe_Unique_Across_Outputs()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.Regular.WithLanguageVersion(LanguageVersion.Preview);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+            Assert.Single(compilation.SyntaxTrees);
+
+            var generator = new PipelineCallbackGenerator((ctx) =>
+            {
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (spc, c) =>
+                {
+                    spc.AddSource("test", SourceText.From("public class D{}", Encoding.UTF8));
+
+                    // throws immediately, because we're within the same output node
+                    Assert.Throws<ArgumentException>("hintName", () => spc.AddSource("test", SourceText.From("public class D{}", Encoding.UTF8)));
+
+                    // throws for .cs too
+                    Assert.Throws<ArgumentException>("hintName", () => spc.AddSource("test.cs", SourceText.From("public class D{}", Encoding.UTF8)));
+                });
+
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (spc, c) =>
+                {
+                    // will not throw at this point, because we have no way of knowing what the other outputs added
+                    // we *will* throw later in the driver when we combine them however (this is a change for V2, but not visible from V1)
+                    spc.AddSource("test", SourceText.From("public class D{}", Encoding.UTF8));
+                });
+            });
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator.AsSourceGenerator() }, parseOptions: parseOptions);
+            driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);
+            outputCompilation.VerifyDiagnostics();
+            generatorDiagnostics.Verify(
+                Diagnostic("CS8785").WithArguments("PipelineCallbackGenerator", "ArgumentException", "The hintName 'test.cs' of the added source file must be unique within a generator. (Parameter 'hintName')").WithLocation(1, 1)
+                );
+            Assert.Equal(1, outputCompilation.SyntaxTrees.Count());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -485,7 +485,7 @@ class C { }
             Assert.Equal(2, outputCompilation.SyntaxTrees.Count());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(MonoOrCoreClrOnly), Reason = "Desktop CLR displays argument exceptions differently")]
         public void Generator_HintName_MustBe_Unique_Across_Outputs()
         {
             var source = @"

--- a/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
@@ -97,6 +97,8 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
+        public void CopyTo(AdditionalSourcesCollection asc) => asc._sourcesAdded.AddRange(this._sourcesAdded);
+
         internal ImmutableArray<GeneratedSourceText> ToImmutableAndFree() => _sourcesAdded.ToImmutableAndFree();
 
         internal ImmutableArray<GeneratedSourceText> ToImmutable() => _sourcesAdded.ToImmutable();

--- a/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
@@ -97,7 +97,26 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
-        public void CopyTo(AdditionalSourcesCollection asc) => asc._sourcesAdded.AddRange(this._sourcesAdded);
+        public void CopyTo(AdditionalSourcesCollection asc)
+        {
+            // we know the individual hint names are valid, but we do need to check that they
+            // don't collide with any we already have
+            if (asc._sourcesAdded.Count == 0)
+            {
+                asc._sourcesAdded.AddRange(this._sourcesAdded);
+            }
+            else
+            {
+                foreach (var source in this._sourcesAdded)
+                {
+                    if (asc.Contains(source.HintName))
+                    {
+                        throw new ArgumentException(string.Format(CodeAnalysisResources.HintNameUniquePerGenerator, source.HintName), "hintName");
+                    }
+                    asc._sourcesAdded.Add(source);
+                }
+            }
+        }
 
         internal ImmutableArray<GeneratedSourceText> ToImmutableAndFree() => _sourcesAdded.ToImmutableAndFree();
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
@@ -15,11 +15,14 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal sealed class SourceGeneratorAdaptor : IIncrementalGenerator
     {
+        private readonly string _sourceExtension;
+
         internal ISourceGenerator SourceGenerator { get; }
 
-        public SourceGeneratorAdaptor(ISourceGenerator generator)
+        public SourceGeneratorAdaptor(ISourceGenerator generator, string sourceExtension)
         {
             SourceGenerator = generator;
+            _sourceExtension = sourceExtension;
         }
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -48,7 +51,7 @@ namespace Microsoft.CodeAnalysis
 
             context.RegisterSourceOutput(contextBuilderSource, (productionContext, contextBuilder) =>
             {
-                var generatorExecutionContext = contextBuilder.ToExecutionContext(productionContext.CancellationToken);
+                var generatorExecutionContext = contextBuilder.ToExecutionContext(_sourceExtension, productionContext.CancellationToken);
                 SourceGenerator.Execute(generatorExecutionContext);
 
                 // copy the contents of the old context to the new
@@ -67,10 +70,10 @@ namespace Microsoft.CodeAnalysis
 
             public ISyntaxContextReceiver? Receiver;
 
-            public GeneratorExecutionContext ToExecutionContext(CancellationToken cancellationToken)
+            public GeneratorExecutionContext ToExecutionContext(string sourceExtension, CancellationToken cancellationToken)
             {
                 Debug.Assert(ParseOptions is object && ConfigOptions is object);
-                return new GeneratorExecutionContext(Compilation, ParseOptions, AdditionalTexts, ConfigOptions, Receiver, cancellationToken);
+                return new GeneratorExecutionContext(Compilation, ParseOptions, AdditionalTexts, ConfigOptions, Receiver, sourceExtension, cancellationToken);
             }
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis
 
         internal GeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider optionsProvider, ImmutableArray<AdditionalText> additionalTexts, GeneratorDriverOptions driverOptions)
         {
-            (var filteredGenerators, var incrementalGenerators) = GetIncrementalGenerators(generators);
+            (var filteredGenerators, var incrementalGenerators) = GetIncrementalGenerators(generators, SourceExtension);
             _state = new GeneratorDriverState(parseOptions, optionsProvider, filteredGenerators, incrementalGenerators, additionalTexts, ImmutableArray.Create(new GeneratorState[filteredGenerators.Length]), DriverStateTable.Empty, driverOptions.DisabledOutputs);
         }
 
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
 
         public GeneratorDriver AddGenerators(ImmutableArray<ISourceGenerator> generators)
         {
-            (var filteredGenerators, var incrementalGenerators) = GetIncrementalGenerators(generators);
+            (var filteredGenerators, var incrementalGenerators) = GetIncrementalGenerators(generators, SourceExtension);
             var newState = _state.With(sourceGenerators: _state.Generators.AddRange(filteredGenerators),
                                        incrementalGenerators: _state.IncrementalGenerators.AddRange(incrementalGenerators),
                                        generatorStates: _state.GeneratorStates.AddRange(new GeneratorState[filteredGenerators.Length]));
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis
                     var outputBuilder = ArrayBuilder<IIncrementalGeneratorOutputNode>.GetInstance();
                     var inputBuilder = ArrayBuilder<ISyntaxInputNode>.GetInstance();
                     var postInitSources = ImmutableArray<GeneratedSyntaxTree>.Empty;
-                    var pipelineContext = new IncrementalGeneratorInitializationContext(inputBuilder, outputBuilder);
+                    var pipelineContext = new IncrementalGeneratorInitializationContext(inputBuilder, outputBuilder, SourceExtension);
 
                     Exception? ex = null;
                     try
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis
         private IncrementalExecutionContext UpdateOutputs(ImmutableArray<IIncrementalGeneratorOutputNode> outputNodes, IncrementalGeneratorOutputKind outputKind, CancellationToken cancellationToken, DriverStateTable.Builder? driverStateBuilder = null)
         {
             Debug.Assert(outputKind != IncrementalGeneratorOutputKind.None);
-            IncrementalExecutionContext context = new IncrementalExecutionContext(driverStateBuilder, CreateSourcesCollection());
+            IncrementalExecutionContext context = new IncrementalExecutionContext(driverStateBuilder, new AdditionalSourcesCollection(SourceExtension));
             foreach (var outputNode in outputNodes)
             {
                 // if we're looking for this output kind, and it has not been explicitly disabled
@@ -343,7 +343,7 @@ namespace Microsoft.CodeAnalysis
             {
                 IncrementalGeneratorWrapper igw => igw.Generator,
                 IIncrementalGenerator ig => ig,
-                _ => new SourceGeneratorAdaptor(g)
+                _ => new SourceGeneratorAdaptor(g, sourceExtension)
             }));
 
         }
@@ -354,6 +354,6 @@ namespace Microsoft.CodeAnalysis
 
         internal abstract SyntaxTree ParseGeneratedSourceText(GeneratedSourceText input, string fileName, CancellationToken cancellationToken);
 
-        internal abstract AdditionalSourcesCollection CreateSourcesCollection();
+        internal abstract string SourceExtension { get; }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis
             return Path.Combine(type.Assembly.GetName().Name ?? string.Empty, type.FullName!);
         }
 
-        private static (ImmutableArray<ISourceGenerator>, ImmutableArray<IIncrementalGenerator>) GetIncrementalGenerators(ImmutableArray<ISourceGenerator> generators)
+        private static (ImmutableArray<ISourceGenerator>, ImmutableArray<IIncrementalGenerator>) GetIncrementalGenerators(ImmutableArray<ISourceGenerator> generators, string sourceExtension)
         {
             return (generators, generators.SelectAsArray(g => g switch
             {

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -19,11 +19,13 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly ArrayBuilder<ISyntaxInputNode> _syntaxInputBuilder;
         private readonly ArrayBuilder<IIncrementalGeneratorOutputNode> _outputNodes;
+        private readonly string _sourceExtension;
 
-        internal IncrementalGeneratorInitializationContext(ArrayBuilder<ISyntaxInputNode> syntaxInputBuilder, ArrayBuilder<IIncrementalGeneratorOutputNode> outputNodes)
+        internal IncrementalGeneratorInitializationContext(ArrayBuilder<ISyntaxInputNode> syntaxInputBuilder, ArrayBuilder<IIncrementalGeneratorOutputNode> outputNodes, string sourceExtension)
         {
             _syntaxInputBuilder = syntaxInputBuilder;
             _outputNodes = outputNodes;
+            _sourceExtension = sourceExtension;
         }
 
         public SyntaxValueProvider SyntaxProvider => new SyntaxValueProvider(_syntaxInputBuilder, RegisterOutput);
@@ -38,13 +40,13 @@ namespace Microsoft.CodeAnalysis
 
         public IncrementalValueProvider<MetadataReference> MetadataReferencesProvider => new IncrementalValueProvider<MetadataReference>(SharedInputNodes.MetadataReferences.WithRegisterOutput(RegisterOutput));
 
-        public void RegisterSourceOutput<TSource>(IncrementalValueProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Source);
+        public void RegisterSourceOutput<TSource>(IncrementalValueProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Source, _sourceExtension);
 
-        public void RegisterSourceOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Source);
+        public void RegisterSourceOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Source, _sourceExtension);
 
-        public void RegisterImplementationSourceOutput<TSource>(IncrementalValueProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Implementation);
+        public void RegisterImplementationSourceOutput<TSource>(IncrementalValueProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Implementation, _sourceExtension);
 
-        public void RegisterImplementationSourceOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Implementation);
+        public void RegisterImplementationSourceOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Implementation, _sourceExtension);
 
         public void RegisterPostInitializationOutput(Action<IncrementalGeneratorPostInitializationContext> callback) => _outputNodes.Add(new PostInitOutputNode(callback.WrapUserAction()));
 
@@ -56,9 +58,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private static void RegisterSourceOutput<TSource>(IIncrementalGeneratorNode<TSource> node, Action<SourceProductionContext, TSource> action, IncrementalGeneratorOutputKind kind)
+        private static void RegisterSourceOutput<TSource>(IIncrementalGeneratorNode<TSource> node, Action<SourceProductionContext, TSource> action, IncrementalGeneratorOutputKind kind, string sourceExt)
         {
-            node.RegisterOutput(new SourceOutputNode<TSource>(node, action.WrapUserAction(), kind));
+            node.RegisterOutput(new SourceOutputNode<TSource>(node, action.WrapUserAction(), kind, sourceExt));
         }
     }
 
@@ -100,10 +102,10 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public readonly struct SourceProductionContext
     {
-        internal readonly ArrayBuilder<GeneratedSourceText> Sources;
+        internal readonly AdditionalSourcesCollection Sources;
         internal readonly DiagnosticBag Diagnostics;
 
-        internal SourceProductionContext(ArrayBuilder<GeneratedSourceText> sources, DiagnosticBag diagnostics, CancellationToken cancellationToken)
+        internal SourceProductionContext(AdditionalSourcesCollection sources, DiagnosticBag diagnostics, CancellationToken cancellationToken)
         {
             CancellationToken = cancellationToken;
             Sources = sources;
@@ -124,7 +126,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="hintName">An identifier that can be used to reference this source text, must be unique within this generator</param>
         /// <param name="sourceText">The <see cref="SourceText"/> to add to the compilation</param>
-        public void AddSource(string hintName, SourceText sourceText) => Sources.Add(new GeneratedSourceText(hintName, sourceText));
+        public void AddSource(string hintName, SourceText sourceText) => Sources.Add(hintName, sourceText);
 
         /// <summary>
         /// Adds a <see cref="Diagnostic"/> to the users compilation 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -21,13 +21,16 @@ namespace Microsoft.CodeAnalysis
 
         private readonly IncrementalGeneratorOutputKind _outputKind;
 
-        public SourceOutputNode(IIncrementalGeneratorNode<TInput> source, Action<SourceProductionContext, TInput> action, IncrementalGeneratorOutputKind outputKind)
+        private readonly string _sourceExtension;
+
+        public SourceOutputNode(IIncrementalGeneratorNode<TInput> source, Action<SourceProductionContext, TInput> action, IncrementalGeneratorOutputKind outputKind, string sourceExtension)
         {
             _source = source;
             _action = action;
 
             Debug.Assert(outputKind == IncrementalGeneratorOutputKind.Source || outputKind == IncrementalGeneratorOutputKind.Implementation);
             _outputKind = outputKind;
+            _sourceExtension = sourceExtension;
         }
 
         public IncrementalGeneratorOutputKind Kind => _outputKind;
@@ -54,7 +57,7 @@ namespace Microsoft.CodeAnalysis
                     // the diagnostics and sources produced and compare them, to see if they are any different 
                     // than before.
 
-                    var sourcesBuilder = ArrayBuilder<GeneratedSourceText>.GetInstance();
+                    var sourcesBuilder = new AdditionalSourcesCollection(_sourceExtension);
                     var diagnostics = DiagnosticBag.GetInstance();
 
                     SourceProductionContext context = new SourceProductionContext(sourcesBuilder, diagnostics, cancellationToken);

--- a/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicGeneratorDriver.vb
+++ b/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicGeneratorDriver.vb
@@ -44,9 +44,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Create(generators, additionalTexts, parseOptions, analyzerConfigOptionsProvider, driverOptions:=Nothing)
         End Function
 
-        Friend Overrides Function CreateSourcesCollection() As AdditionalSourcesCollection
-            Return New AdditionalSourcesCollection(".vb")
-        End Function
+        Friend Overrides ReadOnly Property SourceExtension As String
+            Get
+                Return ".vb"
+            End Get
+        End Property
 
     End Class
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/54185

In V1 we threw an exception at the point where a duplicate hint name was added. In V2 we were not throwing until we combined all the outputs, meaning a generator had no way of catching and responding to it.

This change restores the immediate exception behavior _within the same output node_. This means V1 generators will function as before, as the emulation layer executes them within a single node. 

V2 generators will have a slightly different behaviour, as we don't know about duplicates until we combine all the outputs (and some may be cached etc). But the author won't see any difference until they have multiple output nodes, so even most ports to V2 should continue to work as written.

