### PR TITLE
Make 'Languages' not part of hte state of an optionset

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -330,8 +330,6 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                             metadataReferences: new [] { MetadataReference.CreateFromFile(file.Path) })
                 });
 
-            var languages = ImmutableHashSet.Create(LanguageNames.CSharp);
-
             using var remoteWorkspace = new RemoteWorkspace(FeaturesTestCompositions.RemoteHost.GetHostServices(), WorkspaceKind.RemoteWorkspace);
             var optionService = remoteWorkspace.Services.GetRequiredService<IOptionService>();
             var options = new SerializableOptionSet(optionService, ImmutableHashSet<IOption>.Empty, ImmutableDictionary<OptionKey, object>.Empty, ImmutableHashSet<OptionKey>.Empty);

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -334,7 +334,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             using var remoteWorkspace = new RemoteWorkspace(FeaturesTestCompositions.RemoteHost.GetHostServices(), WorkspaceKind.RemoteWorkspace);
             var optionService = remoteWorkspace.Services.GetRequiredService<IOptionService>();
-            var options = new SerializableOptionSet(languages, optionService, ImmutableHashSet<IOption>.Empty, ImmutableDictionary<OptionKey, object>.Empty, ImmutableHashSet<OptionKey>.Empty);
+            var options = new SerializableOptionSet(optionService, ImmutableHashSet<IOption>.Empty, ImmutableDictionary<OptionKey, object>.Empty, ImmutableHashSet<OptionKey>.Empty);
 
             // this shouldn't throw exception
             remoteWorkspace.TrySetCurrentSolution(solutionInfo, workspaceVersion: 1, options, out var solution);

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -725,23 +725,23 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             Assert.Equal(solutionChecksum, await syncedFullSolution.State.GetChecksumAsync(CancellationToken.None));
             Assert.Equal(2, syncedFullSolution.Projects.Count());
             var options = (SerializableOptionSet)syncedFullSolution.Options;
-            Assert.Equal(2, options.Languages.Count);
+            Assert.Equal(2, options.GetTestAccessor().Languages.Count);
 
             var project1Checksum = await solution.State.GetChecksumAsync(project1.Id, CancellationToken.None);
             var project1SyncedSolution = await remoteWorkspace.GetSolutionAsync(assetProvider, project1Checksum, fromPrimaryBranch: false, workspaceVersion: -1, project1.Id, CancellationToken.None);
             Assert.Equal(1, project1SyncedSolution.Projects.Count());
             Assert.Equal(project1.Name, project1SyncedSolution.Projects.Single().Name);
             var project1Options = (SerializableOptionSet)project1SyncedSolution.Options;
-            Assert.Equal(1, project1Options.Languages.Count);
-            Assert.Contains(LanguageNames.CSharp, project1Options.Languages);
+            Assert.Equal(1, project1Options.GetTestAccessor().Languages.Count);
+            Assert.Contains(LanguageNames.CSharp, project1Options.GetTestAccessor().Languages);
 
             var project2Checksum = await solution.State.GetChecksumAsync(project2.Id, CancellationToken.None);
             var project2SyncedSolution = await remoteWorkspace.GetSolutionAsync(assetProvider, project2Checksum, fromPrimaryBranch: false, workspaceVersion: -1, project2.Id, CancellationToken.None);
             Assert.Equal(1, project2SyncedSolution.Projects.Count());
             Assert.Equal(project2.Name, project2SyncedSolution.Projects.Single().Name);
             var project2Options = (SerializableOptionSet)project2SyncedSolution.Options;
-            Assert.Equal(1, project2Options.Languages.Count);
-            Assert.Contains(LanguageNames.VisualBasic, project2Options.Languages);
+            Assert.Equal(1, project2Options.GetTestAccessor().Languages.Count);
+            Assert.Contains(LanguageNames.VisualBasic, project2Options.GetTestAccessor().Languages);
         }
 
         private static async Task VerifySolutionUpdate(string code, Func<Solution, Solution> newSolutionGetter)

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -732,7 +732,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             Assert.Equal(1, project1SyncedSolution.Projects.Count());
             Assert.Equal(project1.Name, project1SyncedSolution.Projects.Single().Name);
             var project1Options = (SerializableOptionSet)project1SyncedSolution.Options;
