### PR TITLE
Only allow Contract.ThrowIfNull() to be called on nullable types

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             Dictionary<ISymbol, List<ProjectId>>? invalidProjectMap,
             List<ProjectId>? totalProjects)
         {
-            Contract.ThrowIfNull(symbols);
+            Contract.ThrowIfTrue(symbols.IsDefault);
 
             SupportedPlatformData? supportedPlatformData = null;
             if (invalidProjectMap != null)

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.cs
@@ -404,8 +404,8 @@ namespace Microsoft.CodeAnalysis.Interactive
         /// </summary>
         public Task<RemoteExecutionResult> SetPathsAsync(ImmutableArray<string> referenceSearchPaths, ImmutableArray<string> sourceSearchPaths, string baseDirectory)
         {
-            Contract.ThrowIfNull(referenceSearchPaths);
-            Contract.ThrowIfNull(sourceSearchPaths);
+            Contract.ThrowIfTrue(referenceSearchPaths.IsDefault);
+            Contract.ThrowIfTrue(sourceSearchPaths.IsDefault);
             Contract.ThrowIfNull(baseDirectory);
 
             return ExecuteRemoteAsync(nameof(Service.SetPathsAsync), referenceSearchPaths, sourceSearchPaths, baseDirectory);

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             lock (_gate)
             {
                 // We should not have an existing computation active
-                Contract.ThrowIfNull(_cancellationTokenSource == null);
+                Contract.ThrowIfTrue(_cancellationTokenSource is not null);
 
                 _cancellationTokenSource = new CancellationTokenSource();
                 var cancellationToken = _cancellationTokenSource.Token;

--- a/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SerializationValidator.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             // deserialize bits to object
             var result = Serializer.Deserialize<T>(data.Kind, reader, CancellationToken.None);
-            Contract.ThrowIfNull(result);
+            Contract.ThrowIfNull<object?>(result);
             return result;
         }
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/OnTypeRename/OnTypeRenameHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/OnTypeRename/OnTypeRenameHandler.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
                 return null;
             }
 
-            Contract.ThrowIfNull(result.Ranges);
+            Contract.ThrowIfTrue(result.Ranges.IsDefault);
 
             return new LinkedEditingRanges
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 keySuffix: "_Metadata_" + filePath,
                 tryReadObject: reader => TryReadSymbolTreeInfo(reader, checksum, nodes => GetSpellCheckerAsync(services, solutionKey, checksum, database, filePath, nodes)),
                 cancellationToken: cancellationToken);
-            Contract.ThrowIfNull(result != null);
+            Contract.ThrowIfNull(result);
             return result;
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/Contract.cs
@@ -22,7 +22,20 @@ namespace Roslyn.Utilities
         /// all builds
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNull<T>([NotNull] T value, [CallerLineNumber] int lineNumber = 0)
+        public static void ThrowIfNull<T>([NotNull] T value, [CallerLineNumber] int lineNumber = 0) where T : class?
+        {
+            if (value is null)
+            {
+                Fail("Unexpected null", lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is null.  This method executes in
+        /// all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNull<T>([NotNull] T? value, [CallerLineNumber] int lineNumber = 0) where T : struct
         {
             if (value is null)
             {


### PR DESCRIPTION
We had some places we were calling it on bools.