### PR TITLE
When "assigned", a `discard` doesn't escape out of the current expression.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2509,8 +2509,7 @@ moreArguments:
                     return Binder.ExternalScope;
 
                 case BoundKind.DiscardExpression:
-                    // same as uninitialized local
-                    return Binder.ExternalScope;
+                    return ((BoundDiscardExpression)expr).ValEscape;
 
                 case BoundKind.DeconstructValuePlaceholder:
                     return ((BoundDeconstructValuePlaceholder)expr).ValEscape;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -805,11 +805,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static BoundDiscardExpression BindDiscardExpression(
+        private BoundDiscardExpression BindDiscardExpression(
             SyntaxNode syntax,
             TypeWithAnnotations declTypeWithAnnotations)
         {
-            return new BoundDiscardExpression(syntax, declTypeWithAnnotations.Type);
+            // Cannot escape out of the current expression, as it's a compiler-synthesized location.
+            return new BoundDiscardExpression(syntax, LocalScopeDepth, declTypeWithAnnotations.Type);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1553,7 +1553,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else if (FallBackOnDiscard(identifier, diagnostics))
                     {
-                        expression = new BoundDiscardExpression(node, type: null);
+                        // Cannot escape out of the current expression, as it's a compiler-synthesized location.
+                        expression = new BoundDiscardExpression(node, LocalScopeDepth, type: null);
                     }
                 }
 
@@ -2781,7 +2782,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var declType = BindVariableTypeWithAnnotations(designation, diagnostics, typeSyntax, ref isConst, out isVar, out alias);
                         Debug.Assert(isVar != declType.HasType);
 
-                        return new BoundDiscardExpression(declarationExpression, declType.Type);
+                        // ValEscape is the same as for an uninitialized local
+                        return new BoundDiscardExpression(declarationExpression, Binder.ExternalScope, declType.Type);
                     }
                 case SyntaxKind.SingleVariableDesignation:
                     return BindOutVariableDeclarationArgument(declarationExpression, diagnostics);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression SetInferredTypeWithAnnotations(TypeWithAnnotations type)
         {
             Debug.Assert(Type is null && type.HasType);
-            return this.Update(type.Type);
+            return this.Update(ValEscape, type.Type);
         }
 
         public BoundDiscardExpression FailInference(Binder binder, BindingDiagnosticBag? diagnosticsOpt)
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Binder.Error(diagnosticsOpt, ErrorCode.ERR_DiscardTypeInferenceFailed, this.Syntax);
             }
-            return this.Update(binder.CreateErrorType("var"));
+            return this.Update(ValEscape, binder.CreateErrorType("var"));
         }
 
         public override Symbol ExpressionSymbol

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -2150,6 +2150,7 @@
          is null before type inference, and it is replaced by a BoundDiscardExpression with a non-null
          type after inference. -->
     <Field Name="Type" Type="TypeSymbol?" Override="true"/>
+    <Field Name="ValEscape" Type="uint" Null="NotApplicable"/>
   </Node>
 
   <Node Name="BoundThrowExpression" Base="BoundExpression">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -2594,22 +2594,23 @@ public ref struct S<T>
 {
     public readonly Span<T> this[Span<T> span] { get => default; set {} }
 
-    public unsafe static void N(S<byte> b)
+    public unsafe static Span<byte> N(S<byte> b)
     {
         Span<byte> x = stackalloc byte[5];
         _ = b[x];
         b[x] = x;
+        return b[x];
     }
 }
 ";
             var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
-                // (11,13): error CS8347: Cannot use a result of 'S<byte>.this[Span<byte>]' in this context because it may expose variables referenced by parameter 'span' outside of their declaration scope
-                //         _ = b[x];
-                Diagnostic(ErrorCode.ERR_EscapeCall, "b[x]").WithArguments("S<byte>.this[System.Span<byte>]", "span").WithLocation(11, 13),
-                // (11,15): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
-                //         _ = b[x];
-                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(11, 15));
+                // (13,16): error CS8347: Cannot use a result of 'S<byte>.this[Span<byte>]' in this context because it may expose variables referenced by parameter 'span' outside of their declaration scope
+                //         return b[x];
+                Diagnostic(ErrorCode.ERR_EscapeCall, "b[x]").WithArguments("S<byte>.this[System.Span<byte>]", "span").WithLocation(13, 16),
+                // (13,18): error CS8352: Cannot use local 'x' in this context because it may expose referenced variables outside of their declaration scope
+                //         return b[x];
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "x").WithArguments("x").WithLocation(13, 18));
         }
 
         [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
@@ -2744,7 +2745,7 @@ public class C
         (global, local) = local; // error 2
         (local, local) = local;
         (global, _) = local; // error 3
-        (local, _) = local; // error 4
+        (local, _) = local;
         (global, _) = global;
     }
     public static void Main()
