### PR TITLE
Add support for all parenthesized binary additions of interpolated strings

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodeExtensions.cs
@@ -186,11 +186,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             where TInterpolatedStringType : BoundInterpolatedStringBase
         {
             int i = 0;
-            var originalStack = ArrayBuilder<BoundBinaryOperator>.GetInstance();
 
-            var result = doRewrite(binary, arg, interpolatedStringFactory, binaryOperatorFactory, originalStack, ref i);
+            var result = doRewrite(binary, arg, interpolatedStringFactory, binaryOperatorFactory, ref i);
 
-            originalStack.Free();
             return result;
 
             static TResult doRewrite(
@@ -198,10 +196,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TArg arg,
                 Func<TInterpolatedStringType, int, TArg, TResult> interpolatedStringFactory,
                 Func<BoundBinaryOperator, TResult, TResult, TArg, TResult> binaryOperatorFactory,
-                ArrayBuilder<BoundBinaryOperator> originalStack,
                 ref int i)
             {
                 TResult? result = default;
+                var originalStack = ArrayBuilder<BoundBinaryOperator>.GetInstance();
 
                 pushLeftNodes(binary, originalStack);
 
@@ -222,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var rewrittenRight = currentBinary.Right switch
                     {
                         TInterpolatedStringType interpolatedString => interpolatedStringFactory(interpolatedString, i++, arg),
-                        BoundBinaryOperator binaryOperator => doRewrite(binaryOperator, arg, interpolatedStringFactory, binaryOperatorFactory, originalStack, ref i),
+                        BoundBinaryOperator binaryOperator => doRewrite(binaryOperator, arg, interpolatedStringFactory, binaryOperatorFactory, ref i),
                         _ => throw ExceptionUtilities.UnexpectedValue(currentBinary.Right.Kind)
                     };
 
@@ -230,6 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 Debug.Assert(result != null);
+                originalStack.Free();
 
                 return result;
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodeExtensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public static bool VisitBinaryOperatorInterpolatedString<TArg, TInterpolatedStringType>(
             this BoundBinaryOperator binary,
-            TArg arg, 
+            TArg arg,
             Func<TInterpolatedStringType, TArg, bool> visitor,
             Action<BoundBinaryOperator, TArg>? binaryOperatorCallback = null)
             where TInterpolatedStringType : BoundExpression

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2507,7 +2507,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             node.VisitBinaryOperatorInterpolatedString(
                 (parts, @this: this),
-                stringCallback: (BoundInterpolatedString interpolatedString, (ArrayBuilder<BoundInterpolatedString> parts, AbstractFlowPass<TLocalState, TLocalFunctionState> @this) arg) =>
+                stringCallback: static (BoundInterpolatedString interpolatedString, (ArrayBuilder<BoundInterpolatedString> parts, AbstractFlowPass<TLocalState, TLocalFunctionState> @this) arg) =>
                 {
                     arg.parts.Add(interpolatedString);
                     return true;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2507,12 +2507,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             node.VisitBinaryOperatorInterpolatedString(
                 (parts, @this: this),
-                visitor: (BoundInterpolatedString interpolatedString, (ArrayBuilder<BoundInterpolatedString> parts, AbstractFlowPass<TLocalState, TLocalFunctionState> @this) arg) =>
+                stringCallback: (BoundInterpolatedString interpolatedString, (ArrayBuilder<BoundInterpolatedString> parts, AbstractFlowPass<TLocalState, TLocalFunctionState> @this) arg) =>
                 {
                     arg.parts.Add(interpolatedString);
                     return true;
                 },
-                binaryOperatorCallback: (op, arg) => arg.@this.OnPushBinaryOperatorInterpolatedStringChildren(op));
+                binaryOperatorCallback: (op, arg) => arg.@this.VisitInterpolatedStringBinaryOperatorNode(op));
 
             Debug.Assert(parts.Count >= 2);
 
@@ -2536,7 +2536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             parts.Free();
         }
 
-        protected virtual void OnPushBinaryOperatorInterpolatedStringChildren(BoundBinaryOperator node) { }
+        protected virtual void VisitInterpolatedStringBinaryOperatorNode(BoundBinaryOperator node) { }
 
         protected virtual bool VisitInterpolatedStringHandlerParts(BoundInterpolatedStringBase node, bool usesBoolReturns, bool firstPartIsConditional, ref TLocalState? shortCircuitState)
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4031,7 +4031,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        protected override void OnPushBinaryOperatorInterpolatedStringChildren(BoundBinaryOperator node)
+        protected override void VisitInterpolatedStringBinaryOperatorNode(BoundBinaryOperator node)
         {
             SetNotNullResult(node);
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4031,11 +4031,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        protected override BoundBinaryOperator? PushBinaryOperatorInterpolatedStringChildren(BoundBinaryOperator node, ArrayBuilder<BoundInterpolatedString> stack)
+        protected override void OnPushBinaryOperatorInterpolatedStringChildren(BoundBinaryOperator node)
         {
-            var result = base.PushBinaryOperatorInterpolatedStringChildren(node, stack);
             SetNotNullResult(node);
-            return result;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -154,33 +154,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node.OperatorKind == BinaryOperatorKind.StringConcatenation);
             Debug.Assert(node.InterpolatedStringHandlerData is not null);
             var partsBuilder = ArrayBuilder<BoundExpression>.GetInstance();
-            while (true)
+            node.VisitBinaryOperatorInterpolatedString(partsBuilder, (BoundInterpolatedString interpolatedString, ArrayBuilder<BoundExpression> partsBuilder) =>
             {
-                addReversedParts((BoundInterpolatedString)node.Right);
-
-                if (node.Left is BoundBinaryOperator next)
-                {
-                    node = next;
-                }
-                else
-                {
-                    addReversedParts((BoundInterpolatedString)node.Left);
-                    break;
-                }
-            }
-
-            partsBuilder.ReverseContents();
-
-            ImmutableArray<BoundExpression> parts = partsBuilder.ToImmutableAndFree();
-            return parts;
-
-            void addReversedParts(BoundInterpolatedString boundInterpolated)
-            {
-                for (int i = boundInterpolated.Parts.Length - 1; i >= 0; i--)
-                {
-                    partsBuilder.Add(boundInterpolated.Parts[i]);
-                }
-            }
+                partsBuilder.AddRange(interpolatedString.Parts);
+                return true;
+            });
+            return partsBuilder.ToImmutableAndFree();
         }
 
         private BoundExpression MakeBinaryOperator(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -154,11 +154,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node.OperatorKind == BinaryOperatorKind.StringConcatenation);
             Debug.Assert(node.InterpolatedStringHandlerData is not null);
             var partsBuilder = ArrayBuilder<BoundExpression>.GetInstance();
-            node.VisitBinaryOperatorInterpolatedString(partsBuilder, (BoundInterpolatedString interpolatedString, ArrayBuilder<BoundExpression> partsBuilder) =>
-            {
-                partsBuilder.AddRange(interpolatedString.Parts);
-                return true;
-            });
+            node.VisitBinaryOperatorInterpolatedString(partsBuilder,
+                static (BoundInterpolatedString interpolatedString, ArrayBuilder<BoundExpression> partsBuilder) =>
+                {
+                    partsBuilder.AddRange(interpolatedString.Parts);
+                    return true;
+                });
             return partsBuilder.ToImmutableAndFree();
         }
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -1294,14 +1295,17 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isImplicit = boundUnaryOperator.WasCompilerGenerated;
             return new UnaryOperation(unaryOperatorKind, operand, isLifted, isChecked, operatorMethod, _semanticModel, syntax, type, constantValue, isImplicit);
         }
