### PR TITLE
Revert "Avoid switching to UI thread in some option persisters"

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Options/FeatureFlagPersisterProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/FeatureFlagPersisterProvider.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 {
@@ -23,10 +22,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public FeatureFlagPersisterProvider(
-            [Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider serviceProvider)
+        public FeatureFlagPersisterProvider(SVsServiceProvider serviceProvider)
         {
-            _serviceProvider = serviceProvider;
+            _serviceProvider = (IAsyncServiceProvider)serviceProvider;
         }
 
         public async ValueTask<IOptionPersister> GetOrCreatePersisterAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/Options/LocalUserRegistryOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/LocalUserRegistryOptionPersister.cs
@@ -2,17 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.Win32;
-using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 {
@@ -27,25 +28,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         private readonly object _gate = new();
         private readonly RegistryKey _registryKey;
 
-        private LocalUserRegistryOptionPersister(RegistryKey registryKey)
+        public LocalUserRegistryOptionPersister(IThreadingContext threadingContext, IServiceProvider serviceProvider)
         {
-            _registryKey = registryKey;
+            // Starting with Dev16, the ILocalRegistry service is expected to be free-threaded, and aquiring it from the
+            // global service provider is expected to complete without any UI thread marshaling requirements. However,
+            // since none of this is publicly documented, we keep this assertion for maximum compatibility assurance.
+            // https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.vsregistry.registryroot
+            // https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.ilocalregistry
+            // https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.slocalregistry
+            threadingContext.ThrowIfNotOnUIThread();
+
+            _registryKey = VSRegistry.RegistryRoot(serviceProvider, __VsLocalRegistryType.RegType_UserSettings, writable: true);
         }
 
-        public static async Task<LocalUserRegistryOptionPersister> CreateAsync(IAsyncServiceProvider provider)
-        {
-            var localRegistry = await provider.GetServiceAsync<SLocalRegistry, ILocalRegistry4>(throwOnFailure: true).ConfigureAwait(false);
-            Contract.ThrowIfFalse(ErrorHandler.Succeeded(localRegistry!.GetLocalRegistryRootEx((uint)__VsLocalRegistryType.RegType_UserSettings, out var rootHandle, out var rootPath)));
-
-            var handle = (__VsLocalRegistryRootHandle)rootHandle;
-            Contract.ThrowIfTrue(string.IsNullOrEmpty(rootPath));
-            Contract.ThrowIfTrue(handle == __VsLocalRegistryRootHandle.RegHandle_Invalid);
-
-            var root = (__VsLocalRegistryRootHandle.RegHandle_LocalMachine == handle) ? Registry.LocalMachine : Registry.CurrentUser;
-            return new LocalUserRegistryOptionPersister(root.CreateSubKey(rootPath, RegistryKeyPermissionCheck.ReadWriteSubTree));
-        }
-
-        private static bool TryGetKeyPathAndName(IOption option, [NotNullWhen(true)] out string? path, [NotNullWhen(true)] out string? key)
+        private static bool TryGetKeyPathAndName(IOption option, out string path, out string key)
         {
             var serialization = option.StorageLocations.OfType<LocalUserProfileStorageLocation>().SingleOrDefault();
 
@@ -64,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             }
         }
 
-        bool IOptionPersister.TryFetch(OptionKey optionKey, out object? value)
+        bool IOptionPersister.TryFetch(OptionKey optionKey, out object value)
         {
             if (!TryGetKeyPathAndName(optionKey.Option, out var path, out var key))
             {
@@ -84,7 +80,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 // Options that are of type bool have to be serialized as integers
                 if (optionKey.Option.Type == typeof(bool))
                 {
-                    value = subKey.GetValue(key, defaultValue: (bool)optionKey.Option.DefaultValue! ? 1 : 0).Equals(1);
+                    value = subKey.GetValue(key, defaultValue: (bool)optionKey.Option.DefaultValue ? 1 : 0).Equals(1);
                     return true;
                 }
                 else if (optionKey.Option.Type == typeof(long))
@@ -137,7 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             return false;
         }
 
-        bool IOptionPersister.TryPersist(OptionKey optionKey, object? value)
+        bool IOptionPersister.TryPersist(OptionKey optionKey, object value)
         {
             if (_registryKey == null)
             {
@@ -152,27 +148,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             lock (_gate)
             {
                 using var subKey = _registryKey.CreateSubKey(path);
-
                 // Options that are of type bool have to be serialized as integers
                 if (optionKey.Option.Type == typeof(bool))
                 {
-                    Contract.ThrowIfNull(value);
                     subKey.SetValue(key, (bool)value ? 1 : 0, RegistryValueKind.DWord);
                     return true;
                 }
-
-                if (optionKey.Option.Type == typeof(long))
+                else if (optionKey.Option.Type == typeof(long))
                 {
-                    Contract.ThrowIfNull(value);
-
                     subKey.SetValue(key, value, RegistryValueKind.QWord);
                     return true;
                 }
-
-                if (optionKey.Option.Type.IsEnum)
+                else if (optionKey.Option.Type.IsEnum)
                 {
-                    Contract.ThrowIfNull(value);
-
                     // If the enum is larger than an int, store as a QWord
                     if (Marshal.SizeOf(Enum.GetUnderlyingType(optionKey.Option.Type)) > Marshal.SizeOf(typeof(int)))
                     {
@@ -185,9 +173,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
                     return true;
                 }
-
-                subKey.SetValue(key, value);
-                return true;
+                else
+                {
+                    subKey.SetValue(key, value);
+                    return true;
+                }
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServices.Setup;
 using Microsoft.VisualStudio.Settings;
@@ -22,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
     /// <summary>
     /// Serializes settings marked with <see cref="RoamingProfileStorageLocation"/> to and from the user's roaming profile.
     /// </summary>
-    internal sealed class RoamingVisualStudioProfileOptionPersister : IOptionPersister
+    internal sealed class RoamingVisualStudioProfileOptionPersister : ForegroundThreadAffinitizedObject, IOptionPersister
     {
         // NOTE: This service is not public or intended for use by teams/individuals outside of Microsoft. Any data stored is subject to deletion without warning.
         [Guid("9B164E40-C3A2-4363-9BC5-EB4039DEF653")]
@@ -42,7 +43,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         /// <remarks>
         /// We make sure this code is from the UI by asking for all <see cref="IOptionPersister"/> in <see cref="RoslynPackage.InitializeAsync"/>
         /// </remarks>
-        public RoamingVisualStudioProfileOptionPersister(IGlobalOptionService globalOptionService, ISettingsManager? settingsManager)
+        public RoamingVisualStudioProfileOptionPersister(IThreadingContext threadingContext, IGlobalOptionService globalOptionService, ISettingsManager? settingsManager)
+            : base(threadingContext, assertIsForeground: true)
         {
             Contract.ThrowIfNull(globalOptionService);
 

--- a/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersisterProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersisterProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
     [Export(typeof(IOptionPersisterProvider))]
     internal sealed class RoamingVisualStudioProfileOptionPersisterProvider : IOptionPersisterProvider
     {
+        private readonly IThreadingContext _threadingContext;
         private readonly IAsyncServiceProvider _serviceProvider;
         private readonly IGlobalOptionService _optionService;
         private RoamingVisualStudioProfileOptionPersister? _lazyPersister;
@@ -26,9 +27,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public RoamingVisualStudioProfileOptionPersisterProvider(
+            IThreadingContext threadingContext,
             [Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider serviceProvider,
             IGlobalOptionService optionService)
         {
+            _threadingContext = threadingContext;
             _serviceProvider = serviceProvider;
             _optionService = optionService;
         }
@@ -40,9 +43,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 return _lazyPersister;
             }
 
+            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
             var settingsManager = (ISettingsManager?)await _serviceProvider.GetServiceAsync(typeof(SVsSettingsPersistenceManager)).ConfigureAwait(true);
 
-            _lazyPersister ??= new RoamingVisualStudioProfileOptionPersister(_optionService, settingsManager);
+            _lazyPersister ??= new RoamingVisualStudioProfileOptionPersister(_threadingContext, _optionService, settingsManager);
             return _lazyPersister;
         }
     }


### PR DESCRIPTION
Reverts dotnet/roslyn#56553

UI thread dependencies in code cannot be removed until the free-threaded nature of the dependency is publicly documented. As it stands, these dependencies _do_ require the main thread from all available information.