### PR TITLE
Move compiler test ref assemblies to NuPkg

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,6 +50,8 @@
   -->
   <PropertyGroup>
     <BasicUndoVersion>0.9.3</BasicUndoVersion>
+    <BasicReferenceAssembliesNetStandard20Version>1.2.1</BasicReferenceAssembliesNetStandard20Version>
+    <BasicReferenceAssembliesNet472Version>1.2.1</BasicReferenceAssembliesNet472Version>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <BenchmarkDotNetDiagnosticsWindowsVersion>0.13.0</BenchmarkDotNetDiagnosticsWindowsVersion>
     <DiffPlexVersion>1.4.4</DiffPlexVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,7 +51,7 @@
   <PropertyGroup>
     <BasicUndoVersion>0.9.3</BasicUndoVersion>
     <BasicReferenceAssembliesNetStandard20Version>1.2.1</BasicReferenceAssembliesNetStandard20Version>
-    <BasicReferenceAssembliesNet472Version>1.2.1</BasicReferenceAssembliesNet472Version>
+    <BasicReferenceAssembliesNet50Version>1.2.1</BasicReferenceAssembliesNet50Version>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <BenchmarkDotNetDiagnosticsWindowsVersion>0.13.0</BenchmarkDotNetDiagnosticsWindowsVersion>
     <DiffPlexVersion>1.4.4</DiffPlexVersion>

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -1202,7 +1202,7 @@ namespace System
                    {
                    }
                 }
-            ", targetFramework: TargetFramework.Standard);
+            ", targetFramework: TargetFramework.NetStandard20);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1213,7 +1213,7 @@ namespace System
             int positionInC = someMemberInC.SpanStart;
 
             var namesInC = model.LookupNames(positionInC, namespacesAndTypesOnly: true);
-            Assert.Equal(6, namesInC.Count);  // A, B, C, System, Microsoft
+            Assert.Equal(5, namesInC.Count);  // A, B, C, System, Microsoft
             Assert.Contains("A", namesInC);
             Assert.Contains("B", namesInC);
             Assert.Contains("C", namesInC);
@@ -1222,7 +1222,7 @@ namespace System
 
             var methodM = (MethodDeclarationSyntax)typeDeclC.Members[1];
             var namesInM = model.LookupNames(methodM.Body.SpanStart);
-            Assert.Equal(17, namesInM.Count);
+            Assert.Equal(16, namesInM.Count);
         }
 
         [Fact]
@@ -1238,7 +1238,7 @@ namespace System
                 {
                    public int Y;
                 }
-            ", targetFramework: TargetFramework.Standard);
+            ", targetFramework: TargetFramework.NetStandard20);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1248,7 +1248,7 @@ namespace System
             var someMemberInA = (MemberDeclarationSyntax)typeDeclA.Members[0];
 
             var namesInA = model.LookupNames(someMemberInA.SpanStart);
-            Assert.Equal(14, namesInA.Count);
+            Assert.Equal(13, namesInA.Count);
             Assert.Contains("X", namesInA);
             Assert.Contains("Y", namesInA);
             Assert.Contains("ToString", namesInA);
@@ -1272,7 +1272,7 @@ namespace System
                 {
                    void CM();
                 }
-            ", targetFramework: TargetFramework.Standard);
+            ", targetFramework: TargetFramework.NetStandard20);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1282,7 +1282,7 @@ namespace System
             var someMemberInC = (MemberDeclarationSyntax)typeDeclC.Members[0];
 
             var namesInC = model.LookupNames(someMemberInC.SpanStart);
-            Assert.Equal(14, namesInC.Count); // everything with exception of protected members in System.Object is included, with an uncertain count
+            Assert.Equal(13, namesInC.Count); // everything with exception of protected members in System.Object is included, with an uncertain count
             Assert.Contains("A", namesInC);
             Assert.Contains("B", namesInC);
             Assert.Contains("C", namesInC);
@@ -1372,7 +1372,7 @@ class D<T>
                    void F();
                    void M<T, U, V>(T t, U u, V v);
                 }
-            ", targetFramework: TargetFramework.Standard);
+            ", targetFramework: TargetFramework.NetStandard20);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1384,7 +1384,7 @@ class D<T>
 
             var symbolsInC = model.LookupSymbols(positionInC);
             var test = symbolsInC.Where(s => s.ContainingAssembly == null).ToList();
-            Assert.Equal(10, symbolsInC.Where(s => s.ContainingType == null || s.ContainingType.SpecialType != SpecialType.System_Object).Count());
+            Assert.Equal(9, symbolsInC.Where(s => s.ContainingType == null || s.ContainingType.SpecialType != SpecialType.System_Object).Count());
             Assert.True(symbolsInC.Any(s => s.Name == "A" && s.Kind == SymbolKind.NamedType));
             Assert.True(symbolsInC.Any(s => s.Name == "B" && s.Kind == SymbolKind.NamedType));
             Assert.True(symbolsInC.Any(s => s.Name == "C" && s.Kind == SymbolKind.NamedType));
@@ -1585,7 +1585,7 @@ interface IB<T3, T4>
                    {
                    }
                 }
-            ", targetFramework: TargetFramework.Standard);
+            ", targetFramework: TargetFramework.NetStandard20);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1596,7 +1596,7 @@ interface IB<T3, T4>
 
             // specify (name = null) returns symbols for all names in scope
             var symbols = model.LookupNamespacesAndTypes(someMemberInC.SpanStart);
-            Assert.Equal(6, symbols.Length);  // A, B, C, System, Microsoft
+            Assert.Equal(5, symbols.Length);  // A, B, C, System, Microsoft
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -1213,7 +1213,7 @@ namespace System
             int positionInC = someMemberInC.SpanStart;
 
             var namesInC = model.LookupNames(positionInC, namespacesAndTypesOnly: true);
-            Assert.Equal(5, namesInC.Count);  // A, B, C, System, Microsoft
+            Assert.Equal(6, namesInC.Count);  // A, B, C, System, Microsoft
             Assert.Contains("A", namesInC);
             Assert.Contains("B", namesInC);
             Assert.Contains("C", namesInC);
@@ -1222,7 +1222,7 @@ namespace System
 
             var methodM = (MethodDeclarationSyntax)typeDeclC.Members[1];
             var namesInM = model.LookupNames(methodM.Body.SpanStart);
-            Assert.Equal(16, namesInM.Count);
+            Assert.Equal(17, namesInM.Count);
         }
 
         [Fact]
@@ -1248,7 +1248,7 @@ namespace System
             var someMemberInA = (MemberDeclarationSyntax)typeDeclA.Members[0];
 
             var namesInA = model.LookupNames(someMemberInA.SpanStart);
-            Assert.Equal(13, namesInA.Count);
+            Assert.Equal(14, namesInA.Count);
             Assert.Contains("X", namesInA);
             Assert.Contains("Y", namesInA);
             Assert.Contains("ToString", namesInA);
@@ -1282,7 +1282,7 @@ namespace System
             var someMemberInC = (MemberDeclarationSyntax)typeDeclC.Members[0];
 
             var namesInC = model.LookupNames(someMemberInC.SpanStart);
-            Assert.Equal(13, namesInC.Count); // everything with exception of protected members in System.Object is included, with an uncertain count
+            Assert.Equal(14, namesInC.Count); // everything with exception of protected members in System.Object is included, with an uncertain count
             Assert.Contains("A", namesInC);
             Assert.Contains("B", namesInC);
             Assert.Contains("C", namesInC);
