### PR TITLE
Report and catch error on renaming

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
@@ -9,6 +9,9 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
+using Microsoft.CodeAnalysis.Notification;
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Extensions;
 
 #if !COCOA
 using System.Linq;
@@ -83,6 +86,38 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             catch (ArgumentOutOfRangeException)
             {
                 return null;
+            }
+        }
+
+        protected override void Commit(InlineRenameSession activeSession, ITextView textView)
+        {
+            try
+            {
+                base.Commit(activeSession, textView);
+            }
+            catch (NotSupportedException ex)
+            {
+                // Session.Commit can throw if it can't commit
+                // rename operation.
+                // handle that case gracefully
+                var notificationService = activeSession.Workspace.Services.GetService<INotificationService>();
+                notificationService?.SendNotification(ex.Message, title: EditorFeaturesResources.Rename, severity: NotificationSeverity.Error);
+            }
+            catch (Exception ex) when (FatalError.ReportAndCatch(ex))
+            {
+                // Show a nice error to the user via an info bar
+                var errorReportingService = activeSession.Workspace.Services.GetService<IErrorReportingService>();
+                if (errorReportingService is null)
+                {
+                    return;
+                }
+
+                errorReportingService.ShowGlobalErrorInfo(
+                    string.Format(EditorFeaturesWpfResources.Error_performing_rename_0, ex.Message),
+                    new InfoBarUI(
+                        WorkspacesResources.Show_Stack_Trace,
+                        InfoBarUI.UIKind.HyperLink,
+                        () => errorReportingService.ShowDetailedErrorInfo(ex), closeAfterAction: true));
             }
         }
 #else

--- a/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/AbstractRenameCommandHandler_ReturnHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/CommandHandlers/AbstractRenameCommandHandler_ReturnHandler.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
@@ -20,12 +22,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // InlineRenameSession will call IUIThreadOperationExecutor to sets up our own IUIThreadOperationContext
                 context.OperationContext.TakeOwnership();
 
-                _renameService.ActiveSession.Commit();
-                SetFocusToTextView(args.TextView);
+                Commit(_renameService.ActiveSession, args.TextView);
                 return true;
             }
 
             return false;
+        }
+
+        protected virtual void Commit(InlineRenameSession activeSession, ITextView textView)
+        {
+            activeSession.Commit();
+            SetFocusToTextView(textView);
         }
     }
 }


### PR DESCRIPTION
Fix #54918

I copied the code from `Dashboard.xaml.cs`. 

https://github.com/dotnet/roslyn/blob/315c2e149ba7889b0937d872274c33fcbfe9af5f/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs#L330,L361