### PR TITLE
Ensure local function invocations and method references always have null receivers

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -103,7 +103,14 @@ namespace Microsoft.CodeAnalysis.Operations
             }
 
             // Static members cannot have an implicit this receiver
-            if (symbol != null && symbol.IsStatic && instance.WasCompilerGenerated && instance.Kind == BoundKind.ThisReference)
+            if (symbol?.IsStatic == true && instance.WasCompilerGenerated && instance.Kind == BoundKind.ThisReference)
+            {
+                return null;
+            }
+
+            // Local functions are not invoked on receivers from a language point of view, and thus we do not expose
+            // a receiver for them.
+            if (symbol is MethodSymbol { MethodKind: MethodKind.LocalFunction })
             {
                 return null;
             }

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInvocationOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInvocationOperation.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -1311,6 +1312,82 @@ Block[B9] - Exit
     Statements (0)
 ";
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
+        }
+
+        [Theory, WorkItem(51715, "https://github.com/dotnet/roslyn/issues/51715")]
+        [InlineData("static")]
+        [InlineData("")]
+        public void Invocation_LocalFunction_01(string modifier)
+        {
+            var code = @"
+using System;
+
+/*<bind>*/localFunction()/*</bind>*/;
+
+" + modifier + @" void localFunction() {}
+";
+
+            var expectedDiagnostics = DiagnosticDescription.None;
+            var expectedTree = @"
+IInvocationOperation (void localFunction()) (OperationKind.Invocation, Type: System.Void) (Syntax: 'localFunction()')
+  Instance Receiver:
+    null
+  Arguments(0)
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, expectedTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(51715, "https://github.com/dotnet/roslyn/issues/51715")]
+        public void Invocation_LocalFunction_02()
+        {
+            var code = @"
+using System;
+
+int localVariable = 1;
+/*<bind>*/localFunction()/*</bind>*/;
+
+int localFunction() => localVariable;
+";
+
+            var expectedDiagnostics = DiagnosticDescription.None;
+            var expectedTree = @"
+IInvocationOperation (System.Int32 localFunction()) (OperationKind.Invocation, Type: System.Int32) (Syntax: 'localFunction()')
+  Instance Receiver:
+    null
+  Arguments(0)
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, expectedTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(51715, "https://github.com/dotnet/roslyn/issues/51715")]
+        public void Invocation_LocalFunction_03()
+        {
+            var code = @"
+using System;
+
+int localVariable = 1;
+/*<bind>*/localFunction()/*</bind>*/;
+
+static int localFunction() => localVariable;
+";
+
+            var expectedDiagnostics = new DiagnosticDescription[]
+            {
+                // (7,31): error CS8421: A static local function cannot contain a reference to 'localVariable'.
+                // static int localFunction() => localVariable;
+                Diagnostic(ErrorCode.ERR_StaticLocalFunctionCannotCaptureVariable, "localVariable").WithArguments("localVariable").WithLocation(7, 31)
+            };
+
+            var expectedTree = @"
+IInvocationOperation (System.Int32 localFunction()) (OperationKind.Invocation, Type: System.Int32) (Syntax: 'localFunction()')
+  Instance Receiver:
+    null
+  Arguments(0)
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(code, expectedTree, expectedDiagnostics);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/51715.