@@ -1384,7 +1384,7 @@ class D<T>
 
             var symbolsInC = model.LookupSymbols(positionInC);
             var test = symbolsInC.Where(s => s.ContainingAssembly == null).ToList();
-            Assert.Equal(9, symbolsInC.Where(s => s.ContainingType == null || s.ContainingType.SpecialType != SpecialType.System_Object).Count());
+            Assert.Equal(10, symbolsInC.Where(s => s.ContainingType == null || s.ContainingType.SpecialType != SpecialType.System_Object).Count());
             Assert.True(symbolsInC.Any(s => s.Name == "A" && s.Kind == SymbolKind.NamedType));
             Assert.True(symbolsInC.Any(s => s.Name == "B" && s.Kind == SymbolKind.NamedType));
             Assert.True(symbolsInC.Any(s => s.Name == "C" && s.Kind == SymbolKind.NamedType));
@@ -1596,7 +1596,7 @@ interface IB<T3, T4>
 
             // specify (name = null) returns symbols for all names in scope
             var symbols = model.LookupNamespacesAndTypes(someMemberInC.SpanStart);
-            Assert.Equal(5, symbols.Length);  // A, B, C, System, Microsoft
+            Assert.Equal(6, symbols.Length);  // A, B, C, System, Microsoft
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -1202,7 +1202,7 @@ namespace System
                    {
                    }
                 }
-            ", targetFramework: TargetFramework.StandardCompat);
+            ", targetFramework: TargetFramework.Standard);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1238,7 +1238,7 @@ namespace System
                 {
                    public int Y;
                 }
-            ", targetFramework: TargetFramework.StandardCompat);
+            ", targetFramework: TargetFramework.Standard);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1272,7 +1272,7 @@ namespace System
                 {
                    void CM();
                 }
-            ", targetFramework: TargetFramework.StandardCompat);
+            ", targetFramework: TargetFramework.Standard);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1372,7 +1372,7 @@ class D<T>
                    void F();
                    void M<T, U, V>(T t, U u, V v);
                 }
-            ", targetFramework: TargetFramework.StandardCompat);
+            ", targetFramework: TargetFramework.Standard);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1585,7 +1585,7 @@ interface IB<T3, T4>
                    {
                    }
                 }
-            ", targetFramework: TargetFramework.StandardCompat);
+            ", targetFramework: TargetFramework.Standard);
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CorLibrary/CorTypes.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -49,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
         [Fact]
         public void PresentCorLib()
         {
-            var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[] { TestMetadata.NetCoreApp.SystemRuntime });
+            var assemblies = MetadataTestHelpers.GetSymbolsForReferences(new[] { NetCoreApp.SystemRuntime });
 
             MetadataOrSourceAssemblySymbol msCorLibRef = (MetadataOrSourceAssemblySymbol)assemblies[0];
 
@@ -75,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.CorLibrary
 
             Assert.False(msCorLibRef.KeepLookingForDeclaredSpecialTypes);
 
