### PR TITLE
Improve the tooltip of Inheritance Margin

### DIFF
--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginItem.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         {
             var targetItems = await serializableItem.TargetItems.SelectAsArrayAsync(
                     (item, _) => InheritanceTargetItem.ConvertAsync(solution, item, cancellationToken), cancellationToken).ConfigureAwait(false);
-            return new InheritanceMarginItem(serializableItem.LineNumber, serializableItem.DisplayTexts, serializableItem.Glyph, targetItems);
+            return new InheritanceMarginItem(serializableItem.LineNumber, serializableItem.DisplayTaggedTexts, serializableItem.Glyph, targetItems);
         }
     }
 }

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginItem.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         /// <summary>
         /// Tagged texts used to show colorized display name for this member.
         /// </summary>
-        public readonly ImmutableArray<TaggedText> TaggedTexts;
+        public readonly ImmutableArray<TaggedText> DisplayTaggedTexts;
 
         /// <summary>
         /// Member's glyph.
@@ -32,12 +32,12 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
         public InheritanceMarginItem(
             int lineNumber,
-            ImmutableArray<TaggedText> displayTexts,
+            ImmutableArray<TaggedText> displayTaggedTexts,
             Glyph glyph,
             ImmutableArray<InheritanceTargetItem> targetItems)
         {
             LineNumber = lineNumber;
-            TaggedTexts = displayTexts;
+            DisplayTaggedTexts = displayTaggedTexts;
             Glyph = glyph;
             TargetItems = targetItems;
         }

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginItem.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         public readonly int LineNumber;
 
         /// <summary>
-        /// Display texts for this member.
+        /// Tagged texts used to show colorized display name for this member.
         /// </summary>
-        public readonly ImmutableArray<TaggedText> DisplayTexts;
+        public readonly ImmutableArray<TaggedText> TaggedTexts;
 
         /// <summary>
         /// Member's glyph.
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             ImmutableArray<InheritanceTargetItem> targetItems)
         {
             LineNumber = lineNumber;
-            DisplayTexts = displayTexts;
+            TaggedTexts = displayTexts;
             Glyph = glyph;
             TargetItems = targetItems;
         }

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginServiceHelpers.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginServiceHelpers.cs
@@ -359,8 +359,6 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 includeHiddenLocations: false,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            var displayName = targetSymbol.ToDisplayString(s_displayFormat);
-
             return new SerializableInheritanceTargetItem(
                 inheritanceRelationship,
                 // Id is used by FAR service for caching, it is not used in inheritance margin

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginServiceHelpers.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceMarginServiceHelpers.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
             return new SerializableInheritanceMarginItem(
                 lineNumber,
-                FindUsagesHelpers.GetDisplayParts(interfaceSymbol),
+                GetDisplayTaggedTexts(interfaceSymbol),
                 interfaceSymbol.GetGlyph(),
                 baseSymbolItems.Concat(derivedTypeItems));
         }
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
             return new SerializableInheritanceMarginItem(
                 lineNumber,
-                FindUsagesHelpers.GetDisplayParts(memberSymbol),
+                GetDisplayTaggedTexts(memberSymbol),
                 memberSymbol.GetGlyph(),
                 implementedMemberItems);
         }
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
             return new SerializableInheritanceMarginItem(
                 lineNumber,
-                FindUsagesHelpers.GetDisplayParts(memberSymbol),
+                GetDisplayTaggedTexts(memberSymbol),
                 memberSymbol.GetGlyph(),
                 baseSymbolItems.Concat(derivedTypeItems));
         }
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
             return new SerializableInheritanceMarginItem(
                 lineNumber,
-                FindUsagesHelpers.GetDisplayParts(memberSymbol),
+                GetDisplayTaggedTexts(memberSymbol),
                 memberSymbol.GetGlyph(),
                 implementedMemberItems.Concat(overridenMemberItems).Concat(overridingMemberItems));
         }
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 // Id is used by FAR service for caching, it is not used in inheritance margin
                 SerializableDefinitionItem.Dehydrate(id: 0, definition),
                 targetSymbol.GetGlyph(),
-                displayName);
+                GetDisplayTaggedTexts(targetSymbol));
         }
 
         private static ImmutableArray<ISymbol> GetImplementedSymbolsForTypeMember(
@@ -487,5 +487,11 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                     cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
+
+        /// <summary>
+        /// Generate the tagged text used in the tooltip.
+        /// </summary>
+        private static ImmutableArray<TaggedText> GetDisplayTaggedTexts(ISymbol symbol)
+            => symbol.ToDisplayParts(s_displayFormat).ToTaggedText();
     }
 }

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindUsages;
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         public readonly Glyph Glyph;
 
         /// <summary>
-        /// The display name used in margin.
+        /// The display name used in the glyph's context menu.
         /// </summary>
         public readonly string DisplayName;
 

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
@@ -30,20 +30,20 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         public readonly Glyph Glyph;
 
         /// <summary>
-        /// The display name used in the glyph's context menu.
+        /// TaggedTexts used to show the colorized display name.
         /// </summary>
-        public readonly string DisplayName;
+        public readonly ImmutableArray<TaggedText> DisplayTaggedTexts;
 
         public InheritanceTargetItem(
             InheritanceRelationship relationToMember,
             DefinitionItem.DetachedDefinitionItem definitionItem,
             Glyph glyph,
-            string displayName)
+            ImmutableArray<TaggedText> displayTaggedTexts)
         {
             RelationToMember = relationToMember;
             DefinitionItem = definitionItem;
             Glyph = glyph;
-            DisplayName = displayName;
+            DisplayTaggedTexts = displayTaggedTexts;
         }
 
         public static async ValueTask<InheritanceTargetItem> ConvertAsync(
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 serializableItem.RelationToMember,
                 definitionItem.Detach(),
                 serializableItem.Glyph,
-                serializableItem.DisplayName);
+                serializableItem.DisplayTaggedTexts);
         }
     }
 }

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
         private static async Task VerifyInheritanceMemberAsync(TestWorkspace testWorkspace, TestInheritanceMemberItem expectedItem, InheritanceMarginItem actualItem)
         {
             Assert.Equal(expectedItem.LineNumber, actualItem.LineNumber);
-            Assert.Equal(expectedItem.MemberName, actualItem.DisplayTexts.JoinText());
+            Assert.Equal(expectedItem.MemberName, actualItem.TaggedTexts.JoinText());
             Assert.Equal(expectedItem.Targets.Length, actualItem.TargetItems.Length);
             var expectedTargets = expectedItem.Targets
                 .Select(info => TestInheritanceTargetItem.Create(info, testWorkspace))

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -88,13 +88,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
         private static async Task VerifyInheritanceMemberAsync(TestWorkspace testWorkspace, TestInheritanceMemberItem expectedItem, InheritanceMarginItem actualItem)
         {
             Assert.Equal(expectedItem.LineNumber, actualItem.LineNumber);
-            Assert.Equal(expectedItem.MemberName, actualItem.TaggedTexts.JoinText());
+            Assert.Equal(expectedItem.MemberName, actualItem.DisplayTaggedTexts.JoinText());
             Assert.Equal(expectedItem.Targets.Length, actualItem.TargetItems.Length);
             var expectedTargets = expectedItem.Targets
                 .Select(info => TestInheritanceTargetItem.Create(info, testWorkspace))
                 .OrderBy(target => target.TargetSymbolName)
                 .ToImmutableArray();
-            var sortedActualTargets = actualItem.TargetItems.OrderBy(target => target.DefinitionItem.DisplayParts.JoinText())
+            var sortedActualTargets = actualItem.TargetItems.OrderBy(target => target.DisplayTaggedTexts.JoinText())
                 .ToImmutableArray();
             for (var i = 0; i < expectedTargets.Length; i++)
             {
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
 
         private static async Task VerifyInheritanceTargetAsync(TestInheritanceTargetItem expectedTarget, InheritanceTargetItem actualTarget)
         {
-            Assert.Equal(expectedTarget.TargetSymbolName, actualTarget.DefinitionItem.DisplayParts.JoinText());
+            Assert.Equal(expectedTarget.TargetSymbolName, actualTarget.DisplayTaggedTexts.JoinText());
             Assert.Equal(expectedTarget.RelationshipToMember, actualTarget.RelationToMember);
 
             if (expectedTarget.IsInMetadata)
@@ -221,8 +221,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
             public TestInheritanceTargetItem(
                 string targetSymbolName,
                 InheritanceRelationship relationshipToMember,
-                 ImmutableArray<DocumentSpan> documentSpans,
-                  bool isInMetadata)
+                ImmutableArray<DocumentSpan> documentSpans,
+                bool isInMetadata)
             {
                 TargetSymbolName = targetSymbolName;
                 RelationshipToMember = relationshipToMember;
@@ -294,17 +294,17 @@ public class Bar : IEnumerable
 }";
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "class Bar",
+                memberName: "Bar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface IEnumerable",
+                        targetSymbolDisplayName: "IEnumerable",
                         relationship: InheritanceRelationship.ImplementedInterface,
                         inMetadata: true)));
 
             var itemForGetEnumerator = new TestInheritanceMemberItem(
                 lineNumber: 5,
-                memberName: "IEnumerator Bar.GetEnumerator()",
+                memberName: "Bar.GetEnumerator",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "IEnumerator IEnumerable.GetEnumerator()",
+                        targetSymbolDisplayName: "IEnumerable.GetEnumerator",
                         relationship: InheritanceRelationship.ImplementedMember,
                         inMetadata: true)));
 
@@ -323,17 +323,17 @@ public class {|target2:Bar|} : IBar
 
             var itemOnLine2 = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "interface IBar",
+                memberName: "IBar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class Bar",
+                        targetSymbolDisplayName: "Bar",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementingType)));
 
             var itemOnLine3 = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "class Bar",
+                memberName: "Bar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface IBar",
+                        targetSymbolDisplayName: "IBar",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementedInterface)));
 
@@ -354,18 +354,18 @@ public class {|target2:Bar|} : IBar
 
             var itemOnLine2 = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "interface IBar",
+                memberName: "IBar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface IBar2",
+                        targetSymbolDisplayName: "IBar2",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementingType))
                 );
             var itemOnLine3 = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "interface IBar2",
+                memberName: "IBar2",
                 targets: ImmutableArray<TargetInfo>.Empty
                     .Add(new TargetInfo(
-                        targetSymbolDisplayName: "interface IBar",
+                        targetSymbolDisplayName: "IBar",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.InheritedInterface))
                 );
@@ -387,17 +387,17 @@ public class {|target2:Bar|} : IBar
 
             var itemOnLine2 = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "class A",
+                memberName: "A",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class B",
+                        targetSymbolDisplayName: "B",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.DerivedType))
             );
             var itemOnLine3 = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "class B",
+                memberName: "B",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class A",
+                        targetSymbolDisplayName: "A",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.BaseType))
             );
@@ -442,10 +442,10 @@ public class {|target2:Bar|} : IBar
                 LanguageNames.CSharp,
                 new TestInheritanceMemberItem(
                     lineNumber: 4,
-                    memberName: "class Bar",
+                    memberName: "Bar",
                     targets: ImmutableArray.Create(
                         new TargetInfo(
-                            targetSymbolDisplayName: "class Bar1",
+                            targetSymbolDisplayName: "Bar1",
                             locationTag: "target1",
                             relationship: InheritanceRelationship.BaseType))));
         }
@@ -468,33 +468,33 @@ public class {|target2:Bar|} : IBar
         }";
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "interface IBar",
+                memberName: "IBar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "class Bar",
+                    targetSymbolDisplayName: "Bar",
                     locationTag: "target1",
                     relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "class Bar",
+                memberName: "Bar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "interface IBar",
+                    targetSymbolDisplayName: "IBar",
                     locationTag: "target2",
                     relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForEventInInterface = new TestInheritanceMemberItem(
                 lineNumber: 5,
-                memberName: "event EventHandler IBar.e",
+                memberName: "IBar.e",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "event EventHandler Bar.e",
+                    targetSymbolDisplayName: "Bar.e",
                     locationTag: "target3",
                     relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForEventInClass = new TestInheritanceMemberItem(
                 lineNumber: 9,
-                memberName: "event EventHandler Bar.e",
+                memberName: "Bar.e",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "event EventHandler IBar.e",
+                    targetSymbolDisplayName: "IBar.e",
                     locationTag: "target4",
                     relationship: InheritanceRelationship.ImplementedMember)));
 
@@ -521,49 +521,49 @@ public class {|target2:Bar|} : IBar
         }";
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "interface IBar",
+                memberName: "IBar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "class Bar",
+                    targetSymbolDisplayName: "Bar",
                     locationTag: "target1",
                     relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 6,
-                memberName: "class Bar",
+                memberName: "Bar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "interface IBar",
+                    targetSymbolDisplayName: "IBar",
                     locationTag: "target2",
                     relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForE1InInterface = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "event EventHandler IBar.e1",
+                memberName: "IBar.e1",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "event EventHandler Bar.e1",
+                    targetSymbolDisplayName: "Bar.e1",
                     locationTag: "target3",
                     relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForE2InInterface = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "event EventHandler IBar.e2",
+                memberName: "IBar.e2",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "event EventHandler Bar.e2",
+                    targetSymbolDisplayName: "Bar.e2",
                     locationTag: "target4",
                     relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForE1InClass = new TestInheritanceMemberItem(
                 lineNumber: 8,
-                memberName: "event EventHandler Bar.e1",
+                memberName: "Bar.e1",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "event EventHandler IBar.e1",
+                    targetSymbolDisplayName: "IBar.e1",
                     locationTag: "target5",
                     relationship: InheritanceRelationship.ImplementedMember)));
 
             var itemForE2InClass = new TestInheritanceMemberItem(
                 lineNumber: 8,
-                memberName: "event EventHandler Bar.e2",
+                memberName: "Bar.e2",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "event EventHandler IBar.e2",
+                    targetSymbolDisplayName: "IBar.e2",
                     locationTag: "target6",
                     relationship: InheritanceRelationship.ImplementedMember)));
 
@@ -598,90 +598,90 @@ public class {|target2:Bar|} : IBar
         }";
             var itemForEooInClass = new TestInheritanceMemberItem(
                 lineNumber: 13,
-                memberName: "event EventHandler Bar.Eoo",
+                memberName: "Bar.Eoo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "event EventHandler IBar.Eoo",
+                        targetSymbolDisplayName: "IBar.Eoo",
                         locationTag: "target8",
                         relationship: InheritanceRelationship.ImplementedMember))
                 );
 
             var itemForEooInInterface = new TestInheritanceMemberItem(
                 lineNumber: 6,
-                memberName: "event EventHandler IBar.Eoo",
+                memberName: "IBar.Eoo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "event EventHandler Bar.Eoo",
+                        targetSymbolDisplayName: "Bar.Eoo",
                         locationTag: "target7",
                         relationship: InheritanceRelationship.ImplementingMember))
                 );
 
             var itemForPooInInterface = new TestInheritanceMemberItem(
                 lineNumber: 5,
-                memberName: "int IBar.Poo { get; set; }",
+                memberName: "IBar.Poo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "int Bar.Poo { get; set; }",
+                        targetSymbolDisplayName: "Bar.Poo",
                         locationTag: "target5",
                         relationship: InheritanceRelationship.ImplementingMember))
                 );
 
             var itemForPooInClass = new TestInheritanceMemberItem(
                 lineNumber: 12,
-                memberName: "int Bar.Poo { get; set; }",
+                memberName: "Bar.Poo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "int IBar.Poo { get; set; }",
+                        targetSymbolDisplayName: "IBar.Poo",
                         locationTag: "target6",
                         relationship: InheritanceRelationship.ImplementedMember))
                 );
 
             var itemForFooInInterface = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "void IBar.Foo()",
+                memberName: "IBar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void Bar.Foo()",
+                        targetSymbolDisplayName: "Bar.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.ImplementingMember))
                 );
 
             var itemForFooInClass = new TestInheritanceMemberItem(
                 lineNumber: 11,
-                memberName: "void Bar.Foo()",
+                memberName: "Bar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void IBar.Foo()",
+                        targetSymbolDisplayName: "IBar.Foo",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementedMember))
                 );
 
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "interface IBar",
+                memberName: "IBar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class Bar",
+                        targetSymbolDisplayName: "Bar",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementingType))
                 );
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 9,
-                memberName: "class Bar",
+                memberName: "Bar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface IBar",
+                        targetSymbolDisplayName: "IBar",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementedInterface))
                 );
 
             var itemForIndexerInClass = new TestInheritanceMemberItem(
                 lineNumber: 14,
-                memberName: "int Bar.this[int] { get; set; }",
+                memberName: "Bar.this",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "int IBar.this[int] { get; set; }",
+                        targetSymbolDisplayName: "IBar.this",
                         locationTag: "target9",
                         relationship: InheritanceRelationship.ImplementedMember))
                 );
 
             var itemForIndexerInInterface = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "int IBar.this[int] { get; set; }",
