### PR TITLE
Fix equals operator with split state on right

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2429,7 +2429,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     || !learnFromOperator(binary))
                 {
                     Unsplit();
-                    Visit(binary.Right);
+                    VisitRvalue(binary.Right);
                 }
 
                 if (stack.Count == 0)


### PR DESCRIPTION
Fixes #56298.

The expectation here is that except for `||`/`&&`, a binary operator where both operands are not constant values and are not conditional accesses does not propagate out any conditional state. The modified code path in this PR is for just such an operator. Before we would actually propagate out conditional state from the right side, which doesn't make sense. The fix is to just use VisitRvalue instead of Visit here.

Nullable doesn't use this code path and an [ad-hoc check](https://sharplab.io/#v2:EYLgtghglgdgNAFxFANnAJiA1AHwMQwCuKKEwKApgAQUxmUCwAUAAIBMAjMyxwAxUAPKgF4qAIgCCYgNzc+VAJ4jxAIRnMoAMyoAKHUKgBnKjAD2CE8RQBKKgEJROpUZPnLJa9eZUfVHgE4nADoAFVMAZQQAJ1gAcx1PaSoAemSqLiYgA===) indicates that there isn't a corresponding bug present in nullable analysis.

Relates to test plan https://github.com/dotnet/roslyn/issues/51463