### PR TITLE
Update generate-compiler-code.ps1

### DIFF
--- a/eng/generate-compiler-code.ps1
+++ b/eng/generate-compiler-code.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference="Stop"
 function Run-Tool($projectFilePath, $toolArgs, $targetFramework) {
   $toolName = Split-Path -leaf $projectFilePath
   Write-Host "Running $toolName $toolArgs"
-  Exec-Console $dotnet "run -p $projectFilePath --framework $targetFramework $toolArgs"
+  Exec-Console $dotnet "run --project $projectFilePath --framework $targetFramework $toolArgs"
 }
 
 function Run-LanguageCore($language, $languageSuffix, $languageDir, $syntaxProject, $errorFactsProject, $generatedDir, $generatedTestDir) {


### PR DESCRIPTION
Prevents the following warning from being issued when running generate-compiler-code:

`Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.`