+                memberName: "IBar.this",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "int Bar.this[int] { get; set; }",
+                        targetSymbolDisplayName: "Bar.this",
                         locationTag: "target10",
                         relationship: InheritanceRelationship.ImplementingMember))
                 );
@@ -723,65 +723,65 @@ public class {|target2:Bar|} : IBar
 
             var itemForEooInClass = new TestInheritanceMemberItem(
                 lineNumber: 12,
-                memberName: "override event EventHandler Bar2.Eoo",
+                memberName: "Bar2.Eoo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: $"{modifier} event EventHandler Bar.Eoo",
+                        targetSymbolDisplayName: "Bar.Eoo",
                         locationTag: "target8",
                         relationship: InheritanceRelationship.OverriddenMember)));
 
             var itemForEooInAbstractClass = new TestInheritanceMemberItem(
                 lineNumber: 6,
-                memberName: $"{modifier} event EventHandler Bar.Eoo",
+                memberName: "Bar.Eoo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "override event EventHandler Bar2.Eoo",
+                        targetSymbolDisplayName: "Bar2.Eoo",
                         locationTag: "target7",
                         relationship: InheritanceRelationship.OverridingMember)));
 
             var itemForPooInClass = new TestInheritanceMemberItem(
                     lineNumber: 11,
-                    memberName: "override int Bar2.Poo { get; set; }",
+                    memberName: "Bar2.Poo",
                     targets: ImmutableArray.Create(new TargetInfo(
-                            targetSymbolDisplayName: $"{modifier} int Bar.Poo {{ get; set; }}",
+                            targetSymbolDisplayName: "Bar.Poo",
                             locationTag: "target6",
                             relationship: InheritanceRelationship.OverriddenMember)));
 
             var itemForPooInAbstractClass = new TestInheritanceMemberItem(
                     lineNumber: 5,
-                    memberName: $"{modifier} int Bar.Poo {{ get; set; }}",
+                    memberName: "Bar.Poo",
                     targets: ImmutableArray.Create(new TargetInfo(
-                            targetSymbolDisplayName: "override int Bar2.Poo { get; set; }",
+                            targetSymbolDisplayName: "Bar2.Poo",
                             locationTag: "target5",
                             relationship: InheritanceRelationship.OverridingMember)));
 
             var itemForFooInAbstractClass = new TestInheritanceMemberItem(
                     lineNumber: 4,
-                    memberName: $"{modifier} void Bar.Foo()",
+                    memberName: "Bar.Foo",
                     targets: ImmutableArray.Create(new TargetInfo(
-                            targetSymbolDisplayName: "override void Bar2.Foo()",
+                            targetSymbolDisplayName: "Bar2.Foo",
                             locationTag: "target3",
                             relationship: InheritanceRelationship.OverridingMember)));
 
             var itemForFooInClass = new TestInheritanceMemberItem(
                 lineNumber: 10,
-                memberName: "override void Bar2.Foo()",
+                memberName: "Bar2.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: $"{modifier} void Bar.Foo()",
+                        targetSymbolDisplayName: "Bar.Foo",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.OverriddenMember)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "class Bar",
+                memberName: "Bar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class Bar2",
+                        targetSymbolDisplayName: "Bar2",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.DerivedType)));
 
             var itemForBar2 = new TestInheritanceMemberItem(
                 lineNumber: 8,
-                memberName: "class Bar2",
+                memberName: "Bar2",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class Bar",
+                        targetSymbolDisplayName: "Bar",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.BaseType)));
 
@@ -832,74 +832,74 @@ public class {|target2:Bar|} : IBar
 
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "interface IBar",
+                memberName: "IBar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class Bar1",
+                        targetSymbolDisplayName: "Bar1",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementingType),
                 new TargetInfo(
-                    targetSymbolDisplayName: "class Bar2",
+                    targetSymbolDisplayName: "Bar2",
                     locationTag: "target5",
                     relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForFooInIBar = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "void IBar.Foo()",
+                memberName: "IBar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "virtual void Bar1.Foo()",
+                        targetSymbolDisplayName: "Bar1.Foo",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementingMember),
                     new TargetInfo(
-                        targetSymbolDisplayName: "override void Bar2.Foo()",
+                        targetSymbolDisplayName: "Bar2.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForBar1 = new TestInheritanceMemberItem(
                 lineNumber: 6,
-                memberName: "class Bar1",
+                memberName: "Bar1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface IBar",
+                        targetSymbolDisplayName: "IBar",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementedInterface),
                     new TargetInfo(
-                        targetSymbolDisplayName: "class Bar2",
+                        targetSymbolDisplayName: "Bar2",
                         locationTag: "target5",
                         relationship: InheritanceRelationship.DerivedType)));
 
             var itemForFooInBar1 = new TestInheritanceMemberItem(
                 lineNumber: 8,
-                memberName: "virtual void Bar1.Foo()",
+                memberName: "Bar1.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void IBar.Foo()",
+                        targetSymbolDisplayName: "IBar.Foo",
                         locationTag: "target6",
                         relationship: InheritanceRelationship.ImplementedMember),
                     new TargetInfo(
-                        targetSymbolDisplayName: "override void Bar2.Foo()",
+                        targetSymbolDisplayName: "Bar2.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.OverridingMember)));
 
             var itemForBar2 = new TestInheritanceMemberItem(
                 lineNumber: 10,
-                memberName: "class Bar2",
+                memberName: "Bar2",
                 targets: ImmutableArray.Create(
                     new TargetInfo(
-                        targetSymbolDisplayName: "class Bar1",
+                        targetSymbolDisplayName: "Bar1",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.BaseType),
                     new TargetInfo(
-                        targetSymbolDisplayName: "interface IBar",
+                        targetSymbolDisplayName: "IBar",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForFooInBar2 = new TestInheritanceMemberItem(
                 lineNumber: 12,
-                memberName: "override void Bar2.Foo()",
+                memberName: "Bar2.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void IBar.Foo()",
+                        targetSymbolDisplayName: "IBar.Foo",
                         locationTag: "target6",
                         relationship: InheritanceRelationship.ImplementedMember),
                     new TargetInfo(
-                        targetSymbolDisplayName: "virtual void Bar1.Foo()",
+                        targetSymbolDisplayName: "Bar1.Foo",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.OverriddenMember)));
 
@@ -930,35 +930,35 @@ public class {|target1:Bar2|} : IBar<int>, IBar<string>
 
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "interface IBar<T>",
+                memberName: "IBar<T>",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class Bar2",
+                        targetSymbolDisplayName: "Bar2",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForFooInIBar = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "void IBar<T>.Foo()",
+                memberName: "IBar<T>.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void Bar2.Foo()",
+                        targetSymbolDisplayName: "Bar2.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
             // Only have one IBar<T> item
             var itemForBar2 = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "class Bar2",
+                memberName: "Bar2",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface IBar<T>",
+                        targetSymbolDisplayName: "IBar<T>",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementedInterface)));
 
             // Only have one IBar<T>.Foo item
             var itemForFooInBar2 = new TestInheritanceMemberItem(
                 lineNumber: 9,
-                memberName: "void Bar2.Foo()",
+                memberName: "Bar2.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void IBar<T>.Foo()",
+                        targetSymbolDisplayName: "IBar<T>.Foo",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
@@ -989,33 +989,33 @@ abstract class {|target1:AbsBar|} : IBar<int>
 }";
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "interface IBar<T>",
+                memberName: "IBar<T>",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class AbsBar",
+                        targetSymbolDisplayName: "AbsBar",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForFooInIBar = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "void IBar<T>.Foo(T)",
+                memberName: "IBar<T>.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void AbsBar.IBar<int>.Foo(int)",
+                        targetSymbolDisplayName: "AbsBar.IBar<int>.Foo",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForAbsBar = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "class AbsBar",
+                memberName: "AbsBar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface IBar<T>",
+                        targetSymbolDisplayName: "IBar<T>",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForFooInAbsBar = new TestInheritanceMemberItem(
                 lineNumber: 9,
-                memberName: "void AbsBar.IBar<int>.Foo(int)",
+                memberName: "AbsBar.IBar<int>.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void IBar<T>.Foo(T)",
+                        targetSymbolDisplayName: "IBar<T>.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.ImplementedMember)
                 ));
@@ -1052,97 +1052,97 @@ public class {|target1:Class1|} : I1<Class1>
 }";
             var itemForI1 = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "interface I1<T>",
+                memberName: "I1<T>",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class Class1",
+                        targetSymbolDisplayName: "Class1",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForM1InI1 = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "void I1<T>.M1()",
+                memberName: "I1<T>.M1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "static void Class1.M1()",
+                        targetSymbolDisplayName: "Class1.M1",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForAbsClass1 = new TestInheritanceMemberItem(
                 lineNumber: 11,
-                memberName: "class Class1",
+                memberName: "Class1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface I1<T>",
+                        targetSymbolDisplayName: "I1<T>",
                         locationTag: "target5",
                         relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForM1InClass1 = new TestInheritanceMemberItem(
                 lineNumber: 13,
-                memberName: "static void Class1.M1()",
+                memberName: "Class1.M1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void I1<T>.M1()",
+                        targetSymbolDisplayName: "I1<T>.M1",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
             var itemForP1InI1 = new TestInheritanceMemberItem(
                 lineNumber: 5,
-                memberName: "int I1<T>.P1 { get; set; }",
+                memberName: "I1<T>.P1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "static int Class1.P1 { get; set; }",
+                        targetSymbolDisplayName: "Class1.P1",
                         locationTag: "target6",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForP1InClass1 = new TestInheritanceMemberItem(
                 lineNumber: 14,
-                memberName: "static int Class1.P1 { get; set; }",
+                memberName: "Class1.P1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "int I1<T>.P1 { get; set; }",
+                        targetSymbolDisplayName: "I1<T>.P1",
                         locationTag: "target7",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
             var itemForE1InI1 = new TestInheritanceMemberItem(
                 lineNumber: 6,
-                memberName: "event EventHandler I1<T>.e1",
+                memberName: "I1<T>.e1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "static event EventHandler Class1.e1",
+                        targetSymbolDisplayName: "Class1.e1",
                         locationTag: "target8",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForE1InClass1 = new TestInheritanceMemberItem(
                 lineNumber: 15,
-                memberName: "static event EventHandler Class1.e1",
+                memberName: "Class1.e1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "event EventHandler I1<T>.e1",
+                        targetSymbolDisplayName: "I1<T>.e1",
                         locationTag: "target9",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
             var itemForPlusOperatorInI1 = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "int I1<T>.operator +(T)",
+                memberName: "I1<T>.operator +",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "static int Class1.operator +(Class1)",
+                        targetSymbolDisplayName: "Class1.operator +",
                         locationTag: "target10",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForPlusOperatorInClass1 = new TestInheritanceMemberItem(
                 lineNumber: 16,
-                memberName: "static int Class1.operator +(Class1)",
+                memberName: "Class1.operator +",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "int I1<T>.operator +(T)",
+                        targetSymbolDisplayName: "I1<T>.operator +",
                         locationTag: "target11",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
             var itemForIntOperatorInI1 = new TestInheritanceMemberItem(
                 lineNumber: 8,
-                memberName: "I1<T>.implicit operator int(T)",
+                memberName: "I1<T>.implicit operator int",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "static Class1.implicit operator int(Class1)",
+                        targetSymbolDisplayName: "Class1.implicit operator int",
                         locationTag: "target13",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForIntOperatorInClass1 = new TestInheritanceMemberItem(
                 lineNumber: 17,
-                memberName: "static Class1.implicit operator int(Class1)",
+                memberName: "Class1.implicit operator int",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "I1<T>.implicit operator int(T)",
+                        targetSymbolDisplayName: "I1<T>.implicit operator int",
                         locationTag: "target12",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
@@ -1194,17 +1194,17 @@ public class {|target1:Class1|} : I1<Class1>
         End Namespace";
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "Class Bar",
+                memberName: "Bar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Interface IEnumerable",
+                        targetSymbolDisplayName: "IEnumerable",
                         relationship: InheritanceRelationship.ImplementedInterface,
                         inMetadata: true)));
 
             var itemForGetEnumerator = new TestInheritanceMemberItem(
                 lineNumber: 5,
-                memberName: "Function Bar.GetEnumerator() As IEnumerator",
+                memberName: "Bar.GetEnumerator",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Function IEnumerable.GetEnumerator() As IEnumerator",
+                        targetSymbolDisplayName: "IEnumerable.GetEnumerator",
                         relationship: InheritanceRelationship.ImplementedMember,
                         inMetadata: true)));
 
@@ -1222,17 +1222,17 @@ public class {|target1:Class1|} : I1<Class1>
         End Class";
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "Interface IBar",
+                memberName: "IBar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Class Bar",
+                    targetSymbolDisplayName: "Bar",
                     locationTag: "target1",
                     relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "Class Bar",
+                memberName: "Bar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Interface IBar",
+                    targetSymbolDisplayName: "IBar",
                     locationTag: "target2",
                     relationship: InheritanceRelationship.ImplementedInterface)));
 
@@ -1255,17 +1255,17 @@ public class {|target1:Class1|} : I1<Class1>
 
             var itemForIBar2 = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "Interface IBar2",
+                memberName: "IBar2",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Interface IBar",
+                    targetSymbolDisplayName: "IBar",
                     locationTag: "target1",
                     relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "Interface IBar",
+                memberName: "IBar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Interface IBar2",
+                    targetSymbolDisplayName: "IBar2",
                     locationTag: "target2",
                     relationship: InheritanceRelationship.InheritedInterface)));
             return VerifyInSingleDocumentAsync(markup, LanguageNames.VisualBasic, itemForIBar2, itemForIBar);
@@ -1283,17 +1283,17 @@ public class {|target1:Class1|} : I1<Class1>
 
             var itemForBar2 = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "Class Bar2",
+                memberName: "Bar2",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Class Bar",
+                    targetSymbolDisplayName: "Bar",
                     locationTag: "target1",
                     relationship: InheritanceRelationship.DerivedType)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "Class Bar",
+                memberName: "Bar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Class Bar2",
+                    targetSymbolDisplayName: "Bar2",
                     locationTag: "target2",
                     relationship: InheritanceRelationship.BaseType)));
             return VerifyInSingleDocumentAsync(markup, LanguageNames.VisualBasic, itemForBar2, itemForBar);
@@ -1326,10 +1326,10 @@ public class {|target1:Class1|} : I1<Class1>
                 LanguageNames.VisualBasic,
                 new TestInheritanceMemberItem(
                     lineNumber: 3,
-                    memberName: "Class Bar",
+                    memberName: "Bar",
                     targets: ImmutableArray.Create(
                         new TargetInfo(
-                            targetSymbolDisplayName: "Interface IEnumerable",
+                            targetSymbolDisplayName: "IEnumerable",
                             relationship: InheritanceRelationship.ImplementedInterface,
                             inMetadata: true))));
         }
@@ -1348,33 +1348,33 @@ public class {|target1:Class1|} : I1<Class1>
 
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "Interface IBar",
+                memberName: "IBar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Class Bar",
+                    targetSymbolDisplayName: "Bar",
                     locationTag: "target1",
                     relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 5,
-                memberName: "Class Bar",
+                memberName: "Bar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Interface IBar",
+                    targetSymbolDisplayName: "IBar",
                     locationTag: "target2",
                     relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForEventInInterface = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "Event IBar.e As EventHandler",
+                memberName: "IBar.e",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Event Bar.e As EventHandler",
+                    targetSymbolDisplayName: "Bar.e",
                     locationTag: "target3",
                     relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForEventInClass = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "Event Bar.e As EventHandler",
+                memberName: "Bar.e",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Event IBar.e As EventHandler",
+                    targetSymbolDisplayName: "IBar.e",
                     locationTag: "target4",
                     relationship: InheritanceRelationship.ImplementedMember)));
 
@@ -1401,33 +1401,33 @@ public class {|target1:Class1|} : I1<Class1>
         End Class";
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "Interface IBar",
+                memberName: "IBar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Class Bar",
+                    targetSymbolDisplayName: "Bar",
                     locationTag: "target1",
                     relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 5,
-                memberName: "Class Bar",
+                memberName: "Bar",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Interface IBar",
+                    targetSymbolDisplayName: "IBar",
                     locationTag: "target2",
                     relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForEventInInterface = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "Event IBar.e As EventHandler",
+                memberName: "IBar.e",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Event Bar.e As EventHandler",
+                    targetSymbolDisplayName: "Bar.e",
                     locationTag: "target3",
                     relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForEventInClass = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "Event Bar.e As EventHandler",
+                memberName: "Bar.e",
                 ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Event IBar.e As EventHandler",
+                    targetSymbolDisplayName: "IBar.e",
                     locationTag: "target4",
                     relationship: InheritanceRelationship.ImplementedMember)));
 
@@ -1464,49 +1464,49 @@ public class {|target1:Class1|} : I1<Class1>
         End Class";
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "Interface IBar",
+                memberName: "IBar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Class Bar",
+                    targetSymbolDisplayName: "Bar",
                     locationTag: "target1",
                     relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "Class Bar",