-            Assert.Equal(1, project1Options.GetTestAccessor().Languages.Count);
+            Assert.Equal(2, project1Options.GetTestAccessor().Languages.Count);
             Assert.Contains(LanguageNames.CSharp, project1Options.GetTestAccessor().Languages);
 
             var project2Checksum = await solution.State.GetChecksumAsync(project2.Id, CancellationToken.None);
@@ -740,7 +740,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             Assert.Equal(1, project2SyncedSolution.Projects.Count());
             Assert.Equal(project2.Name, project2SyncedSolution.Projects.Single().Name);
             var project2Options = (SerializableOptionSet)project2SyncedSolution.Options;
-            Assert.Equal(1, project2Options.GetTestAccessor().Languages.Count);
+            Assert.Equal(2, project2Options.GetTestAccessor().Languages.Count);
             Assert.Contains(LanguageNames.VisualBasic, project2Options.GetTestAccessor().Languages);
         }
 

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.Options
             var changedOptionsKeysSerializable = _changedOptionKeys
                 .Where(key => serializableOptions.Contains(key.Option) && (!key.Option.IsPerLanguage || languages.Contains(key.Language!)))
                 .ToImmutableHashSet();
-            return new SerializableOptionSet(languages, optionService, serializableOptions, serializableOptionValues, changedOptionsKeysSerializable);
+            return new SerializableOptionSet(optionService, serializableOptions, serializableOptionValues, changedOptionsKeysSerializable);
         }
 
         private ImmutableDictionary<OptionKey, object?> GetSerializableOptionValues(ImmutableHashSet<IOption> optionKeys, ImmutableHashSet<string> languages)

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Options
 
         /// <summary>
         /// Set of languages references in <see cref="_serializableOptionValues"/>.  Cached
-        /// only so we can shortcircuit <see cref="WithLanguages"/>.
+        /// only so we can shortcircuit <see cref="UnionWithLanguages"/>.
         /// </summary>
         private readonly Lazy<ImmutableHashSet<string>> _languages;
 
@@ -86,9 +86,9 @@ namespace Microsoft.CodeAnalysis.Options
         /// <summary>
         /// Returns an option set with all the serializable option values prefetched for given <paramref name="languages"/>,
         /// while also retaining all the explicitly changed option values in this option set for any language.
-        /// NOTE: All the provided <paramref name="languages"/> must be <see cref="RemoteSupportedLanguages.IsSupported(string)"/>.
+        /// Note: All the provided <paramref name="languages"/> must be <see cref="RemoteSupportedLanguages.IsSupported(string)"/>.
         /// </summary>
-        public SerializableOptionSet WithLanguages(ImmutableHashSet<string> languages)
+        public SerializableOptionSet UnionWithLanguages(ImmutableHashSet<string> languages)
         {
             Debug.Assert(languages.All(RemoteSupportedLanguages.IsSupported));
 

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Options
             Debug.Assert(changedOptionKeysSerializable.All(optionKey => ShouldSerialize(optionKey)));
             Debug.Assert(changedOptionKeysNonSerializable.All(optionKey => !ShouldSerialize(optionKey)));
 
-            _languages = new Lazy<ImmutableHashSet<string>>(() => this.GetLanguagesAndValuesToSerialize().languages);
+            _languages = new Lazy<ImmutableHashSet<string>>(() => this.GetLanguagesAndValuesToSerialize(includeValues: false).languages);
         }
 
         internal SerializableOptionSet(
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Options
             }
         }
 