-
         private IOperation CreateBoundBinaryOperatorBase(BoundBinaryOperatorBase boundBinaryOperatorBase)
         {
+            if (boundBinaryOperatorBase is BoundBinaryOperator { InterpolatedStringHandlerData: not null } binary)
+            {
+                return CreateBoundInterpolatedStringBinaryOperator(binary);
+            }
+
             // Binary operators can be nested _many_ levels deep, and cause a stack overflow if we manually recurse.
             // To solve this, we use a manual stack for the left side.
             var stack = ArrayBuilder<BoundBinaryOperatorBase>.GetInstance();
             BoundBinaryOperatorBase? currentBinary = boundBinaryOperatorBase;
-            InterpolatedStringHandlerData? interpolatedData = (boundBinaryOperatorBase as BoundBinaryOperator)?.InterpolatedStringHandlerData;
 
             do
             {
@@ -1309,19 +1313,16 @@ namespace Microsoft.CodeAnalysis.Operations
                 currentBinary = currentBinary.Left as BoundBinaryOperatorBase;
             } while (currentBinary is not null and not BoundBinaryOperator { InterpolatedStringHandlerData: not null });
 
-            Debug.Assert(interpolatedData == null || interpolatedData.GetValueOrDefault().PositionInfo.Length == stack.Count + 1);
-
             Debug.Assert(stack.Count > 0);
             IOperation? left = null;
-            int positionInfoIndex = 0;
 
             while (stack.TryPop(out currentBinary))
             {
-                left ??= visitOperand(currentBinary.Left);
-                IOperation right = visitOperand(currentBinary.Right);
+                left ??= Create(currentBinary.Left);
+                IOperation right = Create(currentBinary.Right);
                 left = currentBinary switch
                 {
-                    BoundBinaryOperator binaryOp => createBoundBinaryOperatorOperation(binaryOp, left, right),
+                    BoundBinaryOperator binaryOp => CreateBoundBinaryOperatorOperation(binaryOp, left, right),
                     BoundUserDefinedConditionalLogicalOperator logicalOp => createBoundUserDefinedConditionalLogicalOperator(logicalOp, left, right),
                     { Kind: var kind } => throw ExceptionUtilities.UnexpectedValue(kind)
                 };
@@ -1330,37 +1331,6 @@ namespace Microsoft.CodeAnalysis.Operations
             Debug.Assert(left is not null && stack.Count == 0);
             stack.Free();
             return left;
-
-            IOperation visitOperand(BoundExpression operand)
-                => interpolatedData is { } data
-                    ? CreateBoundInterpolatedStringExpressionOperation((BoundInterpolatedString)operand, data.PositionInfo[positionInfoIndex++])
-                    : Create(operand);
-
-            IBinaryOperation createBoundBinaryOperatorOperation(BoundBinaryOperator boundBinaryOperator, IOperation left, IOperation right)
-            {
-                BinaryOperatorKind operatorKind = Helper.DeriveBinaryOperatorKind(boundBinaryOperator.OperatorKind);
-                IMethodSymbol? operatorMethod = boundBinaryOperator.Method.GetPublicSymbol();
-                IMethodSymbol? unaryOperatorMethod = null;
-
-                // For dynamic logical operator MethodOpt is actually the unary true/false operator
-                if (boundBinaryOperator.Type.IsDynamic() &&
-                    (operatorKind == BinaryOperatorKind.ConditionalAnd || operatorKind == BinaryOperatorKind.ConditionalOr) &&
-                    operatorMethod?.Parameters.Length == 1)
-                {
-                    unaryOperatorMethod = operatorMethod;
-                    operatorMethod = null;
-                }
-
-                SyntaxNode syntax = boundBinaryOperator.Syntax;
-                ITypeSymbol? type = boundBinaryOperator.GetPublicTypeSymbol();
-                ConstantValue? constantValue = boundBinaryOperator.ConstantValue;
-                bool isLifted = boundBinaryOperator.OperatorKind.IsLifted();
-                bool isChecked = boundBinaryOperator.OperatorKind.IsChecked();
-                bool isCompareText = false;
-                bool isImplicit = boundBinaryOperator.WasCompilerGenerated;
-                return new BinaryOperation(operatorKind, left, right, isLifted, isChecked, isCompareText, operatorMethod, unaryOperatorMethod,
-                                           _semanticModel, syntax, type, constantValue, isImplicit);
-            }
 
             IBinaryOperation createBoundUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator boundBinaryOperator, IOperation left, IOperation right)
             {
@@ -1379,6 +1349,57 @@ namespace Microsoft.CodeAnalysis.Operations
                 return new BinaryOperation(operatorKind, left, right, isLifted, isChecked, isCompareText, operatorMethod, unaryOperatorMethod,
                                            _semanticModel, syntax, type, constantValue, isImplicit);
             }
+        }
+
+        private IBinaryOperation CreateBoundBinaryOperatorOperation(BoundBinaryOperator boundBinaryOperator, IOperation left, IOperation right)
+        {
+            BinaryOperatorKind operatorKind = Helper.DeriveBinaryOperatorKind(boundBinaryOperator.OperatorKind);
+            IMethodSymbol? operatorMethod = boundBinaryOperator.Method.GetPublicSymbol();
+            IMethodSymbol? unaryOperatorMethod = null;
+
+            // For dynamic logical operator MethodOpt is actually the unary true/false operator
+            if (boundBinaryOperator.Type.IsDynamic() &&
+                (operatorKind == BinaryOperatorKind.ConditionalAnd || operatorKind == BinaryOperatorKind.ConditionalOr) &&
+                operatorMethod?.Parameters.Length == 1)
+            {
+                unaryOperatorMethod = operatorMethod;
+                operatorMethod = null;
+            }
+
+            SyntaxNode syntax = boundBinaryOperator.Syntax;
+            ITypeSymbol? type = boundBinaryOperator.GetPublicTypeSymbol();
+            ConstantValue? constantValue = boundBinaryOperator.ConstantValue;
+            bool isLifted = boundBinaryOperator.OperatorKind.IsLifted();
+            bool isChecked = boundBinaryOperator.OperatorKind.IsChecked();
+            bool isCompareText = false;
+            bool isImplicit = boundBinaryOperator.WasCompilerGenerated;
+            return new BinaryOperation(operatorKind, left, right, isLifted, isChecked, isCompareText, operatorMethod, unaryOperatorMethod,
+                                       _semanticModel, syntax, type, constantValue, isImplicit);
+        }
+
+        private IOperation CreateBoundInterpolatedStringBinaryOperator(BoundBinaryOperator boundBinaryOperator)
+        {
+            Debug.Assert(boundBinaryOperator.InterpolatedStringHandlerData is not null);
+            Func<(CSharpOperationFactory, InterpolatedStringHandlerData), BoundInterpolatedString, int, IOperation> createInterpolatedString
+                = createInterpolatedStringOperand;
+
+            Func<(CSharpOperationFactory, InterpolatedStringHandlerData), BoundBinaryOperator, IOperation, IOperation, IOperation> createBinaryOperator
+                = createBoundBinaryOperatorOperation;
+
+            return boundBinaryOperator.RewriteInterpolatedStringAddition((this, boundBinaryOperator.InterpolatedStringHandlerData.GetValueOrDefault()), createInterpolatedString, createBinaryOperator);
+
+            static IInterpolatedStringOperation createInterpolatedStringOperand(
+                (CSharpOperationFactory @this, InterpolatedStringHandlerData Data) arg,
+                BoundInterpolatedString boundInterpolatedString,
+                int i)
+                => arg.@this.CreateBoundInterpolatedStringExpressionOperation(boundInterpolatedString, arg.Data.PositionInfo[i]);
+
+            static IBinaryOperation createBoundBinaryOperatorOperation(
+                (CSharpOperationFactory @this, InterpolatedStringHandlerData _) arg,
+                BoundBinaryOperator boundBinaryOperator,
+                IOperation left,
+                IOperation right)
+                => arg.@this.CreateBoundBinaryOperatorOperation(boundBinaryOperator, left, right);
         }
 
         private ITupleBinaryOperation CreateBoundTupleBinaryOperatorOperation(BoundTupleBinaryOperator boundTupleBinaryOperator)

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1380,25 +1380,25 @@ namespace Microsoft.CodeAnalysis.Operations
         private IOperation CreateBoundInterpolatedStringBinaryOperator(BoundBinaryOperator boundBinaryOperator)
         {
             Debug.Assert(boundBinaryOperator.InterpolatedStringHandlerData is not null);
-            Func<(CSharpOperationFactory, InterpolatedStringHandlerData), BoundInterpolatedString, int, IOperation> createInterpolatedString
+            Func<BoundInterpolatedString, int, (CSharpOperationFactory, InterpolatedStringHandlerData), IOperation> createInterpolatedString
                 = createInterpolatedStringOperand;
 
-            Func<(CSharpOperationFactory, InterpolatedStringHandlerData), BoundBinaryOperator, IOperation, IOperation, IOperation> createBinaryOperator
+            Func<BoundBinaryOperator, IOperation, IOperation, (CSharpOperationFactory, InterpolatedStringHandlerData), IOperation> createBinaryOperator
                 = createBoundBinaryOperatorOperation;
 
             return boundBinaryOperator.RewriteInterpolatedStringAddition((this, boundBinaryOperator.InterpolatedStringHandlerData.GetValueOrDefault()), createInterpolatedString, createBinaryOperator);
 
             static IInterpolatedStringOperation createInterpolatedStringOperand(
-                (CSharpOperationFactory @this, InterpolatedStringHandlerData Data) arg,
                 BoundInterpolatedString boundInterpolatedString,
-                int i)
+                int i,
+                (CSharpOperationFactory @this, InterpolatedStringHandlerData Data) arg)
                 => arg.@this.CreateBoundInterpolatedStringExpressionOperation(boundInterpolatedString, arg.Data.PositionInfo[i]);
 
             static IBinaryOperation createBoundBinaryOperatorOperation(
-                (CSharpOperationFactory @this, InterpolatedStringHandlerData _) arg,
                 BoundBinaryOperator boundBinaryOperator,
                 IOperation left,
-                IOperation right)
+                IOperation right,
+                (CSharpOperationFactory @this, InterpolatedStringHandlerData _) arg)
                 => arg.@this.CreateBoundBinaryOperatorOperation(boundBinaryOperator, left, right);
         }
 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
