### PR TITLE
When we're loading dependencies, don't require exact versions

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var loader = new DefaultAnalyzerAssemblyLoader();
 
-            Assert.Throws<ArgumentNullException>("fullPath", () => loader.AddDependencyLocation(null));
+            Assert.Throws<ArgumentNullException>("fullPath", () => loader.AddDependencyLocation(null!));
             Assert.Throws<ArgumentException>("fullPath", () => loader.AddDependencyLocation("a"));
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
@@ -353,7 +353,7 @@ Delta: Epsilon: Test E
             // In non-core, we cache by assembly identity; since we don't use multiple AppDomains we have no
             // way to load different assemblies with the same identity, no matter what. Thus, we'll get the
             // same assembly for both of these.
-            Assert.Equal(delta2B, delta2);
+            Assert.Same(delta2B, delta2);
 #endif
         }
 
@@ -408,6 +408,8 @@ Delta: Epsilon: Test E
             var delta1File = tempDir.CreateFile("Delta.dll").CopyContentFrom(_testFixture.Delta1.Path);
 
             // Epsilon wants Delta2, but since Delta1 is in the same directory, we prefer Delta1 over Delta2.
+            // This is because the CLR will see it first and load it, without giving us any chance to redirect
+            // in the AssemblyResolve hook.
             var loader = new DefaultAnalyzerAssemblyLoader();
             loader.AddDependencyLocation(delta1File.Path);
             loader.AddDependencyLocation(_testFixture.Delta2.Path);
@@ -514,6 +516,67 @@ Delta: Epsilon: Test E
             eWrite.Invoke(e, new object[] { sb, "Test E" });
             Assert.Equal(
 @"Delta: Gamma: Test G
+",
+                actual);
+        }
+
+        [Fact]
+        public void AssemblyLoading_UnifyToHighest()
+        {
+            var sb = new StringBuilder();
+
+            var loader = new DefaultAnalyzerAssemblyLoader();
+
+            // Gamma depends on Delta v1, and Epsilon depends on Delta v2. But both should load
+            // and both use Delta v2. We intentionally here are not adding a reference to Delta1, since
+            // this test is testing what happens if it's not present. A simple example for this scenario
+            // is an analyzer that depends on both Gamma and Epsilon; an analyzer package can't reasonably
+            // package both Delta v1 and Delta v2, so it'll only package the highest and things should work.
+            loader.AddDependencyLocation(_testFixture.GammaReferencingPublicSigned.Path);
+            loader.AddDependencyLocation(_testFixture.EpsilonReferencingPublicSigned.Path);
+            loader.AddDependencyLocation(_testFixture.DeltaPublicSigned2.Path);
+
+            var gamma = loader.LoadFromPath(_testFixture.GammaReferencingPublicSigned.Path);
+            var g = gamma.CreateInstance("Gamma.G")!;
+            g.GetType().GetMethod("Write")!.Invoke(g, new object[] { sb, "Test G" });
+
+            var epsilon = loader.LoadFromPath(_testFixture.EpsilonReferencingPublicSigned.Path);
+            var e = epsilon.CreateInstance("Epsilon.E")!;
+            e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
+
+            var actual = sb.ToString();
+
+            Assert.Equal(
+@"Delta.2: Gamma: Test G
+Delta.2: Epsilon: Test E
+",
+                actual);
+        }
+
+        [Fact]
+        public void AssemblyLoading_CanLoadDifferentVersionsDirectly()
+        {
+            var sb = new StringBuilder();
+
+            var loader = new DefaultAnalyzerAssemblyLoader();
+
+            // Ensure that no matter what, if we have two analyzers of different versions, we never unify them.
+            loader.AddDependencyLocation(_testFixture.DeltaPublicSigned1.Path);
+            loader.AddDependencyLocation(_testFixture.DeltaPublicSigned2.Path);
+
+            var delta1Assembly = loader.LoadFromPath(_testFixture.DeltaPublicSigned1.Path);
+            var delta1Instance = delta1Assembly.CreateInstance("Delta.D")!;
+            delta1Instance.GetType().GetMethod("Write")!.Invoke(delta1Instance, new object[] { sb, "Test D1" });
+
+            var delta2Assembly = loader.LoadFromPath(_testFixture.DeltaPublicSigned2.Path);
+            var delta2Instance = delta2Assembly.CreateInstance("Delta.D")!;
+            delta2Instance.GetType().GetMethod("Write")!.Invoke(delta2Instance, new object[] { sb, "Test D2" });
+
+            var actual = sb.ToString();
+
+            Assert.Equal(
+@"Delta: Test D1
+Delta.2: Test D2
 ",
                 actual);
         }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -18,8 +18,6 @@ namespace Microsoft.CodeAnalysis
 
         // lock _guard to read/write
         private readonly Dictionary<string, Assembly> _loadedAssembliesByPath = new();
