### PR TITLE
Eliminate 75GB allocations during binding in a performance trace

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3860,6 +3860,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             return loc1.Span.Start - loc2.Span.Start;
         }
 
+        internal override int CompareSourceLocations(SyntaxNode loc1, SyntaxNode loc2)
+        {
+            var comparison = CompareSyntaxTreeOrdering(loc1.SyntaxTree, loc2.SyntaxTree);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+
+            return loc1.Span.Start - loc2.Span.Start;
+        }
+
         /// <summary>
         /// Return true if there is a source declaration symbol name that meets given predicate.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
@@ -204,8 +205,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     if (syntax != null)
                     {
-                        foreach (var loc in memberT.Locations)
+                        // PERF: Avoid accessing Locations for performance, but assert that the alternative approach is
+                        // equivalent.
+                        Debug.Assert(memberT.MergedDeclaration.Declarations.SelectAsArray(decl => decl.NameLocation).SequenceEqual(memberT.Locations));
+                        foreach (var declaration in memberT.MergedDeclaration.Declarations)
                         {
+                            var loc = declaration.NameLocation;
                             if (loc.IsInSource && loc.SourceTree == syntax.SyntaxTree && syntax.Span.Contains(loc.SourceSpan))
                             {
                                 return memberT;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -889,7 +889,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _lazyLexicalSortKey;
         }
 
-        public override ImmutableArray<Location> Locations
+        public sealed override ImmutableArray<Location> Locations
         {
             get
             {

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -3237,6 +3237,12 @@ namespace Microsoft.CodeAnalysis
         internal abstract int CompareSourceLocations(SyntaxReference loc1, SyntaxReference loc2);
 
         /// <summary>
+        /// Compare two source locations, using their containing trees, and then by Span.First within a tree.
+        /// Can be used to get a total ordering on declarations, for example.
+        /// </summary>
+        internal abstract int CompareSourceLocations(SyntaxNode loc1, SyntaxNode loc2);
+
+        /// <summary>
         /// Return the lexically first of two locations.
         /// </summary>
         internal TLocation FirstSourceLocation<TLocation>(TLocation first, TLocation second)

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeLocationComparer.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeLocationComparer.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -33,7 +31,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return _compilation.CompareSourceLocations(x.GetLocation(), y.GetLocation());
+                return _compilation.CompareSourceLocations(x, y);
             }
         }
     }

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1251,6 +1251,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return LexicalSortKey.Compare(first, second, Me)
         End Function
 
+        ''' <summary>
+        ''' Compare two source locations, using their containing trees, and then by Span.First within a tree. 
+        ''' Can be used to get a total ordering on declarations, for example.
+        ''' </summary>
+        Friend Overrides Function CompareSourceLocations(first As SyntaxNode, second As SyntaxNode) As Integer
+            Return LexicalSortKey.Compare(first, second, Me)
+        End Function
+
         Friend Overrides Function GetSyntaxTreeOrdinal(tree As SyntaxTree) As Integer
             Debug.Assert(Me.ContainsSyntaxTree(tree))
             Return _syntaxTreeOrdinalMap(tree)

--- a/src/Compilers/VisualBasic/Portable/Symbols/LexicalSortKey.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/LexicalSortKey.vb
@@ -207,6 +207,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return LexicalSortKey.Compare(firstKey, secondKey)
         End Function
 
+        Public Shared Function Compare(first As SyntaxNode, second As SyntaxNode, compilation As VisualBasicCompilation) As Integer
+            ' This is a shortcut to avoid building complete keys for the case when both locations belong to the same tree.
+            ' Also saves us in some speculative SemanticModel scenarios when the tree we are dealing with doesn't belong to
+            ' the compilation and an attempt of building the LexicalSortKey will simply assert and crash.
+            If first.SyntaxTree IsNot Nothing AndAlso first.SyntaxTree Is second.SyntaxTree Then
+                Return first.Span.Start - second.Span.Start
+            End If
+
+            Dim firstKey = New LexicalSortKey(first.SyntaxTree, first.SpanStart, compilation)
+            Dim secondKey = New LexicalSortKey(second.SyntaxTree, second.SpanStart, compilation)
+            Return LexicalSortKey.Compare(firstKey, secondKey)
+        End Function
+
         Public Shared Function First(xSortKey As LexicalSortKey, ySortKey As LexicalSortKey) As LexicalSortKey
             Dim comparison As Integer = Compare(xSortKey, ySortKey)
             Return If(comparison > 0, ySortKey, xSortKey)


### PR DESCRIPTION
Fixes two of the most expensive allocation paths shown in the performance trace attached to [AB#1389013](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1389013).

Fixes [AB#1389013](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1389013)