### PR TITLE
Move static members Root Namespace + OK button enabled fixes

### DIFF
--- a/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -244,6 +244,43 @@ namespace TestNs1
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestMoveNothing()
+        {
+            var initialMarkup = @"
+namespace TestNs1
+{
+    public class Class1
+    {
+        public static int Test[||]Method()
+        {
+            return 0;
+        }
+    }
+}";
+            var selectedDestinationName = "Class1Helpers";
+            var newFileName = "Class1Helpers.cs";
+            var selectedMembers = ImmutableArray<string>.Empty;
+            var expectedResult1 = @"
+namespace TestNs1
+{
+    public class Class1
+    {
+        public static int Test[||]Method()
+        {
+            return 0;
+        }
+    }
+}";
+            var expectedResult2 = @"namespace TestNs1
+{
+    internal static class Class1Helpers
+    {
+    }
+}";
+            await TestMovementNewFileAsync(initialMarkup, expectedResult1, expectedResult2, newFileName, selectedMembers, selectedDestinationName).ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
         public async Task TestMoveMethodWithTrivia()
         {
             var initialMarkup = @"

--- a/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
@@ -244,6 +244,36 @@ End Namespace
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function TestMoveNothing() As Task
+            Dim initialMarkup = "
+Namespace TestNs
+    Public Class Class1
+        Public Shared Function Test[||]Func() As Integer
+            Return 0
+        End Function
+    End Class
+End Namespace"
+            Dim newTypeName = "Class1Helpers"
+            Dim newFileName = "Class1Helpers.vb"
+            Dim selection = ImmutableArray(Of String).Empty
+            Dim expectedText1 = "
+Namespace TestNs
+    Public Class Class1
+        Public Shared Function Test[||]Func() As Integer
+            Return 0
+        End Function
+    End Class
+End Namespace"
+            Dim expectedText2 = "Namespace TestNs
+    Class Class1Helpers
+    End Class
+End Namespace
+"
+
+            Await TestMovementNewFileAsync(initialMarkup, expectedText1, expectedText2, newFileName, selection, newTypeName)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
         Public Async Function TestMoveFunctionWithTrivia() As Task
             Dim initialMarkup = "
 Namespace TestNs

--- a/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
@@ -71,9 +71,10 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             var generateTypeService = newDocument.GetRequiredLanguageService<IGenerateTypeService>();
             var rootNamespace = generateTypeService.GetRootNamespace(newDocument.Project.CompilationOptions);
             var index = rootNamespace.IsEmpty() ? -1 : containingNamespaceDisplay.IndexOf(rootNamespace);
-            // if we did find the root namespace as the first element, then we remove it plus the "." character
+            // if we did find the root namespace as the first element, then we remove it
+            // this may leave us with an extra "." character at the start, but when we split it shouldn't matter
             var namespaceWithoutRoot = index == 0
-                ? containingNamespaceDisplay.Remove(index, rootNamespace.Length + 1)
+                ? containingNamespaceDisplay.Remove(index, rootNamespace.Length)
                 : containingNamespaceDisplay;
 
             var namespaceParts = namespaceWithoutRoot.Split('.').Where(s => !string.IsNullOrEmpty(s));

--- a/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialog.xaml
@@ -133,7 +133,8 @@
                     Click="OK_Click" 
                     IsDefault="True"
                     MinWidth="73"
-                    MinHeight="21"/>
+                    MinHeight="21"
+                    IsEnabled="{Binding CanSubmit}"/>
             <Button x:Uid="CancelButton" 
                     Name="CancelButton"
                     Content="{Binding ElementName=dialog, Path=Cancel}"

--- a/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveStaticMembers/MoveStaticMembersDialogViewModel.cs
@@ -52,9 +52,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembe
             // TODO change once we allow movement to existing types
             var fullyQualifiedTypeName = PrependedNamespace + DestinationName;
             var isNewType = !_existingNames.Contains(fullyQualifiedTypeName);
-            _isValidName = isNewType && IsValidType(fullyQualifiedTypeName);
+            CanSubmit = isNewType && IsValidType(fullyQualifiedTypeName);
 
-            if (_isValidName)
+            if (CanSubmit)
             {
                 Icon = KnownMonikers.StatusInformation;
                 Message = ServicesVSResources.New_Type_Name_colon;
@@ -118,10 +118,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveStaticMembe
             private set => SetProperty(ref _showMessage, value);
         }
 
-        private bool _isValidName = true;
+        private bool _canSubmit = true;
         public bool CanSubmit
         {
-            get => _isValidName && MemberSelectionViewModel.CheckedMembers.Length > 0;
+            get => _canSubmit;
+            set => SetProperty(ref _canSubmit, value);
         }
     }
 }

--- a/src/VisualStudio/Core/Test/MoveStaticMembers/MoveStaticMembersViewModelTest.vb
+++ b/src/VisualStudio/Core/Test/MoveStaticMembers/MoveStaticMembersViewModelTest.vb
@@ -305,22 +305,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
             DeselectMember("Dependent", selectionVm)
 
             Assert.True(selectionVm.CheckedMembers.IsEmpty)
-            Assert.False(viewModel.CanSubmit)
 
             selectionVm.SelectAll()
             ' If constructor and operators are able to be selected, this would be a higher number
             Assert.Equal(7, selectionVm.CheckedMembers.Length)
-            Assert.True(viewModel.CanSubmit)
 
             selectionVm.DeselectAll()
             Assert.True(selectionVm.CheckedMembers.IsEmpty)
-            Assert.False(viewModel.CanSubmit)
 
             SelectMember("Dependent", selectionVm)
             selectionVm.SelectDependents()
             Assert.True(FindMemberByName("Barbar", selectionVm.Members).IsChecked)
             Assert.Equal(2, selectionVm.CheckedMembers.Length)
-            Assert.True(viewModel.CanSubmit)
         End Function
 #End Region
 
@@ -586,22 +582,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.MoveStaticMembers
             DeselectMember("Dependent", selectionVm)
 
             Assert.True(selectionVm.CheckedMembers.IsEmpty)
-            Assert.False(viewModel.CanSubmit)
 
             selectionVm.SelectAll()
             ' If constructor and operators are able to be selected, this would be a higher number
             Assert.Equal(7, selectionVm.CheckedMembers.Length)
-            Assert.True(viewModel.CanSubmit)
 
             selectionVm.DeselectAll()
             Assert.True(selectionVm.CheckedMembers.IsEmpty)
-            Assert.False(viewModel.CanSubmit)
 
             SelectMember("Dependent", selectionVm)
             selectionVm.SelectDependents()
             Assert.True(FindMemberByName("Barbar", selectionVm.Members).IsChecked)
             Assert.Equal(2, selectionVm.CheckedMembers.Length)
-            Assert.True(viewModel.CanSubmit)
         End Function
 #End Region
     End Class


### PR DESCRIPTION
1. Root namespaces now get correctly removed in VB. This fixes a crash in VB when a project had a root namespace and the class the refactoring was triggered had no namespace.
2. The dialog "OK" button now cannot be clicked unless the destination is valid. Before the button could be clicked, but no refactoring happened.
3. Previously, selecting no members also performed no action. With this change, selecting no members does allow the user to press the "OK" button, and an empty class will be created. This brings the functionality more in line with "Extract Base Class" when creating a new class and selecting no members.