+                memberName: "Bar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Interface IBar",
+                    targetSymbolDisplayName: "IBar",
                     locationTag: "target2",
                     relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForPooInInterface = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "Property IBar.Poo As Integer",
+                memberName: "IBar.Poo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Property Bar.Poo As Integer",
+                    targetSymbolDisplayName: "Bar.Poo",
                     locationTag: "target3",
                     relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForPooInClass = new TestInheritanceMemberItem(
                 lineNumber: 9,
-                memberName: "Property Bar.Poo As Integer",
+                memberName: "Bar.Poo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Property IBar.Poo As Integer",
+                    targetSymbolDisplayName: "IBar.Poo",
                     locationTag: "target4",
                     relationship: InheritanceRelationship.ImplementedMember)));
 
             var itemForFooInInterface = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "Function IBar.Foo() As Integer",
+                memberName: "IBar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Function Bar.Foo() As Integer",
+                    targetSymbolDisplayName: "Bar.Foo",
                     locationTag: "target5",
                     relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForFooInClass = new TestInheritanceMemberItem(
                 lineNumber: 16,
-                memberName: "Function Bar.Foo() As Integer",
+                memberName: "Bar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "Function IBar.Foo() As Integer",
+                    targetSymbolDisplayName: "IBar.Foo",
                     locationTag: "target6",
                     relationship: InheritanceRelationship.ImplementedMember)));
 
@@ -1536,33 +1536,33 @@ public class {|target1:Class1|} : I1<Class1>
         End Class";
             var itemForBar1 = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "Class Bar1",
+                memberName: "Bar1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: $"Class Bar",
+                        targetSymbolDisplayName: $"Bar",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.DerivedType)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 6,
-                memberName: "Class Bar",
+                memberName: "Bar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Class Bar1",
+                        targetSymbolDisplayName: "Bar1",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.BaseType)));
 
             var itemForFooInBar1 = new TestInheritanceMemberItem(
                     lineNumber: 3,
-                    memberName: "MustOverride Sub Bar1.Foo()",
+                    memberName: "Bar1.Foo",
                     targets: ImmutableArray.Create(new TargetInfo(
-                            targetSymbolDisplayName: "Overrides Sub Bar.Foo()",
+                            targetSymbolDisplayName: "Bar.Foo",
                             locationTag: "target3",
                             relationship: InheritanceRelationship.OverridingMember)));
 
             var itemForFooInBar = new TestInheritanceMemberItem(
                     lineNumber: 8,
-                    memberName: "Overrides Sub Bar.Foo()",
+                    memberName: "Bar.Foo",
                     targets: ImmutableArray.Create(new TargetInfo(
-                            targetSymbolDisplayName: "MustOverride Sub Bar1.Foo()",
+                            targetSymbolDisplayName: "Bar1.Foo",
                             locationTag: "target4",
                             relationship: InheritanceRelationship.OverriddenMember)));
 
@@ -1614,74 +1614,74 @@ public class {|target1:Class1|} : I1<Class1>
         End Class";
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "Interface IBar",
+                memberName: "IBar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Class Bar1",
+                        targetSymbolDisplayName: "Bar1",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementingType),
                 new TargetInfo(
-                    targetSymbolDisplayName: "Class Bar2",
+                    targetSymbolDisplayName: "Bar2",
                     locationTag: "target5",
                     relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForFooInIBar = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "Sub IBar.Foo()",
+                memberName: "IBar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Overridable Sub Bar1.Foo()",
+                        targetSymbolDisplayName: "Bar1.Foo",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementingMember),
                     new TargetInfo(
-                        targetSymbolDisplayName: "Overrides Sub Bar2.Foo()",
+                        targetSymbolDisplayName: "Bar2.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForBar1 = new TestInheritanceMemberItem(
                 lineNumber: 6,
-                memberName: "Class Bar1",
+                memberName: "Bar1",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Interface IBar",
+                        targetSymbolDisplayName: "IBar",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementedInterface),
                     new TargetInfo(
-                        targetSymbolDisplayName: "Class Bar2",
+                        targetSymbolDisplayName: "Bar2",
                         locationTag: "target5",
                         relationship: InheritanceRelationship.DerivedType)));
 
             var itemForFooInBar1 = new TestInheritanceMemberItem(
                 lineNumber: 8,
-                memberName: "Overridable Sub Bar1.Foo()",
+                memberName: "Bar1.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Sub IBar.Foo()",
+                        targetSymbolDisplayName: "IBar.Foo",
                         locationTag: "target6",
                         relationship: InheritanceRelationship.ImplementedMember),
                     new TargetInfo(
-                        targetSymbolDisplayName: "Overrides Sub Bar2.Foo()",
+                        targetSymbolDisplayName: "Bar2.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.OverridingMember)));
 
             var itemForBar2 = new TestInheritanceMemberItem(
                 lineNumber: 12,
-                memberName: "Class Bar2",
+                memberName: "Bar2",
                 targets: ImmutableArray.Create(
                     new TargetInfo(
-                        targetSymbolDisplayName: "Class Bar1",
+                        targetSymbolDisplayName: "Bar1",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.BaseType),
                     new TargetInfo(
-                        targetSymbolDisplayName: "Interface IBar",
+                        targetSymbolDisplayName: "IBar",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForFooInBar2 = new TestInheritanceMemberItem(
                 lineNumber: 14,
-                memberName: "Overrides Sub Bar2.Foo()",
+                memberName: "Bar2.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Sub IBar.Foo()",
+                        targetSymbolDisplayName: "IBar.Foo",
                         locationTag: "target6",
                         relationship: InheritanceRelationship.ImplementedMember),
                     new TargetInfo(
-                        targetSymbolDisplayName: "Overridable Sub Bar1.Foo()",
+                        targetSymbolDisplayName: "Bar1.Foo",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.OverriddenMember)));
 
@@ -1719,45 +1719,45 @@ public class {|target1:Class1|} : I1<Class1>
 
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 2,
-                memberName: "Interface IBar(Of T)",
+                memberName: "IBar(Of T)",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Class Bar",
+                        targetSymbolDisplayName: "Bar",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForFooInIBar = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "Sub IBar(Of T).Foo()",
+                memberName: "IBar(Of T).Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Sub Bar.Foo()",
+                        targetSymbolDisplayName: "Bar.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.ImplementingMember),
                         new TargetInfo(
-                            targetSymbolDisplayName: "Sub Bar.IBar_Foo()",
+                            targetSymbolDisplayName: "Bar.IBar_Foo",
                             locationTag: "target4",
                             relationship: InheritanceRelationship.ImplementingMember)));
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 6,
-                memberName: "Class Bar",
+                memberName: "Bar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Interface IBar(Of T)",
+                        targetSymbolDisplayName: "IBar(Of T)",
                         locationTag: "target5",
                         relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForFooInBar = new TestInheritanceMemberItem(
                 lineNumber: 10,
-                memberName: "Sub Bar.Foo()",
+                memberName: "Bar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Sub IBar(Of T).Foo()",
+                        targetSymbolDisplayName: "IBar(Of T).Foo",
                         locationTag: "target6",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
             var itemForIBar_FooInBar = new TestInheritanceMemberItem(
                 lineNumber: 14,
-                memberName: "Sub Bar.IBar_Foo()",
+                memberName: "Bar.IBar_Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Sub IBar(Of T).Foo()",
+                        targetSymbolDisplayName: "IBar(Of T).Foo",
                         locationTag: "target6",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
@@ -1795,33 +1795,33 @@ public class {|target1:Class1|} : I1<Class1>
 
             var itemForBar = new TestInheritanceMemberItem(
                 lineNumber: 5,
-                memberName: "class Bar",
+                memberName: "Bar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Interface IBar",
+                        targetSymbolDisplayName: "IBar",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForFooInMarkup1 = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "void Bar.Foo()",
+                memberName: "Bar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Sub IBar.Foo()",
+                        targetSymbolDisplayName: "IBar.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 3,
-                memberName: "Interface IBar",
+                memberName: "IBar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "class Bar",
+                        targetSymbolDisplayName: "Bar",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForFooInMarkup2 = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "Sub IBar.Foo()",
+                memberName: "IBar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void Bar.Foo()",
+                        targetSymbolDisplayName: "Bar.Foo",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementingMember)));
 
@@ -1857,33 +1857,33 @@ public class {|target1:Class1|} : I1<Class1>
 
             var itemForBar44 = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "Class Bar44",
+                memberName: "Bar44",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "interface IBar",
+                        targetSymbolDisplayName: "IBar",
                         locationTag: "target1",
                         relationship: InheritanceRelationship.ImplementedInterface)));
 
             var itemForFooInMarkup1 = new TestInheritanceMemberItem(
                 lineNumber: 7,
-                memberName: "Sub Bar44.Foo()",
+                memberName: "Bar44.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "void IBar.Foo()",
+                        targetSymbolDisplayName: "IBar.Foo",
                         locationTag: "target3",
                         relationship: InheritanceRelationship.ImplementedMember)));
 
             var itemForIBar = new TestInheritanceMemberItem(
                 lineNumber: 4,
-                memberName: "interface IBar",
+                memberName: "IBar",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Class Bar44",
+                        targetSymbolDisplayName: "Bar44",
                         locationTag: "target2",
                         relationship: InheritanceRelationship.ImplementingType)));
 
             var itemForFooInMarkup2 = new TestInheritanceMemberItem(
                 lineNumber: 6,
-                memberName: "void IBar.Foo()",
+                memberName: "IBar.Foo",
                 targets: ImmutableArray.Create(new TargetInfo(
-                        targetSymbolDisplayName: "Sub Bar44.Foo()",
+                        targetSymbolDisplayName: "Bar44.Foo",
                         locationTag: "target4",
                         relationship: InheritanceRelationship.ImplementingMember)));
 

--- a/src/Features/Core/Portable/InheritanceMargin/InheritanceRelationship.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/InheritanceRelationship.cs
@@ -60,6 +60,6 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         /// <summary>
         /// Implmenting member for member in interface. Shown as I↓
         /// </summary>
-        ImplementingMember = 256
+        ImplementingMember = 256,
     }
 }

--- a/src/Features/Core/Portable/InheritanceMargin/InheritanceRelationship.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/InheritanceRelationship.cs
@@ -7,7 +7,9 @@ using System;
 namespace Microsoft.CodeAnalysis.InheritanceMargin
 {
     /// <summary>
-    /// Indicate the relationship between the member and its inheritance target
+    /// Indicate the relationship between the member and its inheritance target.
+    /// Note: the value of the enum value is used to order headers of the context menu items, and to make sure they match
+    /// the content of tooltip.
     /// </summary>
     [Flags]
     internal enum InheritanceRelationship
@@ -18,7 +20,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         None = 0,
 
         /// <summary>
-        /// Implented interfaces for class or struct. Shown as I↑
+        /// Implemented interfaces for class or struct. Shown as I↑
         /// </summary>
         ImplementedInterface = 1,
 
@@ -53,12 +55,12 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         OverriddenMember = 64,
 
         /// <summary>
-        /// Overrrding member for member in class or structure. Shown as O↓
+        /// Overriding member for member in class or structure. Shown as O↓
         /// </summary>
         OverridingMember = 128,
 
         /// <summary>
-        /// Implmenting member for member in interface. Shown as I↓
+        /// Implementing member for member in interface. Shown as I↓
         /// </summary>
         ImplementingMember = 256,
     }

--- a/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceMarginItem.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceMarginItem.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         public readonly int LineNumber;
 
         [DataMember(Order = 1)]
-        public readonly ImmutableArray<TaggedText> DisplayTexts;
+        public readonly ImmutableArray<TaggedText> DisplayTaggedTexts;
 
         [DataMember(Order = 2)]
         public readonly Glyph Glyph;
@@ -22,10 +22,10 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         [DataMember(Order = 3)]
         public readonly ImmutableArray<SerializableInheritanceTargetItem> TargetItems;
 
-        public SerializableInheritanceMarginItem(int lineNumber, ImmutableArray<TaggedText> displayTexts, Glyph glyph, ImmutableArray<SerializableInheritanceTargetItem> targetItems)
+        public SerializableInheritanceMarginItem(int lineNumber, ImmutableArray<TaggedText> displayTaggedTexts, Glyph glyph, ImmutableArray<SerializableInheritanceTargetItem> targetItems)
         {
             LineNumber = lineNumber;
-            DisplayTexts = displayTexts;
+            DisplayTaggedTexts = displayTaggedTexts;
             Glyph = glyph;
             TargetItems = targetItems;
         }

--- a/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceTargetItem.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceTargetItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.FindUsages;
 
@@ -20,18 +21,18 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         public readonly Glyph Glyph;
 
         [DataMember(Order = 3)]
