### PR TITLE
Track duplicate hintNames as they are added (#55905)

### DIFF
--- a/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
+++ b/src/Compilers/CSharp/Portable/SourceGeneration/CSharpGeneratorDriver.cs
@@ -73,6 +73,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override CommonMessageProvider MessageProvider => CSharp.MessageProvider.Instance;
 
-        internal override AdditionalSourcesCollection CreateSourcesCollection() => new AdditionalSourcesCollection(".cs");
+        internal override string SourceExtension => ".cs";
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
@@ -137,6 +137,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             Assert.Contains(hintName2, exception.Message);
         }
 
+        [Fact]
+        public void Hint_Name_Must_Be_Unique_When_Combining_Soruces()
+        {
+            AdditionalSourcesCollection asc = new AdditionalSourcesCollection(".cs");
+            asc.Add("hintName1", SourceText.From("", Encoding.UTF8));
+            asc.Add("hintName2", SourceText.From("", Encoding.UTF8));
+
+            AdditionalSourcesCollection asc2 = new AdditionalSourcesCollection(".cs");
+            asc2.Add("hintName3", SourceText.From("", Encoding.UTF8));
+            asc2.Add("hintName1", SourceText.From("", Encoding.UTF8));
+
+            var exception = Assert.Throws<ArgumentException>("hintName", () => asc.CopyTo(asc2));
+            Assert.Contains("hintName1", exception.Message);
+        }
+
         [Theory]
         [InlineData("file.cs", "file.cs")]
         [InlineData("file", "file")]

--- a/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
@@ -97,6 +97,27 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
+        public void CopyTo(AdditionalSourcesCollection asc)
+        {
+            // we know the individual hint names are valid, but we do need to check that they
+            // don't collide with any we already have
+            if (asc._sourcesAdded.Count == 0)
+            {
+                asc._sourcesAdded.AddRange(this._sourcesAdded);
+            }
+            else
+            {
+                foreach (var source in this._sourcesAdded)
+                {
+                    if (asc.Contains(source.HintName))
+                    {
+                        throw new ArgumentException(string.Format(CodeAnalysisResources.HintNameUniquePerGenerator, source.HintName), "hintName");
+                    }
+                    asc._sourcesAdded.Add(source);
+                }
+            }
+        }
+
         internal ImmutableArray<GeneratedSourceText> ToImmutableAndFree() => _sourcesAdded.ToImmutableAndFree();
 
         internal ImmutableArray<GeneratedSourceText> ToImmutable() => _sourcesAdded.ToImmutable();

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorAdaptor.cs
@@ -15,11 +15,14 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal sealed class SourceGeneratorAdaptor : IIncrementalGenerator
     {
+        private readonly string _sourceExtension;
+
         internal ISourceGenerator SourceGenerator { get; }
 
-        public SourceGeneratorAdaptor(ISourceGenerator generator)
+        public SourceGeneratorAdaptor(ISourceGenerator generator, string sourceExtension)
         {
             SourceGenerator = generator;
+            _sourceExtension = sourceExtension;
         }
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -48,7 +51,7 @@ namespace Microsoft.CodeAnalysis
 
             context.RegisterSourceOutput(contextBuilderSource, (productionContext, contextBuilder) =>
             {
-                var generatorExecutionContext = contextBuilder.ToExecutionContext(productionContext.CancellationToken);
+                var generatorExecutionContext = contextBuilder.ToExecutionContext(_sourceExtension, productionContext.CancellationToken);
                 SourceGenerator.Execute(generatorExecutionContext);
 
                 // copy the contents of the old context to the new
@@ -67,10 +70,10 @@ namespace Microsoft.CodeAnalysis
 
             public ISyntaxContextReceiver? Receiver;
 
-            public GeneratorExecutionContext ToExecutionContext(CancellationToken cancellationToken)
+            public GeneratorExecutionContext ToExecutionContext(string sourceExtension, CancellationToken cancellationToken)
             {
                 Debug.Assert(ParseOptions is object && ConfigOptions is object);
-                return new GeneratorExecutionContext(Compilation, ParseOptions, AdditionalTexts, ConfigOptions, Receiver, cancellationToken);
+                return new GeneratorExecutionContext(Compilation, ParseOptions, AdditionalTexts, ConfigOptions, Receiver, sourceExtension, cancellationToken);
             }
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/IncrementalContexts.cs
@@ -19,11 +19,13 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly ArrayBuilder<ISyntaxInputNode> _syntaxInputBuilder;
         private readonly ArrayBuilder<IIncrementalGeneratorOutputNode> _outputNodes;
+        private readonly string _sourceExtension;
 
-        internal IncrementalGeneratorInitializationContext(ArrayBuilder<ISyntaxInputNode> syntaxInputBuilder, ArrayBuilder<IIncrementalGeneratorOutputNode> outputNodes)
+        internal IncrementalGeneratorInitializationContext(ArrayBuilder<ISyntaxInputNode> syntaxInputBuilder, ArrayBuilder<IIncrementalGeneratorOutputNode> outputNodes, string sourceExtension)
         {
             _syntaxInputBuilder = syntaxInputBuilder;
             _outputNodes = outputNodes;
+            _sourceExtension = sourceExtension;
         }
 
         public SyntaxValueProvider SyntaxProvider => new SyntaxValueProvider(_syntaxInputBuilder, RegisterOutput);
@@ -38,13 +40,13 @@ namespace Microsoft.CodeAnalysis
 
         public IncrementalValueProvider<MetadataReference> MetadataReferencesProvider => new IncrementalValueProvider<MetadataReference>(SharedInputNodes.MetadataReferences.WithRegisterOutput(RegisterOutput));
 
-        public void RegisterSourceOutput<TSource>(IncrementalValueProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Source);
+        public void RegisterSourceOutput<TSource>(IncrementalValueProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Source, _sourceExtension);
 
-        public void RegisterSourceOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Source);
+        public void RegisterSourceOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Source, _sourceExtension);
 
-        public void RegisterImplementationSourceOutput<TSource>(IncrementalValueProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Implementation);
+        public void RegisterImplementationSourceOutput<TSource>(IncrementalValueProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Implementation, _sourceExtension);
 
-        public void RegisterImplementationSourceOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Implementation);
+        public void RegisterImplementationSourceOutput<TSource>(IncrementalValuesProvider<TSource> source, Action<SourceProductionContext, TSource> action) => RegisterSourceOutput(source.Node, action, IncrementalGeneratorOutputKind.Implementation, _sourceExtension);
 
         public void RegisterPostInitializationOutput(Action<IncrementalGeneratorPostInitializationContext> callback) => _outputNodes.Add(new PostInitOutputNode(callback.WrapUserAction()));
 
