### PR TITLE
Handle XamlDefinition with line and column

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSourceDefinition.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Definitions/XamlSourceDefinition.cs
@@ -2,56 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Definitions
 {
     /// <summary>
     /// XamlDefinition with file path and TextSpan or line and column.
+    /// When XamlSourceDefinition was created, the creator may have had a textSpan or line/column.
+    /// We should either use Span or Line Column.
     /// </summary>
     internal sealed class XamlSourceDefinition : XamlDefinition
     {
-        private readonly TextSpan? _span;
-        private readonly int _line, _column;
-
         public XamlSourceDefinition(string filePath, TextSpan span)
         {
             FilePath = filePath;
-            _span = span;
+            Span = span;
         }
 
         public XamlSourceDefinition(string filePath, int line, int column)
         {
             FilePath = filePath;
-            _line = line;
-            _column = column;
+            Line = line;
+            Column = column;
         }
 
         public string FilePath { get; }
 
-        /// <summary>
-        /// When XamlSourceDefinition was created, the creator may have had a textSpan or line/column.
-        /// We should either use _span or _line _column. This property will tell you which one to use.
-        /// </summary>
-        private bool CanUseSpan => _span != null;
+        public int Line { get; }
+        public int Column { get; }
 
-        public TextSpan? GetTextSpan(SourceText text)
-        {
-            if (CanUseSpan)
-            {
-                return _span;
-            }
-
-            // Convert the line column to TextSpan
-            if (_line < text.Lines.Count)
-            {
-                var column = Math.Min(_column, text.Lines[_line].Span.Length);
-                var start = text.Lines.GetPosition(new LinePosition(_line, column));
-                return new TextSpan(start, 0);
-            }
-
-            return null;
-        }
+        public TextSpan? Span { get; }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlCapabilities.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlCapabilities.cs
@@ -27,8 +27,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             FoldingRangeProvider = new FoldingRangeOptions { },
             DocumentFormattingProvider = true,
             DocumentRangeFormattingProvider = true,
-            DocumentOnTypeFormattingProvider = new DocumentOnTypeFormattingOptions { FirstTriggerCharacter = ">", MoreTriggerCharacter = new string[] { "\n" } },
-            OnAutoInsertProvider = new VSInternalDocumentOnAutoInsertOptions { TriggerCharacters = new[] { "=", "/", ">" } },
+            DocumentOnTypeFormattingProvider = new DocumentOnTypeFormattingOptions { FirstTriggerCharacter = ">" },
+            OnAutoInsertProvider = new VSInternalDocumentOnAutoInsertOptions { TriggerCharacters = new[] { "=", "/" } },
             TextDocumentSync = new TextDocumentSyncOptions
             {
                 Change = TextDocumentSyncKind.None,

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Definitions/GoToDefinitionHandler.cs
@@ -108,38 +108,42 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
         {
             Contract.ThrowIfNull(sourceDefinition.FilePath);
 
-            var document = context.Solution?.GetDocuments(ProtocolConversions.GetUriFromFilePath(sourceDefinition.FilePath)).FirstOrDefault();
-            if (document != null)
+            if (sourceDefinition.Span != null)
             {
-                var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                var span = sourceDefinition.GetTextSpan(sourceText);
-                if (span != null)
+                // If the Span is not null, use the span.
+                var document = context.Solution?.GetDocuments(ProtocolConversions.GetUriFromFilePath(sourceDefinition.FilePath)).FirstOrDefault();
+                if (document != null)
                 {
                     return await ProtocolConversions.TextSpanToLocationAsync(
                                                 document,
-                                                span.Value,
+                                                sourceDefinition.Span.Value,
                                                 isStale: false,
                                                 cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    // Cannot find the file in solution. This is probably a file lives outside of the solution like generic.xaml
+                    // which lives in the Windows SDK folder. Try getting the SourceText from the file path.
+                    using var fileStream = new FileStream(sourceDefinition.FilePath, FileMode.Open, FileAccess.Read);
+                    var sourceText = SourceText.From(fileStream);
+                    return new LSP.Location
+                    {
+                        Uri = new Uri(sourceDefinition.FilePath),
+                        Range = ProtocolConversions.TextSpanToRange(sourceDefinition.Span.Value, sourceText)
+                    };
                 }
             }
             else
             {
-                // Cannot find the file in solution. This is probably a file lives outside of the solution like generic.xaml
-                // which lives in the Windows SDK folder. Try getting the SourceText from the file path.
-                using var fileStream = new FileStream(sourceDefinition.FilePath, FileMode.Open, FileAccess.Read);
-                var sourceText = SourceText.From(fileStream);
-                var span = sourceDefinition.GetTextSpan(sourceText);
-                if (span != null)
-                {
-                    return new LSP.Location
-                    {
-                        Uri = new Uri(sourceDefinition.FilePath),
-                        Range = ProtocolConversions.TextSpanToRange(span.Value, sourceText),
-                    };
-                }
-            }
+                // We should have the line and column, so use them to build the LSP Range.
+                var position = new Position(sourceDefinition.Line, sourceDefinition.Column);
 
-            return null;
+                return new LSP.Location
+                {
+                    Uri = new Uri(sourceDefinition.FilePath),
+                    Range = new LSP.Range() { Start = position, End = position }
+                };
+            }
         }
 
         private static async Task<LSP.Location[]> GetSymbolDefinitionLocationsAsync(XamlSymbolDefinition symbolDefinition, RequestContext context, IMetadataAsSourceFileService metadataAsSourceFileService, CancellationToken cancellationToken)


### PR DESCRIPTION
When XAML GoToDefinitionHandler gets a XamlSourceDefinition, if the line and column values are available, we will use those values to build up the LSP location directly instead of converting them to text span first. This will help our go to definition on event handler scenarios work correctly and also save some exact work.

I also sneaked in a couple XamlCapabilities changes as well:
- Removed "\n" trigger character for OnTypeFormatting as we handle OnEnter formatting in smart indent.
- Removed ">" trigger character for AutoInsert as we are going to let ">" trigger OnTypeFormatting and Auto-insert end tag over there.