### PR TITLE
Move to namespace changes document format

### DIFF
--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -1086,6 +1086,7 @@ namespace [||]Two
 expectedMarkup: @"namespace One
 {
     using Three;
+
     class C1
     {
         private C2 c2;
@@ -1140,8 +1141,8 @@ class MyClass
 expectedMarkup: @$"namespace {{|Warning:A|}}
 {{
     {typeKeyword} MyType
-    {{
-    }}
+{{
+}}
 }}",
 targetNamespace: "A",
 expectedSymbolChanges: new Dictionary<string, string>()


### PR DESCRIPTION
Fixes: #54889

Problem exists in some other features as well, including extract base class, extract interface, etc. Will look into why those errors occur there, but this should fix this for now.