-        public readonly string DisplayName;
+        public readonly ImmutableArray<TaggedText> DisplayTaggedTexts;
 
         public SerializableInheritanceTargetItem(
             InheritanceRelationship relationToMember,
             SerializableDefinitionItem definitionItem,
             Glyph glyph,
-            string displayName)
+            ImmutableArray<TaggedText> displayTaggedTexts)
         {
             RelationToMember = relationToMember;
             DefinitionItem = definitionItem;
             Glyph = glyph;
-            DisplayName = displayName;
+            DisplayTaggedTexts = displayTaggedTexts;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             => headerRelationship switch
             {
                 InheritanceRelationship.ImplementedInterface => ServicesVSResources._0_implements_1,
-                InheritanceRelationship.BaseType => ServicesVSResources._0_is_derived_from__1,
+                InheritanceRelationship.BaseType => ServicesVSResources._0_is_derived_from_1,
                 InheritanceRelationship.DerivedType => ServicesVSResources._0_derives_1,
                 InheritanceRelationship.InheritedInterface => ServicesVSResources._0_is_inherited_from_1,
                 InheritanceRelationship.ImplementingType => ServicesVSResources._0_is_implemented_by_1,
@@ -175,14 +175,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             // 'class Bar' has Implemented interfaces, Base types and Derived types
             if (aggregateRelationship.HasFlag(InheritanceRelationship.ImplementedInterface | InheritanceRelationship.BaseType | InheritanceRelationship.DerivedType))
             {
-                return ServicesVSResources._0_has_implemented_interfaces_based_types_and_derived_types;
+                return ServicesVSResources._0_has_implemented_interfaces_base_types_and_derived_types;
             }
 
             // For class/struct
             // 'class Bar' has Implemented interfaces and Base types
             if (aggregateRelationship.HasFlag(InheritanceRelationship.ImplementedInterface | InheritanceRelationship.BaseType))
             {
-                return ServicesVSResources._0_has_implemented_interfaces_and_based_types;
+                return ServicesVSResources._0_has_implemented_interfaces_and_base_types;
             }
 
             // For class/struct

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -2,14 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.InheritanceMargin;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph;
+using Microsoft.VisualStudio.Text.Classification;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin
@@ -17,25 +24,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
     internal static class InheritanceMarginHelpers
     {
         private static readonly ImmutableArray<InheritanceRelationship> s_relationships_Shown_As_I_Up_Arrow
-            = ImmutableArray<InheritanceRelationship>.Empty
-            .Add(InheritanceRelationship.ImplementedInterface)
-            .Add(InheritanceRelationship.InheritedInterface)
-            .Add(InheritanceRelationship.ImplementedMember);
+            = ImmutableArray.Create(
+                InheritanceRelationship.ImplementedInterface,
+                InheritanceRelationship.InheritedInterface,
+                InheritanceRelationship.ImplementedMember);
 
         private static readonly ImmutableArray<InheritanceRelationship> s_relationships_Shown_As_I_Down_Arrow
-            = ImmutableArray<InheritanceRelationship>.Empty
-            .Add(InheritanceRelationship.ImplementingType)
-            .Add(InheritanceRelationship.ImplementingMember);
+            = ImmutableArray.Create(
+                InheritanceRelationship.ImplementingType,
+                InheritanceRelationship.ImplementingMember);
 
         private static readonly ImmutableArray<InheritanceRelationship> s_relationships_Shown_As_O_Up_Arrow
-            = ImmutableArray<InheritanceRelationship>.Empty
-            .Add(InheritanceRelationship.BaseType)
-            .Add(InheritanceRelationship.OverriddenMember);
+            = ImmutableArray.Create(
+                InheritanceRelationship.BaseType,
+                InheritanceRelationship.OverriddenMember);
 
         private static readonly ImmutableArray<InheritanceRelationship> s_relationships_Shown_As_O_Down_Arrow
-            = ImmutableArray<InheritanceRelationship>.Empty
-            .Add(InheritanceRelationship.DerivedType)
-            .Add(InheritanceRelationship.OverridingMember);
+            = ImmutableArray.Create(InheritanceRelationship.DerivedType, InheritanceRelationship.OverridingMember);
 
         /// <summary>
         /// Decide which moniker should be shown.
@@ -83,6 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         public static ImmutableArray<InheritanceMenuItemViewModel> CreateMenuItemViewModelsForSingleMember(ImmutableArray<InheritanceTargetItem> targets)
             => targets.OrderBy(target => target.DisplayName)
                 .GroupBy(target => target.RelationToMember)
+                .OrderBy(grouping => grouping.Key)
                 .SelectMany(grouping => CreateMenuItemsWithHeader(grouping.Key, grouping))
                 .ToImmutableArray();
 
@@ -134,6 +140,174 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             }
 
             return builder.ToImmutable();
+        }
+
+        private static string GetToolTipTemplateForSingleTarget(InheritanceRelationship headerRelationship)
+            => headerRelationship switch
+            {
+                InheritanceRelationship.ImplementedInterface => ServicesVSResources._0_implements_1,
+                InheritanceRelationship.BaseType => ServicesVSResources._0_is_derived_from__1,
+                InheritanceRelationship.DerivedType => ServicesVSResources._0_derives_1,
+                InheritanceRelationship.InheritedInterface => ServicesVSResources._0_is_inherited_from_1,
+                InheritanceRelationship.ImplementingType => ServicesVSResources._0_is_implemented_by_1,
+                InheritanceRelationship.ImplementedMember => ServicesVSResources._0_implements_1,
+                InheritanceRelationship.OverriddenMember => ServicesVSResources._0_overrides_1,
+                InheritanceRelationship.OverridingMember => ServicesVSResources._0_is_overridden_by_1,
+                InheritanceRelationship.ImplementingMember => ServicesVSResources._0_is_implemented_by_1,
+                _ => throw ExceptionUtilities.UnexpectedValue(headerRelationship),
+            };
+
+        private static string GetToolTipTemplateForMultipleTargetsUnderSameHeader(InheritanceRelationship headerRelationship)
+            => headerRelationship switch
+            {
+                InheritanceRelationship.ImplementedInterface => ServicesVSResources._0_has_multiple_implemented_interfaces,
+                InheritanceRelationship.BaseType => ServicesVSResources._0_has_multiple_base_types,
+                InheritanceRelationship.DerivedType => ServicesVSResources._0_has_multiple_derived_types,
+                InheritanceRelationship.InheritedInterface => ServicesVSResources._0_has_multiple_inherited_interfaces,
+                InheritanceRelationship.ImplementingType => ServicesVSResources._0_has_multiple_implementing_types,
+                InheritanceRelationship.ImplementedMember => ServicesVSResources._0_implements_members_from_multiple_interfaces,
+                InheritanceRelationship.OverriddenMember => ServicesVSResources._0_overrides_members_from_multiple_classes,
+                InheritanceRelationship.OverridingMember => ServicesVSResources._0_is_overridden_by_members_from_multiple_classes,
+                InheritanceRelationship.ImplementingMember => ServicesVSResources._0_is_implemented_by_members_from_multiple_types,
+                _ => throw ExceptionUtilities.UnexpectedValue(headerRelationship)
+            };
+
+        private static string GetToolTipContentForMultipleHeader(InheritanceRelationship aggregateRelationship)
+        {
+            //
+            if (aggregateRelationship.HasFlag(InheritanceRelationship.ImplementedInterface | InheritanceRelationship.BaseType | InheritanceRelationship.DerivedType))
+            {
+                return ServicesVSResources._0_has_implemented_interfaces_based_types_and_derived_types;
+            }
+
+            if (aggregateRelationship.HasFlag(InheritanceRelationship.ImplementedInterface | InheritanceRelationship.BaseType))
+            {
+                return ServicesVSResources._0_has_implemented_interfaces_and_based_types;
+            }
+
+            if (aggregateRelationship.HasFlag(InheritanceRelationship.BaseType | InheritanceRelationship.DerivedType))
+            {
+                return ServicesVSResources._0_has_base_types_and_derived_types;
+            }
+
+            if (aggregateRelationship.HasFlag(InheritanceRelationship.ImplementedInterface | InheritanceRelationship.DerivedType))
+            {
+                return ServicesVSResources._0_has_implemented_interfaces_and_derived_types;
+            }
+
+            //
+            if (aggregateRelationship.HasFlag(InheritanceRelationship.InheritedInterface | InheritanceRelationship.ImplementingType))
+            {
+                return ServicesVSResources._0_has_inherited_interfaces_and_implementing_types;
+            }
+
+            //
+            if (aggregateRelationship.HasFlag(InheritanceRelationship.ImplementedMember | InheritanceRelationship.OverriddenMember | InheritanceRelationship.OverridingMember))
+            {
+                return ServicesVSResources._0_has_implemented_members_overridden_members_and_overriding_members;
+            }
+
+            if (aggregateRelationship.HasFlag(InheritanceRelationship.ImplementedMember | InheritanceRelationship.OverriddenMember))
+            {
+                return ServicesVSResources._0_has_implemented_members_and_overridden_members;
+            }
+
+            if (aggregateRelationship.HasFlag(InheritanceRelationship.ImplementedMember | InheritanceRelationship.OverridingMember))
+            {
+                return ServicesVSResources._0_has_implemented_members_and_overriding_members;
+            }
+
+            if (aggregateRelationship.HasFlag(InheritanceRelationship.OverriddenMember | InheritanceRelationship.OverridingMember))
+            {
+                return ServicesVSResources._0_has_overridden_members_and_overriding_members;
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        public static TextBlock CreateToolTipTextBlockForSingleMember(
+            ClassificationTypeMap classificationTypeMap,
+            IClassificationFormatMap classificationFormatMap,
+            InheritanceMarginItem member)
+        {
+            var targets = member.TargetItems;
+            Contract.ThrowIfTrue(targets.IsEmpty);
+            if (targets.Length == 1)
+            {
+                var target = targets[0];
+                var tooltipTemplate = GetToolTipTemplateForSingleTarget(target.RelationToMember);
+                return Format(classificationTypeMap, classificationFormatMap, tooltipTemplate, member.TaggedTexts, target.DefinitionItem.DisplayParts);
+            }
+            else if (targets.Select(target => target.RelationToMember).IsSingle())
+            {
+                var relationship = targets[0].RelationToMember;
+                var contentTemplate = GetToolTipTemplateForMultipleTargetsUnderSameHeader(relationship);
+                return Format(classificationTypeMap, classificationFormatMap, contentTemplate, member.TaggedTexts);
+            }
+            else
+            {
+                var aggregateRelationship = GetAggregateRelationship(targets.SelectAsArray(target => target.RelationToMember));
+                var contentTemplate = GetToolTipContentForMultipleHeader(aggregateRelationship);
+                return Format(classificationTypeMap, classificationFormatMap, contentTemplate, member.TaggedTexts);
+            }
+        }
+
+        public static InheritanceRelationship GetAggregateRelationship(ImmutableArray<InheritanceRelationship> relationships)
+        {
+            Contract.ThrowIfTrue(relationships.IsEmpty);
+            var result = relationships[0];
+            foreach (var relationship in relationships.Skip(1))
+            {
+                result |= relationship;
+            }
+
+            return result;
+        }
+
+        private static TextBlock Format(
+            ClassificationTypeMap classificationTypeMap,
+            IClassificationFormatMap classificationFormatMap,
+            string contentTemplate,
+            ImmutableArray<TaggedText> memberTaggedText)
+        {
+            var allInlines = new List<Inline>();
+            var startOfTheFirstPlaceholder = contentTemplate.IndexOf("{0}", StringComparison.Ordinal);
+            var prefixString = contentTemplate[..startOfTheFirstPlaceholder];
+            var firstInlines = memberTaggedText.ToInlines(classificationFormatMap, classificationTypeMap);
+            allInlines.Add(new Run(prefixString));
+            allInlines.AddRange(firstInlines);
+            var suffixString = contentTemplate[(startOfTheFirstPlaceholder + "{0}".Length)..];
+            allInlines.Add(new Run(suffixString));
+            var toolTipTextBlock = allInlines.ToTextBlock(classificationFormatMap);
+            toolTipTextBlock.FlowDirection = FlowDirection.LeftToRight;
+            return toolTipTextBlock;
+        }
+
+        private static TextBlock Format(
+            ClassificationTypeMap classificationTypeMap,
+            IClassificationFormatMap classificationFormatMap,
+            string contentTemplate,
+            ImmutableArray<TaggedText> firstTaggedText,
+            ImmutableArray<TaggedText> secondTaggedText)
+        {
+            var allInlines = new List<Inline>();
+            var startOfTheFirstPlaceholder = contentTemplate.IndexOf("{0}", StringComparison.Ordinal);
+
+            var prefixString = contentTemplate[..startOfTheFirstPlaceholder];
+            var firstInlines = firstTaggedText.ToInlines(classificationFormatMap, classificationTypeMap);
+            allInlines.Add(new Run(prefixString));
+            allInlines.AddRange(firstInlines);
+            var startOfTheSecondPlaceholder = contentTemplate.IndexOf("{1}", StringComparison.Ordinal);
+            var stringBetweenFirstAndSecondPlaceHolder = contentTemplate[(startOfTheFirstPlaceholder + "{0}".Length)..startOfTheSecondPlaceholder];
+            allInlines.Add(new Run(stringBetweenFirstAndSecondPlaceHolder));
+            var secondInlines = secondTaggedText.ToInlines(classificationFormatMap, classificationTypeMap);
+            allInlines.AddRange(secondInlines);
+            var suffixString = contentTemplate[(startOfTheSecondPlaceholder + "{1}".Length)..];
+            allInlines.Add(new Run(suffixString));
+
+            var toolTipTextBlock = allInlines.ToTextBlock(classificationFormatMap);
+            toolTipTextBlock.FlowDirection = FlowDirection.LeftToRight;
+            return toolTipTextBlock;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -252,8 +252,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             {
                 var target = targets[0];
                 var contentTemplate = GetToolTipTemplateForSingleTarget(target.RelationToMember);
-                var tooltipTextBlock = FormatTaggedText(classificationTypeMap, classificationFormatMap, contentTemplate, member.TaggedTexts, target.DisplayTaggedTexts);
-                var automationName = string.Format(contentTemplate, member.TaggedTexts.JoinText(), target.DefinitionItem.DisplayParts.JoinText());
+                var tooltipTextBlock = FormatTaggedText(classificationTypeMap, classificationFormatMap, contentTemplate, member.DisplayTaggedTexts, target.DisplayTaggedTexts);
+                var automationName = string.Format(contentTemplate, member.DisplayTaggedTexts.JoinText(), target.DefinitionItem.DisplayParts.JoinText());
                 return (tooltipTextBlock, automationName);
             }
 
@@ -267,16 +267,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             {
                 var relationship = targets[0].RelationToMember;
                 var contentTemplate = GetToolTipTemplateForMultipleTargetsUnderSameHeader(relationship);
-                var toolTipTextBlock = FormatTaggedText(classificationTypeMap, classificationFormatMap, contentTemplate, member.TaggedTexts);
-                var automationName = string.Format(contentTemplate, member.TaggedTexts.JoinText());
+                var toolTipTextBlock = FormatTaggedText(classificationTypeMap, classificationFormatMap, contentTemplate, member.DisplayTaggedTexts);
+                var automationName = string.Format(contentTemplate, member.DisplayTaggedTexts.JoinText());
                 return (toolTipTextBlock, automationName);
             }
             else
             {
                 var aggregateRelationship = GetAggregateRelationship(targetRelationshipSet);
                 var contentTemplate = GetToolTipContentForMultipleHeaders(aggregateRelationship);
-                var toolTipTextBlock = FormatTaggedText(classificationTypeMap, classificationFormatMap, contentTemplate, member.TaggedTexts);
-                var automationName = string.Format(contentTemplate, member.TaggedTexts.JoinText());
+                var toolTipTextBlock = FormatTaggedText(classificationTypeMap, classificationFormatMap, contentTemplate, member.DisplayTaggedTexts);
+                var automationName = string.Format(contentTemplate, member.DisplayTaggedTexts.JoinText());
                 return (toolTipTextBlock, automationName);
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -253,7 +253,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                 var target = targets[0];
                 var contentTemplate = GetToolTipTemplateForSingleTarget(target.RelationToMember);
                 var tooltipTextBlock = FormatTaggedText(classificationTypeMap, classificationFormatMap, contentTemplate, member.DisplayTaggedTexts, target.DisplayTaggedTexts);
-                var automationName = string.Format(contentTemplate, member.DisplayTaggedTexts.JoinText(), target.DefinitionItem.DisplayParts.JoinText());
+                var automationName = string.Format(contentTemplate, member.DisplayTaggedTexts.JoinText(), target.DisplayTaggedTexts.JoinText());
                 return (tooltipTextBlock, automationName);
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         }
 
         public static ImmutableArray<InheritanceMenuItemViewModel> CreateMenuItemViewModelsForSingleMember(ImmutableArray<InheritanceTargetItem> targets)
-            => targets.OrderBy(target => target.DisplayName)
+            => targets.OrderBy(target => target.DisplayTaggedTexts.JoinText())
                 .GroupBy(target => target.RelationToMember)
                 .OrderBy(grouping => grouping.Key)
                 .SelectMany(grouping => CreateMenuItemsWithHeader(grouping.Key, grouping))
@@ -107,9 +107,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         public static ImmutableArray<InheritanceMenuItemViewModel> CreateMenuItemViewModelsForMultipleMembers(ImmutableArray<InheritanceMarginItem> members)
         {
             Contract.ThrowIfTrue(members.Length <= 1);
-            // For multiple members, check if all the targets have the same inheritance relationship.
-            // If so, then don't add the header, because it is already indicated by the margin.
-            // Otherwise, add the Header.
             return members.SelectAsArray(MemberMenuItemViewModel.CreateWithHeaderInTargets).CastArray<InheritanceMenuItemViewModel>();
         }
 
@@ -255,7 +252,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             {
                 var target = targets[0];
                 var contentTemplate = GetToolTipTemplateForSingleTarget(target.RelationToMember);
-                var tooltipTextBlock = FormatTaggedText(classificationTypeMap, classificationFormatMap, contentTemplate, member.TaggedTexts, target.DefinitionItem.DisplayParts);
+                var tooltipTextBlock = FormatTaggedText(classificationTypeMap, classificationFormatMap, contentTemplate, member.TaggedTexts, target.DisplayTaggedTexts);
                 var automationName = string.Format(contentTemplate, member.TaggedTexts.JoinText(), target.DefinitionItem.DisplayParts.JoinText());
                 return (tooltipTextBlock, automationName);
             }

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginViewModel.cs
@@ -71,9 +71,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             if (members.Length == 1)
             {
                 var member = tag.MembersOnLine[0];
-                var automationName = string.Format(ServicesVSResources._0_is_inherited, member.TaggedTexts.JoinText());
                 var menuItemViewModels = InheritanceMarginHelpers.CreateMenuItemViewModelsForSingleMember(member.TargetItems);
-                var tooltipTextBlock = InheritanceMarginHelpers.CreateToolTipTextBlockForSingleMember(classificationTypeMap, classificationFormatMap, member);
+                var (tooltipTextBlock, automationName) = InheritanceMarginHelpers.CreateToolTipForSingleMember(classificationTypeMap, classificationFormatMap, member);
                 return new InheritanceMarginViewModel(tag.Moniker, tooltipTextBlock, automationName, scaleFactor, menuItemViewModels);
             }
             else

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginViewModel.cs
@@ -72,21 +72,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             {
                 var member = tag.MembersOnLine[0];
 
-                // Here we want to show a classified text with loc text,
-                // e.g. 'Bar' is inherited.
-                // But the classified text are inlines, so can't directly use string.format to generate the string
-                var inlines = member.DisplayTexts.ToInlines(classificationFormatMap, classificationTypeMap);
-                var startOfThePlaceholder = ServicesVSResources._0_is_inherited.IndexOf("{0}", StringComparison.Ordinal);
-                var prefixString = ServicesVSResources._0_is_inherited[..startOfThePlaceholder];
-                var suffixString = ServicesVSResources._0_is_inherited[(startOfThePlaceholder + "{0}".Length)..];
-                inlines.Insert(0, new Run(prefixString));
-                inlines.Add(new Run(suffixString));
-                var toolTipTextBlock = inlines.ToTextBlock(classificationFormatMap);
-                toolTipTextBlock.FlowDirection = FlowDirection.LeftToRight;
-
-                var automationName = string.Format(ServicesVSResources._0_is_inherited, member.DisplayTexts.JoinText());
+                //// Here we want to show a classified text with loc text,
+                //// e.g. 'Bar' is inherited.
+                //// But the classified text are inlines, so can't directly use string.format to generate the string
+                //var inlines = member.TaggedTexts.ToInlines(classificationFormatMap, classificationTypeMap);
+                //var startOfThePlaceholder = ServicesVSResources._0_is_inherited.IndexOf("{0}", StringComparison.Ordinal);
+                //var prefixString = ServicesVSResources._0_is_inherited[..startOfThePlaceholder];
+                //var suffixString = ServicesVSResources._0_is_inherited[(startOfThePlaceholder + "{0}".Length)..];
+                //inlines.Insert(0, new Run(prefixString));
+                //inlines.Add(new Run(suffixString));
+                //var toolTipTextBlock = inlines.ToTextBlock(classificationFormatMap);
+                //toolTipTextBlock.FlowDirection = FlowDirection.LeftToRight;
+                var automationName = string.Format(ServicesVSResources._0_is_inherited, member.TaggedTexts.JoinText());
                 var menuItemViewModels = InheritanceMarginHelpers.CreateMenuItemViewModelsForSingleMember(member.TargetItems);
-                return new InheritanceMarginViewModel(tag.Moniker, toolTipTextBlock, automationName, scaleFactor, menuItemViewModels);
+                var tooltipTextBlock = InheritanceMarginHelpers.CreateToolTipTextBlockForSingleMember(classificationTypeMap, classificationFormatMap, member);
+                return new InheritanceMarginViewModel(tag.Moniker, tooltipTextBlock, automationName, scaleFactor, menuItemViewModels);
             }
             else
             {

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginViewModel.cs
@@ -71,18 +71,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             if (members.Length == 1)
             {
                 var member = tag.MembersOnLine[0];
-
-                //// Here we want to show a classified text with loc text,
-                //// e.g. 'Bar' is inherited.
-                //// But the classified text are inlines, so can't directly use string.format to generate the string
-                //var inlines = member.TaggedTexts.ToInlines(classificationFormatMap, classificationTypeMap);
-                //var startOfThePlaceholder = ServicesVSResources._0_is_inherited.IndexOf("{0}", StringComparison.Ordinal);
-                //var prefixString = ServicesVSResources._0_is_inherited[..startOfThePlaceholder];
-                //var suffixString = ServicesVSResources._0_is_inherited[(startOfThePlaceholder + "{0}".Length)..];
-                //inlines.Insert(0, new Run(prefixString));
-                //inlines.Add(new Run(suffixString));
-                //var toolTipTextBlock = inlines.ToTextBlock(classificationFormatMap);
-                //toolTipTextBlock.FlowDirection = FlowDirection.LeftToRight;
                 var automationName = string.Format(ServicesVSResources._0_is_inherited, member.TaggedTexts.JoinText());
                 var menuItemViewModels = InheritanceMarginHelpers.CreateMenuItemViewModelsForSingleMember(member.TargetItems);
                 var tooltipTextBlock = InheritanceMarginHelpers.CreateToolTipTextBlockForSingleMember(classificationTypeMap, classificationFormatMap, member);

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/MemberMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/MemberMenuItemViewModel.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
 
         public static MemberMenuItemViewModel CreateWithHeaderInTargets(InheritanceMarginItem member)
         {
-            var displayName = member.DisplayTexts.JoinText();
+            var displayName = member.TaggedTexts.JoinText();
             var targetsByRelationship = member.TargetItems
                 .OrderBy(item => item.DisplayName)
                 .GroupBy(target => target.RelationToMember)

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/MemberMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/MemberMenuItemViewModel.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
 
         public static MemberMenuItemViewModel CreateWithHeaderInTargets(InheritanceMarginItem member)
         {
-            var displayName = member.TaggedTexts.JoinText();
+            var displayName = member.DisplayTaggedTexts.JoinText();
             var targetsByRelationship = InheritanceMarginHelpers.CreateMenuItemViewModelsForSingleMember(member.TargetItems);
             return new MemberMenuItemViewModel(
                 displayName,

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/MemberMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/MemberMenuItemViewModel.cs
@@ -44,12 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         public static MemberMenuItemViewModel CreateWithHeaderInTargets(InheritanceMarginItem member)
         {
             var displayName = member.TaggedTexts.JoinText();
-            var targetsByRelationship = member.TargetItems
-                .OrderBy(item => item.DisplayName)
-                .GroupBy(target => target.RelationToMember)
-                .SelectMany(grouping => InheritanceMarginHelpers.CreateMenuItemsWithHeader(grouping.Key, grouping))
-                .ToImmutableArray();
-
+            var targetsByRelationship = InheritanceMarginHelpers.CreateMenuItemViewModelsForSingleMember(member.TargetItems);
             return new MemberMenuItemViewModel(
                 displayName,
                 member.Glyph.GetImageMoniker(),

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.InheritanceMargin;
@@ -31,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
 
         public static TargetMenuItemViewModel Create(InheritanceTargetItem target)
         {
-            var displayContent = target.DisplayName;
+            var displayContent = target.DisplayTaggedTexts.JoinText();
             var imageMoniker = target.Glyph.GetImageMoniker();
             return new TargetMenuItemViewModel(
                 displayContent,

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1702,9 +1702,6 @@ Additional information: {1}</value>
   <data name="Multiple_members_are_inherited" xml:space="preserve">
     <value>Multiple members are inherited</value>
   </data>
-  <data name="_0_is_inherited" xml:space="preserve">
-    <value>'{0}' is inherited</value>
-  </data>
   <data name="Navigate_to_0" xml:space="preserve">
     <value>Navigate to '{0}'</value>
   </data>
@@ -1821,14 +1818,14 @@ Additional information: {1}</value>
   <data name="_0_has_base_types_and_derived_types" xml:space="preserve">
     <value>'{0}' has base types and derived types</value>
   </data>
-  <data name="_0_has_implemented_interfaces_and_based_types" xml:space="preserve">
+  <data name="_0_has_implemented_interfaces_and_base_types" xml:space="preserve">
     <value>'{0}' has implemented interfaces and base types</value>
   </data>
   <data name="_0_has_implemented_interfaces_and_derived_types" xml:space="preserve">
     <value>'{0}' has implemented interfaces and derived types</value>
   </data>
-  <data name="_0_has_implemented_interfaces_based_types_and_derived_types" xml:space="preserve">
-    <value>'{0}' has implemented interfaces, based types and derived types</value>
+  <data name="_0_has_implemented_interfaces_base_types_and_derived_types" xml:space="preserve">
+    <value>'{0}' has implemented interfaces, base types and derived types</value>
   </data>
   <data name="_0_has_implemented_members_and_overridden_members" xml:space="preserve">
     <value>'{0}' has implemented members and overridden members</value>
@@ -1866,7 +1863,7 @@ Additional information: {1}</value>
   <data name="_0_implements_members_from_multiple_interfaces" xml:space="preserve">
     <value>'{0}' implements members from multiple interfaces</value>
   </data>
-  <data name="_0_is_derived_from _1" xml:space="preserve">
+  <data name="_0_is_derived_from_1" xml:space="preserve">
     <value>'{0}' is derived from '{1}'</value>
   </data>
   <data name="_0_is_implemented_by_1" xml:space="preserve">

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1815,4 +1815,79 @@ Additional information: {1}</value>
     <value>Default (Open Documents)</value>
     <comment>This text is a menu command</comment>
   </data>
+  <data name="_0_derives_1" xml:space="preserve">
+    <value>'{0}' derives '{1}'</value>
+  </data>
+  <data name="_0_has_base_types_and_derived_types" xml:space="preserve">
+    <value>'{0}' has base types and derived types</value>
+  </data>
+  <data name="_0_has_implemented_interfaces_and_based_types" xml:space="preserve">
+    <value>'{0}' has implemented interfaces and base types</value>
+  </data>
+  <data name="_0_has_implemented_interfaces_and_derived_types" xml:space="preserve">
+    <value>'{0}' has implemented interfaces and derived types</value>
+  </data>
+  <data name="_0_has_implemented_interfaces_based_types_and_derived_types" xml:space="preserve">
+    <value>'{0}' has implemented interfaces, based types and derived types</value>
+  </data>
+  <data name="_0_has_implemented_members_and_overridden_members" xml:space="preserve">
+    <value>'{0}' has implemented members and overridden members</value>
+  </data>
+  <data name="_0_has_implemented_members_and_overriding_members" xml:space="preserve">
+    <value>'{0}' has implemented members and overriding members</value>
+  </data>
+  <data name="_0_has_implemented_members_overridden_members_and_overriding_members" xml:space="preserve">
+    <value>'{0}' has implemented members, overridden members and overriding members</value>
+  </data>
+  <data name="_0_has_inherited_interfaces_and_implementing_types" xml:space="preserve">
+    <value>'{0}' has inherited interfaces and implementing types</value>
+  </data>
+  <data name="_0_has_multiple_base_types" xml:space="preserve">
+    <value>'{0}' has multiple base types</value>
+  </data>
+  <data name="_0_has_multiple_derived_types" xml:space="preserve">
+    <value>'{0}' has multiple derived types</value>
+  </data>
+  <data name="_0_has_multiple_implemented_interfaces" xml:space="preserve">
+    <value>'{0}' has multiple implemented interfaces</value>
+  </data>
+  <data name="_0_has_multiple_implementing_types" xml:space="preserve">
+    <value>'{0}' has mutiple implementing types</value>
+  </data>
+  <data name="_0_has_multiple_inherited_interfaces" xml:space="preserve">
+    <value>'{0}' has multiple inherited interfaces</value>
+  </data>
+  <data name="_0_has_overridden_members_and_overriding_members" xml:space="preserve">
+    <value>'{0}' has overridden members and overriding members</value>
+  </data>
+  <data name="_0_implements_1" xml:space="preserve">
+    <value>'{0}' implements '{1}'</value>
+  </data>
+  <data name="_0_implements_members_from_multiple_interfaces" xml:space="preserve">
+    <value>'{0}' implements members from multiple interfaces</value>
+  </data>
+  <data name="_0_is_derived_from _1" xml:space="preserve">
+    <value>'{0}' is derived from '{1}'</value>
+  </data>
+  <data name="_0_is_implemented_by_1" xml:space="preserve">
+    <value>'{0}' is implemented by '{1}'</value>
+  </data>
+  <data name="_0_is_implemented_by_members_from_multiple_types" xml:space="preserve">
+    <value>'{0}' is implemented by members from multiple types</value>
+  </data>
+  <data name="_0_is_inherited_from_1" xml:space="preserve">
+    <value>'{0}' is inherited from '{1}'</value>
+  </data>
+  <data name="_0_is_overridden_by_1" xml:space="preserve">
+    <value>'{0}' is overridden by '{1}'</value>
+  </data>
+  <data name="_0_is_overridden_by_members_from_multiple_classes" xml:space="preserve">
+    <value>'{0}' is overridden by members from multiple classes</value>
+  </data>
+  <data name="_0_overrides_1" xml:space="preserve">
+    <value>'{0}' overrides '{1}'</value>
+  </data>
+  <data name="_0_overrides_members_from_multiple_classes" xml:space="preserve">
+    <value>'{0}' overrides members from multiple classes</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">Není platnou hodnotou.</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">{0} se dědí.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">{0} se dědí.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">"{0}" wird geerbt.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">Kein gültiger Wert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">"{0}" wird geerbt.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">No es un valor válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">"{0}" is heredado</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">"{0}" is heredado</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">« {0} » est hérité</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">Valeur non valide</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">« {0} » est hérité</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">Valore non valido</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}' è ereditato</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">'{0}' è ereditato</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">'{0}' が継承済み</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">有効な値ではありません</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}' が継承済み</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">'{0}'이(가) 상속되었습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">값이 잘못되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}'이(가) 상속되었습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">Nieprawidłowa wartość</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">Dziedziczone: „{0}”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">Dziedziczone: „{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">'{0}' é herdado</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">O valor não é válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}' é herdado</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">Недопустимое значение</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">"{0}" наследуется</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">"{0}" наследуется</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">Geçerli bir değer değil</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}' devralındı</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">'{0}' devralındı</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">已继承“{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">值无效</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">已继承“{0}”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1462,9 +1462,134 @@
         <target state="translated">值無效</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_derives_1">
+        <source>'{0}' derives '{1}'</source>
+        <target state="new">'{0}' derives '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_base_types_and_derived_types">
+        <source>'{0}' has base types and derived types</source>
+        <target state="new">'{0}' has base types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+        <source>'{0}' has implemented interfaces and base types</source>
+        <target state="new">'{0}' has implemented interfaces and base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_and_derived_types">
+        <source>'{0}' has implemented interfaces and derived types</source>
+        <target state="new">'{0}' has implemented interfaces and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, based types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overridden_members">
+        <source>'{0}' has implemented members and overridden members</source>
+        <target state="new">'{0}' has implemented members and overridden members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_and_overriding_members">
+        <source>'{0}' has implemented members and overriding members</source>
+        <target state="new">'{0}' has implemented members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_implemented_members_overridden_members_and_overriding_members">
+        <source>'{0}' has implemented members, overridden members and overriding members</source>
+        <target state="new">'{0}' has implemented members, overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_inherited_interfaces_and_implementing_types">
+        <source>'{0}' has inherited interfaces and implementing types</source>
+        <target state="new">'{0}' has inherited interfaces and implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_base_types">
+        <source>'{0}' has multiple base types</source>
+        <target state="new">'{0}' has multiple base types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_derived_types">
+        <source>'{0}' has multiple derived types</source>
+        <target state="new">'{0}' has multiple derived types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implemented_interfaces">
+        <source>'{0}' has multiple implemented interfaces</source>
+        <target state="new">'{0}' has multiple implemented interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_implementing_types">
+        <source>'{0}' has mutiple implementing types</source>
+        <target state="new">'{0}' has mutiple implementing types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_multiple_inherited_interfaces">
+        <source>'{0}' has multiple inherited interfaces</source>
+        <target state="new">'{0}' has multiple inherited interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_has_overridden_members_and_overriding_members">
+        <source>'{0}' has overridden members and overriding members</source>
+        <target state="new">'{0}' has overridden members and overriding members</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_1">
+        <source>'{0}' implements '{1}'</source>
+        <target state="new">'{0}' implements '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_implements_members_from_multiple_interfaces">
+        <source>'{0}' implements members from multiple interfaces</source>
+        <target state="new">'{0}' implements members from multiple interfaces</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_derived_from _1">
+        <source>'{0}' is derived from '{1}'</source>
+        <target state="new">'{0}' is derived from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_1">
+        <source>'{0}' is implemented by '{1}'</source>
+        <target state="new">'{0}' is implemented by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
+        <source>'{0}' is implemented by members from multiple types</source>
+        <target state="new">'{0}' is implemented by members from multiple types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">已繼承 '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_inherited_from_1">
+        <source>'{0}' is inherited from '{1}'</source>
+        <target state="new">'{0}' is inherited from '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_1">
+        <source>'{0}' is overridden by '{1}'</source>
+        <target state="new">'{0}' is overridden by '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_is_overridden_by_members_from_multiple_classes">
+        <source>'{0}' is overridden by members from multiple classes</source>
+        <target state="new">'{0}' is overridden by members from multiple classes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_1">
+        <source>'{0}' overrides '{1}'</source>
+        <target state="new">'{0}' overrides '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_overrides_members_from_multiple_classes">
+        <source>'{0}' overrides members from multiple classes</source>
+        <target state="new">'{0}' overrides members from multiple classes</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_will_be_changed_to_abstract">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1472,7 +1472,7 @@
         <target state="new">'{0}' has base types and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_and_based_types">
+      <trans-unit id="_0_has_implemented_interfaces_and_base_types">
         <source>'{0}' has implemented interfaces and base types</source>
         <target state="new">'{0}' has implemented interfaces and base types</target>
         <note />
@@ -1482,9 +1482,9 @@
         <target state="new">'{0}' has implemented interfaces and derived types</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_has_implemented_interfaces_based_types_and_derived_types">
-        <source>'{0}' has implemented interfaces, based types and derived types</source>
-        <target state="new">'{0}' has implemented interfaces, based types and derived types</target>
+      <trans-unit id="_0_has_implemented_interfaces_base_types_and_derived_types">
+        <source>'{0}' has implemented interfaces, base types and derived types</source>
+        <target state="new">'{0}' has implemented interfaces, base types and derived types</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_has_implemented_members_and_overridden_members">
@@ -1547,7 +1547,7 @@
         <target state="new">'{0}' implements members from multiple interfaces</target>
         <note />
       </trans-unit>
-      <trans-unit id="_0_is_derived_from _1">
+      <trans-unit id="_0_is_derived_from_1">
         <source>'{0}' is derived from '{1}'</source>
         <target state="new">'{0}' is derived from '{1}'</target>
         <note />
@@ -1560,11 +1560,6 @@
       <trans-unit id="_0_is_implemented_by_members_from_multiple_types">
         <source>'{0}' is implemented by members from multiple types</source>
         <target state="new">'{0}' is implemented by members from multiple types</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="_0_is_inherited">
-        <source>'{0}' is inherited</source>
-        <target state="translated">已繼承 '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="_0_is_inherited_from_1">

--- a/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
@@ -209,7 +209,7 @@ public class Bar : AbsBar
             Dim targetForAbsFoo = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
                 Add(New TargetMenuItemViewModel("Bar.Foo", KnownMonikers.MethodPublic, "Bar.Foo", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_is_derived_from__1, "Bar", "AbsBar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_is_derived_from_1, "Bar", "AbsBar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
                 Add(New TargetMenuItemViewModel("AbsBar", KnownMonikers.ClassPublic, "AbsBar", Nothing))
 
@@ -623,7 +623,7 @@ public class SubBar : Bar { }"
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
                 Add(New TargetMenuItemViewModel("SubBar", KnownMonikers.ClassPublic, "SubBar", Nothing))
 
-            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_based_types, "SubBar")
+            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_base_types, "SubBar")
             Dim targetForBaseBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
@@ -675,7 +675,7 @@ public class SubBar : Bar
                 Add(New TargetMenuItemViewModel("Bar.GetEnumerator", KnownMonikers.MethodPublic, "Bar.GetEnumerator", Nothing)).
                 Add(New TargetMenuItemViewModel("SubBar.GetEnumerator", KnownMonikers.MethodPublic, "SubBar.GetEnumerator", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_based_types_and_derived_types, "Bar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_base_types_and_derived_types, "Bar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
@@ -691,7 +691,7 @@ public class SubBar : Bar
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
                 Add(New TargetMenuItemViewModel("SubBar.GetEnumerator", KnownMonikers.MethodPublic, "SubBar.GetEnumerator", Nothing))
 
-            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_based_types, "SubBar")
+            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_base_types, "SubBar")
             Dim targetForBaseBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).

--- a/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
@@ -145,11 +145,11 @@ public interface IBar
 public class Bar : IBar
 {
 }"
-            Dim tooltipTextForIBar = String.Format(ServicesVSResources._0_is_inherited, "interface IBar")
+            Dim tooltipTextForIBar = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar", "class Bar")
             Dim targetForIBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_is_inherited, "class Bar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_implements_1, "class Bar", "interface IBar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IBar", KnownMonikers.InterfacePublic, "IBar", Nothing))
 
@@ -181,19 +181,19 @@ public class Bar : AbsBar
     public override void Foo();
 }"
 
-            Dim tooltipTextForAbsBar = String.Format(ServicesVSResources._0_is_inherited, "class AbsBar")
+            Dim tooltipTextForAbsBar = String.Format(ServicesVSResources._0_derives_1, "class AbsBar", "class Bar")
             Dim targetForAbsBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
 
-            Dim tooltipTextForAbstractFoo = String.Format(ServicesVSResources._0_is_inherited, "abstract void AbsBar.Foo()")
+            Dim tooltipTextForAbstractFoo = String.Format(ServicesVSResources._0_is_overridden_by_1, "abstract void AbsBar.Foo()", "override void Bar.Foo()")
             Dim targetForAbsFoo = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
                 Add(New TargetMenuItemViewModel("Bar.Foo", KnownMonikers.MethodPublic, "Bar.Foo", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_is_inherited, "class Bar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_is_derived_from__1, "class Bar", "class AbsBar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
                 Add(New TargetMenuItemViewModel("AbsBar", KnownMonikers.ClassPublic, "AbsBar", Nothing))
 
-            Dim tooltipTextForOverrideFoo = String.Format(ServicesVSResources._0_is_inherited, "override void Bar.Foo()")
+            Dim tooltipTextForOverrideFoo = String.Format(ServicesVSResources._0_overrides_1, "override void Bar.Foo()", "abstract void AbsBar.Foo()")
             Dim targetForOverrideFoo = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
                 Add(New TargetMenuItemViewModel("AbsBar.Foo", KnownMonikers.MethodPublic, "AbsBar.Foo", Nothing))
 
@@ -231,20 +231,20 @@ public interface IBar1 { }
 public interface IBar2 : IBar1 { }
 public interface IBar3 : IBar2 { }
 "
-            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_inherited, "interface IBar1")
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_has_multiple_implementing_types, "interface IBar1")
             Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types),
                 New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfacePublic, "IBar2", Nothing),
                 New TargetMenuItemViewModel("IBar3", KnownMonikers.InterfacePublic, "IBar3", Nothing))
 
-            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_is_inherited, "interface IBar2")
+            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_has_inherited_interfaces_and_implementing_types, "interface IBar2")
             Dim targetForIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Inherited_interfaces, KnownMonikers.Implementing, ServicesVSResources.Inherited_interfaces),
                 New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing),
                 New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types),
                 New TargetMenuItemViewModel("IBar3", KnownMonikers.InterfacePublic, "IBar3", Nothing))
 
-            Dim tooltipTextForIBar3 = String.Format(ServicesVSResources._0_is_inherited, "interface IBar3")
+            Dim tooltipTextForIBar3 = String.Format(ServicesVSResources._0_has_multiple_inherited_interfaces, "interface IBar3")
             Dim targetForIBar3 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Inherited_interfaces, KnownMonikers.Implementing, ServicesVSResources.Inherited_interfaces),
                 New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing),