-        private (ImmutableHashSet<string> languages, SortedDictionary<OptionKey, (OptionValueKind, object?)> values) GetLanguagesAndValuesToSerialize()
+        private (ImmutableHashSet<string> languages, SortedDictionary<OptionKey, (OptionValueKind, object?)> values) GetLanguagesAndValuesToSerialize(bool includeValues)
         {
             var valuesBuilder = new SortedDictionary<OptionKey, (OptionValueKind, object?)>(OptionKeyComparer.Instance);
             var languages = ImmutableHashSet<string>.Empty;
@@ -205,26 +205,29 @@ namespace Microsoft.CodeAnalysis.Options
                 if (optionKey.Language != null)
                     languages = languages.Add(optionKey.Language);
 
-                OptionValueKind kind;
-                switch (value)
+                if (includeValues)
                 {
-                    case ICodeStyleOption:
-                        if (optionKey.Option.Type.GenericTypeArguments.Length != 1)
-                            continue;
+                    OptionValueKind kind;
+                    switch (value)
+                    {
+                        case ICodeStyleOption:
+                            if (optionKey.Option.Type.GenericTypeArguments.Length != 1)
+                                continue;
 
-                        kind = OptionValueKind.CodeStyleOption;
-                        break;
+                            kind = OptionValueKind.CodeStyleOption;
+                            break;
 
-                    case NamingStylePreferences:
-                        kind = OptionValueKind.NamingStylePreferences;
-                        break;
+                        case NamingStylePreferences:
+                            kind = OptionValueKind.NamingStylePreferences;
+                            break;
 
-                    default:
-                        kind = value != null && value.GetType().IsEnum ? OptionValueKind.Enum : OptionValueKind.Object;
-                        break;
+                        default:
+                            kind = value != null && value.GetType().IsEnum ? OptionValueKind.Enum : OptionValueKind.Object;
+                            break;
+                    }
+
+                    valuesBuilder.Add(optionKey, (kind, value));
                 }
-
-                valuesBuilder.Add(optionKey, (kind, value));
             }
 
             return (languages, valuesBuilder);
@@ -241,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Options
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var (languages, values) = this.GetLanguagesAndValuesToSerialize();
+            var (languages, values) = this.GetLanguagesAndValuesToSerialize(includeValues: true);
 
             writer.WriteInt32(languages.Count);
             foreach (var language in languages.Order())
@@ -428,7 +431,7 @@ namespace Microsoft.CodeAnalysis.Options
             }
 
             public ImmutableHashSet<string> Languages
-                => _serializableOptionSet.GetLanguagesAndValuesToSerialize().languages;
+                => _serializableOptionSet.GetLanguagesAndValuesToSerialize(includeValues: true).languages;
         }
 
         private enum OptionValueKind

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Options
         private readonly ImmutableHashSet<OptionKey> _changedOptionKeysNonSerializable;
 
         /// <summary>
-        /// Set of languages references in <see cref="_serializableOptionValues"/>.  Cached
+        /// Set of languages referenced in <see cref="_serializableOptionValues"/>.  Cached
         /// only so we can shortcircuit <see cref="UnionWithLanguages"/>.
         /// </summary>
         private readonly Lazy<ImmutableHashSet<string>> _languages;

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
@@ -48,6 +48,10 @@ namespace Microsoft.CodeAnalysis.Options
         /// </summary>
         private readonly ImmutableHashSet<OptionKey> _changedOptionKeysNonSerializable;
 