@@ -1994,7 +1994,98 @@ IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.St
 ";
 
             VerifyOperationTreeAndDiagnosticsForTest<BinaryExpressionSyntax>(new[] { code, GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: true) },
-                                                                                         expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
+                                                                             expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
+        }
+
+        [Fact]
+        public void ParenthesizedInterpolatedStringsAdded()
+        {
+            var code = @"
+int i1 = 1;
+int i2 = 2;
+int i3 = 3;
+int i4 = 4;
+int i5 = 5;
+int i6 = 6;
+
+string s = /*<bind>*/(($""{i1,1:d}"" + $""{i2,2:f}"") + $""{i3,3:g}"") + ($""{i4,4:h}"" + ($""{i5,5:i}"" + $""{i6,6:j}""))/*</bind>*/;
+";
+
+            var expectedDiagnostics = DiagnosticDescription.None;
+            var expectedOperationTree = @"
+IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '(($""{i1,1:d ... {i6,6:j}""))')
+  Left:
+    IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '($""{i1,1:d} ... $""{i3,3:g}""')
+      Left:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i1,1:d}"" ... $""{i2,2:f}""')
+          Left:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i1,1:d}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i1,1:d}')
+                    Expression:
+                      ILocalReferenceOperation: i1 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i1')
+                    Alignment:
+                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+                    FormatString:
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""d"") (Syntax: ':d')
+          Right:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i2,2:f}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i2,2:f}')
+                    Expression:
+                      ILocalReferenceOperation: i2 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i2')
+                    Alignment:
+                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+                    FormatString:
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""f"") (Syntax: ':f')
+      Right:
+        IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i3,3:g}""')
+          Parts(1):
+              IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i3,3:g}')
+                Expression:
+                  ILocalReferenceOperation: i3 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i3')
+                Alignment:
+                  ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3) (Syntax: '3')
+                FormatString:
+                  ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""g"") (Syntax: ':g')
+  Right:
+    IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i4,4:h}"" ... ""{i6,6:j}"")')
+      Left:
+        IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i4,4:h}""')
+          Parts(1):
+              IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i4,4:h}')
+                Expression:
+                  ILocalReferenceOperation: i4 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i4')
+                Alignment:
+                  ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 4) (Syntax: '4')
+                FormatString:
+                  ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""h"") (Syntax: ':h')
+      Right:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i5,5:i}"" ... $""{i6,6:j}""')
+          Left:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i5,5:i}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i5,5:i}')
+                    Expression:
+                      ILocalReferenceOperation: i5 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i5')
+                    Alignment:
+                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 5) (Syntax: '5')
+                    FormatString:
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""i"") (Syntax: ':i')
+          Right:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i6,6:j}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i6,6:j}')
+                    Expression:
+                      ILocalReferenceOperation: i6 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i6')
+                    Alignment:
+                      ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 6) (Syntax: '6')
+                    FormatString:
+                      ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""j"") (Syntax: ':j')
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<BinaryExpressionSyntax>(new[] { code, GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: true) },
+                                                                             expectedOperationTree, expectedDiagnostics, parseOptions: TestOptions.RegularPreview);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -12796,10 +12796,11 @@ int i4 = 4;
 int i5 = 5;
 int i6 = 6;
 