-            assemblies = MetadataTestHelpers.GetSymbolsForReferences(mrefs: new[] { MetadataReference.CreateFromImage(TestMetadata.ResourcesNetCoreApp.SystemRuntime.AsImmutableOrNull()) });
+            assemblies = MetadataTestHelpers.GetSymbolsForReferences(mrefs: new[] { MetadataReference.CreateFromImage(Net50.Resources.SystemRuntime) });
 
             msCorLibRef = (MetadataOrSourceAssemblySymbol)assemblies[0];
             Assert.True(msCorLibRef.KeepLookingForDeclaredSpecialTypes);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -44313,7 +44313,7 @@ public interface I1
         public void RuntimeFeature_02()
         {
             var compilation1 = CreateCompilation("", options: TestOptions.DebugDll,
-                                                 references: new[] { TestMetadata.NetCoreApp.SystemRuntime },
+                                                 references: new[] { NetCoreApp.SystemRuntime },
                                                  targetFramework: TargetFramework.Empty);
 
             Assert.True(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
@@ -55886,7 +55886,7 @@ public class C0 : I1
         {
             var windowsRuntimeRef = CompilationExtensions.CreateWindowsRuntimeMetadataReference();
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 BuildAssemblyExternClause(windowsRuntimeRef) +
 @"
 .class public auto ansi sealed Event
@@ -56136,7 +56136,7 @@ class C1 : I1, Interface
         public void ExplicitlyImplementedViaAccessors_01()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -56466,7 +56466,7 @@ class Test4 : C1, I1
         public void ExplicitlyImplementedViaAccessors_02()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -56627,7 +56627,7 @@ class Test4 : C1, I1
         public void ExplicitlyImplementedViaAccessors_03()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -56788,7 +56788,7 @@ class Test4 : C1, I1
         public void ExplicitlyImplementedViaAccessors_04()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -57087,7 +57087,7 @@ class C3 : C2, I1
         public void ExplicitlyImplementedViaAccessors_06()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -57331,7 +57331,7 @@ interface I3 : I2
         public void ExplicitlyImplementedViaAccessors_07()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -57442,7 +57442,7 @@ interface I3 : I2
         public void ExplicitlyImplementedViaAccessors_08()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -57553,7 +57553,7 @@ interface I3 : I2
         public void ExplicitlyImplementedViaAccessors_09()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -57668,7 +57668,7 @@ interface I3 : I2
         public void CheckForImplementationOfCorrespondingPropertyOrEvent_01()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -57743,7 +57743,7 @@ class C2 : C1, I1
         public void CheckForImplementationOfCorrespondingPropertyOrEvent_02()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -57822,7 +57822,7 @@ class C2 : C1, I1
         public void CheckForImplementationOfCorrespondingPropertyOrEvent_03()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {
@@ -57896,7 +57896,7 @@ class C2 : C1, I1
         public void CheckForImplementationOfCorrespondingPropertyOrEvent_04()
         {
             var ilSource =
-BuildAssemblyExternClause(TestMetadata.NetCoreApp.SystemRuntime) +
+BuildAssemblyExternClause(NetCoreApp.SystemRuntime) +
 @"
 .class interface public abstract auto ansi I1
 {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -646,12 +646,12 @@ public class LocalTypes3
         public void LocalTypeSubstitution1_2()
         {
             var LocalTypes1 = CreateCompilation(s_sourceLocalTypes1, options: TestOptions.ReleaseDll, assemblyName: "LocalTypes1",
-                                        targetFramework: TargetFramework.StandardCompat,
+                                        targetFramework: TargetFramework.Standard,
                                         references: new[] { TestReferences.SymbolsTests.NoPia.Pia1.WithEmbedInteropTypes(true) });
             CompileAndVerify(LocalTypes1);
 
             var LocalTypes2 = CreateCompilation(s_sourceLocalTypes2, options: TestOptions.ReleaseDll, assemblyName: "LocalTypes2",
-                                        targetFramework: TargetFramework.StandardCompat,
+                                        targetFramework: TargetFramework.Standard,
                                         references: new[] { TestReferences.SymbolsTests.NoPia.Pia1.WithEmbedInteropTypes(true) });
             CompileAndVerify(LocalTypes2);
 
@@ -946,16 +946,16 @@ public class LocalTypes3
         [ConditionalFact(typeof(ClrOnly), typeof(DesktopOnly))]
         public void LocalTypeSubstitution1_3()
         {
-            var Pia1 = CreateCompilation(s_sourcePia1, options: TestOptions.ReleaseDll, assemblyName: "Pia1", targetFramework: TargetFramework.StandardCompat);
+            var Pia1 = CreateCompilation(s_sourcePia1, options: TestOptions.ReleaseDll, assemblyName: "Pia1", targetFramework: TargetFramework.Standard);
             CompileAndVerify(Pia1);
 
             var LocalTypes1 = CreateCompilation(s_sourceLocalTypes1, options: TestOptions.ReleaseDll, assemblyName: "LocalTypes1",
-                                        targetFramework: TargetFramework.StandardCompat,
+                                        targetFramework: TargetFramework.Standard,
                                         references: new MetadataReference[] { new CSharpCompilationReference(Pia1, embedInteropTypes: true) });
             CompileAndVerify(LocalTypes1);
 
             var LocalTypes2 = CreateCompilation(s_sourceLocalTypes2, options: TestOptions.ReleaseDll, assemblyName: "LocalTypes2",
-                                        targetFramework: TargetFramework.StandardCompat,
+                                        targetFramework: TargetFramework.Standard,
                                         references: new MetadataReference[] { new CSharpCompilationReference(Pia1, embedInteropTypes: true) });
             CompileAndVerify(LocalTypes2);
 

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceAppDomainTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceAppDomainTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Test.Utilities.Desktop;
 using Xunit;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
@@ -89,9 +90,9 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 new SyntaxTree[] { CSharp.SyntaxFactory.ParseSyntaxTree(analyzerSource) },
                 new MetadataReference[]
                 {
-                    TestMetadata.NetStandard20.mscorlib,
-                    TestMetadata.NetStandard20.netstandard,
-                    TestMetadata.NetStandard20.SystemRuntime,
+                    NetStandard20.mscorlib,
+                    NetStandard20.netstandard,
+                    NetStandard20.SystemRuntime,
                     MetadataReference.CreateFromFile(immutable.Path),
                     MetadataReference.CreateFromFile(analyzer.Path)
                 },

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var comp = CSharp.CSharpCompilation.Create(
                 "c",
                 options: new CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, warningLevel: CodeAnalysis.Diagnostic.MaxWarningLevel),
-                references: new[] { TestMetadata.NetCoreApp.SystemRuntime });
+                references: new[] { NetCoreApp.SystemRuntime });
 
             var knownMissingTypes = new HashSet<SpecialType>()
             {

--- a/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
+++ b/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
@@ -344,7 +344,7 @@ namespace Nested
             var args = new List<string>(commandLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
             args.Add("/nostdlib");
             args.Add("/deterministic");
-            foreach (var referenceInfo in TestMetadata.ResourcesNetCoreApp.All)
+            foreach (var referenceInfo in NetCoreApp.AllReferenceInfos)
             {
                 AddReference(referenceInfo.FileName, referenceInfo.ImageBytes);
                 args.Add($"/r:{referenceInfo.FileName}");
@@ -511,7 +511,7 @@ End Namespace
             var args = new List<string>(commandLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
             args.Add("/nostdlib");
             args.Add("/deterministic");
-            foreach (var referenceInfo in TestMetadata.ResourcesNetCoreApp.All)
+            foreach (var referenceInfo in NetCoreApp.AllReferenceInfos)
             {
                 AddReference(referenceInfo.FileName, referenceInfo.ImageBytes);
 

--- a/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
@@ -18,6 +18,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Basic.Reference.Assemblies;
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
@@ -113,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var comp = CSharpCompilation.Create(
                 name,
                 new[] { SyntaxFactory.ParseSyntaxTree(@"class C {}") },
-                references: new MetadataReference[] { MetadataReference.CreateFromImage(TestMetadata.ResourcesNetStandard20.netstandard) },
+                references: new MetadataReference[] { NetStandard20.netstandard },
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, warningLevel: Diagnostic.MaxWarningLevel));
             var compFile = directory.CreateFile(name);
             comp.Emit(compFile.Path);

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -14,6 +14,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Basic.Reference.Assemblies;
 using Castle.Core.Resource;
 using Microsoft.CodeAnalysis.CommandLine;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -112,7 +113,7 @@ End Module")
         {
 #if !NET472
             var filePath = Path.Combine(currentDirectory.Path, "netstandard.dll");
-            File.WriteAllBytes(filePath, TestMetadata.ResourcesNetStandard20.netstandard);
+            File.WriteAllBytes(filePath, NetStandard20.Resources.netstandard);
             arguments.Add("/nostdlib");
             arguments.Add("/r:netstandard.dll");
 #endif

--- a/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
+++ b/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Roslyn.Test.Utilities;
@@ -270,9 +271,9 @@ public class Class1
                 syntaxTrees: new SyntaxTree[] { SyntaxFactory.ParseSyntaxTree(csSource) },
                 references: new MetadataReference[]
                 {
-                    TestMetadata.NetStandard20.mscorlib,
-                    TestMetadata.NetStandard20.netstandard,
-                    TestMetadata.NetStandard20.SystemRuntime
+                    NetStandard20.mscorlib,
+                    NetStandard20.netstandard,
+                    NetStandard20.SystemRuntime
                 }.Concat(additionalReferences),
                 options: s_dllWithMaxWarningLevel);
 

--- a/src/Compilers/Test/Core/Generate.ps1
+++ b/src/Compilers/Test/Core/Generate.ps1
@@ -168,34 +168,6 @@ Add-TargetFramework "Net461" '$(PkgMicrosoft_NETFramework_ReferenceAssemblies_ne
   'Microsoft.VisualBasic.dll'
 )
 
-Add-TargetFramework "NetCoreApp" '$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0' @(
-  'mscorlib.dll',
-  'System.dll',
-  'System.Core.dll',
-  'System.Collections.dll',
-  'System.Console.dll',
-  'System.Linq.dll',
-  'System.Linq.Expressions.dll',
-  'System.Runtime.dll',
-  'System.Runtime.InteropServices.dll',
-  'System.Threading.Tasks.dll',
-  'netstandard.dll',
-  'Microsoft.CSharp.dll',
-  'Microsoft.VisualBasic.dll',
-  'Microsoft.VisualBasic.Core.dll'
-)
-
-Add-TargetFramework "NetStandard20" '$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref' @(
-  'mscorlib.dll',
-  'System.dll',
-  'System.Core.dll',
-  'System.Dynamic.Runtime.dll',
-  'System.Linq.dll',
-  'System.Linq.Expressions.dll',
-  'System.Runtime.dll',
-  'netstandard.dll'
-)
-
 Add-TargetFramework "MicrosoftCSharp" '$(NuGetPackageRoot)\microsoft.csharp\$(MicrosoftCSharpVersion)' @(
   'Netstandard10#ref\netstandard1.0\Microsoft.CSharp.dll'
   'Netstandard13Lib#lib\netstandard1.3\Microsoft.CSharp.dll'

--- a/src/Compilers/Test/Core/Generated.cs
+++ b/src/Compilers/Test/Core/Generated.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -218,112 +218,6 @@ namespace Roslyn.Test.Utilities
             public static PortableExecutableReference SystemThreadingTasks { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet461.SystemThreadingTasks).GetReference(display: "System.Threading.Tasks.dll (net461)", filePath: "System.Threading.Tasks.dll");
             public static PortableExecutableReference MicrosoftCSharp { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet461.MicrosoftCSharp).GetReference(display: "Microsoft.CSharp.dll (net461)", filePath: "Microsoft.CSharp.dll");
             public static PortableExecutableReference MicrosoftVisualBasic { get; } = AssemblyMetadata.CreateFromImage(ResourcesNet461.MicrosoftVisualBasic).GetReference(display: "Microsoft.VisualBasic.dll (net461)", filePath: "Microsoft.VisualBasic.dll");
-        }
-        public static class ResourcesNetCoreApp
-        {
-            private static byte[] _mscorlib;
-            public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "netcoreapp.mscorlib.dll");
-            private static byte[] _System;
-            public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "netcoreapp.System.dll");
-            private static byte[] _SystemCore;
-            public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "netcoreapp.System.Core.dll");
-            private static byte[] _SystemCollections;
-            public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "netcoreapp.System.Collections.dll");
-            private static byte[] _SystemConsole;
-            public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "netcoreapp.System.Console.dll");
-            private static byte[] _SystemLinq;
-            public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netcoreapp.System.Linq.dll");
-            private static byte[] _SystemLinqExpressions;
-            public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netcoreapp.System.Linq.Expressions.dll");
-            private static byte[] _SystemRuntime;
-            public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netcoreapp.System.Runtime.dll");
-            private static byte[] _SystemRuntimeInteropServices;
-            public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netcoreapp.System.Runtime.InteropServices.dll");
-            private static byte[] _SystemThreadingTasks;
-            public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netcoreapp.System.Threading.Tasks.dll");
-            private static byte[] _netstandard;
-            public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "netcoreapp.netstandard.dll");
-            private static byte[] _MicrosoftCSharp;
-            public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "netcoreapp.Microsoft.CSharp.dll");
-            private static byte[] _MicrosoftVisualBasic;
-            public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "netcoreapp.Microsoft.VisualBasic.dll");
-            private static byte[] _MicrosoftVisualBasicCore;
-            public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "netcoreapp.Microsoft.VisualBasic.Core.dll");
-            public static ReferenceInfo[] All => new[]
-            {
-                new ReferenceInfo("mscorlib.dll", mscorlib),
-                new ReferenceInfo("System.dll", System),
-                new ReferenceInfo("System.Core.dll", SystemCore),
-                new ReferenceInfo("System.Collections.dll", SystemCollections),
-                new ReferenceInfo("System.Console.dll", SystemConsole),
-                new ReferenceInfo("System.Linq.dll", SystemLinq),
-                new ReferenceInfo("System.Linq.Expressions.dll", SystemLinqExpressions),
-                new ReferenceInfo("System.Runtime.dll", SystemRuntime),
-                new ReferenceInfo("System.Runtime.InteropServices.dll", SystemRuntimeInteropServices),
-                new ReferenceInfo("System.Threading.Tasks.dll", SystemThreadingTasks),
-                new ReferenceInfo("netstandard.dll", netstandard),
-                new ReferenceInfo("Microsoft.CSharp.dll", MicrosoftCSharp),
-                new ReferenceInfo("Microsoft.VisualBasic.dll", MicrosoftVisualBasic),
-                new ReferenceInfo("Microsoft.VisualBasic.Core.dll", MicrosoftVisualBasicCore),
-            };
-        }
-        public static class NetCoreApp
-        {
-            public static PortableExecutableReference mscorlib { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.mscorlib).GetReference(display: "mscorlib.dll (netcoreapp)", filePath: "mscorlib.dll");
-            public static PortableExecutableReference System { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.System).GetReference(display: "System.dll (netcoreapp)", filePath: "System.dll");
-            public static PortableExecutableReference SystemCore { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemCore).GetReference(display: "System.Core.dll (netcoreapp)", filePath: "System.Core.dll");
-            public static PortableExecutableReference SystemCollections { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemCollections).GetReference(display: "System.Collections.dll (netcoreapp)", filePath: "System.Collections.dll");
-            public static PortableExecutableReference SystemConsole { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemConsole).GetReference(display: "System.Console.dll (netcoreapp)", filePath: "System.Console.dll");
-            public static PortableExecutableReference SystemLinq { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemLinq).GetReference(display: "System.Linq.dll (netcoreapp)", filePath: "System.Linq.dll");
-            public static PortableExecutableReference SystemLinqExpressions { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemLinqExpressions).GetReference(display: "System.Linq.Expressions.dll (netcoreapp)", filePath: "System.Linq.Expressions.dll");
-            public static PortableExecutableReference SystemRuntime { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemRuntime).GetReference(display: "System.Runtime.dll (netcoreapp)", filePath: "System.Runtime.dll");
-            public static PortableExecutableReference SystemRuntimeInteropServices { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemRuntimeInteropServices).GetReference(display: "System.Runtime.InteropServices.dll (netcoreapp)", filePath: "System.Runtime.InteropServices.dll");
-            public static PortableExecutableReference SystemThreadingTasks { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.SystemThreadingTasks).GetReference(display: "System.Threading.Tasks.dll (netcoreapp)", filePath: "System.Threading.Tasks.dll");
-            public static PortableExecutableReference netstandard { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.netstandard).GetReference(display: "netstandard.dll (netcoreapp)", filePath: "netstandard.dll");
-            public static PortableExecutableReference MicrosoftCSharp { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.MicrosoftCSharp).GetReference(display: "Microsoft.CSharp.dll (netcoreapp)", filePath: "Microsoft.CSharp.dll");
-            public static PortableExecutableReference MicrosoftVisualBasic { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.MicrosoftVisualBasic).GetReference(display: "Microsoft.VisualBasic.dll (netcoreapp)", filePath: "Microsoft.VisualBasic.dll");
-            public static PortableExecutableReference MicrosoftVisualBasicCore { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetCoreApp.MicrosoftVisualBasicCore).GetReference(display: "Microsoft.VisualBasic.Core.dll (netcoreapp)", filePath: "Microsoft.VisualBasic.Core.dll");
-        }
-        public static class ResourcesNetStandard20
-        {
-            private static byte[] _mscorlib;
-            public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "netstandard20.mscorlib.dll");
-            private static byte[] _System;
-            public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "netstandard20.System.dll");
-            private static byte[] _SystemCore;
-            public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "netstandard20.System.Core.dll");
-            private static byte[] _SystemDynamicRuntime;
-            public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "netstandard20.System.Dynamic.Runtime.dll");
-            private static byte[] _SystemLinq;
-            public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netstandard20.System.Linq.dll");
-            private static byte[] _SystemLinqExpressions;
-            public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netstandard20.System.Linq.Expressions.dll");
-            private static byte[] _SystemRuntime;
-            public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netstandard20.System.Runtime.dll");
-            private static byte[] _netstandard;
-            public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "netstandard20.netstandard.dll");
-            public static ReferenceInfo[] All => new[]
-            {
-                new ReferenceInfo("mscorlib.dll", mscorlib),
-                new ReferenceInfo("System.dll", System),
-                new ReferenceInfo("System.Core.dll", SystemCore),
-                new ReferenceInfo("System.Dynamic.Runtime.dll", SystemDynamicRuntime),
-                new ReferenceInfo("System.Linq.dll", SystemLinq),
-                new ReferenceInfo("System.Linq.Expressions.dll", SystemLinqExpressions),
-                new ReferenceInfo("System.Runtime.dll", SystemRuntime),
-                new ReferenceInfo("netstandard.dll", netstandard),
-            };
-        }
-        public static class NetStandard20
-        {
-            public static PortableExecutableReference mscorlib { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetStandard20.mscorlib).GetReference(display: "mscorlib.dll (netstandard20)", filePath: "mscorlib.dll");
-            public static PortableExecutableReference System { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetStandard20.System).GetReference(display: "System.dll (netstandard20)", filePath: "System.dll");
-            public static PortableExecutableReference SystemCore { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetStandard20.SystemCore).GetReference(display: "System.Core.dll (netstandard20)", filePath: "System.Core.dll");
-            public static PortableExecutableReference SystemDynamicRuntime { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetStandard20.SystemDynamicRuntime).GetReference(display: "System.Dynamic.Runtime.dll (netstandard20)", filePath: "System.Dynamic.Runtime.dll");
-            public static PortableExecutableReference SystemLinq { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetStandard20.SystemLinq).GetReference(display: "System.Linq.dll (netstandard20)", filePath: "System.Linq.dll");
-            public static PortableExecutableReference SystemLinqExpressions { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetStandard20.SystemLinqExpressions).GetReference(display: "System.Linq.Expressions.dll (netstandard20)", filePath: "System.Linq.Expressions.dll");
-            public static PortableExecutableReference SystemRuntime { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetStandard20.SystemRuntime).GetReference(display: "System.Runtime.dll (netstandard20)", filePath: "System.Runtime.dll");
-            public static PortableExecutableReference netstandard { get; } = AssemblyMetadata.CreateFromImage(ResourcesNetStandard20.netstandard).GetReference(display: "netstandard.dll (netstandard20)", filePath: "netstandard.dll");
         }
         public static class ResourcesMicrosoftCSharp
         {

--- a/src/Compilers/Test/Core/Generated.targets
+++ b/src/Compilers/Test/Core/Generated.targets
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
     <ItemGroup>
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net20)\build\.NETFramework\v2.0\mscorlib.dll">
           <LogicalName>net20.mscorlib.dll</LogicalName>