+        /// <summary>
+        /// Set of languages references in <see cref="_serializableOptionValues"/>.  Cached
+        /// only so we can shortcircuit <see cref="WithLanguages"/>.
+        /// </summary>
         private readonly Lazy<ImmutableHashSet<string>> _languages;
 
         private SerializableOptionSet(
@@ -187,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Options
         private (ImmutableHashSet<string> languages, SortedDictionary<OptionKey, (OptionValueKind, object?)> values) GetLanguagesAndValuesToSerialize()
         {
             var valuesBuilder = new SortedDictionary<OptionKey, (OptionValueKind, object?)>(OptionKeyComparer.Instance);
-            var langauges = ImmutableHashSet<string>.Empty;
+            var languages = ImmutableHashSet<string>.Empty;
 
             foreach (var (optionKey, value) in _serializableOptionValues)
             {
@@ -198,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Options
 
                 Debug.Assert(!optionKey.Option.IsPerLanguage || RemoteSupportedLanguages.IsSupported(optionKey.Language));
                 if (optionKey.Language != null)
-                    languages = langauges.Add(optionKey.Language);
+                    languages = languages.Add(optionKey.Language);
 
                 OptionValueKind kind;
                 switch (value)
@@ -222,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Options
                 valuesBuilder.Add(optionKey, (kind, value));
             }
 
-            return (langauges, valuesBuilder);
+            return (languages, valuesBuilder);
         }
 
         public void Serialize(ObjectWriter writer, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
@@ -114,7 +114,8 @@ namespace Microsoft.CodeAnalysis.Options
         }
 
         private bool ShouldSerialize(OptionKey optionKey)
-            => _serializableOptions.Contains(optionKey.Option);
+            => _serializableOptions.Contains(optionKey.Option) &&
+               (!optionKey.Option.IsPerLanguage || RemoteSupportedLanguages.IsSupported(optionKey.Language));
 
         public override OptionSet WithChangedOption(OptionKey optionKey, object? value)
         {

--- a/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/SerializableOptionSet.cs
@@ -92,10 +92,11 @@ namespace Microsoft.CodeAnalysis.Options
         {
             Debug.Assert(languages.All(RemoteSupportedLanguages.IsSupported));
 
-            if (_languages.Value.SetEquals(languages))
+            if (_languages.Value.IsSupersetOf(languages))
                 return this;
 
             // First create a base option set for the given languages.
+            languages = languages.Union(_languages.Value);
             var newOptionSet = _workspaceOptionSet.OptionService.GetSerializableOptionsSnapshot(languages);
 
             // Then apply all the changed options from the current option set to the new option set.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis
             idToProjectStateMap ??= _projectIdToProjectStateMap;
             remoteSupportedProjectLanguages ??= _remoteSupportedLanguages;
             Debug.Assert(remoteSupportedProjectLanguages.SetEquals(GetRemoteSupportedProjectLanguages(idToProjectStateMap)));
-            options ??= Options.WithLanguages(remoteSupportedProjectLanguages);
+            options ??= Options.UnionWithLanguages(remoteSupportedProjectLanguages);
             analyzerReferences ??= AnalyzerReferences;
             projectIdToTrackerMap ??= _projectIdToTrackerMap;
             filePathToDocumentIdsMap ??= _filePathToDocumentIdsMap;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -54,12 +54,10 @@ namespace Microsoft.CodeAnalysis
         private readonly ValueSource<SolutionStateChecksums> _lazyChecksums;
 
         /// <summary>
-        /// Mapping from project-id to the options and checksums needed to synchronize it (and the projects it depends on) over 
-        /// to an OOP host.  Options are stored as well so that when we are attempting to match a request for a particular project-subset
-        /// we can return the options specific to that project-subset (which may be different from the <see cref="Options"/> defined
-        /// for the entire solution).  Lock this specific field before reading/writing to it.
+        /// Mapping from project-id to the checksums needed to synchronize it (and the projects it depends on) over 
+        /// to an OOP host.  Lock this specific field before reading/writing to it.
         /// </summary>
-        private readonly Dictionary<ProjectId, (SerializableOptionSet options, ValueSource<SolutionStateChecksums> checksums)> _lazyProjectChecksums = new();
+        private readonly Dictionary<ProjectId, ValueSource<SolutionStateChecksums>> _lazyProjectChecksums = new();
 
         // holds on data calculated based on the AnalyzerReferences list
         private readonly Lazy<HostDiagnosticAnalyzers> _lazyAnalyzers;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
@@ -81,16 +81,8 @@ namespace Microsoft.CodeAnalysis
                 var projectsToInclude = new HashSet<ProjectId>();
                 AddReferencedProjects(projectsToInclude, projectId);
 
-                // we're syncing a subset of projects, so only sync the options for the particular languages
-                // we're syncing over.
-                var languages = projectsToInclude.Select(id => ProjectStates[id].Language)
-                                                 .Where(s => RemoteSupportedLanguages.IsSupported(s))
-                                                 .ToImmutableHashSet();
-
-                var options = this.Options.WithLanguages(languages);
-
                 return (options, new AsyncLazy<SolutionStateChecksums>(
-                    c => ComputeChecksumsAsync(projectsToInclude, options, c), cacheResult: true));
+                    c => ComputeChecksumsAsync(projectsToInclude, this.Options, c), cacheResult: true));
             }
 
             void AddReferencedProjects(HashSet<ProjectId> result, ProjectId projectId)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
