### PR TITLE
Add File.Exists check when renaming a file as part of InlineRename

### DIFF
--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/MutableConflictResolution.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/MutableConflictResolution.cs
@@ -126,6 +126,14 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                     var versionNumber = 1;
                     while (File.Exists(newDocumentFilePath))
                     {
+                        if (newName.Equals(document.Name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // If the document name is the same as the original, we know 
+                            // it can be renamed to that because the old file on disk will
+                            // be removed.
+                            return;
+                        }
+
                         var nameWithoutExtension = ReplacementText + $"_{versionNumber++}";
                         newName = Path.ChangeExtension(nameWithoutExtension, extension);
                         newDocumentFilePath = Path.Combine(directory, newName);


### PR DESCRIPTION
Fixes #53336 

When there's an on disk conflict, append _{number} until a unique file name is found. Tested locally, not sure how to setup a test for items not in a project with our test infrastructure.