### PR TITLE
Do not include function type conversions in user-defined conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -256,8 +256,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var conversionsWithoutNullability = conversions.WithNullability(false);
-            var t1tot2 = conversionsWithoutNullability.ClassifyImplicitConversionFromType(type1, type2, ref useSiteInfo).Exists;
-            var t2tot1 = conversionsWithoutNullability.ClassifyImplicitConversionFromType(type2, type1, ref useSiteInfo).Exists;
+            var t1tot2 = conversionsWithoutNullability.ClassifyImplicitConversionFromTypeOrImplicitFunctionTypeConversion(type1, type2, ref useSiteInfo).Exists;
+            var t2tot1 = conversionsWithoutNullability.ClassifyImplicitConversionFromTypeOrImplicitFunctionTypeConversion(type2, type1, ref useSiteInfo).Exists;
 
             if (t1tot2 && t2tot1)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -256,8 +256,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var conversionsWithoutNullability = conversions.WithNullability(false);
-            var t1tot2 = conversionsWithoutNullability.ClassifyImplicitConversionFromTypeOrImplicitFunctionTypeConversion(type1, type2, ref useSiteInfo).Exists;
-            var t2tot1 = conversionsWithoutNullability.ClassifyImplicitConversionFromTypeOrImplicitFunctionTypeConversion(type2, type1, ref useSiteInfo).Exists;
+            var t1tot2 = conversionsWithoutNullability.ClassifyImplicitConversionFromTypeWhenNeitherOrBothFunctionTypes(type1, type2, ref useSiteInfo).Exists;
+            var t2tot1 = conversionsWithoutNullability.ClassifyImplicitConversionFromTypeWhenNeitherOrBothFunctionTypes(type2, type1, ref useSiteInfo).Exists;
 
             if (t1tot2 && t2tot1)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -647,60 +647,65 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private Conversion ClassifyStandardImplicitConversion(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
-            var conversion = ClassifyStandardImplicitConversionInternal(source, destination, ref useSiteInfo);
+            var conversion = classifyConversion(source, destination, ref useSiteInfo);
             Debug.Assert(conversion.Kind == ConversionKind.NoConversion || IsStandardImplicitConversionFromType(conversion.Kind));
             return conversion;
-        }
 
-        private Conversion ClassifyStandardImplicitConversionInternal(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
-        {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)destination != null);
-            Debug.Assert(source is not FunctionTypeSymbol);
-
-            if (HasIdentityConversionInternal(source, destination))
+            Conversion classifyConversion(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
-                return Conversion.Identity;
-            }
+                Debug.Assert((object)source != null);
+                Debug.Assert((object)destination != null);
 
-            if (HasImplicitNumericConversion(source, destination))
-            {
-                return Conversion.ImplicitNumeric;
-            }
+                if (HasIdentityConversionInternal(source, destination))
+                {
+                    return Conversion.Identity;
+                }
 
-            var nullableConversion = ClassifyImplicitNullableConversion(source, destination, ref useSiteInfo);
-            if (nullableConversion.Exists)
-            {
-                return nullableConversion;
-            }
+                if (HasImplicitNumericConversion(source, destination))
+                {
+                    return Conversion.ImplicitNumeric;
+                }
 
-            if (HasImplicitReferenceConversion(source, destination, ref useSiteInfo))
-            {
-                return Conversion.ImplicitReference;
-            }
+                var nullableConversion = ClassifyImplicitNullableConversion(source, destination, ref useSiteInfo);
+                if (nullableConversion.Exists)
+                {
+                    return nullableConversion;
+                }
 
-            if (HasBoxingConversion(source, destination, ref useSiteInfo))
-            {
-                return Conversion.Boxing;
-            }
+                if (source is FunctionTypeSymbol)
+                {
+                    Debug.Assert(false);
+                    return Conversion.NoConversion;
+                }
 
-            if (HasImplicitPointerToVoidConversion(source, destination))
-            {
-                return Conversion.PointerToVoid;
-            }
+                if (HasImplicitReferenceConversion(source, destination, ref useSiteInfo))
+                {
+                    return Conversion.ImplicitReference;
+                }
 
