### PR TITLE
Include ref info for parameters > 16 in synthesized delegate type name

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/RefKindVector.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/RefKindVector.cs
@@ -85,14 +85,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             builder.Append("{");
 
             int i = 0;
-            foreach (int byRefIndex in this.Words())
+            foreach (var word in this.Words())
             {
                 if (i > 0)
                 {
                     builder.Append(",");
                 }
 
-                builder.AppendFormat("{0:x8}", byRefIndex);
+                builder.AppendFormat("{0:x8}", word);
                 i++;
             }
 


### PR DESCRIPTION
Fixes #55570.