### PR TITLE
Use NativeIntegerMethodSymbol to represent parameter-less constructor.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -70,7 +70,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<Symbol> makeMembers(ImmutableArray<Symbol> underlyingMembers)
             {
                 var builder = ArrayBuilder<Symbol>.GetInstance();
-                builder.Add(new SynthesizedInstanceConstructor(this));
                 foreach (var underlyingMember in underlyingMembers)
                 {
                     Debug.Assert(_underlyingType.Equals(underlyingMember.ContainingSymbol));
@@ -101,6 +100,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                         default:
                                             builder.Add(new NativeIntegerMethodSymbol(this, underlyingMethod, associatedSymbol: null));
                                             break;
+                                    }
+                                    break;
+
+                                case MethodKind.Constructor:
+                                    if (underlyingMethod.ParameterCount == 0)
+                                    {
+                                        builder.Add(new NativeIntegerMethodSymbol(this, underlyingMethod, associatedSymbol: null));
                                     }
                                     break;
                             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -1094,7 +1094,8 @@ public class B : A<nint>
                 comp.GetMember<MethodSymbol>("B.F").TypeParameters[0].ConstraintTypesNoUseSiteDiagnostics[0].Type;
         }
 
-        [ConditionalFact(typeof(NoUsedAssembliesValidation))] // The test hook is blocked by https://github.com/dotnet/roslyn/issues/49845
+        [Fact]
+        [WorkItem(49845, "https://github.com/dotnet/roslyn/issues/49845")]
         public void Retargeting_06()
         {
             var source1 =
@@ -1108,6 +1109,25 @@ public class B : A<nint>
     public struct Int32 { }
     public class IntPtr { }
     public class UIntPtr { }
+
+    public class Attribute {}
+
+    public class Enum {}
+    public enum AttributeTargets
+    {
+        Class = 0x4,
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = true)]
+    public sealed class AttributeUsageAttribute : Attribute
+    {
+        public bool AllowMultiple {get; set;}
+        public bool Inherited {get; set;}
+        public AttributeTargets ValidOn => 0;
+        public AttributeUsageAttribute(AttributeTargets validOn)
+        {
+        }
+    }
 }";
             var comp = CreateCompilation(new AssemblyIdentity("c804cc09-8f73-44a1-9cfe-9567bed1def6", new Version(1, 0, 0, 0)), new[] { source1 }, references: null);
             var ref1 = comp.EmitToImageReference();
@@ -1117,6 +1137,7 @@ public class B : A<nint>
 {
 }";
             comp = CreateEmptyCompilation(sourceA, references: new[] { ref1 }, parseOptions: TestOptions.Regular9);
+            comp.VerifyEmitDiagnostics();
 
             var refA = comp.ToMetadataReference();
             var typeA = comp.GetMember<NamedTypeSymbol>("A").BaseTypeNoUseSiteDiagnostics;


### PR DESCRIPTION
Fixes #49845.