-        private readonly Dictionary<string, AssemblyIdentity?> _loadedAssemblyIdentitiesByPath = new();
-        private readonly Dictionary<AssemblyIdentity, Assembly> _loadedAssembliesByIdentity = new();
 
         // maps file name to a full path (lock _guard to read/write):
         private readonly Dictionary<string, HashSet<string>> _knownAssemblyPathsBySimpleName = new(StringComparer.OrdinalIgnoreCase);
@@ -53,25 +51,17 @@ namespace Microsoft.CodeAnalysis
 
         #endregion
 
-        private Assembly LoadFromPathUnchecked(string fullPath, AssemblyIdentity? identity = null)
+        protected Assembly LoadFromPathUnchecked(string fullPath)
         {
             Debug.Assert(PathUtilities.IsAbsolute(fullPath));
 
-            // Check if we have already loaded an assembly with the same identity or from the given path.
+            // Check if we have already loaded an assembly from the given path.
             Assembly? loadedAssembly = null;
             lock (_guard)
             {
                 if (_loadedAssembliesByPath.TryGetValue(fullPath, out var existingAssembly))
                 {
                     loadedAssembly = existingAssembly;
-                }
-                else
-                {
-                    identity ??= GetOrAddAssemblyIdentity(fullPath);
-                    if (identity != null && _loadedAssembliesByIdentity.TryGetValue(identity, out existingAssembly))
-                    {
-                        loadedAssembly = existingAssembly;
-                    }
                 }
             }
 
@@ -81,71 +71,13 @@ namespace Microsoft.CodeAnalysis
                 loadedAssembly = LoadFromPathImpl(fullPath);
             }
 
-            // Add the loaded assembly to both path and identity cache.
-            return AddToCache(loadedAssembly, fullPath, identity);
-        }
-
-        private Assembly AddToCache(Assembly assembly, string fullPath, AssemblyIdentity? identity)
-        {
-            Debug.Assert(PathUtilities.IsAbsolute(fullPath));
-            Debug.Assert(assembly != null);
-
-            identity = AddToCache(fullPath, identity ?? AssemblyIdentity.FromAssemblyDefinition(assembly));
-            Debug.Assert(identity != null);
-
+            // Add the loaded assembly to the path cache.
             lock (_guard)
             {
-                // The same assembly may be loaded from two different full paths (e.g. when loaded from GAC, etc.),
-                // or another thread might have loaded the assembly after we checked above.
-                if (_loadedAssembliesByIdentity.TryGetValue(identity, out var existingAssembly))
-                {
-                    assembly = existingAssembly;
-                }
-                else
-                {
-                    _loadedAssembliesByIdentity.Add(identity, assembly);
-                }
-
-                // An assembly file might be replaced by another file with a different identity.
-                // Last one wins.
-                _loadedAssembliesByPath[fullPath] = assembly;
-
-                return assembly;
-            }
-        }
-
-        private AssemblyIdentity? GetOrAddAssemblyIdentity(string fullPath)
-        {
-            Debug.Assert(PathUtilities.IsAbsolute(fullPath));
-
-            lock (_guard)
-            {
-                if (_loadedAssemblyIdentitiesByPath.TryGetValue(fullPath, out var existingIdentity))
-                {
-                    return existingIdentity;
-                }
+                _loadedAssembliesByPath[fullPath] = loadedAssembly;
             }
 
-            var identity = AssemblyIdentityUtils.TryGetAssemblyIdentity(fullPath);
-            return AddToCache(fullPath, identity);
-        }
-
-        [return: NotNullIfNotNull("identity")]
-        private AssemblyIdentity? AddToCache(string fullPath, AssemblyIdentity? identity)
-        {
-            lock (_guard)
-            {
-                if (_loadedAssemblyIdentitiesByPath.TryGetValue(fullPath, out var existingIdentity) && existingIdentity != null)
-                {
-                    identity = existingIdentity;
-                }
-                else
-                {
-                    _loadedAssemblyIdentitiesByPath[fullPath] = identity;
-                }
-            }
-
-            return identity;
+            return loadedAssembly;
         }
 
         protected HashSet<string>? GetPaths(string simpleName)
