### PR TITLE
Set CompilerApiVersion in Microsoft.Managed.Core.targets

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -60,5 +60,45 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Build.Tasks.CodeAnalysis.UnitTests" />
   </ItemGroup>
+
+  <!-- Generate a .targets file that sets $(CompilerApiVersion) to the current Roslyn version -->
+  <PropertyGroup>
+    <CompilerVersionTargetsFileIntermediatePath>$(IntermediateOutputPath)Microsoft.Managed.Core.CurrentVersions.targets</CompilerVersionTargetsFileIntermediatePath>
+  </PropertyGroup>
+
+  <Target Name="GenerateCompilerVersionTargets"
+          BeforeTargets="AssignTargetPaths"
+          DependsOnTargets="GenerateCompilerVersionTargetsFile">
+    <ItemGroup>
+      <Content Include="$(CompilerVersionTargetsFileIntermediatePath)">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Pack>true</Pack>
+        <BuildAction>None</BuildAction>
+        <PackageCopyToOutput>true</PackageCopyToOutput>
+        <PackagePath>contentFiles\any\any</PackagePath>
+      </Content>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GenerateCompilerVersionTargetsFile"
+          Inputs="$(MSBuildThisFileFullPath)"
+          Outputs="$(CompilerVersionTargetsFileIntermediatePath)">
+
+    <PropertyGroup>
+      <CompilerApiVersion>$([System.Version]::Parse($(VersionPrefix)).Major).$([System.Version]::Parse($(VersionPrefix)).Minor)</CompilerApiVersion>
+      <CompilerVersionTargetsFileContent>
+<![CDATA[<Project>
+  <PropertyGroup>
+    <CompilerApiVersion>roslyn$(CompilerApiVersion)</CompilerApiVersion>
+  </PropertyGroup>
+</Project>]]>
+      </CompilerVersionTargetsFileContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(CompilerVersionTargetsFileIntermediatePath)"
+                      Lines="$(CompilerVersionTargetsFileContent)"
+                      Overwrite="true" />
+  </Target>
+
   <Import Project="..\CommandLine\CommandLine.projitems" Label="Shared" />
 </Project>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -6,6 +6,8 @@
   -->
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.MapSourceRoots" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll" />
 
+  <Import Project="Microsoft.Managed.Core.CurrentVersions.targets" />
+
   <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
           BeforeTargets="CoreCompile"
           Condition="'@(ReferencePathWithRefAssemblies)' == ''">

--- a/src/Compilers/Core/MSBuildTaskTests/Microsoft.Build.Tasks.CodeAnalysis.UnitTests.csproj
+++ b/src/Compilers/Core/MSBuildTaskTests/Microsoft.Build.Tasks.CodeAnalysis.UnitTests.csproj
@@ -40,12 +40,16 @@
     <EmbeddedResource Include="TestResources\**\*.*" />
   </ItemGroup>
   <PropertyGroup>
-    <_DotNetSdkVersionFile>$(IntermediateOutputPath)\DotNetSdkVersion.g.cs</_DotNetSdkVersionFile>
+    <_DotNetSdkVersionFile>$(IntermediateOutputPath)\DotNetVersions.g.cs</_DotNetSdkVersionFile>
   </PropertyGroup>
   <Target Name="_GenerateSdkVersionAttribute" BeforeTargets="CoreCompile" Outputs="$(_DotNetSdkVersionFile)">
     <ItemGroup>
       <_Attribute Include="Microsoft.CodeAnalysis.BuildTasks.UnitTests.DotNetSdkVersionAttribute">
         <_Parameter1>$(NETCoreSdkVersion)</_Parameter1>
+      </_Attribute>
+      <_Attribute Include="System.Reflection.AssemblyMetadataAttribute">
+        <_Parameter1>CurrentCompilerApiVersion</_Parameter1>
+        <_Parameter2>$([System.Version]::Parse($(VersionPrefix)).Major).$([System.Version]::Parse($(VersionPrefix)).Minor)</_Parameter2>
       </_Attribute>
     </ItemGroup>
     <WriteCodeFragment AssemblyAttributes="@(_Attribute)" Language="$(Language)" OutputFile="$(_DotNetSdkVersionFile)">

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -891,6 +891,30 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Contains("RoslynComponent", caps);
         }
 
+        [Fact]
+        public void CompilerApiVersionIsSet()
+        {
+            XmlReader xmlReader = XmlReader.Create(new StringReader($@"
+<Project>
+    <Import Project=""Microsoft.Managed.Core.targets"" />
+</Project>
+"));
+
+            var instance = CreateProjectInstance(xmlReader);
+
+            var compilerApiVersionString = instance.GetPropertyValue("CompilerApiVersion");
+            Assert.StartsWith("roslyn", compilerApiVersionString);
+
+            var compilerApiVersion = Version.Parse(compilerApiVersionString.Substring("roslyn".Length));
+
+            var expectedVersionString = GetType().Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Single(a => a.Key == "CurrentCompilerApiVersion")
+                .Value ?? string.Empty;
+            var expectedVersion = Version.Parse(expectedVersionString);
+
+            Assert.Equal(expectedVersion, compilerApiVersion);
+        }
+
         private static ProjectInstance CreateProjectInstance(XmlReader reader)
         {
             Project proj = new Project(reader);

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/DesktopCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/DesktopCompilerArtifacts.targets
@@ -43,6 +43,7 @@
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\net472\VBCSCompiler.exe" NgenArchitecture="all" NgenApplication="VBCSCompiler.exe" NgenPriority="1"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\net472\VBCSCompiler.exe.config"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\Microsoft.Build.Tasks.CodeAnalysis.dll" NgenArchitecture="all" NgenPriority="1"/>
+      <DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\Microsoft.Managed.Core.CurrentVersions.targets"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\Microsoft.Managed.Core.targets"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\Microsoft.CSharp.Core.targets"/>
       <DesktopCompilerArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\net472\Microsoft.VisualBasic.Core.targets"/>


### PR DESCRIPTION
This allows other targets to understand which compiler will be used.
This is useful in the SDK targets that need figure out the version in order to pick the right analyzer assets.

Contributes to #52265

FYI - @dsplaisted. This resolves the feedback from https://github.com/dotnet/sdk/pull/20793#discussion_r707788803