@@ -23,27 +23,20 @@ namespace Microsoft.CodeAnalysis
         public bool TryGetStateChecksums([NotNullWhen(true)] out SolutionStateChecksums? stateChecksums)
             => _lazyChecksums.TryGetValue(out stateChecksums);
 
-        public bool TryGetStateChecksums(ProjectId projectId, out (SerializableOptionSet options, SolutionStateChecksums checksums) result)
+        public bool TryGetStateChecksums(ProjectId projectId, [NotNullWhen(true)] out SolutionStateChecksums? stateChecksums)
         {
-            (SerializableOptionSet options, ValueSource<SolutionStateChecksums> checksums) value;
+            ValueSource<SolutionStateChecksums>? checksums;
             lock (_lazyProjectChecksums)
             {
-                if (!_lazyProjectChecksums.TryGetValue(projectId, out value) ||
-                    value.checksums == null)
+                if (!_lazyProjectChecksums.TryGetValue(projectId, out checksums) ||
+                    checksums == null)
                 {
-                    result = default;
+                    stateChecksums = null;
                     return false;
                 }
             }
 
-            if (!value.checksums.TryGetValue(out var stateChecksums))
-            {
-                result = default;
-                return false;
-            }
-
-            result = (value.options, stateChecksums);
-            return true;
+            return checksums.TryGetValue(out stateChecksums);
         }
 
         public Task<SolutionStateChecksums> GetStateChecksumsAsync(CancellationToken cancellationToken)