@@ -151,94 +151,6 @@
         <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net461)\build\.NETFramework\v4.6.1\Microsoft.VisualBasic.dll">
           <LogicalName>net461.Microsoft.VisualBasic.dll</LogicalName>
           <Link>Resources\ReferenceAssemblies\net461\Microsoft.VisualBasic.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\mscorlib.dll">
-          <LogicalName>netcoreapp.mscorlib.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\mscorlib.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.dll">
-          <LogicalName>netcoreapp.System.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Core.dll">
-          <LogicalName>netcoreapp.System.Core.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.Core.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Collections.dll">
-          <LogicalName>netcoreapp.System.Collections.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.Collections.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Console.dll">
-          <LogicalName>netcoreapp.System.Console.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.Console.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Linq.dll">
-          <LogicalName>netcoreapp.System.Linq.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.Linq.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Linq.Expressions.dll">
-          <LogicalName>netcoreapp.System.Linq.Expressions.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.Linq.Expressions.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Runtime.dll">
-          <LogicalName>netcoreapp.System.Runtime.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.Runtime.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Runtime.InteropServices.dll">
-          <LogicalName>netcoreapp.System.Runtime.InteropServices.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.Runtime.InteropServices.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\System.Threading.Tasks.dll">
-          <LogicalName>netcoreapp.System.Threading.Tasks.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\System.Threading.Tasks.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\netstandard.dll">
-          <LogicalName>netcoreapp.netstandard.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\netstandard.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\Microsoft.CSharp.dll">
-          <LogicalName>netcoreapp.Microsoft.CSharp.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\Microsoft.CSharp.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\Microsoft.VisualBasic.dll">
-          <LogicalName>netcoreapp.Microsoft.VisualBasic.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\Microsoft.VisualBasic.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(PkgMicrosoft_NETCore_App_Ref)\ref\net5.0\Microsoft.VisualBasic.Core.dll">
-          <LogicalName>netcoreapp.Microsoft.VisualBasic.Core.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netcoreapp\Microsoft.VisualBasic.Core.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\mscorlib.dll">
-          <LogicalName>netstandard20.mscorlib.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netstandard20\mscorlib.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.dll">
-          <LogicalName>netstandard20.System.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netstandard20\System.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Core.dll">
-          <LogicalName>netstandard20.System.Core.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netstandard20\System.Core.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Dynamic.Runtime.dll">
-          <LogicalName>netstandard20.System.Dynamic.Runtime.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netstandard20\System.Dynamic.Runtime.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.dll">
-          <LogicalName>netstandard20.System.Linq.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netstandard20\System.Linq.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Expressions.dll">
-          <LogicalName>netstandard20.System.Linq.Expressions.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netstandard20\System.Linq.Expressions.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.dll">
-          <LogicalName>netstandard20.System.Runtime.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netstandard20\System.Runtime.dll</Link>
-        </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\netstandard.dll">
-          <LogicalName>netstandard20.netstandard.dll</LogicalName>
-          <Link>Resources\ReferenceAssemblies\netstandard20\netstandard.dll</Link>
         </EmbeddedResource>
         <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.csharp\$(MicrosoftCSharpVersion)\ref\netstandard1.0\Microsoft.CSharp.dll">
           <LogicalName>netstandard10.microsoftcsharp.Microsoft.CSharp.dll</LogicalName>

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -102,7 +102,7 @@
     <PackageReference Include="Microsoft.VisualBasic" Version="$(MicrosoftVisualBasicVersion)" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
 
     <PackageReference Include="Basic.Reference.Assemblies.NetStandard20" Version="$(BasicReferenceAssembliesNetStandard20Version)" />
