### PR TITLE
Synchronizes calls to Environment.FailFast.  This helps resolve an issue

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -14,7 +14,9 @@ namespace Microsoft.CodeAnalysis
     {
         [DebuggerHidden]
         [DoesNotReturn]
+#if !NETSTANDARD1_3
         [MethodImpl(MethodImplOptions.Synchronized)]
+#endif
         internal static void OnFatalException(Exception exception)
         {
             // EDMAURER Now using the managed API to fail fast so as to default
@@ -41,7 +43,9 @@ namespace Microsoft.CodeAnalysis
 
         [DebuggerHidden]
         [DoesNotReturn]
+#if !NETSTANDARD1_3
         [MethodImpl(MethodImplOptions.Synchronized)]
+#endif
         internal static void Fail(string message)
         {
             DumpStackTrace(message: message);


### PR DESCRIPTION
This helps resolve an issue where Windows Error Reporting (WER) fails to trigger (and therefore
fails to collect dumps) when there are multiple threads triggering Environment.FailFast at the same time.

To validate this locally, I set the WER registry keys to (with the appropriate DumpFolder for my machine).
```
HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps
    DumpType    REG_DWORD    0x2
    DumpFolder    REG_SZ    C:\cores
    DumpCount    REG_DWORD    0x2
```
Without this change, about 50% of the time WER failed to capture a dump.  I hacked together this script for easier running - https://github.com/dibarbet/roslyn/blob/working_helix_dump_logging/run_tests_iter.ps1.  I ran it about 3 times for 30 iterations total, getting dumps 4/10, 6/10 and 4/10 times.

After this change, all 30 iterations successfully collected dumps.

Part of https://github.com/dotnet/roslyn/issues/55639