### PR TITLE
Allow null literals to contribute nullability to type inference

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly HashSet<TypeWithAnnotations>[] _upperBounds;
         private readonly HashSet<TypeWithAnnotations>[] _lowerBounds;
 
-        // https://github.com/dotnet/csharplang/blob/main/proposals/csharp-8.0/nullable-reference-types-specification.md#fixing
+        // https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/nullable-reference-types-specification.md#fixing
         // If the resulting candidate is a reference type or a nonnullable value type and all of the
         // exact bounds or any of the lower bounds are nullable value types, nullable reference
         // types, null or default, then ? is added to the resulting candidate, making it a nullable

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -137,10 +137,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly HashSet<TypeWithAnnotations>[] _lowerBounds;
 
         // https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/nullable-reference-types-specification.md#fixing
-        // If the resulting candidate is a reference type or a nonnullable value type and all of the
-        // exact bounds or any of the lower bounds are nullable value types, nullable reference
-        // types, null or default, then ? is added to the resulting candidate, making it a nullable
-        // value type or reference type.
+        // If the resulting candidate is a reference type and *all* of the exact bounds or *any* of
+        // the lower bounds are nullable reference types, `null` or `default`, then `?` is added to
+        // the resulting candidate, making it a nullable reference type.
         //
         // This set of bounds effectively tracks whether a typeless null expression (i.e. null
         // literal) was used as an argument to a parameter whose type is one of this method's type

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6143,7 +6143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BoundKind.DefaultLiteral:
                     case BoundKind.DefaultExpression:
                     case BoundKind.Literal:
-                        return expr.ConstantValue == ConstantValue.NotAvailable || !expr.ConstantValue.IsNull ? NullableAnnotation.NotAnnotated : NullableAnnotation.Annotated;
+                        return expr.ConstantValue == ConstantValue.NotAvailable || !expr.ConstantValue.IsNull || expr.IsSuppressed ? NullableAnnotation.NotAnnotated : NullableAnnotation.Annotated;
                     case BoundKind.ExpressionWithNullability:
                         return ((BoundExpressionWithNullability)expr).NullableAnnotation;
                     case BoundKind.MethodGroup:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6273,9 +6273,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 group = conversion.ConversionGroupOpt;
                 Debug.Assert(group != null || !conversion.ExplicitCastInCode); // Explicit conversions should include a group.
+                Debug.Assert(conversion.Operand.ConstantValue != ConstantValue.Null
+                    || conversion.Operand is BoundLiteral { Type: null } or (not BoundLiteral and { Type: not null }));
                 if ((!includeExplicitConversions && group?.IsExplicitConversion == true)
                     || (!includePredefinedNullLiteralConversions && group?.Conversion.IsUserDefined != true && conversion.Operand is BoundLiteral { ConstantValue.IsNull: true }))
                 {
+                    Debug.Assert(expr.Type is not null);
                     return (expr, Conversion.Identity);
                 }
                 expr = conversion.Operand;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -11001,6 +11001,30 @@ class Program
         }
 
         [Fact]
+        public void GenericInferenceErrorRecovery()
+        {
+            var code = @"
+class Program
+{
+    public static void Method<T>(in T p)
+    {
+        System.Console.WriteLine(typeof(T).ToString());
+    }
+
+    static void Main()
+    {
+        Method((null, 1));
+    }
+}
+";
+            var comp = CreateCompilation(code);
+            comp.VerifyDiagnostics(
+                // (11,9): error CS0411: The type arguments for method 'Program.Method<T>(in T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         Method((null, 1));
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Method").WithArguments("Program.Method<T>(in T)").WithLocation(11, 9));
+        }
+
+        [Fact]
         public void GenericInferenceLambdaVariance()
         {
             var code = @"


### PR DESCRIPTION
Closes #43536

~~We skip removing conversions from call arguments when the conversion is predefined and applied to a null literal. Note that other kinds of constant-null expressions we do expect to have a natural type, so we do remove their conversion.~~

Changed approach to instead add special "nullable bounds" to method type inference per https://github.com/dotnet/roslyn/pull/56022#issuecomment-909400174. Will update the PR title prior to merge to avoid messing up email threading.