### PR TITLE
Load solution options through RoslynUserOptionsPackage

### DIFF
--- a/src/VisualStudio/Core/Def/Guids.cs
+++ b/src/VisualStudio/Core/Def/Guids.cs
@@ -105,6 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServices
 
         // Roslyn guids
         public const string RoslynPackageIdString = "6cf2e545-6109-4730-8883-cf43d7aec3e1";
+        public const string RoslynUserOptionsPackageIdString = "2384abd0-aa7f-4fa7-9814-6aa5a4b958c5";
         public const string RoslynCommandSetIdString = "9ed8fbd1-02d6-4223-a99c-a938f97e6dbe";
         public const string RoslynGroupIdString = "b61e1a20-8c13-49a9-a727-a0ec091647dd";
 
@@ -117,6 +118,7 @@ namespace Microsoft.VisualStudio.LanguageServices
         public const string RoslynOptionPageExperimentationIdString = "D5AA7ED7-85E2-42A0-9BF6-22AEF1C1ED8C";
 
         public static readonly Guid RoslynPackageId = new(RoslynPackageIdString);
+        public static readonly Guid RoslynUserOptionsPackageId = new(RoslynUserOptionsPackageIdString);
         public static readonly Guid RoslynCommandSetId = new(RoslynCommandSetIdString);
         public static readonly Guid RoslynGroupId = new(RoslynGroupIdString);
 

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -162,16 +162,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             command.Enabled = true;
 
-            // The command is checked if RoslynPackage is loaded and the analysis scope for this command matches the
-            // value saved for the solution.
-            var roslynPackage = _threadingContext.JoinableTaskFactory.Run(() =>
+            // The command is checked if RoslynUserOptionsPackage is loaded and the analysis scope for this command
+            // matches the value saved for the solution.
+            var roslynUserOptionsPackage = _threadingContext.JoinableTaskFactory.Run(() =>
             {
-                return RoslynPackage.GetOrLoadAsync(_threadingContext, (IAsyncServiceProvider)_serviceProvider, _threadingContext.DisposalToken).AsTask();
+                return RoslynUserOptionsPackage.GetOrLoadAsync(_threadingContext, (IAsyncServiceProvider)_serviceProvider, _threadingContext.DisposalToken).AsTask();
             });
 
-            if (roslynPackage is not null)
+            if (roslynUserOptionsPackage is not null)
             {
-                command.Checked = roslynPackage.AnalysisScope == scope;
+                command.Checked = roslynUserOptionsPackage.AnalysisScope == scope;
             }
 
             // For the specific case of the default analysis scope command, update the command text to show the
@@ -235,14 +235,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 return;
             }
 
-            var roslynPackage = _threadingContext.JoinableTaskFactory.Run(() =>
+            var roslynUserOptionsPackage = _threadingContext.JoinableTaskFactory.Run(() =>
             {
-                return RoslynPackage.GetOrLoadAsync(_threadingContext, (IAsyncServiceProvider)_serviceProvider, _threadingContext.DisposalToken).AsTask();
+                return RoslynUserOptionsPackage.GetOrLoadAsync(_threadingContext, (IAsyncServiceProvider)_serviceProvider, _threadingContext.DisposalToken).AsTask();
             });
 
-            Assumes.Present(roslynPackage);
+            Assumes.Present(roslynUserOptionsPackage);
 
-            roslynPackage.AnalysisScope = scope;
+            roslynUserOptionsPackage.AnalysisScope = scope;
         }
 
         private void OnRunCodeAnalysisForSelectedProjectStatus(object sender, EventArgs e)