@@ -285,7 +285,7 @@ public class BarSample : IBar1
     public virtual event EventHandler e1, e2;
 }"
 
-            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_inherited, "interface IBar1")
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar1", "class BarSample")
             Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types),
                 New TargetMenuItemViewModel("BarSample", KnownMonikers.ClassPublic, "BarSample", Nothing))
@@ -299,7 +299,7 @@ public class BarSample : IBar1
                     New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members),
                     New TargetMenuItemViewModel("BarSample.e2", KnownMonikers.EventPublic, "BarSample.e2", Nothing))))
 
-            Dim tooltipTextForBarSample = String.Format(ServicesVSResources._0_is_inherited, "class BarSample")
+            Dim tooltipTextForBarSample = String.Format(ServicesVSResources._0_implements_1, "class BarSample", "interface IBar1")
             Dim targetForBarSample = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces),
                 New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfaceInternal, "IBar1", Nothing))

--- a/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
@@ -3,7 +3,6 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Immutable
-Imports System.Text
 Imports System.Threading
 Imports System.Windows
 Imports System.Windows.Controls
@@ -18,7 +17,6 @@ Imports Microsoft.VisualStudio.Imaging
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph
 Imports Microsoft.VisualStudio.Text.Classification
-Imports Microsoft.VisualStudio.Threading
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.InheritanceMargin
@@ -141,13 +139,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.InheritanceMargin
             Dim markup = "
 public interface IBar
 {
+    void Sub();
 }
 public class Bar : IBar
 {
+    public void Sub() { };
 }"
             Dim tooltipTextForIBar = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar", "class Bar")
             Dim targetForIBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
