### PR TITLE
Don't try to rename references in source generated files

### DIFF
--- a/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
@@ -34,6 +34,28 @@ public class GeneratedClass
         End Sub
 
         <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameWithReferenceInGeneratedFile(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
+                            <Document>
+public class [|$$RegularClass|]
+{
+}
+                            </Document>
+                            <DocumentFromSourceGenerator>
+public class GeneratedClass
+{
+    public void M(RegularClass c) { }
+}
+                            </DocumentFromSourceGenerator>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="A")
+
+            End Using
+        End Sub
+
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(51537, "https://github.com/dotnet/roslyn/issues/51537")>
         Public Sub RenameWithCascadeIntoGeneratedFile(host As RenameTestHost)
             Using result = RenameEngineResult.Create(_outputHelper,

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
@@ -360,6 +360,13 @@ namespace Microsoft.CodeAnalysis.Rename
 
             internal static async Task<IEnumerable<RenameLocation>> GetRenamableReferenceLocationsAsync(ISymbol referencedSymbol, ISymbol originalSymbol, ReferenceLocation location, Solution solution, CancellationToken cancellationToken)
             {
+                // We won't try to update references in source generated files; we'll assume the generator will rerun
+                // and produce an updated document with the new name.
+                if (location.Document is SourceGeneratedDocument)
+                {
+                    return SpecializedCollections.EmptyEnumerable<RenameLocation>();
+                }
+
                 var shouldIncludeSymbol = await ShouldIncludeSymbolAsync(referencedSymbol, originalSymbol, solution, true, cancellationToken).ConfigureAwait(false);
                 if (!shouldIncludeSymbol)
                 {


### PR DESCRIPTION
In afd8743801b925948a59edab256120fd140eb804, I prevented us from trying to rename the definition locations of a symbol that may have appeared in a generated file; that could happen in partial file cases or some cascading cases. But I missed the much simpler case: just having a good old fashioned reference in a generated file. This fixes that oversight.

Fixes https://developercommunity.visualstudio.com/t/Renaming-fails-for-type-referenced-in-a-/1389855 and internal tracking [AB#1393227](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1393227).