### PR TITLE
Fix doubleclick for Value Tracking

### DIFF
--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTree.xaml
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTree.xaml
@@ -38,7 +38,7 @@
             Foreground="{DynamicResource {x:Static vs:ProgressBarColors.IndicatorFillBrushKey}}"
             Background="{DynamicResource {x:Static vs:ProgressBarColors.BackgroundBrushKey}}" />
 
-        <TreeView Grid.Row="1" Grid.Column="0" x:Name="ValueTrackingTreeView" ItemsSource="{Binding Roots}" SelectedItemChanged="ValueTrackingTreeView_SelectedItemChanged" BorderThickness="0" PreviewKeyDown="ValueTrackingTreeView_PreviewKeyDown" MouseDown="ValueTrackingTreeView_MouseClickPreview" PreviewMouseDoubleClick="ValueTrackingTreeView_MouseClickPreview">
+        <TreeView Grid.Row="1" Grid.Column="0" x:Name="ValueTrackingTreeView" ItemsSource="{Binding Roots}" SelectedItemChanged="ValueTrackingTree_SelectedItemChanged" BorderThickness="0" PreviewKeyDown="ValueTrackingTree_PreviewKeyDown" PreviewMouseDoubleClick="ValueTrackingTree_MouseDoubleClickPreview">
             <TreeView.ItemContainerStyle>
                 <Style TargetType="{x:Type TreeViewItem}">
                     <Setter Property="IsExpanded" Value="{Binding IsNodeExpanded, Mode=TwoWay}" />

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTree.xaml.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTree.xaml.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             InitializeComponent();
         }
 
-        private void ValueTrackingTreeView_PreviewKeyDown(object sender, KeyEventArgs e)
+        private void ValueTrackingTree_PreviewKeyDown(object sender, KeyEventArgs e)
         {
             e.Handled = e.Handled || e.Key switch
             {
@@ -64,11 +64,21 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             }
         }
 
-        private void ValueTrackingTreeView_MouseClickPreview(object sender, MouseButtonEventArgs e)
+        private void ValueTrackingTree_MouseDoubleClickPreview(object sender, MouseButtonEventArgs e)
         {
-            if (sender is TreeViewItemBase viewModel && e.ChangedButton == MouseButton.Left)
+            if (e.ChangedButton != MouseButton.Left)
+            {
+                return;
+            }
+
+            if (sender is TreeViewItemBase viewModel)
             {
                 SelectItem(viewModel, true);
+                e.Handled = true;
+            }
+            else if (sender is TreeView)
+            {
+                SelectItem(_viewModel.SelectedItem, true);
                 e.Handled = true;
             }
         }
@@ -111,7 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             return item.GetPreviousInTree();
         }
 
-        private void ValueTrackingTreeView_SelectedItemChanged(object sender, System.Windows.RoutedPropertyChangedEventArgs<object> e)
+        private void ValueTrackingTree_SelectedItemChanged(object sender, System.Windows.RoutedPropertyChangedEventArgs<object> e)
         {
             _viewModel.SelectedItem = ValueTrackingTreeView.SelectedItem as TreeViewItemBase;
         }


### PR DESCRIPTION
New click modality: 

Single click = select item (default for tree)
Double click = Navigate to item. The first click in double click still performs a select.