### PR TITLE
Move Static Members: remove theming

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialog.xaml
@@ -8,7 +8,6 @@
     xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging" 
     xmlns:movestaticmembers="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembers" 
     d:DataContext="{d:DesignInstance Type=movestaticmembers:MoveStaticMembersDialogViewModel}"
-    vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
     x:Uid="MoveStaticMembersDialog"
     x:Name="dialog"
     x:Class="Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembers.MoveStaticMembersDialog"
@@ -22,8 +21,7 @@
     HasDialogFrame="True"
     ShowInTaskbar="False"
     ResizeMode="CanResize"
-    Title="{Binding MoveStaticMembersDialogTitle, ElementName=dialog}"
-    Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
+    Title="{Binding MoveStaticMembersDialogTitle, ElementName=dialog}">
     <vs:DialogWindow.Resources>
         <Thickness x:Key="ButtonPadding">9, 2, 9, 2</Thickness>
         <sys:Double x:Key="ButtonWidth">73</sys:Double>
@@ -54,11 +52,6 @@
 
 
             <GroupBox>
-                <GroupBox.Style>
-                    <Style TargetType="GroupBox">
-                        <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
-                    </Style>
-                </GroupBox.Style>
                 <GroupBox.Header>
                     <StackPanel 
                     Orientation="Horizontal"  
@@ -74,8 +67,7 @@
                         <vs:LiveTextBlock 
                             x:Name="MessageText"
                             Text="{Binding Message}"
-                            Margin="7, 0, 0, 0"
-                            Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+                            Margin="7, 0, 0, 0"/>
                     </StackPanel>
                 </GroupBox.Header>
 
@@ -92,19 +84,17 @@
                         HorizontalAlignment="Right"
                         x:Name="Namespace"
                         Text="{Binding PrependedNamespace}"
-                        TextTrimming="CharacterEllipsis"
-                        Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+                        TextTrimming="CharacterEllipsis"/>
 
                     <vs:LiveTextBlock 
                         Grid.Column="1"
                         x:Name="TypeName"
-                        Text="{Binding DestinationName}"
-                        Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
+                        Text="{Binding DestinationName}"/>
                 </Grid>
             </GroupBox>
         </StackPanel>
 
-        
+
 
         <GroupBox 
             x:Uid="MemberSelectionGroupBox"
@@ -113,11 +103,6 @@
             Grid.Row="1"
             Header="{Binding ElementName=dialog, Path=SelectMembers}"
             BorderThickness="1">
-            <GroupBox.Style>
-                <Style TargetType="GroupBox">
-                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"/>
-                </Style>
-            </GroupBox.Style>
 
             <ContentPresenter Content="{Binding ElementName=dialog, Path=MemberSelectionControl}" />
         </GroupBox>


### PR DESCRIPTION
Dialog theming in dark mode was looking a little weird. Borders and scroll bars were still white, distracting from the content of the dialog. 

There was also a bug with buttons, in that they appeared selected even after being pressed. Removing all the dialog themes fixed that problem as well.

Theming can be a part of the wider effort to coordinate dialog themes across roslyn.