@@ -62,27 +55,27 @@ namespace Microsoft.CodeAnalysis
         {
             Contract.ThrowIfNull(projectId);
 
-            (SerializableOptionSet options, ValueSource<SolutionStateChecksums> checksums) value;
+            ValueSource<SolutionStateChecksums>? checksums;
             lock (_lazyProjectChecksums)
             {
-                if (!_lazyProjectChecksums.TryGetValue(projectId, out value))
+                if (!_lazyProjectChecksums.TryGetValue(projectId, out checksums))
                 {
-                    value = Compute(projectId);
-                    _lazyProjectChecksums.Add(projectId, value);
+                    checksums = Compute(projectId);
+                    _lazyProjectChecksums.Add(projectId, checksums);
                 }
             }
 
-            var collection = await value.checksums.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            var collection = await checksums.GetValueAsync(cancellationToken).ConfigureAwait(false);
             return collection;
 
             // Extracted as a local function to prevent delegate allocations when not needed.
-            (SerializableOptionSet, ValueSource<SolutionStateChecksums>) Compute(ProjectId projectId)
+            ValueSource<SolutionStateChecksums> Compute(ProjectId projectId)
             {
                 var projectsToInclude = new HashSet<ProjectId>();
                 AddReferencedProjects(projectsToInclude, projectId);
 
-                return (options, new AsyncLazy<SolutionStateChecksums>(
-                    c => ComputeChecksumsAsync(projectsToInclude, this.Options, c), cacheResult: true));
+                return new AsyncLazy<SolutionStateChecksums>(
+                    c => ComputeChecksumsAsync(projectsToInclude, this.Options, c), cacheResult: true);
             }
 
             void AddReferencedProjects(HashSet<ProjectId> result, ProjectId projectId)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -48,36 +48,13 @@ namespace Microsoft.CodeAnalysis.Serialization
 
             // verify input
             if (searchingChecksumsLeft.Remove(Checksum))
-            {
                 result[Checksum] = this;
-            }
 
             if (searchingChecksumsLeft.Remove(Attributes))
-            {
                 result[Attributes] = state.SolutionAttributes;
-            }
 
-            // The Options field could be referring to the full solution-options, or it could be referring to a
-            // partially computed options for a project-subset.  Check for both cases.
             if (searchingChecksumsLeft.Remove(Options))
-            {
-                if (state.TryGetStateChecksums(out var stateChecksums) && stateChecksums.Options == Options)
-                {
-                    result[Options] = state.Options;
-                }
-                else
-                {
-                    foreach (var projectId in state.ProjectIds)
-                    {
-                        if (state.TryGetStateChecksums(projectId, out var tuple) &&
-                            tuple.checksums.Options == Options)
-                        {
-                            result[Options] = tuple.options;
-                            break;
-                        }
-                    }
-                }
-            }
+                result[Options] = state.Options;
 
             if (searchingChecksumsLeft.Remove(FrozenSourceGeneratedDocumentIdentity))
             {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis
             // initialize with empty solution
             var info = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Create());
 
-            var emptyOptions = new SerializableOptionSet(languages: ImmutableHashSet<string>.Empty, _optionService,
+            var emptyOptions = new SerializableOptionSet(_optionService,
                 serializableOptions: ImmutableHashSet<IOption>.Empty, values: ImmutableDictionary<OptionKey, object?>.Empty,
                 changedOptionKeysSerializable: ImmutableHashSet<OptionKey>.Empty);
 

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -170,13 +170,13 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (remainingChecksumsToFind.Count == 0)
                     break;
 
-                if (solutionState.TryGetStateChecksums(projectId, out var tuple))
-                    await tuple.checksums.FindAsync(solutionState, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
+                if (solutionState.TryGetStateChecksums(projectId, out var checksums))
+                    await checksums.FindAsync(solutionState, remainingChecksumsToFind, result, cancellationToken).ConfigureAwait(false);
             }
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -326,6 +326,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 //
                 // A better fix in the future is to make all options pure data and remove the general concept of
                 // any part of the system eliding information about any options that have their 'default' value.
+                // https://github.com/dotnet/roslyn/issues/55728
                 this.SetCurrentSolution(this.CurrentSolution.WithOptions(options));
                 SetOptions(options);
 

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -314,6 +314,18 @@ namespace Microsoft.CodeAnalysis.Remote
                 ClearSolutionData();
 
                 OnSolutionAdded(solutionInfo);
+
+                // The call to SetOptions will ensure that the options get pushed into the remote IOptionService
+                // store.  However, we still update our current solution with the options passed in.  This is
+                // due to the fact that the option store will ignore any options it considered unchanged to what
+                // it currently knows about.  This will prevent it from actually going and writing those unchanged
+                // values into Solution.Options.  This is not a correctness issue, but it impacts how checksums and
+                // syncing work in oop.  Currently, the checksum is based off Solution.Options and the values
+                // loaded into it.  If one side has loaded a default value and the other has not, then they will
+                // disagree on their checksum.  This ensures the remote side agrees with the host.
+                //
+                // A better fix in the future is to make all options pure data and remove the general concept of
+                // any part of the system eliding information about any options that have their 'default' value.
                 this.SetCurrentSolution(this.CurrentSolution.WithOptions(options));
                 SetOptions(options);
 

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 ClearSolutionData();
 
                 OnSolutionAdded(solutionInfo);
-
+                this.SetCurrentSolution(this.CurrentSolution.WithOptions(options));
                 SetOptions(options);
 
                 solution = CurrentSolution;


### PR DESCRIPTION
Instead, it can be something about the optionset that is simply computed from the options contained within.

This has been particularly problematic when this was not computed as it was state that could drift away from the data actually stored within. For example, say we had a C# and VB solution on the host side.  The optionsset would contain both those languages.  However, if we were just syncing over a single project to the remote side, the usage of things like .WithLanguages might only load languages for one side, causing a mismatch of data as the two sides communicated.