### PR TITLE
Remove the HasCompilation flag.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -80,15 +80,6 @@ namespace Microsoft.CodeAnalysis
                 Volatile.Write(ref _stateDoNotAccessDirectly, state);
             }
 
-            public bool HasCompilation
-            {
-                get
-                {
-                    var state = this.ReadState();
-                    return state.CompilationWithoutGeneratedDocuments != null && state.CompilationWithoutGeneratedDocuments.TryGetValue(out _) || state.DeclarationOnlyCompilation != null;
-                }
-            }
-
             public bool ContainsAssemblyOrModuleOrDynamic(ISymbol symbol, bool primary)
             {
                 Debug.Assert(symbol.Kind == SymbolKind.Assembly ||

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
@@ -37,8 +37,6 @@ namespace Microsoft.CodeAnalysis
                 _replacedGeneratedDocumentState = replacementDocumentState;
             }
 
-            public bool HasCompilation => _underlyingTracker.HasCompilation;
-
             public ProjectState ProjectState => _underlyingTracker.ProjectState;
 
             public bool ContainsAssemblyOrModuleOrDynamic(ISymbol symbol, bool primary)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.ICompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.ICompilationTracker.cs
@@ -14,20 +14,6 @@ namespace Microsoft.CodeAnalysis
     {
         private interface ICompilationTracker
         {
-            /// <summary>
-            /// Returns true if this tracker currently either points to a compilation, has an in-progress
-            /// compilation being computed, or has a skeleton reference.  Note: this is simply a weak
-            /// statement about the tracker at this exact moment in time.  Immediately after this returns
-            /// the tracker might change and may no longer have a final compilation (for example, if the
-            /// retainer let go of it) or might not have an in-progress compilation (for example, if the
-            /// background compiler finished with it).
-            /// 
-            /// Because of the above limitations, this should only be used by clients as a weak form of
-            /// information about the tracker.  For example, a client may see that a tracker has no
-            /// compilation and may choose to throw it away knowing that it could be reconstructed at a
-            /// later point if necessary.
-            /// </summary>
-            bool HasCompilation { get; }
             ProjectState ProjectState { get; }
 
             /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1586,14 +1586,7 @@ namespace Microsoft.CodeAnalysis
             IEnumerable<ProjectId>? dependencies = null;
 
             foreach (var (id, tracker) in _projectIdToTrackerMap)
-            {
-                if (!tracker.HasCompilation)
-                {
-                    continue;
-                }
-
                 builder.Add(id, CanReuse(id) ? tracker : tracker.Fork(tracker.ProjectState));
-            }
 
             return builder.ToImmutable();
 


### PR DESCRIPTION
Seems to be an odd flag that just allows us to dump prior compilation trackers we might have created *but* which didn't have at least some compilatino in them.  And all we're saving then is the allocation of a tiny object corresponding to that project.  This seems like extra unnecessary complexity (in a very complex area) for no benefit.