-CustomHandler c = (($""{i1}"" + $""{i2}"") + $""{i3}"") + ($""{i4}"" + ($""{i5}"" + $""{i6}""));
+CustomHandler c = /*<bind>*/((($""{i1}"" + $""{i2}"") + $""{i3}"") + ($""{i4}"" + ($""{i5}"" + $""{i6}""))) + (($""{i1}"" + ($""{i2}"" + $""{i3}"")) + (($""{i4}"" + $""{i5}"") + $""{i6}""))/*</bind>*/;
 System.Console.WriteLine(c.ToString());";
 
-            var verifier = CompileAndVerify(new[] { code, GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, expectedOutput: @"
+            var comp = CreateCompilation(new[] { code, GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) });
+            var verifier = CompileAndVerify(comp, expectedOutput: @"
 value:1
 alignment:0
 format:
@@ -12817,8 +12818,207 @@ alignment:0
 format:
 value:6
 alignment:0
-format:");
+format:
+value:1
+alignment:0
+format:
+value:2
+alignment:0
+format:
+value:3
+alignment:0
+format:
+value:4
+alignment:0
+format:
+value:5
+alignment:0
+format:
+value:6
+alignment:0
+format:
+");
             verifier.VerifyDiagnostics();
+
+            VerifyOperationTreeForTest<BinaryExpressionSyntax>(comp, @"
+IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '((($""{i1}""  ... + $""{i6}""))')
+  Left:
+    IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '(($""{i1}"" + ... + $""{i6}""))')
+      Left:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '($""{i1}"" +  ... ) + $""{i3}""')
+          Left:
+            IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i1}"" + $""{i2}""')
+              Left:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i1}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i1}')
+                        Expression:
+                          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i1')
+                            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            Operand:
+                              ILocalReferenceOperation: i1 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i1')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+              Right:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i2}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i2}')
+                        Expression:
+                          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i2')
+                            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            Operand:
+                              ILocalReferenceOperation: i2 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i2')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+          Right:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i3}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i3}')
+                    Expression:
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i3')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand:
+                          ILocalReferenceOperation: i3 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i3')
+                    Alignment:
+                      null
+                    FormatString:
+                      null
+      Right:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i4}"" + ( ...  + $""{i6}"")')
+          Left:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i4}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i4}')
+                    Expression:
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i4')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand:
+                          ILocalReferenceOperation: i4 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i4')
+                    Alignment:
+                      null
+                    FormatString:
+                      null
+          Right:
+            IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i5}"" + $""{i6}""')
+              Left:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i5}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i5}')
+                        Expression:
+                          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i5')
+                            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            Operand:
+                              ILocalReferenceOperation: i5 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i5')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+              Right:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i6}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i6}')
+                        Expression:
+                          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i6')
+                            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            Operand:
+                              ILocalReferenceOperation: i6 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i6')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+  Right:
+    IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '($""{i1}"" +  ...  + $""{i6}"")')
+      Left:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i1}"" + ( ...  + $""{i3}"")')
+          Left:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i1}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i1}')
+                    Expression:
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i1')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand:
+                          ILocalReferenceOperation: i1 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i1')
+                    Alignment:
+                      null
+                    FormatString:
+                      null
+          Right:
+            IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i2}"" + $""{i3}""')
+              Left:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i2}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i2}')
+                        Expression:
+                          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i2')
+                            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            Operand:
+                              ILocalReferenceOperation: i2 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i2')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+              Right:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i3}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i3}')
+                        Expression:
+                          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i3')
+                            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            Operand:
+                              ILocalReferenceOperation: i3 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i3')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+      Right:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '($""{i4}"" +  ... ) + $""{i6}""')
+          Left:
+            IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i4}"" + $""{i5}""')
+              Left:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i4}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i4}')
+                        Expression:
+                          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i4')
+                            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            Operand:
+                              ILocalReferenceOperation: i4 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i4')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+              Right:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i5}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i5}')
+                        Expression:
+                          IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i5')
+                            Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            Operand:
+                              ILocalReferenceOperation: i5 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i5')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+          Right:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i6}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i6}')
+                    Expression:
+                      IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, IsImplicit) (Syntax: 'i6')
+                        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Operand:
+                          ILocalReferenceOperation: i6 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i6')
+                    Alignment:
+                      null
+                    FormatString:
+                      null
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -12711,15 +12711,17 @@ o3.ToString();
             );
         }
 
