### PR TITLE
Fix crash in FindReferences

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -3264,6 +3264,66 @@ class Class2
             Await TestAPIAndFeature(input, kind, host)
         End Function
 
+        <WorkItem(55955, "https://github.com/dotnet/roslyn/issues/55955")>
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestRetargetingInheritanceAcrossProjects(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" AssemblyName="PortableInterfaceLibrary" CommonReferencesPortable="true">
+        <Document><![CDATA[
+using System;
+
+public interface IInterface
+{
+    void {|Definition:$$Method|}(string s) { }
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language="C#" AssemblyName="PortableClassLibrary1" CommonReferencesPortable="true">
+        <ProjectReference>PortableInterfaceLibrary</ProjectReference>
+        <Document><![CDATA[
+using System;
+
+public class PortableClass : IInterface
+{
+    public virtual void {|Definition:Method|}(string s) {}
+}]]>
+        </Document>
+    </Project>
+    <Project Language="C#" AssemblyName="NormalClassLibrary1" CommonReferences="true">
+        <ProjectReference>PortableInterfaceLibrary</ProjectReference>
+        <Document><![CDATA[
+using System;
+
+public class NormalClass : IInterface
+{
+    public virtual void {|Definition:Method|}(string s) {}
+}]]>
+        </Document>
+    </Project>
+    <Project Language="C#" AssemblyName="ReferencesBoth" CommonReferences="true">
+        <ProjectReference>PortableInterfaceLibrary</ProjectReference>
+        <ProjectReference>PortableClassLibrary1</ProjectReference>
+        <ProjectReference>NormalClassLibrary1</ProjectReference>
+        <Document><![CDATA[
+using System;
+
+public class C
+{
+    void X(string s)
+    {
+        new PortableClass().[|Method|](s);
+        new NormalClass().[|Method|](s);
+    }
+}]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestRetargetingMethod_NestedType(kind As TestKind, host As TestHost) As Task
             Dim input =

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.BidirectionalSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.BidirectionalSymbolSet.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// examining all of them to go in both up and down directions in every project we process.  Any time we
             /// add a new symbol to it we'll continue to cascade in both directions looking for more.
             /// </summary>
-            private readonly HashSet<ISymbol> _allSymbols = new();
+            private readonly HashSet<ISymbol> _allSymbols = new(MetadataUnifyingEquivalenceComparer.Instance);
 
             public BidirectionalSymbolSet(FindReferencesSearchEngine engine, HashSet<ISymbol> initialSymbols, HashSet<ISymbol> upSymbols)
                 : base(engine)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.BidirectionalSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.BidirectionalSymbolSet.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// examining all of them to go in both up and down directions in every project we process.  Any time we
             /// add a new symbol to it we'll continue to cascade in both directions looking for more.
             /// </summary>
-            private readonly HashSet<ISymbol> _allSymbols = new(MetadataUnifyingEquivalenceComparer.Instance);
+            private readonly MetadataUnifyingSymbolHashSet _allSymbols = new();
 
             public BidirectionalSymbolSet(FindReferencesSearchEngine engine, HashSet<ISymbol> initialSymbols, HashSet<ISymbol> upSymbols)
                 : base(engine)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
@@ -126,10 +126,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// multi-targetting/shared-project documents.  This will not include symbols up or down the inheritance
             /// hierarchy.
             /// </summary>
-            private static async Task<HashSet<ISymbol>> DetermineInitialSearchSymbolsAsync(
+            private static async Task<MetadataUnifyingSymbolHashSet> DetermineInitialSearchSymbolsAsync(
                 FindReferencesSearchEngine engine, ISymbol symbol, CancellationToken cancellationToken)
             {
-                var result = new HashSet<ISymbol>(MetadataUnifyingEquivalenceComparer.Instance);
+                var result = new MetadataUnifyingSymbolHashSet();
                 var workQueue = new Stack<ISymbol>();
 
                 // Start with the initial symbol we're searching for.
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             private static async Task<HashSet<ISymbol>> DetermineInitialUpSymbolsAsync(
                 FindReferencesSearchEngine engine, HashSet<ISymbol> initialSymbols, CancellationToken cancellationToken)
             {
-                var upSymbols = new HashSet<ISymbol>(MetadataUnifyingEquivalenceComparer.Instance);
+                var upSymbols = new MetadataUnifyingSymbolHashSet();
                 var workQueue = new Stack<ISymbol>();
                 workQueue.Push(initialSymbols);
 
@@ -164,14 +164,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             }
 
             protected static async Task AddCascadedAndLinkedSymbolsToAsync(
-                FindReferencesSearchEngine engine, ImmutableArray<ISymbol> symbols, HashSet<ISymbol> seenSymbols, Stack<ISymbol> workQueue, CancellationToken cancellationToken)
+                FindReferencesSearchEngine engine, ImmutableArray<ISymbol> symbols, MetadataUnifyingSymbolHashSet seenSymbols, Stack<ISymbol> workQueue, CancellationToken cancellationToken)
             {
                 foreach (var symbol in symbols)
                     await AddCascadedAndLinkedSymbolsToAsync(engine, symbol, seenSymbols, workQueue, cancellationToken).ConfigureAwait(false);
             }
 
             protected static async Task AddCascadedAndLinkedSymbolsToAsync(
-                FindReferencesSearchEngine engine, ISymbol symbol, HashSet<ISymbol> seenSymbols, Stack<ISymbol> workQueue, CancellationToken cancellationToken)
+                FindReferencesSearchEngine engine, ISymbol symbol, MetadataUnifyingSymbolHashSet seenSymbols, Stack<ISymbol> workQueue, CancellationToken cancellationToken)
             {
                 var solution = engine._solution;
                 symbol = await MapAndAddLinkedSymbolsAsync(symbol).ConfigureAwait(false);
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// </remarks>
             protected static async Task AddDownSymbolsAsync(
                 FindReferencesSearchEngine engine, ISymbol symbol,
-                HashSet<ISymbol> seenSymbols, Stack<ISymbol> workQueue,
+                MetadataUnifyingSymbolHashSet seenSymbols, Stack<ISymbol> workQueue,
                 ImmutableHashSet<Project> projects, CancellationToken cancellationToken)
             {
                 Contract.ThrowIfFalse(projects.Count == 1, "Only a single project should be passed in");
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// </summary>
             protected static async Task AddUpSymbolsAsync(
                 FindReferencesSearchEngine engine, ISymbol symbol,
-                HashSet<ISymbol> seenSymbols, Stack<ISymbol> workQueue,
+                MetadataUnifyingSymbolHashSet seenSymbols, Stack<ISymbol> workQueue,
                 ImmutableHashSet<Project> projects, CancellationToken cancellationToken)
             {
                 if (!InvolvesInheritance(symbol))

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             private static async Task<HashSet<ISymbol>> DetermineInitialSearchSymbolsAsync(
                 FindReferencesSearchEngine engine, ISymbol symbol, CancellationToken cancellationToken)
             {
-                var result = new HashSet<ISymbol>();
+                var result = new HashSet<ISymbol>(MetadataUnifyingEquivalenceComparer.Instance);
                 var workQueue = new Stack<ISymbol>();
 
                 // Start with the initial symbol we're searching for.
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             private static async Task<HashSet<ISymbol>> DetermineInitialUpSymbolsAsync(
                 FindReferencesSearchEngine engine, HashSet<ISymbol> initialSymbols, CancellationToken cancellationToken)
             {
-                var upSymbols = new HashSet<ISymbol>();
+                var upSymbols = new HashSet<ISymbol>(MetadataUnifyingEquivalenceComparer.Instance);
                 var workQueue = new Stack<ISymbol>();
                 workQueue.Push(initialSymbols);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.UnidirectionalSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.UnidirectionalSymbolSet.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// </summary>
         private sealed class UnidirectionalSymbolSet : SymbolSet
         {
-            private readonly HashSet<ISymbol> _initialAndDownSymbols;
+            private readonly MetadataUnifyingSymbolHashSet _initialAndDownSymbols;
 
             /// <summary>
             /// When we're doing a unidirectional find-references, the initial set of up-symbols can never change.
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// </summary>
             private readonly ImmutableHashSet<ISymbol> _upSymbols;
 
-            public UnidirectionalSymbolSet(FindReferencesSearchEngine engine, HashSet<ISymbol> initialSymbols, HashSet<ISymbol> upSymbols)
+            public UnidirectionalSymbolSet(FindReferencesSearchEngine engine, MetadataUnifyingSymbolHashSet initialSymbols, HashSet<ISymbol> upSymbols)
                 : base(engine)
             {
                 _initialAndDownSymbols = initialSymbols;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/MetadataUnifyingSymbolHashSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/MetadataUnifyingSymbolHashSet.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.FindSymbols
+{
+    internal sealed class MetadataUnifyingSymbolHashSet : HashSet<ISymbol>
+    {
+        public MetadataUnifyingSymbolHashSet() : base(MetadataUnifyingEquivalenceComparer.Instance)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/55955

Different parts of the FAR stack were inconsistently making sets/dictionaries keyed by symbols.  In one part we weren't properly 'unifying' multi-targetted symbols, causing us to report another set of results for what was effectively teh same symbol.  A later receiver of this information then crashed as it wsa unifying and thought we were announcing the same symbol it already knew about for a second time.

--

With multi-targetting you can end up with symbols that look the same to the user, but are considered not exactly equivalent under teh covers (for example, core types in one are in mscorlib.dll, but may be in system.dll in another).  The IDE code unifies these to give a cohesive representation and display for the user. 