### PR TITLE
Make path comparison case insensitive

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -516,7 +516,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         {
                             // TODO: find a cleaner way to fetch this
                             var metadataReference = _workspace.CurrentSolution.GetRequiredProject(Id).MetadataReferences.Cast<PortableExecutableReference>()
-                                                                                    .Single(m => m.FilePath == path && m.Properties == properties);
+                                .Single(m => StringComparer.OrdinalIgnoreCase.Equals(m.FilePath, path) && m.Properties == properties);
 
                             _workspace.FileWatchedReferenceFactory.StopWatchingReference(metadataReference);
 


### PR DESCRIPTION
This is an attempt to fix AB#1155310, which is an NFE where Enumerable.Single with a predicate finds no results and throws.

That NFE is currently the number 9 most frequent fault in 16.11. We don't have a dump to verify that differing path capitalisation is the root cause, but it seems likely and the change is otherwise benign on Windows.