-        [Fact]
-        public void ParenthesizedAdditiveExpression_01()
+        [Theory]
+        [InlineData(@"($""{i1}"" + $""{i2}"") + $""{i3}""")]
+        [InlineData(@"$""{i1}"" + ($""{i2}"" + $""{i3}"")")]
+        public void ParenthesizedAdditiveExpression_01(string expression)
         {
             var code = @"
 int i1 = 1;
 int i2 = 2;
 int i3 = 3;
 
-CustomHandler c = ($""{i1}"" + $""{i2}"") + $""{i3}"";
+CustomHandler c = " + expression + @";
 System.Console.WriteLine(c.ToString());";
 
             var comp = CreateCompilation(new[] { code, GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) });
@@ -12785,77 +12787,6 @@ format:
 
         [Fact]
         public void ParenthesizedAdditiveExpression_02()
-        {
-            var code = @"
-int i1 = 1;
-int i2 = 2;
-int i3 = 3;
-
-CustomHandler c = $""{i1}"" + ($""{i2}"" + $""{i3}"");
-System.Console.WriteLine(c.ToString());";
-
-            var verifier = CompileAndVerify(new[] { code, GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, expectedOutput: @"
-value:1
-alignment:0
-format:
-value:2
-alignment:0
-format:
-value:3
-alignment:0
-format:");
-            verifier.VerifyDiagnostics();
-
-            verifier.VerifyIL("<top-level-statements-entry-point>", @"
-{
-  // Code size       82 (0x52)
-  .maxstack  4
-  .locals init (int V_0, //i1
-                int V_1, //i2
-                int V_2, //i3
-                CustomHandler V_3, //c
-                CustomHandler V_4)
-  IL_0000:  ldc.i4.1
-  IL_0001:  stloc.0
-  IL_0002:  ldc.i4.2
-  IL_0003:  stloc.1
-  IL_0004:  ldc.i4.3
-  IL_0005:  stloc.2
-  IL_0006:  ldloca.s   V_4
-  IL_0008:  ldc.i4.0
-  IL_0009:  ldc.i4.3
-  IL_000a:  call       ""CustomHandler..ctor(int, int)""
-  IL_000f:  ldloca.s   V_4
-  IL_0011:  ldloc.0
-  IL_0012:  box        ""int""
-  IL_0017:  ldc.i4.0
-  IL_0018:  ldnull
-  IL_0019:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_001e:  ldloca.s   V_4
-  IL_0020:  ldloc.1
-  IL_0021:  box        ""int""
-  IL_0026:  ldc.i4.0
-  IL_0027:  ldnull
-  IL_0028:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_002d:  ldloca.s   V_4
-  IL_002f:  ldloc.2
-  IL_0030:  box        ""int""
-  IL_0035:  ldc.i4.0
-  IL_0036:  ldnull
-  IL_0037:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
-  IL_003c:  ldloc.s    V_4
-  IL_003e:  stloc.3
-  IL_003f:  ldloca.s   V_3
-  IL_0041:  constrained. ""CustomHandler""
-  IL_0047:  callvirt   ""string object.ToString()""
-  IL_004c:  call       ""void System.Console.WriteLine(string)""
-  IL_0051:  ret
-}
-");
-        }
-
-        [Fact]
-        public void ParenthesizedAdditiveExpression_03()
         {
             var code = @"
 int i1 = 1;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -13168,6 +13168,168 @@ value:3");
   IL_00f3:  ret
 }");
         }
+        [Fact]
+        public void ParenthesizedAdditiveExpression_05()
+        {
+            var code = @"
+int i1 = 1;
+int i2 = 2;
+int i3 = 3;
+int i4 = 4;
+int i5 = 5;
+int i6 = 6;
+
+string s = /*<bind>*/((($""{i1}"" + $""{i2}"") + $""{i3}"") + ($""{i4}"" + ($""{i5}"" + $""{i6}""))) + (($""{i1}"" + ($""{i2}"" + $""{i3}"")) + (($""{i4}"" + $""{i5}"") + $""{i6}""))/*</bind>*/;
+System.Console.WriteLine(s);";
+
+            var comp = CreateCompilation(code);
+            var verifier = CompileAndVerify(comp, expectedOutput: @"123456123456");
+            verifier.VerifyDiagnostics();
+
+            VerifyOperationTreeForTest<BinaryExpressionSyntax>(comp, @"
+IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '((($""{i1}""  ... + $""{i6}""))')
+  Left:
+    IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '(($""{i1}"" + ... + $""{i6}""))')
+      Left:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '($""{i1}"" +  ... ) + $""{i3}""')
+          Left:
+            IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i1}"" + $""{i2}""')
+              Left:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i1}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i1}')
+                        Expression:
+                          ILocalReferenceOperation: i1 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i1')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+              Right:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i2}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i2}')
+                        Expression:
+                          ILocalReferenceOperation: i2 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i2')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+          Right:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i3}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i3}')
+                    Expression:
+                      ILocalReferenceOperation: i3 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i3')
+                    Alignment:
+                      null
+                    FormatString:
+                      null
+      Right:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i4}"" + ( ...  + $""{i6}"")')
+          Left:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i4}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i4}')
+                    Expression:
+                      ILocalReferenceOperation: i4 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i4')
+                    Alignment:
+                      null
+                    FormatString:
+                      null
+          Right:
+            IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i5}"" + $""{i6}""')
+              Left:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i5}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i5}')
+                        Expression:
+                          ILocalReferenceOperation: i5 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i5')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+              Right:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i6}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i6}')
+                        Expression:
+                          ILocalReferenceOperation: i6 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i6')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+  Right:
+    IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '($""{i1}"" +  ...  + $""{i6}"")')
+      Left:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i1}"" + ( ...  + $""{i3}"")')
+          Left:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i1}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i1}')
+                    Expression:
+                      ILocalReferenceOperation: i1 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i1')
+                    Alignment:
+                      null
+                    FormatString:
+                      null
+          Right:
+            IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i2}"" + $""{i3}""')
+              Left:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i2}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i2}')
+                        Expression:
+                          ILocalReferenceOperation: i2 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i2')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+              Right:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i3}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i3}')
+                        Expression:
+                          ILocalReferenceOperation: i3 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i3')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+      Right:
+        IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '($""{i4}"" +  ... ) + $""{i6}""')
+          Left:
+            IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.String) (Syntax: '$""{i4}"" + $""{i5}""')
+              Left:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i4}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i4}')
+                        Expression:
+                          ILocalReferenceOperation: i4 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i4')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+              Right:
+                IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i5}""')
+                  Parts(1):
+                      IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i5}')
+                        Expression:
+                          ILocalReferenceOperation: i5 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i5')
+                        Alignment:
+                          null
+                        FormatString:
+                          null
+          Right:
+            IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String) (Syntax: '$""{i6}""')
+              Parts(1):
+                  IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{i6}')
+                    Expression:
+                      ILocalReferenceOperation: i6 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i6')
+                    Alignment:
+                      null
+                    FormatString:
+                      null
+");
+        }
 
         [Theory]
         [InlineData(@"$""{1}"", $""{2}""")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -12794,12 +12794,100 @@ int i3 = 3;
 CustomHandler c = $""{i1}"" + ($""{i2}"" + $""{i3}"");
 System.Console.WriteLine(c.ToString());";
 
-            var comp = CreateCompilation(new[] { code, GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) });
-            comp.VerifyDiagnostics(
-                // (6,19): error CS0029: Cannot implicitly convert type 'string' to 'CustomHandler'
-                // CustomHandler c = $"{i1}" + ($"{i2}" + $"{i3}");
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"$""{i1}"" + ($""{i2}"" + $""{i3}"")").WithArguments("string", "CustomHandler").WithLocation(6, 19)
-            );
+            var verifier = CompileAndVerify(new[] { code, GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, expectedOutput: @"
+value:1
+alignment:0
+format:
+value:2
+alignment:0
+format:
+value:3
+alignment:0
+format:");
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", @"
+{
+  // Code size       82 (0x52)
+  .maxstack  4
+  .locals init (int V_0, //i1
+                int V_1, //i2
+                int V_2, //i3
+                CustomHandler V_3, //c
+                CustomHandler V_4)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldc.i4.2
+  IL_0003:  stloc.1
+  IL_0004:  ldc.i4.3
+  IL_0005:  stloc.2
+  IL_0006:  ldloca.s   V_4
+  IL_0008:  ldc.i4.0
+  IL_0009:  ldc.i4.3
+  IL_000a:  call       ""CustomHandler..ctor(int, int)""
+  IL_000f:  ldloca.s   V_4
+  IL_0011:  ldloc.0
+  IL_0012:  box        ""int""
+  IL_0017:  ldc.i4.0
+  IL_0018:  ldnull
+  IL_0019:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_001e:  ldloca.s   V_4
+  IL_0020:  ldloc.1
+  IL_0021:  box        ""int""
+  IL_0026:  ldc.i4.0
+  IL_0027:  ldnull
+  IL_0028:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_002d:  ldloca.s   V_4
+  IL_002f:  ldloc.2
+  IL_0030:  box        ""int""
+  IL_0035:  ldc.i4.0
+  IL_0036:  ldnull
+  IL_0037:  call       ""void CustomHandler.AppendFormatted(object, int, string)""
+  IL_003c:  ldloc.s    V_4
+  IL_003e:  stloc.3
+  IL_003f:  ldloca.s   V_3
+  IL_0041:  constrained. ""CustomHandler""
+  IL_0047:  callvirt   ""string object.ToString()""
+  IL_004c:  call       ""void System.Console.WriteLine(string)""
+  IL_0051:  ret
+}
+");
+        }
+
+        [Fact]
+        public void ParenthesizedAdditiveExpression_03()
+        {
+            var code = @"
+int i1 = 1;
+int i2 = 2;
+int i3 = 3;
+int i4 = 4;
+int i5 = 5;
+int i6 = 6;
+
+CustomHandler c = (($""{i1}"" + $""{i2}"") + $""{i3}"") + ($""{i4}"" + ($""{i5}"" + $""{i6}""));
+System.Console.WriteLine(c.ToString());";
+
+            var verifier = CompileAndVerify(new[] { code, GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false) }, expectedOutput: @"
+value:1
+alignment:0
+format:
+value:2
+alignment:0
+format:
+value:3
+alignment:0
+format:
+value:4
+alignment:0
+format:
+value:5
+alignment:0
+format:
+value:6
+alignment:0
+format:");
+            verifier.VerifyDiagnostics();
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -12821,6 +12821,154 @@ format:");
             verifier.VerifyDiagnostics();
         }
 
+        [Fact]
+        public void ParenthesizedAdditiveExpression_03()
+        {
+            var code = @"
+int i1 = 1;
+int i2 = 2;
+int i3 = 3;
+int i4 = 4;
+int i5 = 5;
+int i6 = 6;
+
+string s = (($""{i1}"" + $""{i2}"") + $""{i3}"") + ($""{i4}"" + ($""{i5}"" + $""{i6}""));
+System.Console.WriteLine(s);";
+
+            var verifier = CompileAndVerify(code, expectedOutput: @"123456");
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ParenthesizedAdditiveExpression_04()
+        {
+            var code = @"
+using System.Threading.Tasks;
+int i1 = 2;
+int i2 = 3;
+
+string s = $""{await GetInt()}"" + ($""{i1}"" + $""{i2}"");
+System.Console.WriteLine(s);
+
+Task<int> GetInt() => Task.FromResult(1);
+";
+
+            var verifier = CompileAndVerify(new[] { code, GetInterpolatedStringHandlerDefinition(includeSpanOverloads: false, useDefaultParameters: false, useBoolReturns: false) }, expectedOutput: @"
+1value:2
+value:3");
+            verifier.VerifyDiagnostics();
+
+            // Note the two DefaultInterpolatedStringHandlers in the IL here. In a future rewrite step in the LocalRewriter, we can potentially
+            // transform the tree to change its shape and pull out all individual Append calls in a sequence (regardless of the level of the tree)
+            // and combine these and other unequal tree shapes. For now, we're going with a simple solution where, if the entire binary expression
+            // cannot be combined, none of it is.
+
+            verifier.VerifyIL("Program.<<Main>$>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      244 (0xf4)
+  .maxstack  4
+  .locals init (int V_0,
+                int V_1,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
+                System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_3,
+                System.Exception V_4)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int Program.<<Main>$>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_004f
+    IL_000a:  ldarg.0
+    IL_000b:  ldc.i4.2
+    IL_000c:  stfld      ""int Program.<<Main>$>d__0.<i1>5__2""
+    IL_0011:  ldarg.0
+    IL_0012:  ldc.i4.3
+    IL_0013:  stfld      ""int Program.<<Main>$>d__0.<i2>5__3""
+    IL_0018:  call       ""System.Threading.Tasks.Task<int> Program.<<Main>$>g__GetInt|0_0()""
+    IL_001d:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0022:  stloc.2
+    IL_0023:  ldloca.s   V_2
+    IL_0025:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_002a:  brtrue.s   IL_006b
+    IL_002c:  ldarg.0
+    IL_002d:  ldc.i4.0
+    IL_002e:  dup
+    IL_002f:  stloc.0
+    IL_0030:  stfld      ""int Program.<<Main>$>d__0.<>1__state""
+    IL_0035:  ldarg.0
+    IL_0036:  ldloc.2
+    IL_0037:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<<Main>$>d__0.<>u__1""
+    IL_003c:  ldarg.0
+    IL_003d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<Main>$>d__0.<>t__builder""
+    IL_0042:  ldloca.s   V_2
+    IL_0044:  ldarg.0
+    IL_0045:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<<Main>$>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<<Main>$>d__0)""
+    IL_004a:  leave      IL_00f3
+    IL_004f:  ldarg.0
+    IL_0050:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<<Main>$>d__0.<>u__1""
+    IL_0055:  stloc.2
+    IL_0056:  ldarg.0
+    IL_0057:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<<Main>$>d__0.<>u__1""
+    IL_005c:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0062:  ldarg.0
+    IL_0063:  ldc.i4.m1
+    IL_0064:  dup
+    IL_0065:  stloc.0
+    IL_0066:  stfld      ""int Program.<<Main>$>d__0.<>1__state""
+    IL_006b:  ldloca.s   V_2
+    IL_006d:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0072:  stloc.1
+    IL_0073:  ldstr      ""{0}""
+    IL_0078:  ldloc.1
+    IL_0079:  box        ""int""
+    IL_007e:  call       ""string string.Format(string, object)""
+    IL_0083:  ldc.i4.0
+    IL_0084:  ldc.i4.1
+    IL_0085:  newobj     ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
+    IL_008a:  stloc.3
+    IL_008b:  ldloca.s   V_3
+    IL_008d:  ldarg.0
+    IL_008e:  ldfld      ""int Program.<<Main>$>d__0.<i1>5__2""
+    IL_0093:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int)""
+    IL_0098:  ldloca.s   V_3
+    IL_009a:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
+    IL_009f:  ldc.i4.0
+    IL_00a0:  ldc.i4.1
+    IL_00a1:  newobj     ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
+    IL_00a6:  stloc.3
+    IL_00a7:  ldloca.s   V_3
+    IL_00a9:  ldarg.0
+    IL_00aa:  ldfld      ""int Program.<<Main>$>d__0.<i2>5__3""
+    IL_00af:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted<int>(int)""
+    IL_00b4:  ldloca.s   V_3
+    IL_00b6:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
+    IL_00bb:  call       ""string string.Concat(string, string, string)""
+    IL_00c0:  call       ""void System.Console.WriteLine(string)""
+    IL_00c5:  leave.s    IL_00e0
+  }
+  catch System.Exception
+  {
+    IL_00c7:  stloc.s    V_4
+    IL_00c9:  ldarg.0
+    IL_00ca:  ldc.i4.s   -2
+    IL_00cc:  stfld      ""int Program.<<Main>$>d__0.<>1__state""
+    IL_00d1:  ldarg.0
+    IL_00d2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<Main>$>d__0.<>t__builder""
+    IL_00d7:  ldloc.s    V_4
+    IL_00d9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00de:  leave.s    IL_00f3
+  }
+  IL_00e0:  ldarg.0
+  IL_00e1:  ldc.i4.s   -2
+  IL_00e3:  stfld      ""int Program.<<Main>$>d__0.<>1__state""
+  IL_00e8:  ldarg.0
+  IL_00e9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<<Main>$>d__0.<>t__builder""
+  IL_00ee:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_00f3:  ret
+}");
+        }
+
         [Theory]
         [InlineData(@"$""{1}"", $""{2}""")]
         [InlineData(@"$""{1}"" + $"""", $""{2}"" + $""""")]