+
+            Dim tooltipTextForSubOfIBar = String.Format(ServicesVSResources._0_is_implemented_by_1, "void IBar.Sub()", "void Bar.Sub()")
+            Dim targetForIBarSub = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members)).
+                Add(New TargetMenuItemViewModel("Bar.Sub", KnownMonikers.MethodPublic, "Bar.Sub", Nothing))
+
+            Dim tooltipTextForSubOfBar = String.Format(ServicesVSResources._0_implements_1, "void Bar.Sub()", "void IBar.Sub()")
+            Dim targetForSubOfBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
+                Add(New TargetMenuItemViewModel("IBar.Sub", KnownMonikers.MethodPublic, "IBar.Sub", Nothing))
 
             Dim tooltipTextForBar = String.Format(ServicesVSResources._0_implements_1, "class Bar", "interface IBar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
@@ -160,12 +168,24 @@ public class Bar : IBar
                     tooltipTextForIBar,
                     1,
                     targetForIBar)},
-                {5, New InheritanceMarginViewModel(
+                {4, New InheritanceMarginViewModel(
+                    KnownMonikers.Implemented,
+                    CreateTextBlock(tooltipTextForSubOfIBar),
+                    tooltipTextForSubOfIBar,
+                    1,
+                    targetForIBarSub)},
+                {6, New InheritanceMarginViewModel(
                     KnownMonikers.Implementing,
                     CreateTextBlock(tooltipTextForBar),
                     tooltipTextForBar,
                     1,
-                    targetForBar)}})
+                    targetForBar)},
+                {8, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForSubOfBar),
+                    tooltipTextForSubOfBar,
+                    1,
+                    targetForSubOfBar)}})
         End Function
 
         <WpfFact>
@@ -339,6 +359,469 @@ public class BarSample : IBar1
                     String.Format(ServicesVSResources.Multiple_members_are_inherited_on_line_0, 10),
                     1,
                     targetForE1AndE2InInBarSample)}})