-    <PackageReference Include="Basic.Reference.Assemblies.Net50" Version="$(BasicReferenceAssembliesNetStandard20Version)" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net50" Version="$(BasicReferenceAssembliesNet50Version)" />
   </ItemGroup>
 
   <Import Project="Generated.targets" />

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -96,11 +96,13 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="$(MicrosoftNETFrameworkReferenceAssembliesnet40Version)" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net20" Version="$(MicrosoftNETFrameworkReferenceAssembliesnet20Version)" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Build.Extensions" Version="$(MicrosoftNETBuildExtensionsVersion)" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.NETCore.App.Ref" Version="$(MicrosoftNETCoreAppRefVersion)" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="$(jnm2ReferenceAssembliesnet35Version)" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.VisualBasic" Version="$(MicrosoftVisualBasicVersion)" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
+
+    <PackageReference Include="Basic.Reference.Assemblies.NetStandard20" Version="$(BasicReferenceAssembliesNetStandard20Version)" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net50" Version="$(BasicReferenceAssembliesNetStandard20Version)" />
   </ItemGroup>
 
   <Import Project="Generated.targets" />

--- a/src/Compilers/Test/Core/Platform/Desktop/TestHelpers.cs
+++ b/src/Compilers/Test/Core/Platform/Desktop/TestHelpers.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.Win32;
+using Basic.Reference.Assemblies;
 
 namespace Roslyn.Test.Utilities
 {
@@ -81,9 +82,9 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 new SyntaxTree[] { SyntaxFactory.ParseSyntaxTree(analyzerSource) },
                 new MetadataReference[]
                 {
-                    TestMetadata.NetStandard20.mscorlib,
-                    TestMetadata.NetStandard20.netstandard,
-                    TestMetadata.NetStandard20.SystemRuntime,
+                    NetStandard20.mscorlib,
+                    NetStandard20.netstandard,
+                    NetStandard20.SystemRuntime,
                     MetadataReference.CreateFromFile(immutable.Path),
                     MetadataReference.CreateFromFile(analyzer.Path)
                 },

--- a/src/Compilers/Test/Core/TargetFrameworkUtil.cs
+++ b/src/Compilers/Test/Core/TargetFrameworkUtil.cs
@@ -80,7 +80,7 @@ namespace Roslyn.Test.Utilities
     /// <summary>
     /// This type holds the reference information for the latest .NET Core platform. Tests
     /// targeting .NET core specifically should use the references here. As the platform moves
-    /// forward these will be moved to target the latset .NET Core supported by the compiler
+    /// forward these will be moved to target the latest .NET Core supported by the compiler
     /// </summary>
     public static class NetCoreApp
     {
@@ -101,18 +101,18 @@ namespace Roslyn.Test.Utilities
             Net50.SystemThreadingTasks,
             Net50.SystemCollections);
 
-        public static PortableExecutableReference netstandard = Net50.netstandard;
-        public static PortableExecutableReference mscorlib = Net50.mscorlib;
-        public static PortableExecutableReference SystemRuntime = Net50.SystemRuntime;
-        public static PortableExecutableReference SystemCore = Net50.SystemCore;
-        public static PortableExecutableReference SystemConsole = Net50.SystemConsole;
-        public static PortableExecutableReference SystemLinq = Net50.SystemLinq;
-        public static PortableExecutableReference SystemLinqExpressions = Net50.SystemLinqExpressions;
-        public static PortableExecutableReference SystemThreadingTasks = Net50.SystemThreadingTasks;
-        public static PortableExecutableReference SystemCollections = Net50.SystemCollections;
-        public static PortableExecutableReference SystemRuntimeInteropServices = Net50.SystemRuntimeInteropServices;
-        public static PortableExecutableReference MicrosoftCSharp = Net50.MicrosoftCSharp;
-        public static PortableExecutableReference MicrosoftVisualBasic = Net50.MicrosoftVisualBasic;
+        public static PortableExecutableReference netstandard { get; } = Net50.netstandard;
+        public static PortableExecutableReference mscorlib { get; } = Net50.mscorlib;
+        public static PortableExecutableReference SystemRuntime { get; } = Net50.SystemRuntime;
+        public static PortableExecutableReference SystemCore { get; } = Net50.SystemCore;
+        public static PortableExecutableReference SystemConsole { get; } = Net50.SystemConsole;
+        public static PortableExecutableReference SystemLinq { get; } = Net50.SystemLinq;
+        public static PortableExecutableReference SystemLinqExpressions { get; } = Net50.SystemLinqExpressions;
+        public static PortableExecutableReference SystemThreadingTasks { get; } = Net50.SystemThreadingTasks;
+        public static PortableExecutableReference SystemCollections { get; } = Net50.SystemCollections;
+        public static PortableExecutableReference SystemRuntimeInteropServices { get; } = Net50.SystemRuntimeInteropServices;
+        public static PortableExecutableReference MicrosoftCSharp { get; } = Net50.MicrosoftCSharp;
+        public static PortableExecutableReference MicrosoftVisualBasic { get; } = Net50.MicrosoftVisualBasic;
     }
 
     /// <summary>