--- a/src/VisualStudio/Core/Def/Implementation/Options/PackageSettingsPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/PackageSettingsPersister.cs
@@ -3,74 +3,38 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.LanguageServices.Setup;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 {
     internal sealed class PackageSettingsPersister : IOptionPersister
     {
-        private readonly IThreadingContext _threadingContext;
-        private readonly IAsyncServiceProvider _serviceProvider;
+        private readonly RoslynUserOptionsPackage _roslynUserOptionsPackage;
         private readonly IGlobalOptionService _optionService;
-        private RoslynPackage? _lazyRoslynPackage;
 
         public PackageSettingsPersister(
-            IThreadingContext threadingContext,
-            IAsyncServiceProvider serviceProvider,
+            RoslynUserOptionsPackage roslynUserOptionsPackage,
             IGlobalOptionService optionService)
         {
-            _threadingContext = threadingContext;
-            _serviceProvider = serviceProvider;
+            _roslynUserOptionsPackage = roslynUserOptionsPackage;
             _optionService = optionService;
 
-            // Start the process of loading the Roslyn package and getting options, but don't wait for it to complete.
-            // The setting will be refreshed once available.
-            InitializeAsync(_threadingContext.DisposalToken).ReportNonFatalErrorAsync().Forget();
-        }
-
-        private async Task InitializeAsync(CancellationToken cancellationToken)
-        {
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            _lazyRoslynPackage = await RoslynPackage.GetOrLoadAsync(_threadingContext, _serviceProvider, cancellationToken).ConfigureAwait(true);
-            Assumes.Present(_lazyRoslynPackage);
-
-            _optionService.RefreshOption(new OptionKey(SolutionCrawlerOptions.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
-            _lazyRoslynPackage.AnalysisScopeChanged += OnAnalysisScopeChanged;
+            _roslynUserOptionsPackage.AnalysisScopeChanged += OnAnalysisScopeChanged;
+            _optionService.RefreshOption(new OptionKey(SolutionCrawlerOptions.SolutionBackgroundAnalysisScopeOption), _roslynUserOptionsPackage.AnalysisScope);
         }
 
         private void OnAnalysisScopeChanged(object? sender, EventArgs e)
         {
-            Assumes.Present(_lazyRoslynPackage);
-            _optionService.RefreshOption(new OptionKey(SolutionCrawlerOptions.SolutionBackgroundAnalysisScopeOption), _lazyRoslynPackage.AnalysisScope);
+            _optionService.RefreshOption(new OptionKey(SolutionCrawlerOptions.SolutionBackgroundAnalysisScopeOption), _roslynUserOptionsPackage.AnalysisScope);
         }
 
         public bool TryFetch(OptionKey optionKey, out object? value)
         {
-            // This option is refreshed via the constructor to avoid UI dependencies when retrieving option values. If
-            // we happen to reach this point before the value is available, try to obtain it without blocking, and
-            // otherwise fall back to the default.
-            if (optionKey.Option == SolutionCrawlerOptions.SolutionBackgroundAnalysisScopeOption)
-            {
-                if (_lazyRoslynPackage is not null)
-                {
-                    value = _lazyRoslynPackage.AnalysisScope;
-                    return true;
-                }
-                else
-                {
-                    value = SolutionCrawlerOptions.SolutionBackgroundAnalysisScopeOption.DefaultValue;
-                    return true;
-                }
-            }
+            // This option is refreshed via the constructor to avoid UI dependencies when retrieving option values
+            Contract.ThrowIfTrue(Equals(optionKey.Option, SolutionCrawlerOptions.SolutionBackgroundAnalysisScopeOption));
 
             value = null;
             return false;
@@ -81,11 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             if (!Equals(optionKey.Option, SolutionCrawlerOptions.SolutionBackgroundAnalysisScopeOption))
                 return false;
 
-            if (_lazyRoslynPackage is not null)
-            {
-                _lazyRoslynPackage.AnalysisScope = (BackgroundAnalysisScope?)value;
-            }
-
+            _roslynUserOptionsPackage.AnalysisScope = (BackgroundAnalysisScope?)value;
             return true;
         }
     }

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -31,9 +31,11 @@
   </ItemGroup>
   <PropertyGroup>
     <RoslynPackageGuid>6cf2e545-6109-4730-8883-cf43d7aec3e1</RoslynPackageGuid>
+    <RoslynUserOptionsPackageGuid>2384abd0-aa7f-4fa7-9814-6aa5a4b958c5</RoslynUserOptionsPackageGuid>
   </PropertyGroup>
   <ItemGroup Label="PkgDef">
     <PkgDefPackageRegistration Include="{$(RoslynPackageGuid)}" Name="RoslynPackage" Class="Microsoft.VisualStudio.LanguageServices.Setup.RoslynPackage" AllowsBackgroundLoad="true" />
+    <PkgDefPackageRegistration Include="{$(RoslynUserOptionsPackageGuid)}" Name="RoslynUserOptionsPackage" Class="Microsoft.VisualStudio.LanguageServices.Setup.RoslynUserOptionsPackage" AllowsBackgroundLoad="true" />
     <None Include="PackageRegistration.pkgdef" PkgDefEntry="FileContent" />
     <None Include=".\ColorSchemes\VisualStudio2019.pkgdef" PkgDefEntry="FileContent" />
   </ItemGroup>

--- a/src/VisualStudio/Core/Def/RoslynUserOptionsPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynUserOptionsPackage.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.SolutionCrawler;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.Setup
+{
+    [Guid(Guids.RoslynUserOptionsPackageIdString)]
+    internal sealed class RoslynUserOptionsPackage : AsyncPackage
+    {
+        // The randomly-generated key name is used for serializing the Background Analysis Scope preference to the .SUO
+        // file. It doesn't have any semantic meaning, but is intended to not conflict with any other extension that
+        // might be saving an "AnalysisScope" named stream to the same file.
+        // note: must be <= 31 characters long
+        private const string BackgroundAnalysisScopeOptionKey = "AnalysisScope-DCE33A29A768";
+        private const byte BackgroundAnalysisScopeOptionVersion = 1;
+
+        private static RoslynUserOptionsPackage? _lazyInstance;
+
+        private BackgroundAnalysisScope? _analysisScope;
+
+        public RoslynUserOptionsPackage()
+        {
+            // We need to register an option in order for OnLoadOptions/OnSaveOptions to be called
+            AddOptionKey(BackgroundAnalysisScopeOptionKey);
+        }
+
+        public BackgroundAnalysisScope? AnalysisScope
+        {
+            get
+            {
+                return _analysisScope;
+            }
+
+            set
+            {
+                if (_analysisScope == value)
+                    return;
+
+                _analysisScope = value;
+                AnalysisScopeChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        public event EventHandler? AnalysisScopeChanged;
+
+        internal static async ValueTask<RoslynUserOptionsPackage?> GetOrLoadAsync(IThreadingContext threadingContext, IAsyncServiceProvider serviceProvider, CancellationToken cancellationToken)
+        {
+            if (_lazyInstance is null)
+            {
+                await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+                var shell = (IVsShell7?)await serviceProvider.GetServiceAsync(typeof(SVsShell)).ConfigureAwait(true);
+                Assumes.Present(shell);
+                await shell.LoadPackageAsync(typeof(RoslynUserOptionsPackage).GUID);
+
+                if (ErrorHandler.Succeeded(((IVsShell)shell).IsPackageLoaded(typeof(RoslynUserOptionsPackage).GUID, out var package)))
+                {
+                    _lazyInstance = (RoslynUserOptionsPackage)package;
+                }
+            }
+
+            return _lazyInstance;
+        }
+
+        protected override void OnLoadOptions(string key, Stream stream)
+        {
+            if (key == BackgroundAnalysisScopeOptionKey)
+            {
+                if (stream.ReadByte() == BackgroundAnalysisScopeOptionVersion)
+                {
+                    var hasValue = stream.ReadByte() == 1;
+                    AnalysisScope = hasValue ? (BackgroundAnalysisScope)stream.ReadByte() : null;
+                }
+                else
+                {
+                    AnalysisScope = null;
+                }
+            }
+
+            base.OnLoadOptions(key, stream);
+        }
+
+        protected override void OnSaveOptions(string key, Stream stream)
+        {
+            if (key == BackgroundAnalysisScopeOptionKey)
+            {
+                stream.WriteByte(BackgroundAnalysisScopeOptionVersion);
+                stream.WriteByte(AnalysisScope.HasValue ? (byte)1 : (byte)0);
+                stream.WriteByte((byte)AnalysisScope.GetValueOrDefault());
+            }
+
+            base.OnSaveOptions(key, stream);
+        }
+    }
+}


### PR DESCRIPTION
This change removes the need to load all of `RoslynPackage` as part of initializing the options subsystem.