### PR TITLE
Utilise `PooledObjects.ArrayList(Of T)' in Features\LanguageServices

### DIFF
--- a/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicAnonymousTypeDisplayService.vb
+++ b/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicAnonymousTypeDisplayService.vb
@@ -62,9 +62,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
         End Function
 
         Private Shared Function MassageDelegateParts(delegateInvoke As IMethodSymbol,
-                                              parts As IEnumerable(Of SymbolDisplayPart)) As IEnumerable(Of SymbolDisplayPart)
+                                              parts As IEnumerable(Of SymbolDisplayPart)) As ImmutableArray(Of SymbolDisplayPart)
             ' So ugly.  We remove the 'Invoke' name that was added by the symbol display service.
-            Dim result = New List(Of SymbolDisplayPart)
+            Dim result = ArrayBuilder(Of SymbolDisplayPart).GetInstance()
             For Each part In parts
                 If Equals(part.Symbol, delegateInvoke) Then
                     Continue For
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
                 result.RemoveAt(1)
             End If
 
-            Return result
+            Return result.ToImmutableAndFree()
         End Function
 
         Private Shared Function GetNormalAnonymousType(

--- a/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.SymbolDescriptionBuilder.vb
+++ b/src/Features/VisualBasic/Portable/LanguageServices/VisualBasicSymbolDisplayService.SymbolDescriptionBuilder.vb
@@ -105,8 +105,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
                 Return Nothing
             End Function
 
-            Private Async Function GetDeclarationsAsync(Of T As SyntaxNode)(symbol As ISymbol) As Task(Of List(Of T))
-                Dim list = New List(Of T)()
+            Private Async Function GetDeclarationsAsync(Of T As SyntaxNode)(symbol As ISymbol) As Task(Of ImmutableArray(Of T))
+                Dim list = PooledObjects.ArrayBuilder(Of T).GetInstance()
                 For Each syntaxRef In symbol.DeclaringSyntaxReferences
                     Dim syntax = Await syntaxRef.GetSyntaxAsync(Me.CancellationToken).ConfigureAwait(False)
                     Dim casted = TryCast(syntax, T)
@@ -115,7 +115,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LanguageServices
                     End If
                 Next
 
-                Return list
+                Return list.ToImmutableAndFree
             End Function
 
             Private Overloads Async Function GetInitializerSourcePartsAsync(symbol As IParameterSymbol) As Task(Of ImmutableArray(Of SymbolDisplayPart))


### PR DESCRIPTION
, rather that creating a new `List(Of T)`  each time.