-            if (HasImplicitPointerConversion(source, destination, ref useSiteInfo))
-            {
-                return Conversion.ImplicitPointer;
-            }
+                if (HasBoxingConversion(source, destination, ref useSiteInfo))
+                {
+                    return Conversion.Boxing;
+                }
 
-            var tupleConversion = ClassifyImplicitTupleConversion(source, destination, ref useSiteInfo);
-            if (tupleConversion.Exists)
-            {
-                return tupleConversion;
-            }
+                if (HasImplicitPointerToVoidConversion(source, destination))
+                {
+                    return Conversion.PointerToVoid;
+                }
 
-            return Conversion.NoConversion;
+                if (HasImplicitPointerConversion(source, destination, ref useSiteInfo))
+                {
+                    return Conversion.ImplicitPointer;
+                }
+
+                var tupleConversion = ClassifyImplicitTupleConversion(source, destination, ref useSiteInfo);
+                if (tupleConversion.Exists)
+                {
+                    return tupleConversion;
+                }
+
+                return Conversion.NoConversion;
+            }
         }
 
         private Conversion ClassifyImplicitBuiltInConversionSlow(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal AssemblySymbol CorLibrary { get { return corLibrary; } }
 
+#nullable enable
         /// <summary>
         /// Determines if the source expression is convertible to the destination type via
         /// any built-in or user-defined implicit conversion.
@@ -84,10 +85,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(sourceExpression != null);
             Debug.Assert((object)destination != null);
 
-            var sourceType = sourceExpression.GetTypeOrFunctionType();
+            var sourceType = sourceExpression.Type;
 
             //PERF: identity conversion is by far the most common implicit conversion, check for that first
-            if ((object)sourceType != null && HasIdentityConversionInternal(sourceType, destination))
+            if (sourceType is { } && HasIdentityConversionInternal(sourceType, destination))
             {
                 return Conversion.Identity;
             }
@@ -98,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return conversion;
             }
 
-            if ((object)sourceType != null)
+            if (sourceType is { })
             {
                 // Try using the short-circuit "fast-conversion" path.
                 Conversion fastConversion = FastClassifyConversion(sourceType, destination);
@@ -116,6 +117,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         return conversion;
                     }
+                }
+            }
+            else if (sourceExpression.GetFunctionType() is { })
+            {
+                if (IsValidFunctionTypeConversionTarget(destination, ref useSiteInfo))
+                {
+                    return Conversion.FunctionType;
                 }
             }
 
@@ -170,6 +178,34 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return GetImplicitUserDefinedConversion(null, source, destination, ref useSiteInfo);
         }
+
+        /// <summary>
+        /// Helper method that calls <see cref="ClassifyImplicitConversionFromType"/> or
+        /// <see cref="HasImplicitFunctionTypeConversion"/> depending on whether the
+        /// types are <see cref="FunctionTypeSymbol"/> instances.
+        /// Used by method type inference and best common type only.
+        /// </summary>
+        public Conversion ClassifyImplicitConversionFromTypeOrImplicitFunctionTypeConversion(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
+            var sourceFunctionType = source as FunctionTypeSymbol;
+            var destinationFunctionType = destination as FunctionTypeSymbol;
+
+            if (sourceFunctionType is null && destinationFunctionType is null)
+            {
+                return ClassifyImplicitConversionFromType(source, destination, ref useSiteInfo);
+            }
+
+            if (sourceFunctionType is { } && destinationFunctionType is { })
+            {
+                return HasImplicitFunctionTypeConversion(sourceFunctionType, destinationFunctionType, ref useSiteInfo) ?
+                    Conversion.FunctionType :
+                    Conversion.NoConversion;
+            }
+
+            Debug.Assert(false);
+            return Conversion.NoConversion;
+        }
+#nullable disable
 
         /// <summary>
         /// Determines if the source expression of given type is convertible to the destination type via
@@ -513,10 +549,57 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Conversion.NoConversion;
         }
 
