### PR TITLE
Fix crash when comparing tuples in symbolequivalence

### DIFF
--- a/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
+++ b/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
@@ -1132,6 +1132,196 @@ class C
         }
 
         [Fact]
+        [WorkItem(1388780, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1388780")]
+        [WorkItem(1391743, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391743")]
+        [WorkItem(1393352, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1393352")]
+        public async Task TestTuples1()
+        {
+            var csharpCode1 =
+@"
+class C
+{
+    void M((int, int) i) { }
+}";
+
+            var csharpCode2 =
+@"
+class C
+{
+    void M(int i) { }
+}";
+
+            using var workspace1 = TestWorkspace.CreateCSharp(csharpCode1);
+            using var workspace2 = TestWorkspace.CreateCSharp(csharpCode2);
+            var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+            var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+
+            var method_v1 = type1_v1.GetMembers("M").Single();
+            var method_v2 = type1_v2.GetMembers("M").Single();
+
+            Assert.False(SymbolEquivalenceComparer.Instance.Equals(method_v1, method_v2));
+        }
+
+        [Fact]
+        [WorkItem(1388780, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1388780")]
+        [WorkItem(1391743, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391743")]
+        [WorkItem(1393352, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1393352")]
+        public async Task TestTuples2()
+        {
+            var csharpCode1 =
+@"
+class C
+{
+    void M((int, int) i) { }
+}";
+
+            var csharpCode2 =
+@"
+class C
+{
+    void M(System.ValueTuple<int> i) { }
+}";
+
+            using var workspace1 = TestWorkspace.CreateCSharp(csharpCode1);
+            using var workspace2 = TestWorkspace.CreateCSharp(csharpCode2);
+            var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+            var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+
+            var method_v1 = type1_v1.GetMembers("M").Single();
+            var method_v2 = type1_v2.GetMembers("M").Single();
+
+            Assert.False(SymbolEquivalenceComparer.Instance.Equals(method_v1, method_v2));
+        }
+
+        [Fact]
+        [WorkItem(1388780, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1388780")]
+        [WorkItem(1391743, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391743")]
+        [WorkItem(1393352, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1393352")]
+        public async Task TestTuples3()
+        {
+            var csharpCode1 =
+@"
+class C
+{
+    void M((int, int) i) { }
+}";
+
+            var csharpCode2 =
+@"
+class C
+{
+    void M(System.ValueTuple<int, int> i) { }
+}";
+
+            using var workspace1 = TestWorkspace.CreateCSharp(csharpCode1);
+            using var workspace2 = TestWorkspace.CreateCSharp(csharpCode2);
+            var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+            var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+
+            var method_v1 = type1_v1.GetMembers("M").Single();
+            var method_v2 = type1_v2.GetMembers("M").Single();
+
+            Assert.True(SymbolEquivalenceComparer.Instance.Equals(method_v1, method_v2));
+            Assert.True(SymbolEquivalenceComparer.TupleNamesMustMatchInstance.Equals(method_v1, method_v2));
+        }
+
+        [Fact]
+        [WorkItem(1388780, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1388780")]
+        [WorkItem(1391743, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391743")]
+        [WorkItem(1393352, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1393352")]
+        public async Task TestTuples4()
+        {
+            var csharpCode1 =
+@"
+class C
+{
+    void M((int a, int b) i) { }
+}";
+
+            var csharpCode2 =
+@"
+class C
+{
+    void M(System.ValueTuple<int, int> i) { }
+}";
+
+            using var workspace1 = TestWorkspace.CreateCSharp(csharpCode1);
+            using var workspace2 = TestWorkspace.CreateCSharp(csharpCode2);
+            var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+            var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+
+            var method_v1 = type1_v1.GetMembers("M").Single();
+            var method_v2 = type1_v2.GetMembers("M").Single();
+
+            Assert.True(SymbolEquivalenceComparer.Instance.Equals(method_v1, method_v2));
+            Assert.False(SymbolEquivalenceComparer.TupleNamesMustMatchInstance.Equals(method_v1, method_v2));
+        }
+
+        [Fact]
+        [WorkItem(1388780, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1388780")]
+        [WorkItem(1391743, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391743")]
+        [WorkItem(1393352, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1393352")]
+        public async Task TestTuples5()
+        {
+            var csharpCode1 =
+@"
+class C
+{
+    void M((int a, int b) i) { }
+}";
+
+            var csharpCode2 =
+@"
+class C
+{
+    void M((int, int) i) { }
+}";
+
+            using var workspace1 = TestWorkspace.CreateCSharp(csharpCode1);
+            using var workspace2 = TestWorkspace.CreateCSharp(csharpCode2);
+            var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+            var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+
+            var method_v1 = type1_v1.GetMembers("M").Single();
+            var method_v2 = type1_v2.GetMembers("M").Single();
+
+            Assert.True(SymbolEquivalenceComparer.Instance.Equals(method_v1, method_v2));
+            Assert.False(SymbolEquivalenceComparer.TupleNamesMustMatchInstance.Equals(method_v1, method_v2));
+        }
+
+        [Fact]
+        [WorkItem(56133, "https://github.com/dotnet/roslyn/issues/56133")]
+        [WorkItem(1388780, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1388780")]
+        [WorkItem(1391743, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391743")]
+        [WorkItem(1393352, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1393352")]
+        public async Task TestTuples6()
+        {
+            var csharpCode1 =
+@"
+class C
+{
+    void M((int a, int b) i) { }
+}";
+
+            var csharpCode2 =
+@"
+class C
+{
+    void M((int a, int b, int c) i) { }
+}";
+
+            using var workspace1 = TestWorkspace.CreateCSharp(csharpCode1);
+            using var workspace2 = TestWorkspace.CreateCSharp(csharpCode2);
+            var type1_v1 = (await workspace1.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+            var type1_v2 = (await workspace2.CurrentSolution.Projects.Single().GetCompilationAsync()).GlobalNamespace.GetTypeMembers("C").Single();
+
+            var method_v1 = type1_v1.GetMembers("M").Single();
+            var method_v2 = type1_v2.GetMembers("M").Single();
+
+            Assert.False(SymbolEquivalenceComparer.Instance.Equals(method_v1, method_v2));
+        }
+
+        [Fact]
         public async Task TestNullable()
         {
             var csharpCode1 =

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -332,6 +332,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             {
                 Debug.Assert(GetTypeKind(x) == GetTypeKind(y));
 
+                if (x.IsTupleType != y.IsTupleType)
+                    return false;
+
                 if (x.IsTupleType)
                     return HandleTupleTypes(x, y, equivalentTypesWithDifferingAssemblies);
 
@@ -340,7 +343,6 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     x.Name != y.Name ||
                     x.IsAnonymousType != y.IsAnonymousType ||
                     x.IsUnboundGenericType != y.IsUnboundGenericType ||
-                    x.IsTupleType != y.IsTupleType ||
                     !NullableAnnotationsEquivalent(x, y))
                 {
                     return false;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/56133
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1388780
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391743
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1393352