--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -218,6 +218,18 @@ namespace Microsoft.CodeAnalysis
             return builder[builder.Count - 1];
         }
 
+        public static bool TryPeek<T>(this ArrayBuilder<T> builder, [MaybeNullWhen(false)] out T result)
+        {
+            if (builder.Count > 0)
+            {
+                result = builder.Peek();
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
         public static ImmutableArray<T> ToImmutableOrEmptyAndFree<T>(this ArrayBuilder<T>? builder)
         {
             return builder?.ToImmutableAndFree() ?? ImmutableArray<T>.Empty;

--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -218,18 +218,6 @@ namespace Microsoft.CodeAnalysis
             return builder[builder.Count - 1];
         }
 
-        public static bool TryPeek<T>(this ArrayBuilder<T> builder, [MaybeNullWhen(false)] out T result)
-        {
-            if (builder.Count > 0)
-            {
-                result = builder.Peek();
-                return true;
-            }
-
-            result = default;
-            return false;
-        }
-
         public static ImmutableArray<T> ToImmutableOrEmptyAndFree<T>(this ArrayBuilder<T>? builder)
         {
             return builder?.ToImmutableAndFree() ?? ImmutableArray<T>.Empty;


### PR DESCRIPTION
Implements the decision from https://github.com/dotnet/csharplang/issues/5106. Test plan at https://github.com/dotnet/roslyn/issues/51499.