+        End Function
+
+        <WpfFact>
+        Public Function TestSingleInterfaceImplementsSingleInterface() As Task
+            Dim markup = "
+interface IBar1
+{
+}
+
+interface IBar2 : IBar1
+{
+}"
+
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar1", "interface IBar2")
+            Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
+                New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types),
+                New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfaceInternal, "IBar2", Nothing))
+
+            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_is_inherited_from_1, "interface IBar2", "interface IBar1")
+            Dim targetForIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
+                New HeaderMenuItemViewModel(ServicesVSResources.Inherited_interfaces, KnownMonikers.Implementing, ServicesVSResources.Inherited_interfaces),
+                New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfaceInternal, "IBar1", Nothing))
+
+            Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, InheritanceMarginViewModel) From {
+                {2, New InheritanceMarginViewModel(
+                    KnownMonikers.Implemented,
+                    CreateTextBlock(tooltipTextForIBar1),
+                    tooltipTextForIBar1,
+                    1,
+                    targetForIBar1)},
+                {6, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForIBar2),
+                    tooltipTextForIBar2,
+                    1,
+                    targetForIBar2)}})
+        End Function
+
+        <WpfFact>
+        Public Function TestClassImplementsMultipleInterfaces() As Task
+            Dim markup = "
+public interface IBar1 { }
+public interface IBar2 : IBar1 { }
+public class Bar : IBar2
+{
+}"
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_has_multiple_implementing_types, "interface IBar1")
+            Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
+                Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing)).
+                Add(New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfacePublic, "IBar2", Nothing))
+
+            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_has_inherited_interfaces_and_implementing_types, "interface IBar2")
+            Dim targetForIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Inherited_interfaces, KnownMonikers.Implementing, ServicesVSResources.Inherited_interfaces)).
+                Add(New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
+                Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
+
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_multiple_implemented_interfaces, "class Bar")
+            Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
+                Add(New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing)).
+                Add(New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfacePublic, "IBar2", Nothing))
+
+            Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, InheritanceMarginViewModel) From {
+                {2, New InheritanceMarginViewModel(
+                    KnownMonikers.Implemented,
+                    CreateTextBlock(tooltipTextForIBar1),
+                    tooltipTextForIBar1,
+                    1,
+                    targetForIBar1)},
+                {3, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForIBar2),
+                    tooltipTextForIBar2,
+                    1,
+                    targetForIBar2)},
+                {4, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForBar),
+                    tooltipTextForBar,
+                    1,
+                    targetForBar)}})
+        End Function
+
+        <WpfFact>
+        Public Function TestClassOverridesMultipleAbstractClasses() As Task
+            Dim markup = "
+public abstract class AbsBar
+{
+    public abstract void Goo();
+}
+
+public class Bar2 : AbsBar
+{
+    public override void Goo() { }
+}
+
+public class Bar : Bar2
+{
+    public override void Goo() { }
+}"
+
+            Dim tooltipTextForAbsBar = String.Format(ServicesVSResources._0_has_multiple_derived_types, "class AbsBar")
+            Dim targetForAbsBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
+                Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing)).
+                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, "Bar2", Nothing))
+
+            Dim tooltipTextForAbstractGoo = String.Format(ServicesVSResources._0_is_overridden_by_members_from_multiple_classes, "abstract void AbsBar.Goo()")
+            Dim targetForAbsGoo = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
+                Add(New TargetMenuItemViewModel("Bar.Goo", KnownMonikers.MethodPublic, "Bar.Goo", Nothing)).
+                Add(New TargetMenuItemViewModel("Bar2.Goo", KnownMonikers.MethodPublic, "Bar2.Goo", Nothing))
+
+            Dim tooltipTextForBar2 = String.Format(ServicesVSResources._0_has_base_types_and_derived_types, "class Bar2")
+            Dim targetForBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
+                Add(New TargetMenuItemViewModel("AbsBar", KnownMonikers.ClassPublic, "AbsBar", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
+                Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
+
+            Dim tooltipTextForOverrideGoo = String.Format(ServicesVSResources._0_has_overridden_members_and_overriding_members, "override void Bar2.Goo()")
+            Dim targetForOverrideFoo = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
+                Add(New TargetMenuItemViewModel("AbsBar.Goo", KnownMonikers.MethodPublic, "AbsBar.Goo", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
+                Add(New TargetMenuItemViewModel("Bar.Goo", KnownMonikers.MethodPublic, "Bar.Goo", Nothing))
+
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_multiple_base_types, "class Bar")
+            Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
+                Add(New TargetMenuItemViewModel("AbsBar", KnownMonikers.ClassPublic, "AbsBar", Nothing)).
+                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, "Bar2", Nothing))
+
+            Dim tooltipTextForGooInBar = String.Format(ServicesVSResources._0_overrides_members_from_multiple_classes, "override void Bar.Goo()")
+            Dim targetForAbsGooInBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
+                Add(New TargetMenuItemViewModel("AbsBar.Goo", KnownMonikers.MethodPublic, "AbsBar.Goo", Nothing)).
+                Add(New TargetMenuItemViewModel("Bar2.Goo", KnownMonikers.MethodPublic, "Bar2.Goo", Nothing))
+
+            Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, InheritanceMarginViewModel) From {
+                {2, New InheritanceMarginViewModel(
+                    KnownMonikers.Overridden,
+                    CreateTextBlock(tooltipTextForAbsBar),
+                    tooltipTextForAbsBar,
+                    1,
+                    targetForAbsBar)},
+                {4, New InheritanceMarginViewModel(
+                    KnownMonikers.Overridden,
+                    CreateTextBlock(tooltipTextForAbstractGoo),
+                    tooltipTextForAbstractGoo,
+                    1,
+                    targetForAbsGoo)},
+                {7, New InheritanceMarginViewModel(
+                    KnownMonikers.Overriding,
+                    CreateTextBlock(tooltipTextForBar2),
+                    tooltipTextForBar2,
+                    1,
+                    targetForBar2)},
+                {9, New InheritanceMarginViewModel(
+                    KnownMonikers.Overriding,
+                    CreateTextBlock(tooltipTextForOverrideGoo),
+                    tooltipTextForOverrideGoo,
+                    1,
+                    targetForOverrideFoo)},
+                {12, New InheritanceMarginViewModel(
+                    KnownMonikers.Overriding,
+                    CreateTextBlock(tooltipTextForBar),
+                    tooltipTextForBar,
+                    1,
+                    targetForBar)},
+                {14, New InheritanceMarginViewModel(
+                    KnownMonikers.Overriding,
+                    CreateTextBlock(tooltipTextForGooInBar),
+                    tooltipTextForGooInBar,
+                    1,
+                    targetForAbsGooInBar)}})
+        End Function
+
+        <WpfFact>
+        Public Function TestClassImplementsMultipleInterfaceMembers() As Task
+            Dim markup = "
+public interface IBar1
+{
+    void Goo();
+}
+public interface IBar2
+{
+    void Goo();
+}
+public class Bar : IBar1, IBar2
+{
+    public void Goo() { }
+}"
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar1", "class Bar")
+            Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
+                Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
+
+            Dim tooltipTextForGooOfIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "void IBar1.Goo()", "void Bar.Goo()")
+            Dim targetForGooOfIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members)).
+                Add(New TargetMenuItemViewModel("Bar.Goo", KnownMonikers.MethodPublic, "Bar.Goo", Nothing))
+
+            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar2", "class Bar")
+            Dim targetForIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
+                Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
+
+            Dim tooltipTextForGooOfIBar2 = String.Format(ServicesVSResources._0_is_implemented_by_1, "void IBar2.Goo()", "void Bar.Goo()")
+            Dim targetForGooOfIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members)).
+                Add(New TargetMenuItemViewModel("Bar.Goo", KnownMonikers.MethodPublic, "Bar.Goo", Nothing))
+
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_multiple_implemented_interfaces, "class Bar")
+            Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
+                Add(New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing)).
+                Add(New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfacePublic, "IBar2", Nothing))
+
+            Dim tooltipTextForGooOfIBar = String.Format(ServicesVSResources._0_implements_members_from_multiple_interfaces, "void Bar.Goo()")
+            Dim targetForGooOfIBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
+                Add(New TargetMenuItemViewModel("IBar1.Goo", KnownMonikers.MethodPublic, "IBar1.Goo", Nothing)).
+                Add(New TargetMenuItemViewModel("IBar2.Goo", KnownMonikers.MethodPublic, "IBar2.Goo", Nothing))
+
+            Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, InheritanceMarginViewModel) From {
+                {2, New InheritanceMarginViewModel(
+                    KnownMonikers.Implemented,
+                    CreateTextBlock(tooltipTextForIBar1),
+                    tooltipTextForIBar1,
+                    1,
+                    targetForIBar1)},
+                {4, New InheritanceMarginViewModel(
+                    KnownMonikers.Implemented,
+                    CreateTextBlock(tooltipTextForGooOfIBar1),
+                    tooltipTextForGooOfIBar1,
+                    1,
+                    targetForGooOfIBar1)},
+                {6, New InheritanceMarginViewModel(
+                    KnownMonikers.Implemented,
+                    CreateTextBlock(tooltipTextForIBar2),
+                    tooltipTextForIBar2,
+                    1,
+                    targetForIBar2)},
+                {8, New InheritanceMarginViewModel(
+                    KnownMonikers.Implemented,
+                    CreateTextBlock(tooltipTextForGooOfIBar2),
+                    tooltipTextForGooOfIBar2,
+                    1,
+                    targetForGooOfIBar2)},
+                {10, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForBar),
+                    tooltipTextForBar,
+                    1,
+                    targetForBar)},
+                {12, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForGooOfIBar),
+                    tooltipTextForGooOfIBar,
+                    1,
+                    targetForGooOfIBar)}})
+        End Function
+
+        <WpfFact>
+        Public Function TestImplementedInterfaceAndDerivedType() As Task
+            Dim markup = "
+using System.Collections;
+public class Bar: IEnumerable { }
+public class SubBar : Bar { }"
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_derived_types, "class Bar")
+            Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
+                Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
+                Add(New TargetMenuItemViewModel("SubBar", KnownMonikers.ClassPublic, "SubBar", Nothing))
+
+            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_based_types, "class SubBar")
+            Dim targetForBaseBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
+                Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
+                Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
+
+            Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, InheritanceMarginViewModel) From {
+                {3, New InheritanceMarginViewModel(
+                    KnownMonikers.ImplementingOverridden,
+                    CreateTextBlock(tooltipTextForBar),
+                    tooltipTextForBar,
+                    1,
+                    targetForBar)},
+                {4, New InheritanceMarginViewModel(
+                    KnownMonikers.ImplementingOverriding,
+                    CreateTextBlock(tooltipTextForSubBar),
+                    tooltipTextForSubBar,
+                    1,
+                    targetForBaseBar1)}})
+        End Function
+
+        <WpfFact>
+        Public Function TestImplementedInterfaceBaseTypeAndDerivedType() As Task
+            Dim markup = "
+using System.Collections;
+public class BaseBar : IEnumerable
+{
+    public virtual IEnumerator GetEnumerator() => throw new NotImplementedException();
+}
+public class Bar: BaseBar, IEnumerable
+{
+    public override IEnumerator GetEnumerator() => throw new NotImplementedException();
+}
+public class SubBar : Bar
+{
+    public override IEnumerator GetEnumerator() => throw new NotImplementedException();
+}"
+
+            Dim tooltipTextForBaseBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_derived_types, "class BaseBar")
+            Dim targetForBaseBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
+                Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
+                Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing)).
+                Add(New TargetMenuItemViewModel("SubBar", KnownMonikers.ClassPublic, "SubBar", Nothing))
+
+            Dim tooltipTextForGetEnumeratorOfBaseBar = String.Format(ServicesVSResources._0_has_implemented_members_and_overriding_members, "virtual IEnumerator BaseBar.GetEnumerator()")
+            Dim targetForGetEnumeratorOfBaseBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
+                Add(New TargetMenuItemViewModel("IEnumerable.GetEnumerator", KnownMonikers.MethodPublic, "IEnumerable.GetEnumerator", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
+                Add(New TargetMenuItemViewModel("Bar.GetEnumerator", KnownMonikers.MethodPublic, "Bar.GetEnumerator", Nothing)).
+                Add(New TargetMenuItemViewModel("SubBar.GetEnumerator", KnownMonikers.MethodPublic, "SubBar.GetEnumerator", Nothing))
+
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_based_types_and_derived_types, "class Bar")
+            Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
+                Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
+                Add(New TargetMenuItemViewModel("BaseBar", KnownMonikers.ClassPublic, "BaseBar", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
+                Add(New TargetMenuItemViewModel("SubBar", KnownMonikers.ClassPublic, "SubBar", Nothing))
+
+            Dim tooltipTextForGetEnumeratorOfBar = String.Format(ServicesVSResources._0_has_implemented_members_overridden_members_and_overriding_members, "override IEnumerator Bar.GetEnumerator()")
+            Dim targetForGetEnumeratorOfBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
+                Add(New TargetMenuItemViewModel("IEnumerable.GetEnumerator", KnownMonikers.MethodPublic, "IEnumerable.GetEnumerator", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
+                Add(New TargetMenuItemViewModel("BaseBar.GetEnumerator", KnownMonikers.MethodPublic, "BaseBar.GetEnumerator", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
+                Add(New TargetMenuItemViewModel("SubBar.GetEnumerator", KnownMonikers.MethodPublic, "SubBar.GetEnumerator", Nothing))
+
+            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_based_types, "class SubBar")
+            Dim targetForBaseBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
+                Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
+                Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing)).
+                Add(New TargetMenuItemViewModel("BaseBar", KnownMonikers.ClassPublic, "BaseBar", Nothing))
+
+            Dim tooltipTextForGetEnumeratorOfSubBar = String.Format(ServicesVSResources._0_has_implemented_members_and_overridden_members, "override IEnumerator SubBar.GetEnumerator()")
+            Dim targetForGetEnumeratorOfSubBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
+                Add(New TargetMenuItemViewModel("IEnumerable.GetEnumerator", KnownMonikers.MethodPublic, "IEnumerable.GetEnumerator", Nothing)).
+                Add(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
+                Add(New TargetMenuItemViewModel("Bar.GetEnumerator", KnownMonikers.MethodPublic, "Bar.GetEnumerator", Nothing)).
+                Add(New TargetMenuItemViewModel("BaseBar.GetEnumerator", KnownMonikers.MethodPublic, "BaseBar.GetEnumerator", Nothing))
+
+            Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, InheritanceMarginViewModel) From {
+                {3, New InheritanceMarginViewModel(
+                    KnownMonikers.ImplementingOverridden,
+                    CreateTextBlock(tooltipTextForBaseBar),
+                    tooltipTextForBaseBar,
+                    1,
+                    targetForBaseBar)},
+                {5, New InheritanceMarginViewModel(
+                    KnownMonikers.ImplementingOverridden,
+                    CreateTextBlock(tooltipTextForGetEnumeratorOfBaseBar),
+                    tooltipTextForGetEnumeratorOfBaseBar,
+                    1,
+                    targetForGetEnumeratorOfBaseBar)},
+                {7, New InheritanceMarginViewModel(
+                    KnownMonikers.ImplementingOverridden,
+                    CreateTextBlock(tooltipTextForBar),
+                    tooltipTextForBar,
+                    1,
+                    targetForBar)},
+                {9, New InheritanceMarginViewModel(
+                    KnownMonikers.ImplementingOverridden,
+                    CreateTextBlock(tooltipTextForGetEnumeratorOfBar),
+                    tooltipTextForGetEnumeratorOfBar,
+                    1,
+                    targetForGetEnumeratorOfBar)},
+                {11, New InheritanceMarginViewModel(
+                    KnownMonikers.ImplementingOverriding,
+                    CreateTextBlock(tooltipTextForSubBar),
+                    tooltipTextForSubBar,
+                    1,
+                    targetForBaseBar1)},
+                {13, New InheritanceMarginViewModel(
+                    KnownMonikers.ImplementingOverriding,
+                    CreateTextBlock(tooltipTextForGetEnumeratorOfSubBar),
+                    tooltipTextForGetEnumeratorOfSubBar,
+                    1,
+                    targetForGetEnumeratorOfSubBar)}})
+        End Function
+
+        <WpfFact>
+        Public Function TestImplementedByMembersFromMultipleType() As Task
+            Dim markup = "
+public interface IBar
+{
+    void Sub();
+}
+public class Bar1: IBar
+{
+    public void Sub() { }
+}
+public class Bar2 : IBar
+{
+    public void Sub() { }
+}"
+            Dim tooltipTextForIBar = String.Format(ServicesVSResources._0_has_multiple_implementing_types, "interface IBar")
+            Dim targetForIBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
+                Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, "Bar1", Nothing)).
+                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, "Bar2", Nothing))
+
+            Dim tooltipTextForSubInIBar = String.Format(ServicesVSResources._0_is_implemented_by_members_from_multiple_types, "void IBar.Sub()")
+            Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members)).
+                Add(New TargetMenuItemViewModel("Bar1.Sub", KnownMonikers.MethodPublic, "Bar1.Sub", Nothing)).
+                Add(New TargetMenuItemViewModel("Bar2.Sub", KnownMonikers.MethodPublic, "Bar2.Sub", Nothing))
+
+            Dim tooltipTextForBar1 = String.Format(ServicesVSResources._0_implements_1, "class Bar1", "interface IBar")
+            Dim targetForBaseBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
+                Add(New TargetMenuItemViewModel("IBar", KnownMonikers.InterfacePublic, "IBar", Nothing))
+
+            Dim tooltipTextForSubInBar1 = String.Format(ServicesVSResources._0_implements_1, "void Bar1.Sub()", "void IBar.Sub()")
+            Dim targetForSubInBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
+                Add(New TargetMenuItemViewModel("IBar.Sub", KnownMonikers.MethodPublic, "IBar.Sub", Nothing))
+
+            Dim tooltipTextForBar2 = String.Format(ServicesVSResources._0_implements_1, "class Bar2", "interface IBar")
+            Dim targetForBaseBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
+                Add(New TargetMenuItemViewModel("IBar", KnownMonikers.InterfacePublic, "IBar", Nothing))
+
+            Dim tooltipTextForSubInBar2 = String.Format(ServicesVSResources._0_implements_1, "void Bar2.Sub()", "void IBar.Sub()")
+            Dim targetForSubInBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
+                Add(New TargetMenuItemViewModel("IBar.Sub", KnownMonikers.MethodPublic, "IBar.Sub", Nothing))
+
+            Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, InheritanceMarginViewModel) From {
+                {2, New InheritanceMarginViewModel(
+                    KnownMonikers.Implemented,
+                    CreateTextBlock(tooltipTextForIBar),
+                    tooltipTextForIBar,
+                    1,
+                    targetForIBar)},
+                {4, New InheritanceMarginViewModel(
+                    KnownMonikers.Implemented,
+                    CreateTextBlock(tooltipTextForSubInIBar),
+                    tooltipTextForSubInIBar,
+                    1,
+                    targetForBar)},
+                {6, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForBar1),
+                    tooltipTextForBar1,
+                    1,
+                    targetForBaseBar1)},
+                {8, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForSubInBar1),
+                    tooltipTextForSubInBar1,
+                    1,
+                    targetForSubInBar1)},
+                {10, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForBar2),
+                    tooltipTextForBar2,
+                    1,
+                    targetForBaseBar2)},
+                {12, New InheritanceMarginViewModel(
+                    KnownMonikers.Implementing,
+                    CreateTextBlock(tooltipTextForSubInBar2),
+                    tooltipTextForSubInBar2,
+                    1,
+                    targetForSubInBar1)}})
         End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
@@ -145,19 +145,19 @@ public class Bar : IBar
 {
     public void Sub() { };
 }"
-            Dim tooltipTextForIBar = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar", "class Bar")
+            Dim tooltipTextForIBar = String.Format(ServicesVSResources._0_is_implemented_by_1, "IBar", "Bar")
             Dim targetForIBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
 
-            Dim tooltipTextForSubOfIBar = String.Format(ServicesVSResources._0_is_implemented_by_1, "void IBar.Sub()", "void Bar.Sub()")
+            Dim tooltipTextForSubOfIBar = String.Format(ServicesVSResources._0_is_implemented_by_1, "IBar.Sub", "Bar.Sub")
             Dim targetForIBarSub = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members)).
                 Add(New TargetMenuItemViewModel("Bar.Sub", KnownMonikers.MethodPublic, "Bar.Sub", Nothing))
 
-            Dim tooltipTextForSubOfBar = String.Format(ServicesVSResources._0_implements_1, "void Bar.Sub()", "void IBar.Sub()")
+            Dim tooltipTextForSubOfBar = String.Format(ServicesVSResources._0_implements_1, "Bar.Sub", "IBar.Sub")
             Dim targetForSubOfBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
                 Add(New TargetMenuItemViewModel("IBar.Sub", KnownMonikers.MethodPublic, "IBar.Sub", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_implements_1, "class Bar", "interface IBar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_implements_1, "Bar", "IBar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IBar", KnownMonikers.InterfacePublic, "IBar", Nothing))
 
@@ -201,19 +201,19 @@ public class Bar : AbsBar
     public override void Foo();
 }"
 
-            Dim tooltipTextForAbsBar = String.Format(ServicesVSResources._0_derives_1, "class AbsBar", "class Bar")
+            Dim tooltipTextForAbsBar = String.Format(ServicesVSResources._0_derives_1, "AbsBar", "Bar")
             Dim targetForAbsBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
 
-            Dim tooltipTextForAbstractFoo = String.Format(ServicesVSResources._0_is_overridden_by_1, "abstract void AbsBar.Foo()", "override void Bar.Foo()")
+            Dim tooltipTextForAbstractFoo = String.Format(ServicesVSResources._0_is_overridden_by_1, "AbsBar.Foo", "Bar.Foo")
             Dim targetForAbsFoo = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
                 Add(New TargetMenuItemViewModel("Bar.Foo", KnownMonikers.MethodPublic, "Bar.Foo", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_is_derived_from__1, "class Bar", "class AbsBar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_is_derived_from__1, "Bar", "AbsBar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
                 Add(New TargetMenuItemViewModel("AbsBar", KnownMonikers.ClassPublic, "AbsBar", Nothing))
 
-            Dim tooltipTextForOverrideFoo = String.Format(ServicesVSResources._0_overrides_1, "override void Bar.Foo()", "abstract void AbsBar.Foo()")
+            Dim tooltipTextForOverrideFoo = String.Format(ServicesVSResources._0_overrides_1, "Bar.Foo", "AbsBar.Foo")
             Dim targetForOverrideFoo = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
                 Add(New TargetMenuItemViewModel("AbsBar.Foo", KnownMonikers.MethodPublic, "AbsBar.Foo", Nothing))
 
@@ -251,20 +251,20 @@ public interface IBar1 { }
 public interface IBar2 : IBar1 { }
 public interface IBar3 : IBar2 { }
 "
-            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_has_multiple_implementing_types, "interface IBar1")
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_has_multiple_implementing_types, "IBar1")
             Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types),
                 New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfacePublic, "IBar2", Nothing),
                 New TargetMenuItemViewModel("IBar3", KnownMonikers.InterfacePublic, "IBar3", Nothing))
 
-            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_has_inherited_interfaces_and_implementing_types, "interface IBar2")
+            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_has_inherited_interfaces_and_implementing_types, "IBar2")
             Dim targetForIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Inherited_interfaces, KnownMonikers.Implementing, ServicesVSResources.Inherited_interfaces),
                 New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing),
                 New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types),
                 New TargetMenuItemViewModel("IBar3", KnownMonikers.InterfacePublic, "IBar3", Nothing))
 
-            Dim tooltipTextForIBar3 = String.Format(ServicesVSResources._0_has_multiple_inherited_interfaces, "interface IBar3")
+            Dim tooltipTextForIBar3 = String.Format(ServicesVSResources._0_has_multiple_inherited_interfaces, "IBar3")
             Dim targetForIBar3 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Inherited_interfaces, KnownMonikers.Implementing, ServicesVSResources.Inherited_interfaces),
                 New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing),
@@ -305,31 +305,31 @@ public class BarSample : IBar1
     public virtual event EventHandler e1, e2;
 }"
 
-            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar1", "class BarSample")
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "IBar1", "BarSample")
             Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types),
                 New TargetMenuItemViewModel("BarSample", KnownMonikers.ClassPublic, "BarSample", Nothing))
 
             Dim tooltipTextForE1AndE2InInterface = ServicesVSResources.Multiple_members_are_inherited
             Dim targetForE1AndE2InInterface = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
-                New MemberMenuItemViewModel("event EventHandler IBar1.e1", KnownMonikers.EventPublic, "event EventHandler IBar1.e1", ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
+                New MemberMenuItemViewModel("IBar1.e1", KnownMonikers.EventPublic, "IBar1.e1", ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                     New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members),
                     New TargetMenuItemViewModel("BarSample.e1", KnownMonikers.EventPublic, "BarSample.e1", Nothing))),
-                New MemberMenuItemViewModel("event EventHandler IBar1.e2", KnownMonikers.EventPublic, "event EventHandler IBar1.e2", ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
+                New MemberMenuItemViewModel("IBar1.e2", KnownMonikers.EventPublic, "IBar1.e2", ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                     New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members),
                     New TargetMenuItemViewModel("BarSample.e2", KnownMonikers.EventPublic, "BarSample.e2", Nothing))))
 
-            Dim tooltipTextForBarSample = String.Format(ServicesVSResources._0_implements_1, "class BarSample", "interface IBar1")
+            Dim tooltipTextForBarSample = String.Format(ServicesVSResources._0_implements_1, "BarSample", "IBar1")
             Dim targetForBarSample = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces),
                 New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfaceInternal, "IBar1", Nothing))
 
             Dim tooltipTextForE1AndE2InBarSample = ServicesVSResources.Multiple_members_are_inherited
             Dim targetForE1AndE2InInBarSample = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
