### PR TITLE
[LSP] Semantic tokens: Utilize frozen partial compilations

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokens.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokens.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Runtime.Serialization;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
+{
+    internal class RoslynSemanticTokens : LSP.SemanticTokens
+    {
+        /// <summary>
+        /// True if the token set may be incomplete.
+        /// </summary>
+        /// <remarks>
+        /// Certain clients such as Razor need to know whether we're returning partial results.
+        /// This may occur if the full compilation is not yet available.
+        /// </remarks>
+        [DataMember(Name = "isPartial")]
+        public bool IsPartial { get; set; }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokens.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokens.cs
@@ -12,13 +12,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
     internal sealed class RoslynSemanticTokens : LSP.SemanticTokens
     {
         /// <summary>
-        /// True if the token set may be incomplete.
+        /// True if the token set is complete, meaning it's generated using a full semantic
+        /// model rather than a frozen one.
         /// </summary>
         /// <remarks>
-        /// Certain clients such as Razor need to know whether we're returning partial results.
-        /// This may occur if the full compilation is not yet available.
+        /// Certain clients such as Razor need to know whether we're returning partial
+        /// (i.e. possibly inaccurate) results. This may occur if the full compilation
+        /// is not yet available.
         /// </remarks>
-        [DataMember(Name = "isPartial")]
-        public bool IsPartial { get; set; }
+        [DataMember(Name = "isFinalized")]
+        public bool IsFinalized { get; set; }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokens.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokens.cs
@@ -9,7 +9,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 {
-    internal class RoslynSemanticTokens : LSP.SemanticTokens
+    internal sealed class RoslynSemanticTokens : LSP.SemanticTokens
     {
         /// <summary>
         /// True if the token set may be incomplete.

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokensDelta.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokensDelta.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+using System.Runtime.Serialization;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
+{
+    internal sealed class RoslynSemanticTokensDelta : LSP.SemanticTokensDelta
+    {
+        /// <summary>
+        /// True if the token set may be incomplete.
+        /// </summary>
+        /// <remarks>
+        /// Certain clients such as Razor need to know whether we're returning partial results.
+        /// This may occur if the full compilation is not yet available.
+        /// </remarks>
+        [DataMember(Name = "isPartial")]
+        public bool IsPartial { get; set; }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokensDelta.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/RoslynSemanticTokensDelta.cs
@@ -10,13 +10,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
     internal sealed class RoslynSemanticTokensDelta : LSP.SemanticTokensDelta
     {
         /// <summary>
-        /// True if the token set may be incomplete.
+        /// True if the token set is complete, meaning it's generated using a full semantic
+        /// model rather than a frozen one.
         /// </summary>
         /// <remarks>
-        /// Certain clients such as Razor need to know whether we're returning partial results.
-        /// This may occur if the full compilation is not yet available.
+        /// Certain clients such as Razor need to know whether we're returning partial
+        /// (i.e. possibly inaccurate) results. This may occur if the full compilation
+        /// is not yet available.
         /// </remarks>
-        [DataMember(Name = "isPartial")]
-        public bool IsPartial { get; set; }
+        [DataMember(Name = "isFinalized")]
+        public bool IsFinalized { get; set; }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -17,7 +17,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 {
     /// <summary>
-    /// Computes the semantic tokens edits for a file. An edit request is received every 500ms,
+    /// Computes the semantic tokens edits for a file. An edit request is received every 2s,
     /// or every time an edit is made by the user.
     /// </summary>
     internal class SemanticTokensEditsHandler : IRequestHandler<LSP.SemanticTokensDeltaParams, SumType<LSP.SemanticTokens, LSP.SemanticTokensDelta>>
@@ -66,9 +66,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 var newResultId = _tokensCache.GetNextResultId();
                 var updatedTokens = new RoslynSemanticTokens
                 {
-                    IsPartial = isPartial,
                     ResultId = newResultId,
-                    Data = newSemanticTokensData
+                    Data = newSemanticTokensData,
+                    IsPartial = isPartial,
                 };
 
                 if (newSemanticTokensData.Length > 0)
@@ -97,8 +97,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
             var edits = new RoslynSemanticTokensDelta
             {
-                Edits = editArray,
                 ResultId = resultId,
+                Edits = editArray,
                 IsPartial = isPartial
             };
 

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -17,7 +17,7 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 {
     /// <summary>
-    /// Computes the semantic tokens edits for a file. An edit request is received every 2s,
+    /// Computes the semantic tokens edits for a file. Clients may make edit requests on a timer,
     /// or every time an edit is made by the user.
     /// </summary>
     internal class SemanticTokensEditsHandler : IRequestHandler<LSP.SemanticTokensDeltaParams, SumType<LSP.SemanticTokens, LSP.SemanticTokensDelta>>
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
             // Even though we want to ultimately pass edits back to LSP, we still need to compute all semantic tokens,
             // both for caching purposes and in order to have a baseline comparison when computing the edits.
-            var (newSemanticTokensData, isPartial) = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
+            var (newSemanticTokensData, isFinalized) = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
                 context.Document, SemanticTokensCache.TokenTypeToIndex,
                 range: null, cancellationToken).ConfigureAwait(false);
 
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 {
                     ResultId = newResultId,
                     Data = newSemanticTokensData,
-                    IsPartial = isPartial,
+                    IsFinalized = isFinalized,
                 };
 
                 if (newSemanticTokensData.Length > 0)
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             {
                 ResultId = resultId,
                 Edits = editArray,
-                IsPartial = isPartial
+                IsFinalized = isFinalized
             };
 
             return edits;

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensEditsHandler.cs
@@ -89,7 +89,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 resultId = _tokensCache.GetNextResultId();
                 if (newSemanticTokensData.Length > 0)
                 {
-                    var updatedTokens = new LSP.SemanticTokens { ResultId = resultId, Data = newSemanticTokensData };
+                    var updatedTokens = new RoslynSemanticTokens
+                    {
+                        ResultId = resultId,
+                        Data = newSemanticTokensData,
+                        IsFinalized = isFinalized
+                    };
+
                     await _tokensCache.UpdateCacheAsync(
                         request.TextDocument.Uri, updatedTokens, cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
@@ -49,12 +49,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             Contract.ThrowIfNull(context.Document, "Document is null.");
 
             var resultId = _tokensCache.GetNextResultId();
-            var tokensData = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
+            var (tokensData, isPartial) = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
                 context.Document, SemanticTokensCache.TokenTypeToIndex,
                 range: null, cancellationToken).ConfigureAwait(false);
 
-            var tokens = new LSP.SemanticTokens { ResultId = resultId, Data = tokensData };
-            await _tokensCache.UpdateCacheAsync(request.TextDocument.Uri, tokens, cancellationToken).ConfigureAwait(false);
+            var tokens = new RoslynSemanticTokens { IsPartial = isPartial, ResultId = resultId, Data = tokensData };
+            if (tokensData.Length > 0)
+            {
+                await _tokensCache.UpdateCacheAsync(request.TextDocument.Uri, tokens, cancellationToken).ConfigureAwait(false);
+            }
+
             return tokens;
         }
     }

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 context.Document, SemanticTokensCache.TokenTypeToIndex,
                 range: null, cancellationToken).ConfigureAwait(false);
 
-            var tokens = new RoslynSemanticTokens { IsPartial = isPartial, ResultId = resultId, Data = tokensData };
+            var tokens = new RoslynSemanticTokens { ResultId = resultId, Data = tokensData, IsPartial = isPartial, };
             if (tokensData.Length > 0)
             {
                 await _tokensCache.UpdateCacheAsync(request.TextDocument.Uri, tokens, cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 context.Document, SemanticTokensCache.TokenTypeToIndex,
                 range: null, cancellationToken).ConfigureAwait(false);
 
-            var tokens = new RoslynSemanticTokens { ResultId = resultId, Data = tokensData, IsPartial = isPartial, };
+            var tokens = new RoslynSemanticTokens { ResultId = resultId, Data = tokensData, IsPartial = isPartial };
             if (tokensData.Length > 0)
             {
                 await _tokensCache.UpdateCacheAsync(request.TextDocument.Uri, tokens, cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHandler.cs
@@ -49,11 +49,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             Contract.ThrowIfNull(context.Document, "Document is null.");
 
             var resultId = _tokensCache.GetNextResultId();
-            var (tokensData, isPartial) = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
+            var (tokensData, isFinalized) = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
                 context.Document, SemanticTokensCache.TokenTypeToIndex,
                 range: null, cancellationToken).ConfigureAwait(false);
 
-            var tokens = new RoslynSemanticTokens { ResultId = resultId, Data = tokensData, IsPartial = isPartial };
+            var tokens = new RoslynSemanticTokens { ResultId = resultId, Data = tokensData, IsFinalized = isFinalized };
             if (tokensData.Length > 0)
             {
                 await _tokensCache.UpdateCacheAsync(request.TextDocument.Uri, tokens, cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
         /// <summary>
         /// Returns the semantic tokens data for a given document with an optional range.
         /// </summary>
-        internal static async Task<(int[], bool isPartial)> ComputeSemanticTokensDataAsync(
+        internal static async Task<(int[], bool isFinalized)> ComputeSemanticTokensDataAsync(
             Document document,
             Dictionary<string, int> tokenTypesToIndex,
             LSP.Range? range,
@@ -119,11 +119,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             // can pass in a range if they wish.
             var textSpan = range is null ? root.FullSpan : ProtocolConversions.RangeToTextSpan(range, text);
 
-            // If the full compilation is not yet available, we'll try getting a partial one.
-            var frozenDocument = document.WithFrozenPartialSemantics(cancellationToken);
-            var semanticModel = await frozenDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            // If the full compilation is not yet available, we'll try getting a partial one. It may contain inaccurate
+            // results but will speed up how quickly we can respond to the client's request.
+            document = document.WithFrozenPartialSemantics(cancellationToken);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             Contract.ThrowIfNull(semanticModel);
-            var isPartial = !(document.Project.TryGetCompilation(out var compilation) && compilation == semanticModel.Compilation);
+            var isFinalized = document.Project.TryGetCompilation(out var compilation) && compilation == semanticModel.Compilation;
 
             var classifiedSpans = Classifier.GetClassifiedSpans(semanticModel, textSpan, document.Project.Solution.Workspace, cancellationToken);
             Contract.ThrowIfNull(classifiedSpans, "classifiedSpans is null");
@@ -134,7 +135,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
             // TO-DO: We should implement support for streaming if LSP adds support for it:
             // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1276300
-            return (ComputeTokens(text.Lines, updatedClassifiedSpans, tokenTypesToIndex), isPartial);
+            return (ComputeTokens(text.Lines, updatedClassifiedSpans, tokenTypesToIndex), isFinalized);
         }
 
         private static ClassifiedSpan[] ConvertMultiLineToSingleLineSpans(SourceText text, ClassifiedSpan[] classifiedSpans)

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             var updatedClassifiedSpans = ConvertMultiLineToSingleLineSpans(text, classifiedSpans.ToArray());
 
             // TO-DO: We should implement support for streaming if LSP adds support for it:
-            // https://devdiv.visualstaaudio.com/DevDiv/_workitems/edit/1276300
+            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1276300
             return (ComputeTokens(text.Lines, updatedClassifiedSpans, tokenTypesToIndex), isPartial);
         }
 

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -121,10 +121,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
             // If the full compilation is not yet available, we'll try getting a partial one. It may contain inaccurate
             // results but will speed up how quickly we can respond to the client's request.
-            document = document.WithFrozenPartialSemantics(cancellationToken);
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var frozenDocument = document.WithFrozenPartialSemantics(cancellationToken);
+            var semanticModel = await frozenDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             Contract.ThrowIfNull(semanticModel);
             var isFinalized = document.Project.TryGetCompilation(out var compilation) && compilation == semanticModel.Compilation;
+            document = frozenDocument;
 
             var classifiedSpans = Classifier.GetClassifiedSpans(semanticModel, textSpan, document.Project.Solution.Workspace, cancellationToken);
             Contract.ThrowIfNull(classifiedSpans, "classifiedSpans is null");

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -118,6 +118,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             // can pass in a range if they wish.
             var textSpan = range == null ? root.FullSpan : ProtocolConversions.RangeToTextSpan(range, text);
 
+            document = document.WithFrozenPartialSemantics(cancellationToken);
             var classifiedSpans = await Classifier.GetClassifiedSpansAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
             Contract.ThrowIfNull(classifiedSpans, "classifiedSpans is null");
 
@@ -126,7 +127,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             var updatedClassifiedSpans = ConvertMultiLineToSingleLineSpans(text, classifiedSpans.ToArray());
 
             // TO-DO: We should implement support for streaming if LSP adds support for it:
-            // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1276300
+            // https://devdiv.visualstaaudio.com/DevDiv/_workitems/edit/1276300
             return ComputeTokens(text.Lines, updatedClassifiedSpans, tokenTypesToIndex);
         }
 

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
@@ -52,11 +52,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             // partial token results. In addition, a range request is only ever called with a whole
             // document request, so caching range results is unnecessary since the whole document
             // handler will cache the results anyway.
-            var (tokensData, isPartial) = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
+            var (tokensData, isFinalized) = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
                 context.Document, SemanticTokensCache.TokenTypeToIndex,
                 request.Range, cancellationToken).ConfigureAwait(false);
 
-            return new RoslynSemanticTokens { ResultId = resultId, Data = tokensData, IsPartial = isPartial };
+            return new RoslynSemanticTokens { ResultId = resultId, Data = tokensData, IsFinalized = isFinalized };
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
@@ -52,10 +52,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             // partial token results. In addition, a range request is only ever called with a whole
             // document request, so caching range results is unnecessary since the whole document
             // handler will cache the results anyway.
-            var tokensData = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
+            var (tokensData, isPartial) = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
                 context.Document, SemanticTokensCache.TokenTypeToIndex,
                 request.Range, cancellationToken).ConfigureAwait(false);
-            return new LSP.SemanticTokens { ResultId = resultId, Data = tokensData };
+
+            return new RoslynSemanticTokens { IsPartial = isPartial, ResultId = resultId, Data = tokensData };
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 context.Document, SemanticTokensCache.TokenTypeToIndex,
                 request.Range, cancellationToken).ConfigureAwait(false);
 
-            return new RoslynSemanticTokens { IsPartial = isPartial, ResultId = resultId, Data = tokensData };
+            return new RoslynSemanticTokens { ResultId = resultId, Data = tokensData, IsPartial = isPartial };
         }
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensTests.cs
@@ -80,6 +80,7 @@ static class C { }
             await VerifyNoMultiLineTokens(testLspServer, rangeResults.Data!).ConfigureAwait(false);
             Assert.Equal(expectedRangeResults.Data, rangeResults.Data);
             Assert.Equal(expectedRangeResults.ResultId, rangeResults.ResultId);
+            Assert.True(rangeResults is RoslynSemanticTokens);
 
             // 2. Whole document handler
             var wholeDocResults = await RunGetSemanticTokensAsync(testLspServer, caretLocation);
@@ -101,6 +102,7 @@ static class C { }
             await VerifyNoMultiLineTokens(testLspServer, wholeDocResults.Data!).ConfigureAwait(false);
             Assert.Equal(expectedWholeDocResults.Data, wholeDocResults.Data);
             Assert.Equal(expectedWholeDocResults.ResultId, wholeDocResults.ResultId);
+            Assert.True(wholeDocResults is RoslynSemanticTokens);
 
             // 3. Edits handler - insert newline at beginning of file
             var newMarkup = @"
@@ -115,10 +117,12 @@ static class C { }
 
             Assert.Equal(expectedEdit, ((LSP.SemanticTokensDelta)editResults).Edits.First());
             Assert.Equal("3", ((LSP.SemanticTokensDelta)editResults).ResultId);
+            Assert.True((LSP.SemanticTokensDelta)editResults is RoslynSemanticTokensDelta);
 
             // 4. Edits handler - no changes (ResultId should remain same)
             var editResultsNoChange = await RunGetSemanticTokensEditsAsync(testLspServer, caretLocation, previousResultId: "3");
             Assert.Equal("3", ((LSP.SemanticTokensDelta)editResultsNoChange).ResultId);
+            Assert.True((LSP.SemanticTokensDelta)editResultsNoChange is RoslynSemanticTokensDelta);
 
             // 5. Re-request whole document handler (may happen if LSP runs into an error)
             var wholeDocResults2 = await RunGetSemanticTokensAsync(testLspServer, caretLocation);
@@ -140,6 +144,7 @@ static class C { }
             await VerifyNoMultiLineTokens(testLspServer, wholeDocResults2.Data!).ConfigureAwait(false);
             Assert.Equal(expectedWholeDocResults2.Data, wholeDocResults2.Data);
             Assert.Equal(expectedWholeDocResults2.ResultId, wholeDocResults2.ResultId);
+            Assert.True(wholeDocResults2 is RoslynSemanticTokens);
         }
 
         [Fact]


### PR DESCRIPTION
Allows Roslyn's LSP semantic token handlers to utilize frozen compilations to compute tokens. The switch to using frozen compilations is fairly straightforward, however Razor needs to know if we're returning partial tokens or not so they know whether to keep asking us for tokens. To accomplish this, we return a `IsFinalized` property along with our results that Razor can deserialize.

Also modified the handlers' logic to not cache 0-length tokens as it is unnecessary.

Likely should be dual-inserted with the Razor-side PR: https://github.com/dotnet/aspnetcore-tooling/pull/4156