### PR TITLE
Remove ErrorTypeException from native int decoder

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
 using System;
 using System.Collections.Immutable;
@@ -12,8 +13,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {
     internal struct NativeIntegerTypeDecoder
     {
-        private sealed class ErrorTypeException : Exception { }
-
         internal static TypeSymbol TransformType(TypeSymbol type, EntityHandle handle, PEModuleSymbol containingModule)
         {
             return containingModule.Module.HasNativeIntegerAttribute(handle, out var transformFlags) ?
@@ -27,8 +26,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             try
             {
                 var result = decoder.TransformType(type);
-                if (decoder._index == transformFlags.Length)
+                if (decoder._hitErrorType)
                 {
+                    // If we failed to decode because there was an error type involved, marking the
+                    // metadata as unsupported means that we'll cover up the error that would otherwise
+                    // be reported for the type. This would likely lead to a worse error message as we
+                    // would just report a BindToBogus, so return the type unchanged.
+                    Debug.Assert(type.ContainsErrorType());
+                    Debug.Assert(result is null);
+                    return type;
+                }
+                else if (decoder._index == transformFlags.Length)
+                {
+                    Debug.Assert(result is object);
                     return result;
                 }
                 else
@@ -40,32 +50,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 return new UnsupportedMetadataTypeSymbol();
             }
-            catch (ErrorTypeException)
-            {
-                // If we failed to decode because there was an error type involved, marking the
-                // metadata as unsupported means that we'll cover up the error that would otherwise
-                // be reported for the type. This would likely lead to a worse error message as we
-                // would just report a BindToBogus, so return the type unchanged.
-                Debug.Assert(type.ContainsErrorType());
-                return type;
-            }
         }
 
         private readonly ImmutableArray<bool> _transformFlags;
         private int _index;
+        private bool _hitErrorType;
 
         private NativeIntegerTypeDecoder(ImmutableArray<bool> transformFlags)
         {
             _transformFlags = transformFlags;
             _index = 0;
+            _hitErrorType = false;
         }
 
-        private TypeWithAnnotations TransformTypeWithAnnotations(TypeWithAnnotations type)
+        private TypeWithAnnotations? TransformTypeWithAnnotations(TypeWithAnnotations type)
         {
-            return type.WithTypeAndModifiers(TransformType(type.Type), type.CustomModifiers);
+            if (TransformType(type.Type) is { } transformedType)
+            {
+                return type.WithTypeAndModifiers(transformedType, type.CustomModifiers);
+            }
+
+            return null;
         }
 
-        private TypeSymbol TransformType(TypeSymbol type)
+        private TypeSymbol? TransformType(TypeSymbol type)
         {
             switch (type.TypeKind)
             {
@@ -86,11 +94,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     return TransformNamedType((NamedTypeSymbol)type);
                 default:
                     Debug.Assert(type.TypeKind == TypeKind.Error);
-                    throw new ErrorTypeException();
+                    _hitErrorType = true;
+                    return null;
             }
         }
 
-        private NamedTypeSymbol TransformNamedType(NamedTypeSymbol type)
+        private NamedTypeSymbol? TransformNamedType(NamedTypeSymbol type)
         {
             if (!type.IsGenericType)
             {
@@ -118,7 +127,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             for (int i = 0; i < allTypeArguments.Count; i++)
             {
                 TypeWithAnnotations oldTypeArgument = allTypeArguments[i];
-                TypeWithAnnotations newTypeArgument = TransformTypeWithAnnotations(oldTypeArgument);
+                if (TransformTypeWithAnnotations(oldTypeArgument) is not { } newTypeArgument)
+                {
+                    return null;
+                }
+
                 if (!oldTypeArgument.IsSameAs(newTypeArgument))
                 {
                     allTypeArguments[i] = newTypeArgument;
@@ -131,19 +144,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return result;
         }
 
-        private ArrayTypeSymbol TransformArrayType(ArrayTypeSymbol type)
+        private ArrayTypeSymbol? TransformArrayType(ArrayTypeSymbol type)
         {
-            return type.WithElementType(TransformTypeWithAnnotations(type.ElementTypeWithAnnotations));
+            if (TransformTypeWithAnnotations(type.ElementTypeWithAnnotations) is { } elementType)
+            {
+                return type.WithElementType(elementType);
+            }
+
+            return null;
         }
 
-        private PointerTypeSymbol TransformPointerType(PointerTypeSymbol type)
+        private PointerTypeSymbol? TransformPointerType(PointerTypeSymbol type)
         {
-            return type.WithPointedAtType(TransformTypeWithAnnotations(type.PointedAtTypeWithAnnotations));
+            if (TransformTypeWithAnnotations(type.PointedAtTypeWithAnnotations) is { } pointedAtType)
+            {
+                return type.WithPointedAtType(pointedAtType);
+            }
+
+            return null;
         }
 
-        private FunctionPointerTypeSymbol TransformFunctionPointerType(FunctionPointerTypeSymbol type)
+        private FunctionPointerTypeSymbol? TransformFunctionPointerType(FunctionPointerTypeSymbol type)
         {
-            var transformedReturnType = TransformTypeWithAnnotations(type.Signature.ReturnTypeWithAnnotations);
+            if (TransformTypeWithAnnotations(type.Signature.ReturnTypeWithAnnotations) is not { } transformedReturnType)
+            {
+                return null;
+            }
+
             var transformedParameterTypes = ImmutableArray<TypeWithAnnotations>.Empty;
             var paramsModified = false;
 
@@ -152,7 +179,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 var builder = ArrayBuilder<TypeWithAnnotations>.GetInstance(type.Signature.ParameterCount);
                 foreach (var param in type.Signature.Parameters)
                 {
-                    var transformedParam = TransformTypeWithAnnotations(param.TypeWithAnnotations);
+                    if (TransformTypeWithAnnotations(param.TypeWithAnnotations) is not { } transformedParam)
+                    {
+                        return null;
+                    }
+
                     paramsModified = paramsModified || !transformedParam.IsSameAs(param.TypeWithAnnotations);
                     builder.Add(transformedParam);
                 }


### PR DESCRIPTION
This change removes the `ErrorTypeException` type from
`NativeIntegerDecoder` and changes the code to propogate `null` + an
error state when it hits error types in decoding.

The reason for this change is to support VS 2022 performance
iniatitives. Even though the exception is thrown and handled on this
code path (never leaks) it was inhibbiting developers debugging with
first chance exceptions enabled as well as overall decreasing the
performance of this scenario. For context this exception is thrown three
times as much as the next common exception
(`OperationCanceledException`). Hence removing it

closes #49823