### PR TITLE
Fixes menu item "Initialize Interactive with Project" missing for .Net Core projects

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Interactive/AbstractResetInteractiveMenuCommand.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Interactive/AbstractResetInteractiveMenuCommand.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interactive
                 GetActiveProject(out var project, out var frameworkName);
                 var available = ResetInteractiveCommand != null
                     && project != null && project.Kind == ProjectKind
-                    && frameworkName != null && frameworkName.Identifier == ".NETFramework";
+                    && frameworkName != null && frameworkName.Identifier.StartsWith(".NET", StringComparison.CurrentCultureIgnoreCase);
 
                 resetInteractiveFromProjectCommand.Enabled = available;
                 resetInteractiveFromProjectCommand.Supported = available;


### PR DESCRIPTION
A feature used often by developers is the ability to take their C# project and initialize a new Interactive console window with the code from their projects.  This feature was contained under the context menu item by the name of "Initialize Interactive with Project" when right-clicking on a project.  However, as reported by issue dotnet/roslyn#26934 , this feature has been missing for .Net Core projects.  The Interactive console has supported running for .Net Core projects for some time, but Visual Studio would not allow for loading a developers project into the window like it did for Framework projects.

I have modified the check during the menu initialization to allow for .Net projects of all types.  Previously, the code was checking only for the string ".NetFramework".  I have adjusted this check to look for strings beginning with .Net which should capture Framework as well as ".NetStandard" and ".NetCore" projects.

I have tested this to be working correctly for these project types and the difference between .Net Core 3.1 and .Net 5/6.