### PR TITLE
Implement INamespaceTypeReference.GetUnit for RootModuleType

### DIFF
--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -521,7 +521,7 @@ namespace Microsoft.CodeAnalysis.Emit
         private HashSet<string> _namesOfTopLevelTypes;
 
         internal readonly TModuleCompilationState CompilationState;
-        public Cci.RootModuleType RootModuleType { get; } = new Cci.RootModuleType();
+        private readonly Cci.RootModuleType _rootModuleType;
 
         public abstract TEmbeddedTypesManager EmbeddedTypesManagerOpt { get; }
 
@@ -541,7 +541,10 @@ namespace Microsoft.CodeAnalysis.Emit
             Compilation = compilation;
             SourceModule = sourceModule;
             this.CompilationState = compilationState;
+            _rootModuleType = new Cci.RootModuleType(this);
         }
+
+        public Cci.RootModuleType RootModuleType => _rootModuleType;
 
         internal sealed override void CompilationFinished()
         {

--- a/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
+++ b/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
@@ -17,7 +17,13 @@ namespace Microsoft.Cci
     /// </summary>
     internal class RootModuleType : INamespaceTypeDefinition
     {
+        private readonly IUnit _unit;
         private IReadOnlyList<IMethodDefinition>? _methods;
+
+        public RootModuleType(IUnit unit)
+        {
+            _unit = unit;
+        }
 
         public void SetStaticConstructorBody(ImmutableArray<byte> il)
         {
@@ -232,7 +238,7 @@ namespace Microsoft.Cci
 
         IUnitReference INamespaceTypeReference.GetUnit(EmitContext context)
         {
-            throw ExceptionUtilities.Unreachable;
+            return _unit;
         }
 
         string INamespaceTypeReference.NamespaceName


### PR DESCRIPTION
Fixes #56412.