@@ -56,9 +58,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private static void RegisterSourceOutput<TSource>(IIncrementalGeneratorNode<TSource> node, Action<SourceProductionContext, TSource> action, IncrementalGeneratorOutputKind kind)
+        private static void RegisterSourceOutput<TSource>(IIncrementalGeneratorNode<TSource> node, Action<SourceProductionContext, TSource> action, IncrementalGeneratorOutputKind kind, string sourceExt)
         {
-            node.RegisterOutput(new SourceOutputNode<TSource>(node, action.WrapUserAction(), kind));
+            node.RegisterOutput(new SourceOutputNode<TSource>(node, action.WrapUserAction(), kind, sourceExt));
         }
     }
 
@@ -100,10 +102,10 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public readonly struct SourceProductionContext
     {
-        internal readonly ArrayBuilder<GeneratedSourceText> Sources;
+        internal readonly AdditionalSourcesCollection Sources;
         internal readonly DiagnosticBag Diagnostics;
 
-        internal SourceProductionContext(ArrayBuilder<GeneratedSourceText> sources, DiagnosticBag diagnostics, CancellationToken cancellationToken)
+        internal SourceProductionContext(AdditionalSourcesCollection sources, DiagnosticBag diagnostics, CancellationToken cancellationToken)
         {
             CancellationToken = cancellationToken;
             Sources = sources;
@@ -124,7 +126,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="hintName">An identifier that can be used to reference this source text, must be unique within this generator</param>
         /// <param name="sourceText">The <see cref="SourceText"/> to add to the compilation</param>
-        public void AddSource(string hintName, SourceText sourceText) => Sources.Add(new GeneratedSourceText(hintName, sourceText));
+        public void AddSource(string hintName, SourceText sourceText) => Sources.Add(hintName, sourceText);
 
         /// <summary>
         /// Adds a <see cref="Diagnostic"/> to the users compilation 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -21,13 +21,16 @@ namespace Microsoft.CodeAnalysis
 
         private readonly IncrementalGeneratorOutputKind _outputKind;
 
-        public SourceOutputNode(IIncrementalGeneratorNode<TInput> source, Action<SourceProductionContext, TInput> action, IncrementalGeneratorOutputKind outputKind)
+        private readonly string _sourceExtension;
+
+        public SourceOutputNode(IIncrementalGeneratorNode<TInput> source, Action<SourceProductionContext, TInput> action, IncrementalGeneratorOutputKind outputKind, string sourceExtension)
         {
             _source = source;
             _action = action;
 
             Debug.Assert(outputKind == IncrementalGeneratorOutputKind.Source || outputKind == IncrementalGeneratorOutputKind.Implementation);
             _outputKind = outputKind;
+            _sourceExtension = sourceExtension;
         }
 
         public IncrementalGeneratorOutputKind Kind => _outputKind;
@@ -54,7 +57,7 @@ namespace Microsoft.CodeAnalysis
                     // the diagnostics and sources produced and compare them, to see if they are any different 
                     // than before.
 
-                    var sourcesBuilder = ArrayBuilder<GeneratedSourceText>.GetInstance();
+                    var sourcesBuilder = new AdditionalSourcesCollection(_sourceExtension);
                     var diagnostics = DiagnosticBag.GetInstance();
 
                     SourceProductionContext context = new SourceProductionContext(sourcesBuilder, diagnostics, cancellationToken);

--- a/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicGeneratorDriver.vb
+++ b/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicGeneratorDriver.vb
@@ -44,9 +44,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Create(generators, additionalTexts, parseOptions, analyzerConfigOptionsProvider, driverOptions:=Nothing)
         End Function
 
-        Friend Overrides Function CreateSourcesCollection() As AdditionalSourcesCollection
-            Return New AdditionalSourcesCollection(".vb")
-        End Function
+        Friend Overrides ReadOnly Property SourceExtension As String
+            Get
+                Return ".vb"
+            End Get
+        End Property
 
     End Class
 


### PR DESCRIPTION
Cherry picks https://github.com/dotnet/roslyn/pull/55905 to the release as it just missed the snap.

//cc @jaredpar 