@@ -2768,10 +2769,7 @@ public static class Extensions
                 Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(11, 27),
                 // (13,23): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
                 //         (global, _) = local; // error 3
-                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(13, 23),
-                // (14,22): error CS8352: Cannot use local 'local' in this context because it may expose referenced variables outside of their declaration scope
-                //         (local, _) = local; // error 4
-                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(14, 22)
+                Diagnostic(ErrorCode.ERR_EscapeLocal, "local").WithArguments("local").WithLocation(13, 23)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -1804,5 +1804,130 @@ struct Struct2
                 Diagnostic(ErrorCode.ERR_EscapeLocal, "span").WithArguments("span").WithLocation(43, 16)
                 );
         }
+
+        [Fact]
+        [WorkItem(39663, "https://github.com/dotnet/roslyn/issues/39663")]
+        public void AssignToDiscard_01()
+        {
+            var text = @"
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        _ = Test(stackalloc int[5]);
+        System.Console.WriteLine(""Done"");
+    }
+
+    static Span<int> Test(Span<int> items) => items;
+}
+";
+
+            CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: "Done").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(39663, "https://github.com/dotnet/roslyn/issues/39663")]
+        public void AssignToDiscard_02()
+        {
+            var text = @"
+using System;
+
+class Program
+{
+    static int[] _array = new int[] {};
+
+    static void Main()
+    {
+        _ = Test;
+        System.Console.WriteLine(""Done"");
+    }
+
+    static Span<int> Test => _array;
+}
+";
+
+            CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "Done").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(39663, "https://github.com/dotnet/roslyn/issues/39663")]
+        public void AssignToDiscard_03()
+        {
+            var text = @"
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        var l = Test(stackalloc int[5]);
+        _ = l;
+        System.Console.WriteLine(""Done"");
+    }
+
+    static Span<int> Test(Span<int> items) => items;
+}
+";
+
+            CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: "Done").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(39663, "https://github.com/dotnet/roslyn/issues/39663")]
+        public void AssignToDiscard_04()
+        {
+            var text = @"
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        var l = Test(stackalloc int[5]);
+
+        {
+            int i = 0;
+            _ = l;
+            i++;
+        }
+
+        System.Console.WriteLine(""Done"");
+    }
+
+    static Span<int> Test(Span<int> items) => items;
+}
+";
+
+            CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: "Done").VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(39663, "https://github.com/dotnet/roslyn/issues/39663")]
+        public void AssignToDiscard_05()
+        {
+            var text = @"
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        Test(stackalloc int[5]);
+        System.Console.WriteLine(""Done"");
+    }
+
+    static Span<int> Test(Span<int> items) => items;
+}
+";
+
+            CSharpCompilation comp = CreateCompilationWithMscorlibAndSpan(text, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: "Done").VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
@@ -2315,11 +2315,7 @@ unsafe class Test
         Span<double> obj2 = stackalloc double[2] { 1, 1.2 };
         _ = stackalloc double[2] { 1, 1.2 };
     }
-}", TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (9,13): error CS8353: A result of a stackalloc expression of type 'Span<double>' cannot be used in this context because it may be exposed outside of the containing method
-                //         _ = stackalloc double[2] { 1, 1.2 };
-                Diagnostic(ErrorCode.ERR_EscapeStackAlloc, "stackalloc double[2] { 1, 1.2 }").WithArguments("System.Span<double>").WithLocation(9, 13)
-                );
+}", TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);
@@ -2425,11 +2421,7 @@ unsafe class Test
         Span<double> obj2 = stackalloc[] { 1, 1.2 };
         _ = stackalloc[] { 1, 1.2 };
     }
-}", TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
-                // (9,13): error CS8353: A result of a stackalloc expression of type 'Span<double>' cannot be used in this context because it may be exposed outside of the containing method
-                //         _ = stackalloc[] { 1, 1.2 };
-                Diagnostic(ErrorCode.ERR_EscapeStackAlloc, "stackalloc[] { 1, 1.2 }").WithArguments("System.Span<double>").WithLocation(9, 13)
-                );
+}", TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees.Single();
             var model = comp.GetSemanticModel(tree);


### PR DESCRIPTION
Fixes #39663.