@@ -129,13 +129,13 @@ namespace Roslyn.Test.Utilities
             NetFx.ValueTuple.tuplelib,
             Net461.SystemRuntime);
 
-        public static PortableExecutableReference mscorlib = Net461.mscorlib;
-        public static PortableExecutableReference System = Net461.System;
-        public static PortableExecutableReference SystemRuntime = Net461.SystemRuntime;
-        public static PortableExecutableReference SystemCore = Net461.SystemCore;
-        public static PortableExecutableReference SystemThreadingTasks = Net461.SystemThreadingTasks;
-        public static PortableExecutableReference MicrosoftCSharp = Net461.MicrosoftCSharp;
-        public static PortableExecutableReference MicrosoftVisualBasic = Net461.MicrosoftVisualBasic;
+        public static PortableExecutableReference mscorlib { get; } = Net461.mscorlib;
+        public static PortableExecutableReference System { get; } = Net461.System;
+        public static PortableExecutableReference SystemRuntime { get; } = Net461.SystemRuntime;
+        public static PortableExecutableReference SystemCore { get; } = Net461.SystemCore;
+        public static PortableExecutableReference SystemThreadingTasks { get; } = Net461.SystemThreadingTasks;
+        public static PortableExecutableReference MicrosoftCSharp { get; } = Net461.MicrosoftCSharp;
+        public static PortableExecutableReference MicrosoftVisualBasic { get; } = Net461.MicrosoftVisualBasic;
     }
 
     public static class TargetFrameworkUtil

--- a/src/Compilers/Test/Core/TargetFrameworkUtil.cs
+++ b/src/Compilers/Test/Core/TargetFrameworkUtil.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using static TestReferences;
 using static Roslyn.Test.Utilities.TestMetadata;
+using Basic.Reference.Assemblies;
 
 namespace Roslyn.Test.Utilities
 {
@@ -21,29 +22,34 @@ namespace Roslyn.Test.Utilities
         /// </summary>
         Empty,
 
+        // These are the preferred values that we should be targeting 
         NetStandard20,
         NetCoreApp,
-        NetCoreAppAndCSharp,
-        WinRT,
-
-        /// <summary>
-        /// Eventually this will be deleted and replaced with NetStandard20. Short term this creates the "standard"
-        /// API set across desktop and coreclr 
-        /// </summary>
-        Standard,
+        NetFramework,
         StandardLatest,
+
+        // Eventually these will be deleted and replaced with NetStandard20. Short term this creates the "standard"
+        // API set across desktop and coreclr. It's also helpful because there are no null annotations hence error
+        // messages have consistent signatures across .NET Core / Framework tests.
+        Standard,
         StandardAndCSharp,
         StandardAndVBRuntime,
-
-        /// <summary>
-        /// This is represents the set of tests which must be mscorlib40 on desktop but full net standard on coreclr.
-        /// </summary>
-        StandardCompat,
 
         /// <summary>
         /// Compat framework for the default set of references many vb compilations get.
         /// </summary>
         DefaultVb,
+
+        /// <summary>
+        /// This will eventually be folded into NetCoreApp. The default experience for compiling .NET Core code 
+        /// includes the Microsoft.CSharp reference hence it should be the default for our tests
+        /// </summary>
+        NetCoreAppAndCSharp,
+
+        /// <summary>
+        /// Used for building tests against WinRT scenarios
+        /// </summary>
+        WinRT,
 
         // The flavors of mscorlib we support + extending them with LINQ and dynamic.
         Mscorlib40,
@@ -71,9 +77,75 @@ namespace Roslyn.Test.Utilities
         MinimalAsync,
     }
 
