### PR TITLE
Bugs/22745 Naming style does not match for camel case and pascal case with underscores

### DIFF
--- a/src/Analyzers/CSharp/Tests/NamingStyles/NamingStylesTests.cs
+++ b/src/Analyzers/CSharp/Tests/NamingStyles/NamingStylesTests.cs
@@ -91,8 +91,8 @@ $@"class C
         }
 
         [Theory, Trait(Traits.Feature, Traits.Features.NamingStyle)]
-        [InlineData("Mars_bar", "bar")]
-        [InlineData("Sars_Bar", "bar")]
+        [InlineData("mars_bar", "mars_Bar")]
+        [InlineData("Sars_Bar", "sars_Bar")]
         public async Task TestCamelCaseField_UnderscoreInName(string fieldName, string correctedName)
         {
             await TestInRegularAndScriptAsync(

--- a/src/Analyzers/CSharp/Tests/NamingStyles/NamingStylesTests.cs
+++ b/src/Analyzers/CSharp/Tests/NamingStyles/NamingStylesTests.cs
@@ -316,6 +316,27 @@ $@"class C
 }", new TestParameters(options: s_options.MethodNamesArePascalCase));
         }
 
+        [Theory, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [InlineData("mars_bar", "Mars_Bar")]
+        [InlineData("Sars_bar", "Sars_Bar")]
+        public async Task TestPascalCaseMethod_UnderscoreInName(string methodName, string correctedName)
+        {
+            await TestInRegularAndScriptAsync(
+$@"class C
+{{
+    void [|{methodName}|]()
+    {{
+    }}
+}}",
+$@"class C
+{{
+    void [|{correctedName}|]()
+    {{
+    }}
+}}",
+            options: s_options.MethodNamesArePascalCase);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public async Task TestPascalCaseMethod_IndexerNameIsIgnored()
         {

--- a/src/Analyzers/CSharp/Tests/NamingStyles/NamingStylesTests.cs
+++ b/src/Analyzers/CSharp/Tests/NamingStyles/NamingStylesTests.cs
@@ -91,6 +91,23 @@ $@"class C
         }
 
         [Theory, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [InlineData("Mars_bar", "bar")]
+        [InlineData("Sars_Bar", "bar")]
+        public async Task TestCamelCaseField_UnderscoreInName(string fieldName, string correctedName)
+        {
+            await TestInRegularAndScriptAsync(
+$@"class C
+{{
+    int [|{fieldName}|];
+}}",
+$@"class C
+{{
+    int [|{correctedName}|];
+}}",
+                options: s_options.FieldNamesAreCamelCase);
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         [InlineData("M_bar", "_bar")]
         [InlineData("S_bar", "_bar")]
         [InlineData("T_bar", "_bar")]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.cs
@@ -256,6 +256,31 @@ namespace Microsoft.CodeAnalysis.NamingStyles
                 }
             }
 
+            if (!violations.Any() && name.Contains("_"))
+            {
+                var rx = new Regex("(?<=[_])");
+                var words = rx.Split(name).Where(str => str.Length > 0);
+                var spanStart = 0;
+                var firstWord = true;
+                foreach (var word in words)
+                {
+                    if (firstWord)
+                    {
+                        firstWord = false;
+                        spanStart += word.Length;
+                        continue;
+                    }
+
+                    var spanToCheck = TextSpan.FromBounds(spanStart, spanStart + word.Length);
+                    if (!wordCheck(name, spanToCheck))
+                    {
+                        violations.Add(Substring(name, spanToCheck));
+                    }
+
+                    spanStart += word.Length;
+                }
+            }
+
             if (violations.Count > 0)
             {
                 reason = string.Format(resourceId, string.Join(", ", violations));
@@ -315,7 +340,7 @@ namespace Microsoft.CodeAnalysis.NamingStyles
             if (!violations.Any() && name.Contains("_"))
             {
                 var rx = new Regex("(?<=[_])");
-                var words = rx.Split(name);
+                var words = rx.Split(name).Where(str => str.Length > 0);
                 var spanStart = 0;
                 var firstWord = true;
                 foreach (var word in words)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -311,6 +312,13 @@ namespace Microsoft.CodeAnalysis.NamingStyles
                 first = false;
             }
 
+            if (!violations.Any() && name.Contains("_"))
+            {
+                var rx = new Regex("(?<=[_])");
+                var words = rx.Split(name);
+                foreach (var word in words
+            }
+
             if (violations.Count > 0)
             {
                 var restString = string.Format(restResourceId, string.Join(", ", violations));
@@ -442,6 +450,11 @@ namespace Microsoft.CodeAnalysis.NamingStyles
 
                     words = newWords;
                 }
+            }
+            else if (name.Contains("_"))
+            {
+                var rx = new Regex("(?<=[_])");
+                words = rx.Split(name);
             }
 
             words = ApplyCapitalization(words);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.cs
@@ -316,7 +316,25 @@ namespace Microsoft.CodeAnalysis.NamingStyles
             {
                 var rx = new Regex("(?<=[_])");
                 var words = rx.Split(name);
-                foreach (var word in words
+                var spanStart = 0;
+                var firstWord = true;
+                foreach (var word in words)
+                {
+                    if (firstWord)
+                    {
+                        firstWord = false;
+                        spanStart += word.Length;
+                        continue;
+                    }
+
+                    var spanToCheck = TextSpan.FromBounds(spanStart, spanStart + word.Length);
+                    if (!restWordCheck(name, spanToCheck))
+                    {
+                        violations.Add(Substring(name, spanToCheck));
+                    }
+
+                    spanStart += word.Length;
+                }
             }
 
             if (violations.Count > 0)


### PR DESCRIPTION
Fixes: #22745

Still working on some parts. Need to figure out if regex is the best way to deal with the underscore case.