### PR TITLE
Fix crashes in some nullable error scenarios

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5317,7 +5317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 for (int i = 0; i < results.Length; i++)
                 {
                     var argumentNoConversion = argumentsNoConversions[i];
-                    var argument = i < arguments.Length ? arguments[i] : argumentsNoConversions[i];
+                    var argument = i < arguments.Length ? arguments[i] : argumentNoConversion;
 
                     if (argument is not BoundConversion && argumentNoConversion is BoundLambda lambda)
                     {
@@ -5336,7 +5336,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // If this assert fails, we are missing necessary info to visit the
                         // conversion of a target typed conditional or switch.
                         Debug.Assert(argumentNoConversion is not (BoundConditionalOperator { WasTargetTyped: true } or BoundConvertedSwitchExpression { WasTargetTyped: true })
-                            && !ConditionalInfoForConversion.ContainsKey(argumentNoConversion));
+                            && _conditionalInfoForConversionOpt?.ContainsKey(argumentNoConversion) is null or false);
 
                         // If this assert fails, it means we failed to visit a lambda for error recovery above.
                         Debug.Assert(argumentNoConversion is not BoundLambda);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5310,25 +5310,45 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool parameterHasNotNullIfNotNull = !IsAnalyzingAttribute && !parametersOpt.IsDefault && parametersOpt.Any(p => !p.NotNullIfParameterNotNull.IsEmpty);
             var notNullParametersBuilder = parameterHasNotNullIfNotNull ? ArrayBuilder<ParameterSymbol>.GetInstance() : null;
-            if (!node.HasErrors && !parametersOpt.IsDefault)
+            if (!parametersOpt.IsDefault)
             {
                 // Visit conversions, inbound assignments including pre-conditions
                 ImmutableHashSet<string>? returnNotNullIfParameterNotNull = IsAnalyzingAttribute ? null : method?.ReturnNotNullIfParameterNotNull;
                 for (int i = 0; i < results.Length; i++)
                 {
+                    var argumentNoConversion = argumentsNoConversions[i];
+                    var argument = i < arguments.Length ? arguments[i] : argumentsNoConversions[i];
+
+                    if (argument is not BoundConversion && argumentNoConversion is BoundLambda lambda)
+                    {
+                        Debug.Assert(node.HasErrors);
+                        Debug.Assert((object)argument == argumentNoConversion);
+                        // 'VisitConversion' only visits a lambda when the lambda has an AnonymousFunction conversion.
+                        // This lambda doesn't have a conversion, so we need to visit it here.
+                        VisitLambda(lambda, delegateTypeOpt: null, results[i].StateForLambda);
+                        continue;
+                    }
+
                     (ParameterSymbol? parameter, TypeWithAnnotations parameterType, FlowAnalysisAnnotations parameterAnnotations, bool isExpandedParamsArgument) =
                         GetCorrespondingParameter(i, parametersOpt, argsToParamsOpt, expanded);
                     if (parameter is null)
                     {
+                        // If this assert fails, we are missing necessary info to visit the
+                        // conversion of a target typed conditional or switch.
+                        Debug.Assert(argumentNoConversion is not (BoundConditionalOperator { WasTargetTyped: true } or BoundConvertedSwitchExpression { WasTargetTyped: true })
+                            && !ConditionalInfoForConversion.ContainsKey(argumentNoConversion));
+
+                        // If this assert fails, it means we failed to visit a lambda for error recovery above.
+                        Debug.Assert(argumentNoConversion is not BoundLambda);
+
                         continue;
                     }
 
-                    var argumentNoConversion = argumentsNoConversions[i];
-                    var argument = i < arguments.Length ? arguments[i] : argumentsNoConversions[i];
-
-                    // we disable nullable warnings on default arguments
+                    // We disable diagnostics when:
+                    // 1. the containing call has errors (to reduce cascading diagnostics)
+                    // 2. on implicit default arguments (since that's really only an issue with the declaration)
                     var previousDisableDiagnostics = _disableDiagnostics;
-                    _disableDiagnostics |= defaultArguments[i];
+                    _disableDiagnostics |= node.HasErrors || defaultArguments[i];
 
                     VisitArgumentConversionAndInboundAssignmentsAndPreConditions(
                         GetConversionIfApplicable(argument, argumentNoConversion),
@@ -5351,19 +5371,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             shouldReturnNotNull = true;
                         }
-                    }
-                }
-            }
-            else
-            {
-                // Normally we delay visiting the lambda until we can visit it along with its conversion.
-                // Since we can't visit its conversion here, or it doesn't have one, we dig back in and
-                // visit the lambda here to ensure all nodes have nullability info for public API
-                for (int i = 0; i < results.Length; i++)
-                {
-                    if (argumentsNoConversions[i] is BoundLambda lambda)
-                    {
-                        VisitLambda(lambda, delegateTypeOpt: null, results[i].StateForLambda);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #55483

I found that when call arguments contain both errors and target typed arguments (conditional operators or switch expressions), we miss visiting the conversion and "dequeueing" the appropriate entry from `ConditionalInfoForConversion`. This can result in both assert failures in the DebugVerifier as well as duplicate key exceptions when adding to `ConditionalInfoForConversion`.

The fix is to try and be more granular with when we skip visiting argument conversions--rather than bailing on the whole thing when `node.HasErrors` is true and using a separate loop to visit lambdas for error recovery, we check per-argument if it's a lambda that needs an "error recovery" visit. Since the old `node.HasErrors` check had the effect of suppressing nullable warnings on the argument conversions, I also disabled warnings on the conversions when `node.HasErrors` is true. (failing to do this results in some weird cascading diagnostics, like complaining about the convertibility of `object?*`, etc.)

I did look into pushing the logic for "error recovery" visits into VisitConversion or similar but it was pretty fraught especially in cases where there is no target type at all (e.g. a lambda is passed as an argument with no corresponding parameter.) Also, I've added some new asserts to try and make us discover as quickly as possible if we've failed to do an error recovery visit when we need to, or if we've failed to visit the conversion of a target typed expression.