+    /// <summary>
+    /// This type holds the reference information for the latest .NET Core platform. Tests
+    /// targeting .NET core specifically should use the references here. As the platform moves
+    /// forward these will be moved to target the latset .NET Core supported by the compiler
+    /// </summary>
+    public static class NetCoreApp
+    {
+        public static ImmutableArray<Net50.ReferenceInfo> AllReferenceInfos { get; } = ImmutableArray.CreateRange(Net50.References.All);
+        public static ImmutableArray<MetadataReference> References { get; } = ImmutableArray.CreateRange<MetadataReference>(Net50.All);
+
+        /// <summary>
+        /// A subset of <see cref="References"/> that can compile 99% of our test code.
+        /// </summary>
+        public static ImmutableArray<MetadataReference> StandardReferences { get; } = ImmutableArray.Create<MetadataReference>(
+            Net50.netstandard,
+            Net50.mscorlib,
+            Net50.SystemRuntime,
+            Net50.SystemCore,
+            Net50.SystemConsole,
+            Net50.SystemLinq,
+            Net50.SystemLinqExpressions,
+            Net50.SystemThreadingTasks,
+            Net50.SystemCollections);
+
+        public static PortableExecutableReference netstandard = Net50.netstandard;
+        public static PortableExecutableReference mscorlib = Net50.mscorlib;
+        public static PortableExecutableReference SystemRuntime = Net50.SystemRuntime;
+        public static PortableExecutableReference SystemCore = Net50.SystemCore;
+        public static PortableExecutableReference SystemConsole = Net50.SystemConsole;
+        public static PortableExecutableReference SystemLinq = Net50.SystemLinq;
+        public static PortableExecutableReference SystemLinqExpressions = Net50.SystemLinqExpressions;
+        public static PortableExecutableReference SystemThreadingTasks = Net50.SystemThreadingTasks;
+        public static PortableExecutableReference SystemCollections = Net50.SystemCollections;
+        public static PortableExecutableReference SystemRuntimeInteropServices = Net50.SystemRuntimeInteropServices;
+        public static PortableExecutableReference MicrosoftCSharp = Net50.MicrosoftCSharp;
+        public static PortableExecutableReference MicrosoftVisualBasic = Net50.MicrosoftVisualBasic;
+    }
+
+    /// <summary>
+    /// This type holds the reference information for the latest .NET Framework. These should be
+    /// used by tests that are specific to .NET Framework. This moves forward much more rarely but
+    /// when it does move forward these will change
+    /// </summary>
+    public static class NetFramework
+    {
+        public static ImmutableArray<MetadataReference> StandardReferences => ImmutableArray.Create<MetadataReference>(
+            Net461.mscorlib,
+            Net461.System,
+            Net461.SystemCore,
+            NetFx.ValueTuple.tuplelib,
+            Net461.SystemRuntime);
+
+        public static PortableExecutableReference mscorlib = Net461.mscorlib;
+        public static PortableExecutableReference System = Net461.System;
+        public static PortableExecutableReference SystemRuntime = Net461.SystemRuntime;
+        public static PortableExecutableReference SystemCore = Net461.SystemCore;
+        public static PortableExecutableReference SystemThreadingTasks = Net461.SystemThreadingTasks;
+        public static PortableExecutableReference MicrosoftCSharp = Net461.MicrosoftCSharp;
+        public static PortableExecutableReference MicrosoftVisualBasic = Net461.MicrosoftVisualBasic;
+    }
+
     public static class TargetFrameworkUtil
     {
-        public static MetadataReference StandardCSharpReference => RuntimeUtilities.IsCoreClrRuntime ? MicrosoftCSharp.Netstandard13Lib : Net451.MicrosoftCSharp;
+        public static ImmutableArray<MetadataReference> StandardLatestReferences => RuntimeUtilities.IsCoreClrRuntime ? NetCoreApp.StandardReferences : NetFramework.StandardReferences;
+        public static ImmutableArray<MetadataReference> StandardReferences => RuntimeUtilities.IsCoreClrRuntime ? NetStandard20References : NetFramework.StandardReferences;
+        public static MetadataReference StandardCSharpReference => RuntimeUtilities.IsCoreClrRuntime ? MicrosoftCSharp.Netstandard13Lib : NetFramework.MicrosoftCSharp;
+        public static MetadataReference StandardVisualBasicReference => RuntimeUtilities.IsCoreClrRuntime ? MicrosoftVisualBasic.Netstandard11 : NetFramework.MicrosoftVisualBasic;
+        public static ImmutableArray<MetadataReference> StandardAndCSharpReferences => StandardReferences.Add(StandardCSharpReference);
+        public static ImmutableArray<MetadataReference> StandardAndVBRuntimeReferences => StandardReferences.Add(StandardVisualBasicReference);
 
         /*
          * ⚠ Dev note ⚠: properties in TestBase are backed by Lazy<T>. Avoid changes to the following properties
@@ -95,23 +167,21 @@ namespace Roslyn.Test.Utilities
         public static ImmutableArray<MetadataReference> Mscorlib461References => ImmutableArray.Create<MetadataReference>(Net461.mscorlib);
         public static ImmutableArray<MetadataReference> Mscorlib461ExtendedReferences => ImmutableArray.Create<MetadataReference>(Net461.mscorlib, Net461.System, Net461.SystemCore, NetFx.ValueTuple.tuplelib, Net461.SystemRuntime);
         public static ImmutableArray<MetadataReference> NetStandard20References => ImmutableArray.Create<MetadataReference>(NetStandard20.netstandard, NetStandard20.mscorlib, NetStandard20.SystemRuntime, NetStandard20.SystemCore, NetStandard20.SystemDynamicRuntime, NetStandard20.SystemLinq, NetStandard20.SystemLinqExpressions);
-        public static ImmutableArray<MetadataReference> NetCoreAppReferences => ImmutableArray.Create<MetadataReference>(NetCoreApp.netstandard, NetCoreApp.mscorlib, NetCoreApp.SystemRuntime, NetCoreApp.SystemCore,
-                                                                                                                           NetCoreApp.SystemConsole, NetCoreApp.SystemLinq, NetCoreApp.SystemLinqExpressions, NetCoreApp.SystemThreadingTasks,
-                                                                                                                           NetCoreApp.SystemCollections);
-        public static ImmutableArray<MetadataReference> NetCoreAppReferencesAndCSharp => NetCoreAppReferences.Add(NetCoreApp.MicrosoftCSharp);
         public static ImmutableArray<MetadataReference> WinRTReferences => ImmutableArray.Create(TestBase.WinRtRefs);
-        public static ImmutableArray<MetadataReference> StandardReferences => RuntimeUtilities.IsCoreClrRuntime ? NetStandard20References : Mscorlib46ExtendedReferences;
-        public static ImmutableArray<MetadataReference> StandardLatestReferences => RuntimeUtilities.IsCoreClrRuntime ? NetCoreAppReferences : Mscorlib46ExtendedReferences;
-        public static ImmutableArray<MetadataReference> StandardAndCSharpReferences => StandardReferences.Add(StandardCSharpReference);
-        public static ImmutableArray<MetadataReference> StandardAndVBRuntimeReferences => RuntimeUtilities.IsCoreClrRuntime ? NetStandard20References.Add(MicrosoftVisualBasic.Netstandard11) : Mscorlib46ExtendedReferences.Add(Net461.MicrosoftVisualBasic);
-        public static ImmutableArray<MetadataReference> StandardCompatReferences => RuntimeUtilities.IsCoreClrRuntime ? NetStandard20References : Mscorlib40References;
         public static ImmutableArray<MetadataReference> DefaultVbReferences => ImmutableArray.Create<MetadataReference>(Net451.mscorlib, Net451.System, Net451.SystemCore, Net451.MicrosoftVisualBasic);
         public static ImmutableArray<MetadataReference> MinimalReferences => ImmutableArray.Create(TestBase.MinCorlibRef);
         public static ImmutableArray<MetadataReference> MinimalAsyncReferences => ImmutableArray.Create(TestBase.MinAsyncCorlibRef);
 
         public static ImmutableArray<MetadataReference> GetReferences(TargetFramework targetFramework) => targetFramework switch
         {
+            // Primary
             TargetFramework.Empty => ImmutableArray<MetadataReference>.Empty,
+            TargetFramework.NetStandard20 => NetStandard20References,
+            TargetFramework.NetCoreApp => NetCoreApp.StandardReferences,
+            TargetFramework.NetCoreAppAndCSharp => NetCoreApp.StandardReferences.Add(NetCoreApp.MicrosoftCSharp),
+            TargetFramework.NetFramework => NetFramework.StandardReferences,
+
+            // Legacy we should be phasing out
             TargetFramework.Mscorlib40 => Mscorlib40References,
             TargetFramework.Mscorlib40Extended => Mscorlib40ExtendedReferences,
             TargetFramework.Mscorlib40AndSystemCore => Mscorlib40andSystemCoreReferences,
@@ -124,18 +194,14 @@ namespace Roslyn.Test.Utilities
             TargetFramework.Mscorlib46Extended => Mscorlib46ExtendedReferences,
             TargetFramework.Mscorlib461 => Mscorlib46References,
             TargetFramework.Mscorlib461Extended => Mscorlib461ExtendedReferences,
-            TargetFramework.NetStandard20 => NetStandard20References,
-            TargetFramework.NetCoreApp => NetCoreAppReferences,
-            TargetFramework.NetCoreAppAndCSharp => NetCoreAppReferencesAndCSharp,
             TargetFramework.WinRT => WinRTReferences,
             TargetFramework.Standard => StandardReferences,
-            TargetFramework.StandardLatest => StandardLatestReferences,
             TargetFramework.StandardAndCSharp => StandardAndCSharpReferences,
             TargetFramework.StandardAndVBRuntime => StandardAndVBRuntimeReferences,
-            TargetFramework.StandardCompat => StandardCompatReferences,
             TargetFramework.DefaultVb => DefaultVbReferences,
             TargetFramework.Minimal => MinimalReferences,
             TargetFramework.MinimalAsync => MinimalAsyncReferences,
+            TargetFramework.StandardLatest => StandardLatestReferences,
             _ => throw new InvalidOperationException($"Unexpected target framework {targetFramework}"),
         };
 

--- a/src/Compilers/Test/Core/TestBase.cs
+++ b/src/Compilers/Test/Core/TestBase.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using static TestReferences.NetFx;
 using static Roslyn.Test.Utilities.TestMetadata;
 using Microsoft.CodeAnalysis.Test.Resources.Proprietary;
+using Basic.Reference.Assemblies;
 
 namespace Roslyn.Test.Utilities
 {
@@ -238,7 +239,7 @@ namespace Roslyn.Test.Utilities
         public static MetadataReference CSharpDesktopRef => s_desktopCSharpRef.Value;
 
         private static readonly Lazy<MetadataReference> s_std20Ref = new Lazy<MetadataReference>(
-            () => AssemblyMetadata.CreateFromImage(ResourcesNetStandard20.netstandard).GetReference(display: "netstandard20.netstandard.dll"),
+            () => AssemblyMetadata.CreateFromImage(NetStandard20.Resources.netstandard).GetReference(display: "netstandard20.netstandard.dll"),
             LazyThreadSafetyMode.PublicationOnly);
 
         public static MetadataReference NetStandard20Ref => s_std20Ref.Value;

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AttributeTests_UnmanagedCallersOnly.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AttributeTests_UnmanagedCallersOnly.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
         Private ReadOnly _parseOptions As CSharp.CSharpParseOptions = CSharp.CSharpParseOptions.Default.WithLanguageVersion(CSharp.LanguageVersion.Default)
         Private ReadOnly _csharpCompOptions As CSharp.CSharpCompilationOptions = New CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe:=True)
-        Private ReadOnly _csharpReferences As ImmutableArray(Of MetadataReference) = TargetFrameworkUtil.NetCoreAppReferences.Add(NetCoreApp.SystemRuntimeInteropServices)
+        Private ReadOnly _csharpReferences As ImmutableArray(Of MetadataReference) = TargetFrameworkUtil.GetReferences(TargetFramework.NetCoreApp).Add(NetCoreApp.SystemRuntimeInteropServices)
 
         Private ReadOnly UnmanagedCallersOnlyAttributeIl As String = <![CDATA[
 .class public auto ansi sealed beforefieldinit System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports Basic.Reference.Assemblies
 Imports CompilationCreationTestHelpers
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Roslyn.Test.Utilities
@@ -53,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
 
             Assert.False(msCorLibRef.KeepLookingForDeclaredSpecialTypes)
 
-            assemblies = MetadataTestHelpers.GetSymbolsForReferences({NetCoreApp.SystemRuntime})
+            assemblies = MetadataTestHelpers.GetSymbolsForReferences({MetadataReference.CreateFromImage(Net50.Resources.SystemRuntime)})
             msCorLibRef = DirectCast(assemblies(0), MetadataOrSourceAssemblySymbol)
             Assert.True(msCorLibRef.KeepLookingForDeclaredSpecialTypes)
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CorLibrary/CorTypes.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
 
         <Fact()>
         Public Sub PresentCorLib()
-            Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences({TestMetadata.NetCoreApp.SystemRuntime})
+            Dim assemblies = MetadataTestHelpers.GetSymbolsForReferences({NetCoreApp.SystemRuntime})
             Dim msCorLibRef As MetadataOrSourceAssemblySymbol = DirectCast(assemblies(0), MetadataOrSourceAssemblySymbol)
 
             Dim knownMissingTypes As HashSet(Of Integer) = New HashSet(Of Integer)
@@ -53,7 +53,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Symbols.CorLibrary
 
             Assert.False(msCorLibRef.KeepLookingForDeclaredSpecialTypes)
 
-            assemblies = MetadataTestHelpers.GetSymbolsForReferences({MetadataReference.CreateFromImage(TestMetadata.ResourcesNetCoreApp.SystemRuntime)})
+            assemblies = MetadataTestHelpers.GetSymbolsForReferences({NetCoreApp.SystemRuntime})
             msCorLibRef = DirectCast(assemblies(0), MetadataOrSourceAssemblySymbol)
             Assert.True(msCorLibRef.KeepLookingForDeclaredSpecialTypes)
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -1061,7 +1061,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 ((bool?)netcore30).HasValue &&
                 ((bool?)netcore30).Value)
             {
-                references = TargetFrameworkUtil.NetCoreAppReferences.ToList();
+                references = NetCoreApp.StandardReferences.ToList();
             }
 
             var netstandard20 = element.Attribute(CommonReferencesNetStandard20Name);


### PR DESCRIPTION
The compiler and ide tests depend on in memory reference assemblies for constructing `Compilation` objects. These in memory reference assemblies are not offered by the platform and hence we were just generating them as a part of our build. That had a number of limitations though:

1. The reference assemblies for .NET Core are tied to the version of `Microsoft.NETCore.App.Ref.nupkg`. That is not a side effect free NuPkg. Referencing it has other impacts to the build. Particularly it is very difficult for us to build referencing multiple versions of that package hence we can't easily have tests that rely on a mix of `net5.0` and `net6.0`. That is very important for the compiler team though when working on cross cutting features.
2. The build infra puts all of the ref assemblies into a single project that is then referenced by every single test project we have. That means every test project carries a copy of the ref assemblies whether or not we use them. There is no realistic way to have a project reference only a subset of the ref assemblies. While the negative impact of build output size is often over stated this is one case where it has caused us real problems in the past (caused us to go over the 10gig limit for azure machines a few times). 

This change begins the process of moving us from generating the ref assemblies in our build to just referencing them as NuPkg from https://github.com/jaredpar/basic-reference-assemblies. The code for generating those assemblies is effectively what we had in our repo. I just cleaned it up a bit and changed it to generate assemblies per TFM so that it was easier to consume them on a "need" basis. Also because that build is much more disconnected it's easy to generate every TFM simultaneously and let us reference `net5.0` and `net6.0` at the same time.

