### PR TITLE
Fix partial method doc comments

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -255,13 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool shouldSkipPartialDefinitionComments = false;
             if (symbol.IsPartialDefinition())
             {
-                if (symbol is not MethodSymbol { PartialImplementationPart: MethodSymbol implementationPart })
-                {
-                    // The partial method has no implementation. Since it won't be present in the
-                    // output assembly, it shouldn't be included in the documentation file.
-                    shouldSkipPartialDefinitionComments = !_isForSingleSymbol;
-                }
-                else
+                if (symbol is MethodSymbol { PartialImplementationPart: MethodSymbol implementationPart })
                 {
                     Visit(implementationPart);
 
@@ -276,6 +270,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                             break;
                         }
                     }
+                }
+                else
+                {
+                    // The partial method has no implementation. Since it won't be present in the
+                    // output assembly, it shouldn't be included in the documentation file.
+                    shouldSkipPartialDefinitionComments = !_isForSingleSymbol;
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -255,8 +255,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool shouldSkipPartialDefinitionComments = false;
             if (symbol.IsPartialDefinition())
             {
-                MethodSymbol implementationPart = ((MethodSymbol)symbol).PartialImplementationPart;
-                if ((object)implementationPart != null)
+                if (symbol is not MethodSymbol { PartialImplementationPart: MethodSymbol implementationPart })
+                {
+                    // The partial method has no implementation. Since it won't be present in the
+                    // output assembly, it shouldn't be included in the documentation file.
+                    shouldSkipPartialDefinitionComments = !_isForSingleSymbol;
+                }
+                else
                 {
                     Visit(implementationPart);
 

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -252,13 +252,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            bool isPartialMethodDefinitionPart = symbol.IsPartialDefinition(); // CONSIDER: ignore this if isForSingleSymbol?
-            if (isPartialMethodDefinitionPart)
+            bool shouldSkipPartialDefinitionComments = false;
+            if (symbol.IsPartialDefinition())
             {
                 MethodSymbol implementationPart = ((MethodSymbol)symbol).PartialImplementationPart;
                 if ((object)implementationPart != null)
                 {
                     Visit(implementationPart);
+
+                    foreach (var trivia in implementationPart.GetNonNullSyntaxNode().GetLeadingTrivia())
+                    {
+                        if (trivia.Kind() is SyntaxKind.SingleLineDocumentationCommentTrivia or SyntaxKind.MultiLineDocumentationCommentTrivia)
+                        {
+                            // If the partial method implementation has doc comments,
+                            // we will not emit any doc comments found on the definition,
+                            // regardless of whether the partial implementation doc comments are valid.
+                            shouldSkipPartialDefinitionComments = true;
+                            break;
+                        }
+                    }
                 }
             }
 
@@ -276,7 +288,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // If there are no doc comments, then no further work is required (other than to report a diagnostic if one is required).
             if (docCommentNodes.IsEmpty)
             {
-                if (maxDocumentationMode >= DocumentationMode.Diagnose && RequiresDocumentationComment(symbol))
+                if (maxDocumentationMode >= DocumentationMode.Diagnose
+                    && RequiresDocumentationComment(symbol)
+                    && !symbol.IsPartialImplementation()
+                    && !shouldSkipPartialDefinitionComments)
                 {
                     // Report the error at a location in the tree that was parsing doc comments.
                     Location location = GetLocationInTreeReportingDocumentationCommentDiagnostics(symbol);
@@ -299,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<CSharpSyntaxNode> includeElementNodes;
             if (!TryProcessDocumentationCommentTriviaNodes(
                     symbol,
-                    isPartialMethodDefinitionPart,
+                    shouldSkipPartialDefinitionComments,
                     docCommentNodes,
                     reportParameterOrTypeParameterDiagnostics,
                     out withUnprocessedIncludes,
@@ -328,11 +343,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // NOTE: we are expanding include elements AFTER formatting the comment, since the included text is pure
                 // XML, not XML mixed with documentation comment trivia (e.g. ///).  If we expanded them before formatting,
                 // the formatting engine would have trouble determining what prefix to remove from each line.
-                TextWriter expanderWriter = isPartialMethodDefinitionPart ? null : _writer; // Don't actually write partial method definition parts.
+                TextWriter expanderWriter = shouldSkipPartialDefinitionComments ? null : _writer; // Don't actually write partial method definition parts.
                 IncludeElementExpander.ProcessIncludes(withUnprocessedIncludes, symbol, includeElementNodes,
                     _compilation, ref documentedParameters, ref documentedTypeParameters, ref _includedFileCache, expanderWriter, _diagnostics, _cancellationToken);
             }
-            else if (_writer != null && !isPartialMethodDefinitionPart)
+            else if (_writer != null && !shouldSkipPartialDefinitionComments)
             {
                 // CONSIDER: The output would look a little different if we ran the XDocument through an XmlWriter.  In particular, 
                 // formatting inside tags (e.g. <__tag___attr__=__"value"__>) would be normalized.  Whitespace in elements would
@@ -396,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <remarks>This was factored out for clarity, not because it's reusable.</remarks>
         private bool TryProcessDocumentationCommentTriviaNodes(
             Symbol symbol,
-            bool isPartialMethodDefinitionPart,
+            bool shouldSkipPartialDefinitionComments,
             ImmutableArray<DocumentationCommentTriviaSyntax> docCommentNodes,
             bool reportParameterOrTypeParameterDiagnostics,
             out string withUnprocessedIncludes,
@@ -438,7 +453,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // We DO want to write out partial method definition parts if we're processing includes
                     // because we need to have XML to process.
-                    if (!isPartialMethodDefinitionPart || _processIncludes)
+                    if (!shouldSkipPartialDefinitionComments || _processIncludes)
                     {
                         WriteLine("<member name=\"{0}\">", symbol.GetDocumentationCommentId());
                         Indent();
@@ -468,7 +483,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // For partial methods, all parts are validated, but only the implementation part is written to the XML stream.
-                if (!isPartialMethodDefinitionPart || _processIncludes)
+                if (!shouldSkipPartialDefinitionComments || _processIncludes)
                 {
                     // This string already has indentation and line breaks, so don't call WriteLine - just write the text directly.
                     Write(formattedXml);
@@ -483,7 +498,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (!isPartialMethodDefinitionPart || _processIncludes)
+            if (!shouldSkipPartialDefinitionComments || _processIncludes)
             {
                 Unindent();
                 WriteLine("</member>");

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -295,6 +295,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (maxDocumentationMode >= DocumentationMode.Diagnose
                     && RequiresDocumentationComment(symbol)
+                    // We never give a missing doc comment warning on a partial method
+                    // implementation, and we skip the missing doc comment warning on a partial
+                    // definition whose documentation we were not going to output anyway.
                     && !symbol.IsPartialImplementation()
                     && !shouldSkipPartialDefinitionComments)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             ref var lazyDocComment = ref expandIncludes ? ref this.lazyExpandedDocComment : ref this.lazyDocComment;
-            return SourceDocumentationCommentUtils.GetAndCacheDocumentationComment(SourcePartialImplementation ?? this, expandIncludes, ref lazyDocComment);
+            return SourceDocumentationCommentUtils.GetAndCacheDocumentationComment(this, expandIncludes, ref lazyDocComment);
         }
 
         protected override SourceMemberMethodSymbol BoundAttributesSource

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
@@ -912,6 +912,34 @@ partial class C
         }
 
         [Fact]
+        public void PartialMethod_NoImplementation()
+        {
+            var source = @"
+partial class C
+{
+    /** <summary>Summary 2</summary>*/
+    partial void M();
+}
+";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.RegularWithDocumentationComments);
+
+            var comp = CreateCompilation(tree, assemblyName: "Test");
+            var actual = GetDocumentationCommentText(comp);
+            var expected = @"
+<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+    </members>
+</doc>
+".Trim();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void ExtendedPartialMethods_MultipleFiles()
         {
             var source1 = @"
@@ -1092,7 +1120,7 @@ partial class C
             var expected = @"
 <?xml version=""1.0""?>
 <doc>
-    <assembly>  
+    <assembly>
         <name>Test</name>
     </assembly>
     <members>

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
@@ -1275,17 +1275,19 @@ partial class C
 
             // Files passed in reverse order.
             verify(new[] { tree2, tree1 });
-            
+
             void verify(CSharpTestSource source)
             {
                 var compilation = CreateCompilation(source, assemblyName: "Test");
-                compilation.VerifyDiagnostics(
+                var verifier = CompileAndVerify(compilation, symbolValidator: module =>
+                {
+                    var method = module.GlobalNamespace.GetMember<MethodSymbol>("C.M");
+                    Assert.Equal("p2", method.Parameters.Single().Name);
+                });
+                verifier.VerifyDiagnostics(
                     // (5,24): warning CS8826: Partial method declarations 'int C.M(int p2)' and 'int C.M(int p1)' have signature differences.
                     //     public partial int M(int p1) => 42;
                     Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("int C.M(int p2)", "int C.M(int p1)").WithLocation(5, 24));
-
-                var method = compilation.GetMember<MethodSymbol>("C.M");
-                Assert.Equal("p2", method.Parameters.Single().Name);
 
                 var actual = GetDocumentationCommentText(compilation);
                 var expected = @"
@@ -1330,20 +1332,22 @@ partial class C
 
             // Files passed in reverse order.
             verify(new[] { tree2, tree1 });
-            
+
             void verify(CSharpTestSource source)
             {
                 var compilation = CreateCompilation(source, assemblyName: "Test");
-                compilation.VerifyDiagnostics(
+                var verifier = CompileAndVerify(compilation, symbolValidator: module =>
+                {
+                    var method = module.GlobalNamespace.GetMember<MethodSymbol>("C.M");
+                    Assert.Equal("p2", method.Parameters.Single().Name);
+                });
+                verifier.VerifyDiagnostics(
                     // (4,42): warning CS1734: XML comment on 'C.M(int)' has a paramref tag for 'p2', but there is no parameter by that name
                     //     /** <summary>Accepts <paramref name="p2"/>.</summary> */
                     Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "p2").WithArguments("p2", "C.M(int)").WithLocation(4, 42),
                     // (5,24): warning CS8826: Partial method declarations 'int C.M(int p2)' and 'int C.M(int p1)' have signature differences.
                     //     public partial int M(int p1) => 42;
                     Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("int C.M(int p2)", "int C.M(int p1)").WithLocation(5, 24));
-
-                var method = compilation.GetMember<MethodSymbol>("C.M");
-                Assert.Equal("p2", method.Parameters.Single().Name);
 
                 var actual = GetDocumentationCommentText(compilation,
                     // (4,42): warning CS1734: XML comment on 'C.M(int)' has a paramref tag for 'p2', but there is no parameter by that name
@@ -1391,20 +1395,22 @@ partial class C
 
             // Files passed in reverse order.
             verify(new[] { tree2, tree1 });
-            
+
             void verify(CSharpTestSource source)
             {
                 var compilation = CreateCompilation(source, assemblyName: "Test");
-                compilation.VerifyDiagnostics(
+                var verifier = CompileAndVerify(compilation, symbolValidator: module =>
+                {
+                    var method = module.GlobalNamespace.GetMember<MethodSymbol>("C.M");
+                    Assert.Equal("p2", method.Parameters.Single().Name);
+                });
+                verifier.VerifyDiagnostics(
                     // (4,24): warning CS8826: Partial method declarations 'int C.M(int p2)' and 'int C.M(int p1)' have signature differences.
                     //     public partial int M(int p1) => 42;
                     Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("int C.M(int p2)", "int C.M(int p1)").WithLocation(4, 24),
                     // (4,42): warning CS1734: XML comment on 'C.M(int)' has a paramref tag for 'p1', but there is no parameter by that name
                     //     /** <summary>Accepts <paramref name="p1"/>.</summary> */
                     Diagnostic(ErrorCode.WRN_UnmatchedParamRefTag, "p1").WithArguments("p1", "C.M(int)").WithLocation(4, 42));
-
-                var method = compilation.GetMember<MethodSymbol>("C.M");
-                Assert.Equal("p2", method.Parameters.Single().Name);
 
                 var actual = GetDocumentationCommentText(compilation,
                     // (4,42): warning CS1734: XML comment on 'C.M(int)' has a paramref tag for 'p1', but there is no parameter by that name
@@ -1452,17 +1458,19 @@ partial class C
 
             // Files passed in reverse order.
             verify(new[] { tree2, tree1 });
-            
+
             void verify(CSharpTestSource source)
             {
                 var compilation = CreateCompilation(source, assemblyName: "Test");
-                compilation.VerifyDiagnostics(
+                var verifier = CompileAndVerify(compilation, symbolValidator: module =>
+                {
+                    var method = module.GlobalNamespace.GetMember<MethodSymbol>("C.M");
+                    Assert.Equal("p2", method.Parameters.Single().Name);
+                });
+                verifier.VerifyDiagnostics(
                     // (4,24): warning CS8826: Partial method declarations 'int C.M(int p2)' and 'int C.M(int p1)' have signature differences.
                     //     public partial int M(int p1) => 42;
                     Diagnostic(ErrorCode.WRN_PartialMethodTypeDifference, "M").WithArguments("int C.M(int p2)", "int C.M(int p1)").WithLocation(4, 24));
-
-                var method = compilation.GetMember<MethodSymbol>("C.M");
-                Assert.Equal("p2", method.Parameters.Single().Name);
 
                 var actual = GetDocumentationCommentText(compilation);
                 var expected = @"

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/PartialTypeDocumentationCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/PartialTypeDocumentationCommentTests.cs
@@ -66,7 +66,11 @@ partial class Goo
         public void TestSummaryOfMethodWithNoImplementation()
         {
             var method = _gooClass.GetMembers("MethodWithNoImplementation").Single();
-            Assert.Equal(string.Empty, method.GetDocumentationCommentXml()); //Matches what would be written to an XML file.
+            Assert.Equal(
+@"<member name=""M:Goo.MethodWithNoImplementation"">
+    <summary>Summary on MethodWithNoImplementation.</summary>
+</member>
+", method.GetDocumentationCommentXml());
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -1221,6 +1221,42 @@ static class Test { static void Method() { MyClass.My$$Method(); } }";
                 Documentation("My Method Definition"));
         }
 
+        [WorkItem(538638, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538638")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestPartialMethodDocComment_05()
+        {
+            var markup =
+@"partial class MyClass
+{
+    ///<summary>My Method Implementation</summary>
+    public partial void MyMethod() { }
+}
+static class Test { static void Method() { MyClass.My$$Method(); } }";
+
+            await TestAsync(markup,
+                MainDescription($"void MyClass.MyMethod()"),
+                Documentation("My Method Implementation"));
+        }
+
+        [WorkItem(538638, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538638")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestPartialMethodDocComment_06()
+        {
+            var markup =
+@"partial class MyClass
+{
+    ///<summary>My Method Definition</summary>
+    partial void MyMethod();
+
+    partial void MyMethod() { }
+}
+static class Test { static void Method() { MyClass.My$$Method(); } }";
+
+            await TestAsync(markup,
+                MainDescription($"void MyClass.MyMethod()"),
+                Documentation("My Method Definition"));
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task TestMetadataFieldMinimal()
         {

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -1140,6 +1140,70 @@ static class Test { static void Method() { int a = MyStruct.Some$$Field; } }";
                 Documentation("My Field"));
         }
 
+        [WorkItem(538638, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538638")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestPartialMethodDocComment_01()
+        {
+            var markup =
+@"partial class MyClass
+{
+    ///<summary>My Method Definition</summary>
+    public partial void MyMethod();
+
+    ///<summary>My Method Implementation</summary>
+    public partial void MyMethod()
+    {
+    }
+}
+static class Test { static void Method() { MyClass.My$$Method(); } }";
+
+            await TestAsync(markup,
+                MainDescription($"void MyClass.MyMethod()"),
+                Documentation("My Method Implementation"));
+        }
+
+        [WorkItem(538638, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538638")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestPartialMethodDocComment_02()
+        {
+            var markup =
+@"partial class MyClass
+{
+    ///<summary>My Method Definition</summary>
+    public partial void MyMethod();
+
+    public partial void MyMethod()
+    {
+    }
+}
+static class Test { static void Method() { MyClass.My$$Method(); } }";
+
+            await TestAsync(markup,
+                MainDescription($"void MyClass.MyMethod()"),
+                Documentation("My Method Definition"));
+        }
+
+        [WorkItem(538638, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538638")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestPartialMethodDocComment_03()
+        {
+            var markup =
+@"partial class MyClass
+{
+    public partial void MyMethod();
+
+    ///<summary>My Method Implementation</summary>
+    public partial void MyMethod()
+    {
+    }
+}
+static class Test { static void Method() { MyClass.My$$Method(); } }";
+
+            await TestAsync(markup,
+                MainDescription($"void MyClass.MyMethod()"),
+                Documentation("My Method Implementation"));
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task TestMetadataFieldMinimal()
         {

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -1204,6 +1204,23 @@ static class Test { static void Method() { MyClass.My$$Method(); } }";
                 Documentation("My Method Implementation"));
         }
 
+        [WorkItem(538638, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538638")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestPartialMethodDocComment_04()
+        {
+            var markup =
+@"partial class MyClass
+{
+    ///<summary>My Method Definition</summary>
+    public partial void MyMethod();
+}
+static class Test { static void Method() { MyClass.My$$Method(); } }";
+
+            await TestAsync(markup,
+                MainDescription($"void MyClass.MyMethod()"),
+                Documentation("My Method Definition"));
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task TestMetadataFieldMinimal()
         {


### PR DESCRIPTION
Fixes #54103.

The specific rule changes implemented in this PR are laid out in dotnet/csharplang#5193.

Have added tests to ensure that the expected documentation is shown in Quick Info.