-                New MemberMenuItemViewModel("virtual event EventHandler BarSample.e1", KnownMonikers.EventPublic, "virtual event EventHandler BarSample.e1", ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
+                New MemberMenuItemViewModel("BarSample.e1", KnownMonikers.EventPublic, "BarSample.e1", ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                     New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members),
                     New TargetMenuItemViewModel("IBar1.e1", KnownMonikers.EventPublic, "IBar1.e1", Nothing)).CastArray(Of InheritanceMenuItemViewModel)),
-                New MemberMenuItemViewModel("virtual event EventHandler BarSample.e2", KnownMonikers.EventPublic, "virtual event EventHandler BarSample.e2", ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
+                New MemberMenuItemViewModel("BarSample.e2", KnownMonikers.EventPublic, "BarSample.e2", ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                     New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members),
                     New TargetMenuItemViewModel("IBar1.e2", KnownMonikers.EventPublic, "IBar1.e2", Nothing)).CastArray(Of InheritanceMenuItemViewModel))) _
             .CastArray(Of InheritanceMenuItemViewModel)
@@ -372,12 +372,12 @@ interface IBar2 : IBar1
 {
 }"
 
-            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar1", "interface IBar2")
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "IBar1", "IBar2")
             Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types),
                 New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfaceInternal, "IBar2", Nothing))
 
-            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_is_inherited_from_1, "interface IBar2", "interface IBar1")
+            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_is_inherited_from_1, "IBar2", "IBar1")
             Dim targetForIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Inherited_interfaces, KnownMonikers.Implementing, ServicesVSResources.Inherited_interfaces),
                 New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfaceInternal, "IBar1", Nothing))
@@ -405,18 +405,18 @@ public interface IBar2 : IBar1 { }
 public class Bar : IBar2
 {
 }"
-            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_has_multiple_implementing_types, "interface IBar1")
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_has_multiple_implementing_types, "IBar1")
             Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing)).
                 Add(New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfacePublic, "IBar2", Nothing))
 
-            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_has_inherited_interfaces_and_implementing_types, "interface IBar2")
+            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_has_inherited_interfaces_and_implementing_types, "IBar2")
             Dim targetForIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Inherited_interfaces, KnownMonikers.Implementing, ServicesVSResources.Inherited_interfaces)).
                 Add(New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_multiple_implemented_interfaces, "class Bar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_multiple_implemented_interfaces, "Bar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing)).
                 Add(New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfacePublic, "IBar2", Nothing))
@@ -460,34 +460,34 @@ public class Bar : Bar2
     public override void Goo() { }
 }"
 
-            Dim tooltipTextForAbsBar = String.Format(ServicesVSResources._0_has_multiple_derived_types, "class AbsBar")
+            Dim tooltipTextForAbsBar = String.Format(ServicesVSResources._0_has_multiple_derived_types, "AbsBar")
             Dim targetForAbsBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing)).
                 Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, "Bar2", Nothing))
 
-            Dim tooltipTextForAbstractGoo = String.Format(ServicesVSResources._0_is_overridden_by_members_from_multiple_classes, "abstract void AbsBar.Goo()")
+            Dim tooltipTextForAbstractGoo = String.Format(ServicesVSResources._0_is_overridden_by_members_from_multiple_classes, "AbsBar.Goo")
             Dim targetForAbsGoo = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
                 Add(New TargetMenuItemViewModel("Bar.Goo", KnownMonikers.MethodPublic, "Bar.Goo", Nothing)).
                 Add(New TargetMenuItemViewModel("Bar2.Goo", KnownMonikers.MethodPublic, "Bar2.Goo", Nothing))
 
-            Dim tooltipTextForBar2 = String.Format(ServicesVSResources._0_has_base_types_and_derived_types, "class Bar2")
+            Dim tooltipTextForBar2 = String.Format(ServicesVSResources._0_has_base_types_and_derived_types, "Bar2")
             Dim targetForBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
                 Add(New TargetMenuItemViewModel("AbsBar", KnownMonikers.ClassPublic, "AbsBar", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
 
-            Dim tooltipTextForOverrideGoo = String.Format(ServicesVSResources._0_has_overridden_members_and_overriding_members, "override void Bar2.Goo()")
+            Dim tooltipTextForOverrideGoo = String.Format(ServicesVSResources._0_has_overridden_members_and_overriding_members, "Bar2.Goo")
             Dim targetForOverrideFoo = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
                 Add(New TargetMenuItemViewModel("AbsBar.Goo", KnownMonikers.MethodPublic, "AbsBar.Goo", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
                 Add(New TargetMenuItemViewModel("Bar.Goo", KnownMonikers.MethodPublic, "Bar.Goo", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_multiple_base_types, "class Bar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_multiple_base_types, "Bar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
                 Add(New TargetMenuItemViewModel("AbsBar", KnownMonikers.ClassPublic, "AbsBar", Nothing)).
                 Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, "Bar2", Nothing))
 
-            Dim tooltipTextForGooInBar = String.Format(ServicesVSResources._0_overrides_members_from_multiple_classes, "override void Bar.Goo()")
+            Dim tooltipTextForGooInBar = String.Format(ServicesVSResources._0_overrides_members_from_multiple_classes, "Bar.Goo")
             Dim targetForAbsGooInBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
                 Add(New TargetMenuItemViewModel("AbsBar.Goo", KnownMonikers.MethodPublic, "AbsBar.Goo", Nothing)).
                 Add(New TargetMenuItemViewModel("Bar2.Goo", KnownMonikers.MethodPublic, "Bar2.Goo", Nothing))
@@ -546,28 +546,28 @@ public class Bar : IBar1, IBar2
 {
     public void Goo() { }
 }"
-            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar1", "class Bar")
+            Dim tooltipTextForIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "IBar1", "Bar")
             Dim targetForIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
 
-            Dim tooltipTextForGooOfIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "void IBar1.Goo()", "void Bar.Goo()")
+            Dim tooltipTextForGooOfIBar1 = String.Format(ServicesVSResources._0_is_implemented_by_1, "IBar1.Goo", "Bar.Goo")
             Dim targetForGooOfIBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members)).
                 Add(New TargetMenuItemViewModel("Bar.Goo", KnownMonikers.MethodPublic, "Bar.Goo", Nothing))
 
-            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_is_implemented_by_1, "interface IBar2", "class Bar")
+            Dim tooltipTextForIBar2 = String.Format(ServicesVSResources._0_is_implemented_by_1, "IBar2", "Bar")
             Dim targetForIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing))
 
-            Dim tooltipTextForGooOfIBar2 = String.Format(ServicesVSResources._0_is_implemented_by_1, "void IBar2.Goo()", "void Bar.Goo()")
+            Dim tooltipTextForGooOfIBar2 = String.Format(ServicesVSResources._0_is_implemented_by_1, "IBar2.Goo", "Bar.Goo")
             Dim targetForGooOfIBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members)).
                 Add(New TargetMenuItemViewModel("Bar.Goo", KnownMonikers.MethodPublic, "Bar.Goo", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_multiple_implemented_interfaces, "class Bar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_multiple_implemented_interfaces, "Bar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IBar1", KnownMonikers.InterfacePublic, "IBar1", Nothing)).
                 Add(New TargetMenuItemViewModel("IBar2", KnownMonikers.InterfacePublic, "IBar2", Nothing))
 
-            Dim tooltipTextForGooOfIBar = String.Format(ServicesVSResources._0_implements_members_from_multiple_interfaces, "void Bar.Goo()")
+            Dim tooltipTextForGooOfIBar = String.Format(ServicesVSResources._0_implements_members_from_multiple_interfaces, "Bar.Goo")
             Dim targetForGooOfIBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
                 Add(New TargetMenuItemViewModel("IBar1.Goo", KnownMonikers.MethodPublic, "IBar1.Goo", Nothing)).
                 Add(New TargetMenuItemViewModel("IBar2.Goo", KnownMonikers.MethodPublic, "IBar2.Goo", Nothing))
@@ -617,13 +617,13 @@ public class Bar : IBar1, IBar2
 using System.Collections;
 public class Bar: IEnumerable { }
 public class SubBar : Bar { }"
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_derived_types, "class Bar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_derived_types, "Bar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
                 Add(New TargetMenuItemViewModel("SubBar", KnownMonikers.ClassPublic, "SubBar", Nothing))
 
-            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_based_types, "class SubBar")
+            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_based_types, "SubBar")
             Dim targetForBaseBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
@@ -661,21 +661,21 @@ public class SubBar : Bar
     public override IEnumerator GetEnumerator() => throw new NotImplementedException();
 }"
 
-            Dim tooltipTextForBaseBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_derived_types, "class BaseBar")
+            Dim tooltipTextForBaseBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_derived_types, "BaseBar")
             Dim targetForBaseBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing)).
                 Add(New TargetMenuItemViewModel("SubBar", KnownMonikers.ClassPublic, "SubBar", Nothing))
 
-            Dim tooltipTextForGetEnumeratorOfBaseBar = String.Format(ServicesVSResources._0_has_implemented_members_and_overriding_members, "virtual IEnumerator BaseBar.GetEnumerator()")
+            Dim tooltipTextForGetEnumeratorOfBaseBar = String.Format(ServicesVSResources._0_has_implemented_members_and_overriding_members, "BaseBar.GetEnumerator")
             Dim targetForGetEnumeratorOfBaseBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
                 Add(New TargetMenuItemViewModel("IEnumerable.GetEnumerator", KnownMonikers.MethodPublic, "IEnumerable.GetEnumerator", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
                 Add(New TargetMenuItemViewModel("Bar.GetEnumerator", KnownMonikers.MethodPublic, "Bar.GetEnumerator", Nothing)).
                 Add(New TargetMenuItemViewModel("SubBar.GetEnumerator", KnownMonikers.MethodPublic, "SubBar.GetEnumerator", Nothing))
 
-            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_based_types_and_derived_types, "class Bar")
+            Dim tooltipTextForBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_based_types_and_derived_types, "Bar")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
@@ -683,7 +683,7 @@ public class SubBar : Bar
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
                 Add(New TargetMenuItemViewModel("SubBar", KnownMonikers.ClassPublic, "SubBar", Nothing))
 
-            Dim tooltipTextForGetEnumeratorOfBar = String.Format(ServicesVSResources._0_has_implemented_members_overridden_members_and_overriding_members, "override IEnumerator Bar.GetEnumerator()")
+            Dim tooltipTextForGetEnumeratorOfBar = String.Format(ServicesVSResources._0_has_implemented_members_overridden_members_and_overriding_members, "Bar.GetEnumerator")
             Dim targetForGetEnumeratorOfBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
                 Add(New TargetMenuItemViewModel("IEnumerable.GetEnumerator", KnownMonikers.MethodPublic, "IEnumerable.GetEnumerator", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
@@ -691,14 +691,14 @@ public class SubBar : Bar
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Overriding_members, KnownMonikers.Overridden, ServicesVSResources.Overriding_members)).
                 Add(New TargetMenuItemViewModel("SubBar.GetEnumerator", KnownMonikers.MethodPublic, "SubBar.GetEnumerator", Nothing))
 
-            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_based_types, "class SubBar")
+            Dim tooltipTextForSubBar = String.Format(ServicesVSResources._0_has_implemented_interfaces_and_based_types, "SubBar")
             Dim targetForBaseBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IEnumerable", KnownMonikers.InterfacePublic, "IEnumerable", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
                 Add(New TargetMenuItemViewModel("Bar", KnownMonikers.ClassPublic, "Bar", Nothing)).
                 Add(New TargetMenuItemViewModel("BaseBar", KnownMonikers.ClassPublic, "BaseBar", Nothing))
 
-            Dim tooltipTextForGetEnumeratorOfSubBar = String.Format(ServicesVSResources._0_has_implemented_members_and_overridden_members, "override IEnumerator SubBar.GetEnumerator()")
+            Dim tooltipTextForGetEnumeratorOfSubBar = String.Format(ServicesVSResources._0_has_implemented_members_and_overridden_members, "SubBar.GetEnumerator")
             Dim targetForGetEnumeratorOfSubBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
                 Add(New TargetMenuItemViewModel("IEnumerable.GetEnumerator", KnownMonikers.MethodPublic, "IEnumerable.GetEnumerator", Nothing)).
                 Add(New HeaderMenuItemViewModel(ServicesVSResources.Overridden_members, KnownMonikers.Overriding, ServicesVSResources.Overridden_members)).
@@ -759,29 +759,29 @@ public class Bar2 : IBar
 {
     public void Sub() { }
 }"
-            Dim tooltipTextForIBar = String.Format(ServicesVSResources._0_has_multiple_implementing_types, "interface IBar")
+            Dim tooltipTextForIBar = String.Format(ServicesVSResources._0_has_multiple_implementing_types, "IBar")
             Dim targetForIBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_types, KnownMonikers.Implemented, ServicesVSResources.Implementing_types)).
                 Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, "Bar1", Nothing)).
                 Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, "Bar2", Nothing))
 
-            Dim tooltipTextForSubInIBar = String.Format(ServicesVSResources._0_is_implemented_by_members_from_multiple_types, "void IBar.Sub()")
+            Dim tooltipTextForSubInIBar = String.Format(ServicesVSResources._0_is_implemented_by_members_from_multiple_types, "IBar.Sub")
             Dim targetForBar = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implementing_members, KnownMonikers.Implemented, ServicesVSResources.Implementing_members)).
                 Add(New TargetMenuItemViewModel("Bar1.Sub", KnownMonikers.MethodPublic, "Bar1.Sub", Nothing)).
                 Add(New TargetMenuItemViewModel("Bar2.Sub", KnownMonikers.MethodPublic, "Bar2.Sub", Nothing))
 
-            Dim tooltipTextForBar1 = String.Format(ServicesVSResources._0_implements_1, "class Bar1", "interface IBar")
+            Dim tooltipTextForBar1 = String.Format(ServicesVSResources._0_implements_1, "Bar1", "IBar")
             Dim targetForBaseBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IBar", KnownMonikers.InterfacePublic, "IBar", Nothing))
 
-            Dim tooltipTextForSubInBar1 = String.Format(ServicesVSResources._0_implements_1, "void Bar1.Sub()", "void IBar.Sub()")
+            Dim tooltipTextForSubInBar1 = String.Format(ServicesVSResources._0_implements_1, "Bar1.Sub", "IBar.Sub")
             Dim targetForSubInBar1 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
                 Add(New TargetMenuItemViewModel("IBar.Sub", KnownMonikers.MethodPublic, "IBar.Sub", Nothing))
 
-            Dim tooltipTextForBar2 = String.Format(ServicesVSResources._0_implements_1, "class Bar2", "interface IBar")
+            Dim tooltipTextForBar2 = String.Format(ServicesVSResources._0_implements_1, "Bar2", "IBar")
             Dim targetForBaseBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_interfaces, KnownMonikers.Implementing, ServicesVSResources.Implemented_interfaces)).
                 Add(New TargetMenuItemViewModel("IBar", KnownMonikers.InterfacePublic, "IBar", Nothing))
 
-            Dim tooltipTextForSubInBar2 = String.Format(ServicesVSResources._0_implements_1, "void Bar2.Sub()", "void IBar.Sub()")
+            Dim tooltipTextForSubInBar2 = String.Format(ServicesVSResources._0_implements_1, "Bar2.Sub", "IBar.Sub")
             Dim targetForSubInBar2 = ImmutableArray.Create(Of InheritanceMenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Implemented_members, KnownMonikers.Implementing, ServicesVSResources.Implemented_members)).
                 Add(New TargetMenuItemViewModel("IBar.Sub", KnownMonikers.MethodPublic, "IBar.Sub", Nothing))
 


### PR DESCRIPTION
As discussed here https://github.com/dotnet/roslyn/issues/54454
Change the tooltip of the Inheritance Margin to give more information.
Some exmaple:
Before:
![image](https://user-images.githubusercontent.com/24360909/131453988-eeaa0cc2-857b-42f1-822e-6262d298dc57.png)
(We always use the same tooltip before)
After:
1. When there is only one navigation target.
![image](https://user-images.githubusercontent.com/24360909/131454291-39f9c604-b4a0-45a9-89bc-ff0bbccc484f.png)
![image](https://user-images.githubusercontent.com/24360909/131454380-eda7182f-8606-49c2-b965-a916c2cc4995.png)
![image](https://user-images.githubusercontent.com/24360909/131454403-c9712562-bcc3-45ee-a53d-c7599228c412.png)
![image](https://user-images.githubusercontent.com/24360909/131454465-bac32233-40bc-41ee-b6d8-68953b3c2a84.png)

![image](https://user-images.githubusercontent.com/24360909/131455018-9bcb436d-d5de-4980-9884-9351365a8c94.png)
![image](https://user-images.githubusercontent.com/24360909/131455032-3f187358-819b-4b51-bcfe-349ad19166a0.png)

