### PR TITLE
Freeze semantics for all branches when asked

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Diagnostics;
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis
@@ -11,6 +12,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// solution branch Id
     /// </summary>
+    [DebuggerDisplay("{_id}")]
     internal class BranchId
     {
         private static int s_nextId;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Threading;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -447,13 +447,11 @@ namespace Microsoft.CodeAnalysis
             var solution = this.Project.Solution;
             var workspace = solution.Workspace;
 
-            // only produce doc with frozen semantics if this document is part of the workspace's
-            // primary branch and there is actual background compilation going on, since w/o
+            // only produce doc with frozen semantics if this workspace has support for that, as without
             // background compilation the semantics won't be moving toward completeness.  Also,
             // ensure that the project that this document is part of actually supports compilations,
             // as partial semantics don't make sense otherwise.
-            if (solution.BranchId == workspace.PrimaryBranchId &&
-                workspace.PartialSemanticsEnabled &&
+            if (workspace.PartialSemanticsEnabled &&
                 this.Project.SupportsCompilation)
             {
                 var newSolution = this.Project.Solution.WithFrozenPartialCompilationIncludingSpecificDocument(this.Id, cancellationToken);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTestHelpers.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTestHelpers.cs
@@ -32,6 +32,18 @@ namespace Microsoft.CodeAnalysis.UnitTests
             return workspace;
         }
 
+        public static Workspace CreateWorkspaceWithPartalSemantics(Type[]? additionalParts = null)
+            => new WorkspaceWithPartialSemantics(FeaturesTestCompositions.Features.AddParts(additionalParts).GetHostServices());
+
+        private class WorkspaceWithPartialSemantics : Workspace
+        {
+            public WorkspaceWithPartialSemantics(HostServices hostServices) : base(hostServices, workspaceKind: nameof(WorkspaceWithPartialSemantics))
+            {
+            }
+
+            protected internal override bool PartialSemanticsEnabled => true;
+        }
+
         public static Project AddEmptyProject(Solution solution, string languageName = LanguageNames.CSharp)
         {
             var id = ProjectId.CreateNewId();

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTestHelpers.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTestHelpers.cs
@@ -106,7 +106,5 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 Assert.Throws<ArgumentException>(() => factory(instanceWithNoItem, new TValue[] { item, item }));
             }
         }
-
-#nullable enable
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2567,6 +2567,31 @@ public class C : A {
         }
 
         [Fact]
+        public async Task TestFrozenPartialProjectHasDifferentSemanticVersions()
+        {
+            using var workspace = CreateWorkspaceWithPartalSemantics();
+            var project = workspace.CurrentSolution.AddProject("CSharpProject", "CSharpProject", LanguageNames.CSharp);
+            project = project.AddDocument("Extra.cs", SourceText.From("class Extra { }")).Project;
+
+            var documentToFreeze = project.AddDocument("DocumentToFreeze.cs", SourceText.From(""));
+            var frozenDocument = documentToFreeze.WithFrozenPartialSemantics(CancellationToken.None);
+
+            // Because we had no compilation produced yet, we expect that only the DocumentToFreeze is in the compilation
+            Assert.NotSame(frozenDocument, documentToFreeze);
+            var tree = Assert.Single((await frozenDocument.Project.GetCompilationAsync()).SyntaxTrees);
+            Assert.Equal("DocumentToFreeze.cs", tree.FilePath);
+
+            // Versions should be different
+            Assert.NotEqual(
+                await documentToFreeze.Project.GetDependentSemanticVersionAsync(),
+                await frozenDocument.Project.GetDependentSemanticVersionAsync());
+
+            Assert.NotEqual(
+                await documentToFreeze.Project.GetSemanticVersionAsync(),
+                await frozenDocument.Project.GetSemanticVersionAsync());
+        }
+
+        [Fact]
         public void TestFrozenPartialProjectAlwaysIsIncomplete()
         {
             var workspace = new AdhocWorkspace();

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public async Task PartialCompilationsIncludeGeneratedFilesAfterFullGeneration()
         {
-            using var workspace = CreateWorkspace();
+            using var workspace = CreateWorkspaceWithPartalSemantics();
             var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
             var project = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
@@ -178,6 +178,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(2, fullCompilation.SyntaxTrees.Count());
 
             var partialProject = project.Documents.Single().WithFrozenPartialSemantics(CancellationToken.None).Project;
+            Assert.NotSame(partialProject, project);
             var partialCompilation = await partialProject.GetRequiredCompilationAsync(CancellationToken.None);
 
             Assert.Same(fullCompilation, partialCompilation);
@@ -301,7 +302,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public async Task GetDocumentWithGeneratedTreeForInProgressReturnsGeneratedDocument()
         {
-            using var workspace = CreateWorkspace();
+            using var workspace = CreateWorkspaceWithPartalSemantics();
             var analyzerReference = new TestGeneratorReference(new GenerateFileForEachAdditionalFileWithContentsCommented());
             var project = WithPreviewLanguageVersion(AddEmptyProject(workspace.CurrentSolution))
                 .AddAnalyzerReference(analyzerReference)
@@ -554,6 +555,39 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.False(workspace.IsDocumentOpen(generatedDocumentIdentity.DocumentId));
             Assert.Null(differentOpenTextContainer.CurrentText.GetOpenDocumentInCurrentContextWithChanges());
+        }
+
+        [Theory, CombinatorialData]
+        public async Task FreezingSolutionEnsuresGeneratorsDoNotRun(bool forkBeforeFreeze)
+        {
+            var generatorRan = false;
+            var generator = new CallbackGenerator(onInit: _ => { }, onExecute: _ => { generatorRan = true; });
+
+            using var workspace = CreateWorkspaceWithPartalSemantics();
+            var analyzerReference = new TestGeneratorReference(generator);
+            var project = AddEmptyProject(workspace.CurrentSolution)
+                .AddAnalyzerReference(analyzerReference)
+                .AddDocument("RegularDocument.cs", "// Source File", filePath: "RegularDocument.cs").Project;
+
+            Assert.True(workspace.SetCurrentSolution(_ => project.Solution, WorkspaceChangeKind.SolutionChanged));
+
+            var documentToFreeze = workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+            // The generator shouldn't have ran before any of this since we didn't do anything that would ask for a compilation
+            Assert.False(generatorRan);
+
+            if (forkBeforeFreeze)
+            {
+                // Forking before freezing means we'll have to do extra work to produce the final compilation, but we should still
+                // not be running generators
+                documentToFreeze = documentToFreeze.WithText(SourceText.From("// Changed Source File"));
+            }
+
+            var frozenDocument = documentToFreeze.WithFrozenPartialSemantics(CancellationToken.None);
+            Assert.NotSame(frozenDocument, documentToFreeze);
+            await frozenDocument.GetSemanticModelAsync(CancellationToken.None);
+
+            Assert.False(generatorRan);
         }
     }
 }


### PR DESCRIPTION
We had logic in Document.WithFrozenPartialSemantics which meant we would only freeze semantics if the Soluion in question was the "primary" branch, that is the actual instance from some Workspace.CurrentSolution. This seems terribly unwise: features like completion call GetOpenDocumentInCurrentContextWithChanges when doing things like computing entries or committing; if the text snapshots were out of sync then that would always be forking. In that case Freeze did nothing at all -- it would return the original Solution instance, so asking for semantics would build the full compilation like before. This is even worse with source generators, since we weren't freezing the generator state either and would rerun generators when later asked.

The comment before the code to me isn't really explaining why this behavior is desirable: it's correct that if you have a forked Solution there is no background compiler pulling it forward. But it'll still have the state that was computed when it was forked, which should be enough for anybody opting into partial semantics in the first place.

While writing a test, I also discovered our existing tests around frozen partial semantics and generators weren't actually testing
anything, since the workspace didn't have partial semantics on in the first place. Worse off, they still didn't work unless we also
remove the BranchId check.