### PR TITLE
Inline Diagnostics TaggerDelay

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsTaggerProvider.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
         private readonly IClassificationTypeRegistryService _classificationTypeRegistryService;
 
         protected sealed override IEnumerable<PerLanguageOption2<bool>> PerLanguageOptions => SpecializedCollections.SingletonEnumerable(InlineDiagnosticsOptions.EnableInlineDiagnostics);
+        protected override TaggerDelay EventChangeDelay => TaggerDelay.OnIdle;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]


### PR DESCRIPTION
Here are two videos with differing TaggerDelays to make it so the diagnostics do not feel as obstructive.

**Medium Delay:**

https://user-images.githubusercontent.com/40616383/133143137-4c3fcc65-d4e3-4c53-90d3-8497ec7a3d5b.mp4


**OnIdle Delay**

https://user-images.githubusercontent.com/40616383/133143203-1d840aeb-fbd0-4f31-ac94-366ed99c3674.mp4


@mikadumont 