+        private static bool IsStandardImplicitConversionFromExpression(ConversionKind kind)
+        {
+            if (IsStandardImplicitConversionFromType(kind))
+            {
+                return true;
+            }
+
+            // See comment in ClassifyStandardImplicitConversion(BoundExpression, ...)
+            // where the set of standard implicit conversions is extended from the spec
+            // to include conversions from expression.
+            switch (kind)
+            {
+                case ConversionKind.AnonymousFunction:
+                case ConversionKind.MethodGroup:
+                case ConversionKind.ImplicitEnumeration:
+                case ConversionKind.ImplicitDynamic:
+                case ConversionKind.ImplicitNullToPointer:
+                case ConversionKind.ImplicitTupleLiteral:
+                case ConversionKind.StackAllocToPointerType:
+                case ConversionKind.StackAllocToSpanType:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        // See https://github.com/dotnet/csharplang/blob/main/spec/conversions.md#standard-conversions:
+        // "The standard conversions are those pre-defined conversions that can occur as part of a user-defined conversion."
+        private static bool IsStandardImplicitConversionFromType(ConversionKind kind)
+        {
+            switch (kind)
+            {
+                case ConversionKind.Identity:
+                case ConversionKind.ImplicitNumeric:
+                case ConversionKind.ImplicitNullable:
+                case ConversionKind.ImplicitReference:
+                case ConversionKind.Boxing:
+                case ConversionKind.ImplicitConstant:
+                case ConversionKind.ImplicitPointer:
+                case ConversionKind.ImplicitPointerToVoid:
+                case ConversionKind.ImplicitTuple:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         private Conversion ClassifyStandardImplicitConversion(BoundExpression sourceExpression, TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             Debug.Assert(sourceExpression != null || (object)source != null);
-            Debug.Assert(sourceExpression == null || (object)sourceExpression.GetTypeOrFunctionType() == (object)source);
+            Debug.Assert(sourceExpression == null || (object)sourceExpression.Type == (object)source);
             Debug.Assert((object)destination != null);
 
             // SPEC: The following implicit conversions are classified as standard implicit conversions:
@@ -550,6 +633,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Conversion conversion = ClassifyImplicitBuiltInConversionFromExpression(sourceExpression, source, destination, ref useSiteInfo);
             if (conversion.Exists)
             {
+                Debug.Assert(IsStandardImplicitConversionFromExpression(conversion.Kind));
                 return conversion;
             }
 
@@ -563,8 +647,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private Conversion ClassifyStandardImplicitConversion(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
+            var conversion = ClassifyStandardImplicitConversionInternal(source, destination, ref useSiteInfo);
+            Debug.Assert(conversion.Kind == ConversionKind.NoConversion || IsStandardImplicitConversionFromType(conversion.Kind));
+            return conversion;
+        }
+
+        private Conversion ClassifyStandardImplicitConversionInternal(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
             Debug.Assert((object)source != null);
             Debug.Assert((object)destination != null);
+            Debug.Assert(source is not FunctionTypeSymbol);
 
             if (HasIdentityConversionInternal(source, destination))
             {
@@ -580,13 +672,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (nullableConversion.Exists)
             {
                 return nullableConversion;
-            }
-
-            if (source is FunctionTypeSymbol functionType)
-            {
-                return HasImplicitFunctionTypeConversion(functionType, destination, ref useSiteInfo) ?
-                    Conversion.FunctionType :
-                    Conversion.NoConversion;
             }
 
             if (HasImplicitReferenceConversion(source, destination, ref useSiteInfo))
@@ -867,7 +952,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private Conversion ClassifyImplicitBuiltInConversionFromExpression(BoundExpression sourceExpression, TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             Debug.Assert(sourceExpression != null || (object)source != null);
-            Debug.Assert(sourceExpression == null || (object)sourceExpression.GetTypeOrFunctionType() == (object)source);
+            Debug.Assert(sourceExpression == null || (object)sourceExpression.Type == (object)source);
             Debug.Assert((object)destination != null);
 
             if (HasImplicitDynamicConversionFromExpression(source, destination))
@@ -1188,6 +1273,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
+#nullable enable
         private Conversion ClassifyExplicitOnlyConversionFromExpression(BoundExpression sourceExpression, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool forCast)
         {
             Debug.Assert(sourceExpression != null);
@@ -1205,8 +1291,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            var sourceType = sourceExpression.GetTypeOrFunctionType();
-            if ((object)sourceType != null)
+            var sourceType = sourceExpression.Type;
+            if (sourceType is { })
             {
                 // Try using the short-circuit "fast-conversion" path.
                 Conversion fastConversion = FastClassifyConversion(sourceType, destination);
@@ -1223,11 +1309,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
+            else if (sourceExpression.GetFunctionType() is { })
+            {
+                if (IsValidFunctionTypeConversionTarget(destination, ref useSiteInfo))
+                {
+                    return Conversion.FunctionType;
+                }
+            }
 
             return GetExplicitUserDefinedConversion(sourceExpression, sourceType, destination, ref useSiteInfo);
         }
 
-#nullable enable
         private static bool HasImplicitEnumerationConversion(BoundExpression source, TypeSymbol destination)
         {
             Debug.Assert((object)source != null);
@@ -2572,16 +2664,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        private bool HasImplicitFunctionTypeConversion(FunctionTypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
-        {
-            if (destination is FunctionTypeSymbol destinationFunctionType)
-            {
-                return HasImplicitSignatureConversion(source, destinationFunctionType, ref useSiteInfo);
-            }
-
-            return IsValidFunctionTypeConversionTarget(destination, ref useSiteInfo);
-        }
-
         internal bool IsValidFunctionTypeConversionTarget(TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (destination.SpecialType == SpecialType.System_MulticastDelegate)
@@ -2604,7 +2686,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        private bool HasImplicitSignatureConversion(FunctionTypeSymbol sourceType, FunctionTypeSymbol destinationType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private bool HasImplicitFunctionTypeConversion(FunctionTypeSymbol sourceType, FunctionTypeSymbol destinationType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             var sourceDelegate = sourceType.GetInternalDelegateType();
             var destinationDelegate = destinationType.GetInternalDelegateType();

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -119,9 +119,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
-            else if (sourceExpression.GetFunctionType() is { })
+            else if (sourceExpression.GetFunctionType() is { } sourceFunctionType)
             {
-                if (IsValidFunctionTypeConversionTarget(destination, ref useSiteInfo))
+                if (HasImplicitFunctionTypeConversion(sourceFunctionType, destination, ref useSiteInfo))
                 {
                     return Conversion.FunctionType;
                 }
@@ -181,11 +181,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Helper method that calls <see cref="ClassifyImplicitConversionFromType"/> or
-        /// <see cref="HasImplicitFunctionTypeConversion"/> depending on whether the
+        /// <see cref="HasImplicitFunctionTypeToFunctionTypeConversion"/> depending on whether the
         /// types are <see cref="FunctionTypeSymbol"/> instances.
         /// Used by method type inference and best common type only.
         /// </summary>
-        public Conversion ClassifyImplicitConversionFromTypeOrImplicitFunctionTypeConversion(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        public Conversion ClassifyImplicitConversionFromTypeWhenNeitherOrBothFunctionTypes(TypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             var sourceFunctionType = source as FunctionTypeSymbol;
             var destinationFunctionType = destination as FunctionTypeSymbol;
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (sourceFunctionType is { } && destinationFunctionType is { })
             {
-                return HasImplicitFunctionTypeConversion(sourceFunctionType, destinationFunctionType, ref useSiteInfo) ?
+                return HasImplicitFunctionTypeToFunctionTypeConversion(sourceFunctionType, destinationFunctionType, ref useSiteInfo) ?
                     Conversion.FunctionType :
                     Conversion.NoConversion;
             }
@@ -1314,9 +1314,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
-            else if (sourceExpression.GetFunctionType() is { })
+            else if (sourceExpression.GetFunctionType() is { } sourceFunctionType)
             {
-                if (IsValidFunctionTypeConversionTarget(destination, ref useSiteInfo))
+                if (HasImplicitFunctionTypeConversion(sourceFunctionType, destination, ref useSiteInfo))
                 {
                     return Conversion.FunctionType;
                 }
@@ -2669,6 +2669,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
+        private bool HasImplicitFunctionTypeConversion(FunctionTypeSymbol source, TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
+            if (destination is FunctionTypeSymbol destinationFunctionType)
+            {
+                return HasImplicitFunctionTypeToFunctionTypeConversion(source, destinationFunctionType, ref useSiteInfo);
+            }
+
+            return IsValidFunctionTypeConversionTarget(destination, ref useSiteInfo);
+        }
+
         internal bool IsValidFunctionTypeConversionTarget(TypeSymbol destination, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             if (destination.SpecialType == SpecialType.System_MulticastDelegate)
@@ -2691,7 +2701,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        private bool HasImplicitFunctionTypeConversion(FunctionTypeSymbol sourceType, FunctionTypeSymbol destinationType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private bool HasImplicitFunctionTypeToFunctionTypeConversion(FunctionTypeSymbol sourceType, FunctionTypeSymbol destinationType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
             var sourceDelegate = sourceType.GetInternalDelegateType();
             var destinationDelegate = destinationType.GetInternalDelegateType();

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1314,13 +1314,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
-            else if (sourceExpression.GetFunctionType() is { } sourceFunctionType)
-            {
-                if (HasImplicitFunctionTypeConversion(sourceFunctionType, destination, ref useSiteInfo))
-                {
-                    return Conversion.FunctionType;
-                }
-            }
 
             return GetExplicitUserDefinedConversion(sourceExpression, sourceType, destination, ref useSiteInfo);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -606,6 +606,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Not "standard".
                 case ConversionKind.ImplicitUserDefined:
                 case ConversionKind.ExplicitUserDefined:
+                case ConversionKind.FunctionType:
 
                 // Not implicit.
                 case ConversionKind.ExplicitNumeric:
@@ -642,9 +643,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // Added for C# 7.1
                 case ConversionKind.DefaultLiteral:
-
-                // Added for C# 10.
-                case ConversionKind.FunctionType:
                     return true;
 
                 default:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -642,6 +642,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // Added for C# 7.1
                 case ConversionKind.DefaultLiteral:
+
+                // Added for C# 10.
+                case ConversionKind.FunctionType:
                     return true;
 
                 default:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -606,15 +606,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 !MakeExplicitParameterTypeInferences((BoundTupleLiteral)argument, target, kind, ref useSiteInfo))
             {
                 // Either the argument is not a tuple literal, or we were unable to do the inference from its elements, let's try to infer from argument type
-                if (IsReallyAType(argument.GetTypeOrFunctionType()))
+                var argumentType = _extensions.GetTypeWithAnnotations(argument);
+                if (IsReallyAType(argumentType.Type))
                 {
-                    ExactOrBoundsInference(kind, _extensions.GetTypeWithAnnotations(argument), target, ref useSiteInfo);
+                    ExactOrBoundsInference(kind, argumentType, target, ref useSiteInfo);
                 }
                 else if (IsUnfixedTypeParameter(target) && kind is ExactOrBoundsKind.LowerBound)
                 {
                     var ordinal = ((TypeParameterSymbol)target.Type).Ordinal;
-                    var typeWithAnnotations = _extensions.GetTypeWithAnnotations(argument);
-                    _nullableAnnotationLowerBounds[ordinal] = _nullableAnnotationLowerBounds[ordinal].Join(typeWithAnnotations.NullableAnnotation);
+                    _nullableAnnotationLowerBounds[ordinal] = _nullableAnnotationLowerBounds[ordinal].Join(argumentType.NullableAnnotation);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2793,7 +2793,7 @@ OuterBreak:
                 return false;
             }
 
-            return conversions.ClassifyImplicitConversionFromTypeOrImplicitFunctionTypeConversion(source, destination, ref useSiteInfo).Exists;
+            return conversions.ClassifyImplicitConversionFromTypeWhenNeitherOrBothFunctionTypes(source, destination, ref useSiteInfo).Exists;
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2793,7 +2793,7 @@ OuterBreak:
                 return false;
             }
 
-            return conversions.ClassifyImplicitConversionFromType(source, destination, ref useSiteInfo).Exists;
+            return conversions.ClassifyImplicitConversionFromTypeOrImplicitFunctionTypeConversion(source, destination, ref useSiteInfo).Exists;
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -257,9 +257,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Conversion classifyConversion(bool fromExpression, TypeSymbol targetInterface, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
-                return fromExpression ?
-                    originalBinder.Conversions.ClassifyImplicitConversionFromExpression(expressionOpt!, targetInterface, ref useSiteInfo) :
-                    originalBinder.Conversions.ClassifyImplicitConversionFromType(declarationTypeOpt!, targetInterface, ref useSiteInfo);
+                var conversions = originalBinder.Conversions;
+                if (fromExpression)
+                {
+                    Debug.Assert(expressionOpt is { });
+                    return conversions.ClassifyImplicitConversionFromExpression(expressionOpt, targetInterface, ref useSiteInfo);
+                }
+                else
+                {
+                    Debug.Assert(declarationTypeOpt is { });
+                    return conversions.ClassifyImplicitConversionFromType(declarationTypeOpt, targetInterface, ref useSiteInfo);
+                }
             }
 
             TypeSymbol getDisposableInterface(bool isAsync)

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -258,8 +258,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Conversion classifyConversion(bool fromExpression, TypeSymbol targetInterface, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
                 return fromExpression ?
-                    originalBinder.Conversions.ClassifyImplicitConversionFromExpression(expressionOpt, targetInterface, ref useSiteInfo) :
-                    originalBinder.Conversions.ClassifyImplicitConversionFromType(declarationTypeOpt, targetInterface, ref useSiteInfo);
+                    originalBinder.Conversions.ClassifyImplicitConversionFromExpression(expressionOpt!, targetInterface, ref useSiteInfo) :
+                    originalBinder.Conversions.ClassifyImplicitConversionFromType(declarationTypeOpt!, targetInterface, ref useSiteInfo);
             }
 
             TypeSymbol getDisposableInterface(bool isAsync)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6327,10 +6327,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return useExpression ?
                 (fromExplicitCast ?
                     conversions.ClassifyConversionFromExpression(sourceExpression, destinationType, ref discardedUseSiteInfo, forCast: true) :
-                    conversions.ClassifyImplicitConversionFromExpression(sourceExpression, destinationType, ref discardedUseSiteInfo)) :
+                    conversions.ClassifyImplicitConversionFromExpression(sourceExpression!, destinationType, ref discardedUseSiteInfo)) :
                 (fromExplicitCast ?
                     conversions.ClassifyConversionFromType(sourceType, destinationType, ref discardedUseSiteInfo, forCast: true) :
-                    conversions.ClassifyImplicitConversionFromType(sourceType, destinationType, ref discardedUseSiteInfo));
+                    conversions.ClassifyImplicitConversionFromType(sourceType!, destinationType, ref discardedUseSiteInfo));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6156,6 +6156,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BoundKind.MethodGroup:
                     case BoundKind.UnboundLambda:
                     case BoundKind.UnconvertedObjectCreationExpression:
+                    case BoundKind.ConvertedTupleLiteral:
                         return NullableAnnotation.NotAnnotated;
                     default:
                         Debug.Assert(false); // unexpected value

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -6478,7 +6478,7 @@ D4");
         }
 
         [Fact]
-        public void ClassifyConversionFromExpressionToFunctionType()
+        public void ClassifyConversionFromExpression()
         {
             var source =
 @"class Program


### PR DESCRIPTION
Removes "function type conversions" from the set of "standard conversions" so that function type conversions (from the inferred type of a lambda expression or method group to `Delegate`, `Expression` or a base type) are not considered for user-defined conversions.

Fixes #56407

Relates to test plan #52192