@@ -162,47 +94,6 @@ namespace Microsoft.CodeAnalysis
         protected virtual string GetPathToLoad(string fullPath)
         {
             return fullPath;
-        }
-
-        public Assembly? Load(string displayName)
-        {
-            if (!AssemblyIdentity.TryParseDisplayName(displayName, out var requestedIdentity))
-            {
-                return null;
-            }
-
-            ImmutableArray<string> candidatePaths;
-            lock (_guard)
-            {
-
-                // First, check if this loader already loaded the requested assembly:
-                if (_loadedAssembliesByIdentity.TryGetValue(requestedIdentity, out var existingAssembly))
-                {
-                    return existingAssembly;
-                }
-                // Second, check if an assembly file of the same simple name was registered with the loader:
-                if (!_knownAssemblyPathsBySimpleName.TryGetValue(requestedIdentity.Name, out var pathList))
-                {
-                    return null;
-                }
-
-                Debug.Assert(pathList.Count > 0);
-                candidatePaths = pathList.ToImmutableArray();
-            }
-
-            // Multiple assemblies of the same simple name but different identities might have been registered.
-            // Load the one that matches the requested identity (if any).
-            foreach (var candidatePath in candidatePaths)
-            {
-                var candidateIdentity = GetOrAddAssemblyIdentity(candidatePath);
-
-                if (requestedIdentity.Equals(candidateIdentity))
-                {
-                    return LoadFromPathUnchecked(candidatePath, candidateIdentity);
-                }
-            }
-
-            return null;
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -53,12 +53,7 @@ namespace Microsoft.CodeAnalysis
 
         #endregion
 
-        private Assembly LoadFromPathUnchecked(string fullPath)
-        {
-            return LoadFromPathUncheckedCore(fullPath);
-        }
-
-        private Assembly LoadFromPathUncheckedCore(string fullPath, AssemblyIdentity? identity = null)
+        private Assembly LoadFromPathUnchecked(string fullPath, AssemblyIdentity? identity = null)
         {
             Debug.Assert(PathUtilities.IsAbsolute(fullPath));
 
@@ -203,7 +198,7 @@ namespace Microsoft.CodeAnalysis
 
                 if (requestedIdentity.Equals(candidateIdentity))
                 {
-                    return LoadFromPathUncheckedCore(candidatePath, candidateIdentity);
+                    return LoadFromPathUnchecked(candidatePath, candidateIdentity);
                 }
             }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// When overridden in a derived class, allows substituting an assembly path after we've
         /// identified the context to load an assembly in, but before the assembly is actually
-        /// loaded from disk.
+        /// loaded from disk. This is used to substitute out the original path with the shadow-copied version.
         /// </summary>
         protected virtual string GetPathToLoad(string fullPath)
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Core.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis
         private readonly object _guard = new object();
         private readonly Dictionary<string, DirectoryLoadContext> _loadContextByDirectory = new Dictionary<string, DirectoryLoadContext>(StringComparer.Ordinal);
 
-        protected override Assembly LoadFromPathImpl(string fullPath)
+        protected override Assembly LoadFromPathUncheckedImpl(string fullPath)
         {
             DirectoryLoadContext? loadContext;
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 #if !NETCOREAPP
 
 using System;
@@ -38,7 +36,7 @@ namespace Microsoft.CodeAnalysis
             return Assembly.LoadFrom(pathToLoad);
         }
 
-        private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        private Assembly? CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
         {
             try
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
@@ -149,7 +149,9 @@ namespace Microsoft.CodeAnalysis
             string? bestPath = null;
             Version? bestIdentityVersion = null;
 
-            foreach (var candidatePath in candidatePaths)
+            // Sort the candidate paths by ordinal, to ensure determinism with the same inputs if you were to have multiple assemblies
+            // providing the same version.
+            foreach (var candidatePath in candidatePaths.OrderBy(StringComparer.Ordinal))
             {
                 var candidateIdentity = GetOrAddAssemblyIdentity(candidatePath);
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
@@ -101,16 +101,12 @@ namespace Microsoft.CodeAnalysis
             }
 
             var identity = AssemblyIdentityUtils.TryGetAssemblyIdentity(fullPath);
-            return AddToCache(fullPath, identity);
-        }
 
-        [return: NotNullIfNotNull("identity")]
-        private AssemblyIdentity? AddToCache(string fullPath, AssemblyIdentity? identity)
-        {
             lock (_guard)
             {
                 if (_loadedAssemblyIdentitiesByPath.TryGetValue(fullPath, out var existingIdentity) && existingIdentity != null)
                 {
+                    // Somebody else beat us, so used the cached value
                     identity = existingIdentity;
                 }
                 else

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis
                 return null;
             }
 
-            ImmutableArray<string> candidatePaths;
+            ImmutableHashSet<string> candidatePaths;
             lock (_guard)
             {
 
@@ -138,14 +138,13 @@ namespace Microsoft.CodeAnalysis
                     return existingAssembly;
                 }
                 // Second, check if an assembly file of the same simple name was registered with the loader:
-                var pathList = GetPaths(requestedIdentity.Name);
-                if (pathList is null)
+                candidatePaths = GetPaths(requestedIdentity.Name);
+                if (candidatePaths is null)
                 {
                     return null;
                 }
 
-                Debug.Assert(pathList.Count > 0);
-                candidatePaths = pathList.ToImmutableArray();
+                Debug.Assert(candidatePaths.Count > 0);
             }
 
             // Multiple assemblies of the same simple name but different identities might have been registered.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis
         {
             try
             {
-                return Load(AppDomain.CurrentDomain.ApplyPolicy(args.Name));
+                return GetOrLoad(AppDomain.CurrentDomain.ApplyPolicy(args.Name));
             }
             catch
             {
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis
             return identity;
         }
 
-        private Assembly? Load(string displayName)
+        private Assembly? GetOrLoad(string displayName)
         {
             if (!AssemblyIdentity.TryParseDisplayName(displayName, out var requestedIdentity))
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis
 
         private int _hookedAssemblyResolve;
 
-        protected override Assembly LoadFromPathImpl(string fullPath)
+        protected override Assembly LoadFromPathUncheckedImpl(string fullPath)
         {
             if (Interlocked.CompareExchange(ref _hookedAssemblyResolve, 0, 1) == 0)
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.Desktop.cs
@@ -78,6 +78,9 @@ namespace Microsoft.CodeAnalysis
 
         private Assembly? CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
         {
+            // In the .NET Framework, if a handler to AssemblyResolve throws an exception, other handlers
+            // are not called. To avoid any bug in our handler breaking other handlers running in the same process
+            // we catch exceptions here. We do not expect exceptions to be thrown though.
             try
             {
                 return GetOrLoad(AppDomain.CurrentDomain.ApplyPolicy(args.Name));

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,7 +33,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         private int _assemblyDirectoryId;
 
-        public ShadowCopyAnalyzerAssemblyLoader(string baseDirectory = null)
+        public ShadowCopyAnalyzerAssemblyLoader(string? baseDirectory = null)
         {
             if (baseDirectory != null)
             {
@@ -72,7 +69,7 @@ namespace Microsoft.CodeAnalysis
             foreach (var subDirectory in subDirectories)
             {
                 string name = Path.GetFileName(subDirectory).ToLowerInvariant();
-                Mutex mutex = null;
+                Mutex? mutex = null;
                 try
                 {
                     // We only want to try deleting the directory if no-one else is currently
@@ -98,14 +95,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-#nullable enable
         protected override string GetPathToLoad(string fullPath)
         {
             string assemblyDirectory = CreateUniqueDirectoryForAssembly();
             string shadowCopyPath = CopyFileAndResources(fullPath, assemblyDirectory);
             return shadowCopyPath;
         }
-#nullable disable
 
         private static string CopyFileAndResources(string fullPath, string assemblyDirectory)
         {
@@ -114,7 +109,7 @@ namespace Microsoft.CodeAnalysis
 
             CopyFile(fullPath, shadowCopyPath);
 
-            string originalDirectory = Path.GetDirectoryName(fullPath);
+            string originalDirectory = Path.GetDirectoryName(fullPath)!;
             string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileNameWithExtension);
             string resourcesNameWithoutExtension = fileNameWithoutExtension + ".resources";
             string resourcesNameWithExtension = resourcesNameWithoutExtension + ".dll";

--- a/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
+++ b/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
@@ -20,15 +20,45 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         private readonly TempRoot _temp;
         private readonly TempDirectory _directory;
 
+        /// <summary>
+        /// An assembly with no references, assembly version 1.
+        /// </summary>
         public TempFile Delta1 { get; }
+
+        /// <summary>
+        /// An assembly with a reference to <see cref="Delta1"/>.
+        /// </summary>
         public TempFile Gamma { get; }
+
+        /// <summary>
+        /// An assembly with a reference to <see cref="Gamma"/>.
+        /// </summary>
         public TempFile Beta { get; }
+
+        /// <summary>
+        /// An assembly with a reference to <see cref="Gamma"/>.
+        /// </summary>
         public TempFile Alpha { get; }
 
+        /// <summary>
+        /// An assembly with no references, assembly version 2.
+        /// </summary>
         public TempFile Delta2 { get; }
+
+        /// <summary>
+        /// An assembly with a reference to <see cref="Delta2"/>.
+        /// </summary>
         public TempFile Epsilon { get; }
 
+        /// <summary>
+        /// An assembly with no references, assembly version 2. The implementation however is different than
+        /// <see cref="Delta2"/> so we can test having two assemblies that look the same but aren't.
+        /// </summary>
         public TempFile Delta2B { get; }
+
+        /// <summary>
+        /// An assembly with no references, assembly version 3.
+        /// </summary>
         public TempFile Delta3 { get; }
 
         public TempFile UserSystemCollectionsImmutable { get; }

--- a/src/Tools/ExternalAccess/OmniSharp/Analyzers/OmnisharpAnalyzerLoaderFactory.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Analyzers/OmnisharpAnalyzerLoaderFactory.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Analyzers
+{
+    internal static class OmnisharpAnalyzerAssemblyLoaderFactory
+    {
+        public static IAnalyzerAssemblyLoader CreateShadowCopyAnalyzerAssemblyLoader(string? baseDirectory = null)
+        {
+            return new ShadowCopyAnalyzerAssemblyLoader(baseDirectory);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -800,7 +800,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
         private class MissingAnalyzerLoader : AnalyzerAssemblyLoader
         {
-            protected override Assembly LoadFromPathImpl(string fullPath)
+            protected override Assembly LoadFromPathUncheckedImpl(string fullPath)
                 => throw new FileNotFoundException(fullPath);
         }
 


### PR DESCRIPTION
When we're loading analyzer dependencies, our current logic was to require the exact version that was requested from the loading assembly. This is problematic in a lot of cases where you would normally have a binding redirect to ensure assemblies load cleanly; by requiring exact versions we'd end up in diamond dependency cases where you couldn't practically produce an analyzer package that would cleanly load.

While doing this change, @RikkiGibson and I noticed several other problems:

1. There was an errant cache that was left in the .NET Core implementation, which meant that we'd sometimes reuse assemblies even when we were able to load them correctly. This has also been fixed as a prerequisite to the main fix, since otherwise it was difficult to prove that the behavior changes here weren't also going to impact the .NET Core implementation.
2. There were some race conditions in the implementation.

**REVIEWING COMMIT-AT-A-TIME IS HIGHLY RECOMMENDED**, since those changes are broken out to separate commits.

Fixes #53672
Fixes #56216