### PR TITLE
Concurrency issue with fixed fields

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1417,17 +1417,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             }
         }
 
-        internal NamedTypeSymbol GetFixedImplementationType(FieldSymbol field)
-        {
-            // Note that this method is called only after ALL fixed buffer types have been placed in the map.
-            // At that point the map is all filled in and will not change further.  Therefore it is safe to
-            // pull values from the map without locking.
-            NamedTypeSymbol result;
-            var found = _fixedImplementationTypes.TryGetValue(field, out result);
-            Debug.Assert(found);
-            return result;
-        }
-
         protected override Cci.IMethodDefinition CreatePrivateImplementationDetailsStaticConstructor(PrivateImplementationDetails details, SyntaxNode syntaxOpt, DiagnosticBag diagnostics)
         {
             return new SynthesizedPrivateImplementationDetailsStaticConstructor(SourceModule, details, GetUntranslatedSpecialType(SpecialType.System_Void, syntaxOpt, diagnostics)).GetCciAdapter();

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
@@ -739,6 +739,45 @@ one");
 	extends [mscorlib]System.Object
 {
 	// Nested Types
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x2115
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2121
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x2129
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<Main>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -752,7 +791,7 @@ one");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2115
+			// Method begins at RVA 0x2121
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -773,7 +812,7 @@ one");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2115
+			// Method begins at RVA 0x2121
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -783,7 +822,7 @@ one");
 		.method assembly hidebysig 
 			instance void '<Main>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x211d
+			// Method begins at RVA 0x212b
 			// Code size 42 (0x2a)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -802,45 +841,6 @@ one");
 			IL_0029: ret
 		} // end of method '<>c__DisplayClass0_1'::'<Main>b__0'
 	} // end of class <>c__DisplayClass0_1
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x2148
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2115
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x2154
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<Main>b__0_1'
-	} // end of class <>c
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 
@@ -1138,6 +1138,45 @@ one");
 	extends [mscorlib]System.Object
 {
 	// Nested Types
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x2124
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2130
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x2138
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<Main>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -1150,7 +1189,7 @@ one");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2124
+			// Method begins at RVA 0x2130
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -1172,7 +1211,7 @@ one");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2124
+			// Method begins at RVA 0x2130
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -1182,7 +1221,7 @@ one");
 		.method assembly hidebysig 
 			instance void '<Main>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x213a
 			// Code size 35 (0x23)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -1198,45 +1237,6 @@ one");
 			IL_0022: ret
 		} // end of method '<>c__DisplayClass0_1'::'<Main>b__0'
 	} // end of class <>c__DisplayClass0_1
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x2150
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2124
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x215c
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<Main>b__0_1'
-	} // end of class <>c
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 
@@ -1371,6 +1371,45 @@ public class Program
 	extends [mscorlib]System.Object
 {
 	// Nested Types
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x209e
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2053
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<M>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x20aa
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<M>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -1415,7 +1454,7 @@ public class Program
 		.method assembly hidebysig 
 			instance void '<M>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x209e
+			// Method begins at RVA 0x20ac
 			// Code size 35 (0x23)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -1431,45 +1470,6 @@ public class Program
 			IL_0022: ret
 		} // end of method '<>c__DisplayClass0_1'::'<M>b__0'
 	} // end of class <>c__DisplayClass0_1
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x20c2
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2053
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<M>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x20ce
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<M>b__0_1'
-	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<M>d__0'
 		extends [mscorlib]System.ValueType
 		implements [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine
@@ -1680,11 +1680,11 @@ public class Program
 			[0] valuetype Program/'<M>d__0'
 		)
 		IL_0000: ldloca.s 0
- 		IL_0002: call valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder::Create()
- 		IL_0007: stfld valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder Program/'<M>d__0'::'<>t__builder'
- 		IL_000c: ldloca.s 0
- 		IL_000e: ldarg.0
- 		IL_000f: stfld class C Program/'<M>d__0'::enumerable
+		IL_0002: call valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder::Create()
+		IL_0007: stfld valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder Program/'<M>d__0'::'<>t__builder'
+		IL_000c: ldloca.s 0
+		IL_000e: ldarg.0
+		IL_000f: stfld class C Program/'<M>d__0'::enumerable
 		IL_0014: ldloca.s 0
 		IL_0016: ldc.i4.m1
 		IL_0017: stfld int32 Program/'<M>d__0'::'<>1__state'
@@ -1847,6 +1847,45 @@ public static class Program
 	extends [mscorlib]System.Object
 {
 	// Nested Types
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x20b0
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20bc
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x20c4
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<Main>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -1861,7 +1900,7 @@ public static class Program
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20b0
+			// Method begins at RVA 0x20bc
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -1871,7 +1910,7 @@ public static class Program
 		.method assembly hidebysig 
 			instance void '<Main>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x20b8
+			// Method begins at RVA 0x20c6
 			// Code size 30 (0x1e)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -1886,45 +1925,6 @@ public static class Program
 			IL_001d: ret
 		} // end of method '<>c__DisplayClass0_0'::'<Main>b__0'
 	} // end of class <>c__DisplayClass0_0
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x20d7
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x20b0
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x20e3
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<Main>b__0_1'
-	} // end of class <>c
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 
@@ -1999,6 +1999,45 @@ public static class Program
 	extends [mscorlib]System.Object
 {
 	// Nested Types
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x20ce
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20da
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x20e2
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<Main>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -2013,7 +2052,7 @@ public static class Program
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ce
+			// Method begins at RVA 0x20da
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -2023,7 +2062,7 @@ public static class Program
 		.method assembly hidebysig 
 			instance void '<Main>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x20d6
+			// Method begins at RVA 0x20e4
 			// Code size 30 (0x1e)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -2038,45 +2077,6 @@ public static class Program
 			IL_001d: ret
 		} // end of method '<>c__DisplayClass0_0'::'<Main>b__0'
 	} // end of class <>c__DisplayClass0_0
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x20f5
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x20ce
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x2101
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<Main>b__0_1'
-	} // end of class <>c
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 
@@ -2343,46 +2343,6 @@ one");
 			IL_0006: ret
 		} // end of method Disposable::.ctor
 	} // end of class Disposable
-	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public class [mscorlib]System.Collections.Generic.List`1<string> strings
-		.field public class Program/Disposable disposable
-		.field public int32 i
-		// Methods
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x20da
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c__DisplayClass0_0'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0' () cil managed 
-		{
-			// Method begins at RVA 0x20e2
-			// Code size 39 (0x27)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: ldfld class Program/Disposable Program/'<>c__DisplayClass0_0'::disposable
-			IL_0006: callvirt instance string [mscorlib]System.Object::ToString()
-			IL_000b: call void [mscorlib]System.Console::WriteLine(string)
-			IL_0010: ldarg.0
-			IL_0011: ldfld class [mscorlib]System.Collections.Generic.List`1<string> Program/'<>c__DisplayClass0_0'::strings
-			IL_0016: ldarg.0
-			IL_0017: ldfld int32 Program/'<>c__DisplayClass0_0'::i
-			IL_001c: callvirt instance !0 class [mscorlib]System.Collections.Generic.List`1<string>::get_Item(int32)
-			IL_0021: call void [mscorlib]System.Console::WriteLine(string)
-			IL_0026: ret
-		} // end of method '<>c__DisplayClass0_0'::'<Main>b__0'
-	} // end of class <>c__DisplayClass0_0
 	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
 		extends [mscorlib]System.Object
 	{
@@ -2396,7 +2356,7 @@ one");
 		.method private hidebysig specialname rtspecialname static 
 			void .cctor () cil managed 
 		{
-			// Method begins at RVA 0x210a
+			// Method begins at RVA 0x20e2
 			// Code size 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
@@ -2422,6 +2382,46 @@ one");
 			IL_0000: ret
 		} // end of method '<>c'::'<Main>b__0_1'
 	} // end of class <>c
+	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public class [mscorlib]System.Collections.Generic.List`1<string> strings
+		.field public class Program/Disposable disposable
+		.field public int32 i
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20da
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c__DisplayClass0_0'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0' () cil managed 
+		{
+			// Method begins at RVA 0x20ee
+			// Code size 39 (0x27)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: ldfld class Program/Disposable Program/'<>c__DisplayClass0_0'::disposable
+			IL_0006: callvirt instance string [mscorlib]System.Object::ToString()
+			IL_000b: call void [mscorlib]System.Console::WriteLine(string)
+			IL_0010: ldarg.0
+			IL_0011: ldfld class [mscorlib]System.Collections.Generic.List`1<string> Program/'<>c__DisplayClass0_0'::strings
+			IL_0016: ldarg.0
+			IL_0017: ldfld int32 Program/'<>c__DisplayClass0_0'::i
+			IL_001c: callvirt instance !0 class [mscorlib]System.Collections.Generic.List`1<string>::get_Item(int32)
+			IL_0021: call void [mscorlib]System.Console::WriteLine(string)
+			IL_0026: ret
+		} // end of method '<>c__DisplayClass0_0'::'<Main>b__0'
+	} // end of class <>c__DisplayClass0_0
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 
@@ -2550,6 +2550,45 @@ one");
 			IL_0006: ret
 		} // end of method Disposable::.ctor
 	} // end of class Disposable
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x21ba
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x21b2
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x21b0
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<Main>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -2617,7 +2656,7 @@ one");
 		.method assembly hidebysig 
 			instance void '<Main>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x21bc
+			// Method begins at RVA 0x21c8
 			// Code size 82 (0x52)
 			.maxstack 3
 			IL_0000: ldarg.0
@@ -2648,45 +2687,6 @@ one");
 			IL_0051: ret
 		} // end of method '<>c__DisplayClass0_2'::'<Main>b__0'
 	} // end of class <>c__DisplayClass0_2
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x221a
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x21b2
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x21b0
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<Main>b__0_1'
-	} // end of class <>c
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 
@@ -2856,6 +2856,45 @@ three");
 	extends [mscorlib]System.Object
 {
 	// Nested Types
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x20f2
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20fe
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x2106
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<Main>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -2868,7 +2907,7 @@ three");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f2
+			// Method begins at RVA 0x20fe
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -2890,7 +2929,7 @@ three");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f2
+			// Method begins at RVA 0x20fe
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -2900,7 +2939,7 @@ three");
 		.method assembly hidebysig 
 			instance void '<Main>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x20fa
+			// Method begins at RVA 0x2108
 			// Code size 35 (0x23)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -2916,45 +2955,6 @@ three");
 			IL_0022: ret
 		} // end of method '<>c__DisplayClass0_1'::'<Main>b__0'
 	} // end of class <>c__DisplayClass0_1
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x211e
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x20f2
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x212a
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<Main>b__0_1'
-	} // end of class <>c
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 
@@ -3058,6 +3058,45 @@ one");
 	extends [mscorlib]System.Object
 {
 	// Nested Types
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x20fa
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2106
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x210e
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<Main>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -3071,7 +3110,7 @@ one");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fa
+			// Method begins at RVA 0x2106
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -3092,7 +3131,7 @@ one");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fa
+			// Method begins at RVA 0x2106
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -3102,7 +3141,7 @@ one");
 		.method assembly hidebysig 
 			instance void '<Main>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x2102
+			// Method begins at RVA 0x2110
 			// Code size 42 (0x2a)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -3121,45 +3160,6 @@ one");
 			IL_0029: ret
 		} // end of method '<>c__DisplayClass0_1'::'<Main>b__0'
 	} // end of class <>c__DisplayClass0_1
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x212d
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x20fa
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x2139
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<Main>b__0_1'
-	} // end of class <>c
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 
@@ -3260,6 +3260,45 @@ public static class Program
 	extends [mscorlib]System.Object
 {
 	// Nested Types
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x20df
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20eb
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x20f3
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<Main>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -3273,7 +3312,7 @@ public static class Program
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20df
+			// Method begins at RVA 0x20eb
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -3294,7 +3333,7 @@ public static class Program
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20df
+			// Method begins at RVA 0x20eb
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -3304,7 +3343,7 @@ public static class Program
 		.method assembly hidebysig 
 			instance void '<Main>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x20e7
+			// Method begins at RVA 0x20f5
 			// Code size 42 (0x2a)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -3323,45 +3362,6 @@ public static class Program
 			IL_0029: ret
 		} // end of method '<>c__DisplayClass0_1'::'<Main>b__0'
 	} // end of class <>c__DisplayClass0_1
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x2112
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x20df
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x211e
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<Main>b__0_1'
-	} // end of class <>c
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 
@@ -3739,6 +3739,45 @@ one");
 	extends [mscorlib]System.Object
 {
 	// Nested Types
+	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
+		extends [mscorlib]System.Object
+	{
+		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+			01 00 00 00
+		)
+		// Fields
+		.field public static initonly class Program/'<>c' '<>9'
+		.field public static class [mscorlib]System.Action '<>9__0_1'
+		// Methods
+		.method private hidebysig specialname rtspecialname static 
+			void .cctor () cil managed 
+		{
+			// Method begins at RVA 0x2104
+			// Code size 11 (0xb)
+			.maxstack 8
+			IL_0000: newobj instance void Program/'<>c'::.ctor()
+			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
+			IL_000a: ret
+		} // end of method '<>c'::.cctor
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2110
+			// Code size 7 (0x7)
+			.maxstack 8
+			IL_0000: ldarg.0
+			IL_0001: call instance void [mscorlib]System.Object::.ctor()
+			IL_0006: ret
+		} // end of method '<>c'::.ctor
+		.method assembly hidebysig 
+			instance void '<Main>b__0_1' () cil managed 
+		{
+			// Method begins at RVA 0x2118
+			// Code size 1 (0x1)
+			.maxstack 8
+			IL_0000: ret
+		} // end of method '<>c'::'<Main>b__0_1'
+	} // end of class <>c
 	.class nested private auto ansi sealed beforefieldinit '<>c__DisplayClass0_0'
 		extends [mscorlib]System.Object
 	{
@@ -3752,7 +3791,7 @@ one");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2104
+			// Method begins at RVA 0x2110
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -3773,7 +3812,7 @@ one");
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2104
+			// Method begins at RVA 0x2110
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -3783,7 +3822,7 @@ one");
 		.method assembly hidebysig 
 			instance void '<Main>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x210c
+			// Method begins at RVA 0x211a
 			// Code size 42 (0x2a)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -3802,45 +3841,6 @@ one");
 			IL_0029: ret
 		} // end of method '<>c__DisplayClass0_1'::'<Main>b__0'
 	} // end of class <>c__DisplayClass0_1
-	.class nested private auto ansi sealed serializable beforefieldinit '<>c'
-		extends [mscorlib]System.Object
-	{
-		.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
-			01 00 00 00
-		)
-		// Fields
-		.field public static initonly class Program/'<>c' '<>9'
-		.field public static class [mscorlib]System.Action '<>9__0_1'
-		// Methods
-		.method private hidebysig specialname rtspecialname static 
-			void .cctor () cil managed 
-		{
-			// Method begins at RVA 0x2137
-			// Code size 11 (0xb)
-			.maxstack 8
-			IL_0000: newobj instance void Program/'<>c'::.ctor()
-			IL_0005: stsfld class Program/'<>c' Program/'<>c'::'<>9'
-			IL_000a: ret
-		} // end of method '<>c'::.cctor
-		.method public hidebysig specialname rtspecialname 
-			instance void .ctor () cil managed 
-		{
-			// Method begins at RVA 0x2104
-			// Code size 7 (0x7)
-			.maxstack 8
-			IL_0000: ldarg.0
-			IL_0001: call instance void [mscorlib]System.Object::.ctor()
-			IL_0006: ret
-		} // end of method '<>c'::.ctor
-		.method assembly hidebysig 
-			instance void '<Main>b__0_1' () cil managed 
-		{
-			// Method begins at RVA 0x2143
-			// Code size 1 (0x1)
-			.maxstack 8
-			IL_0000: ret
-		} // end of method '<>c'::'<Main>b__0_1'
-	} // end of class <>c
 	// Methods
 	.method public hidebysig static 
 		void Main () cil managed 

--- a/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
@@ -18,6 +18,8 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting;
+using Microsoft.CodeAnalysis.PooledObjects;
+using System.Security.Cryptography;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
 {
@@ -437,6 +439,71 @@ Partial.c = 3";
                 var comp2 = cv.Compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(trees[1], trees[0], trees[2]);
                 CompileAndVerify(comp2, expectedOutput: expectedOutput2);
                 CompileAndVerify(source: new string[] { x2, x1, x3 }, expectedOutput: expectedOutput2);
+            }
+        }
+
+        [Fact, WorkItem(53865, "https://github.com/dotnet/roslyn/issues/53865")]
+        public void DeterminismWithFixedFields()
+        {
+            string source = @"
+public unsafe struct UnsafeStructNUMBER1
+{
+    public fixed ushort FixedField1[10];
+    public fixed ushort FixedField2[10];
+    public UnsafeStructNUMBER2* pStruct;
+
+    public void AccessMethod()
+    {
+        pStruct->FixedField2[0] = 0;
+    }
+}
+";
+            byte[] result = null;
+
+            var sourceBuilder = ArrayBuilder<string>.GetInstance();
+            int max = 20;
+            for (int i = 0; i < max; i++)
+            {
+                int j = (i + 7) % max;
+                sourceBuilder.Add(source.Replace("NUMBER1", i.ToString()).Replace("NUMBER2", j.ToString()));
+            }
+            string[] source1 = sourceBuilder.ToArrayAndFree();
+
+            var opt = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+            const string assemblyName = "TestAssembly";
+            opt = opt.WithConcurrentBuild(true)
+                .WithOptimizationLevel(OptimizationLevel.Debug)
+                .WithDeterministic(true)
+                .WithPlatform(Platform.AnyCpu)
+                .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)
+                .WithAllowUnsafe(true)
+                .WithOverflowChecks(false)
+                .WithModuleName(assemblyName);
+
+            for (int j = 0; j < 10; j++)
+            {
+                var comp = CreateCompilation(source1, options: opt, assemblyName: assemblyName);
+                comp.VerifyDiagnostics();
+
+                var optEmit = new EmitOptions()
+                    .WithDebugInformationFormat(DebugInformationFormat.PortablePdb)
+                    .WithPdbChecksumAlgorithm(HashAlgorithmName.SHA256);
+
+                using var streamDll = new MemoryStream();
+                using var streamXml = new MemoryStream();
+                using var streamPdb = new MemoryStream();
+                var emitResult = comp.Emit(streamDll, xmlDocumentationStream: streamXml,
+                    pdbStream: optEmit.DebugInformationFormat != DebugInformationFormat.Embedded ? streamPdb : null,
+                    options: optEmit);
+                var newResult = streamDll.ToArray();
+                if (result is null)
+                {
+                    result = newResult;
+                }
+                else
+                {
+                    Assert.Equal(result, newResult);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DeterministicTests.cs
@@ -461,7 +461,7 @@ public unsafe struct UnsafeStructNUMBER1
             byte[] result = null;
 
             var sourceBuilder = ArrayBuilder<string>.GetInstance();
-            int max = 20;
+            const int max = 20;
             for (int i = 0; i < max; i++)
             {
                 int j = (i + 7) % max;

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -1073,7 +1073,7 @@ class C
                 "C.<>c__DisplayClass1_1: {<>h__TransparentIdentifier0, <F>b__6}",
                 "C.<>c__DisplayClass1_0: {<>h__TransparentIdentifier0, <F>b__5}",
                 "C.<>c: {<>9__1_0, <>9__1_1, <>9__1_4, <F>b__1_0, <F>b__1_1, <F>b__1_4}",
-                "C: {<F>b__1_2, <F>b__1_3, <>c__DisplayClass1_0, <>c__DisplayClass1_1, <>c}",
+                "C: {<F>b__1_2, <F>b__1_3, <>c, <>c__DisplayClass1_0, <>c__DisplayClass1_1}",
                 "<>f__AnonymousType0<<a>j__TPar, <b>j__TPar>: {Equals, GetHashCode, ToString}");
 
             var md1 = diff1.GetMetadata();
@@ -1087,10 +1087,10 @@ class C
                 Row(8, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(11, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(13, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(14, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(15, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(16, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(18, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(19, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(20, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(5, TableIndex.Param, EditAndContinueOperation.Default),
                 Row(6, TableIndex.Param, EditAndContinueOperation.Default),
@@ -1162,7 +1162,7 @@ class C
                 "C.<>c: {<>9__1_1, <F>b__1_1}",
                 "<>f__AnonymousType0<<a>j__TPar, <b>j__TPar>: {Equals, GetHashCode, ToString}",
                 "C.<>c__DisplayClass1_0: {a, <F>b__2}",
-                "C: {<F>b__1_0, <>c__DisplayClass1_0, <>c}");
+                "C: {<F>b__1_0, <>c, <>c__DisplayClass1_0}");
 
             var md1 = diff1.GetMetadata();
             var reader1 = md1.Reader;
@@ -1173,7 +1173,7 @@ class C
                 Row(7, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(8, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(12, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(13, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(15, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(5, TableIndex.Param, EditAndContinueOperation.Default),
                 Row(6, TableIndex.Param, EditAndContinueOperation.Default),
@@ -1334,7 +1334,7 @@ class C
 
             // no new synthesized members generated (with #1 in names):
             diff1.VerifySynthesizedMembers(
-                "C: {<F>b__1_2, <>c__DisplayClass1_0, <>c}",
+                "C: {<F>b__1_2, <>c, <>c__DisplayClass1_0}",
                 "C.<>c: {<>9__1_0, <>9__1_1, <F>b__1_0, <F>b__1_1}",
                 "C.<>c__DisplayClass1_0: {g, <F>b__3}");
 
@@ -1347,8 +1347,8 @@ class C
                 Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(9, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(7, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(8, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(2, TableIndex.Param, EditAndContinueOperation.Default),
                 Row(3, TableIndex.Param, EditAndContinueOperation.Default),
@@ -1416,7 +1416,7 @@ class C
 
             // no new synthesized members generated (with #1 in names):
             diff1.VerifySynthesizedMembers(
-                "C: {<F>b__1_1, <>c__DisplayClass1_0, <>c}",
+                "C: {<F>b__1_1, <>c, <>c__DisplayClass1_0}",
                 "C.<>c: {<>9__1_0, <F>b__1_0}",
                 "C.<>c__DisplayClass1_0: {g, <F>b__2}");
 
@@ -1429,7 +1429,7 @@ class C
                 Row(5, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(7, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(9, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(2, TableIndex.Param, EditAndContinueOperation.Default),
                 Row(3, TableIndex.Param, EditAndContinueOperation.Default),
@@ -2328,9 +2328,9 @@ public class C
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var reader0 = md0.MetadataReader;
-            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "<>c__DisplayClass0_0", "<>c");
-            CheckNames(reader0, reader0.GetMethodDefNames(), "F", ".ctor", ".ctor", "<F>b__1", "<F>b__2", ".cctor", ".ctor", "<F>b__0_0");
-            CheckNames(reader0, reader0.GetFieldDefNames(), "<>4__this", "a", "<>9", "<>9__0_0");
+            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "<>c", "<>c__DisplayClass0_0");
+            CheckNames(reader0, reader0.GetMethodDefNames(), "F", ".ctor", ".cctor", ".ctor", "<F>b__0_0", ".ctor", "<F>b__1", "<F>b__2");
+            CheckNames(reader0, reader0.GetFieldDefNames(), "<>9", "<>9__0_0", "<>4__this", "a");
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
             var diff1 = compilation1.EmitDifference(
@@ -2341,11 +2341,11 @@ public class C
             var reader1 = diff1.GetMetadata().Reader;
 
             CheckNames(new[] { reader0, reader1 }, reader1.GetTypeDefNames(), "<>c__DisplayClass0#1_0#1");
-            CheckNames(new[] { reader0, reader1 }, reader1.GetMethodDefNames(), ".ctor", "F", ".ctor", "<F>b__1#1", "<F>b__2#1", "<F>b__0#1_0#1");
-            CheckNames(new[] { reader0, reader1 }, reader1.GetFieldDefNames(), "<>4__this", "a", "<>9__0#1_0#1");
+            CheckNames(new[] { reader0, reader1 }, reader1.GetMethodDefNames(), ".ctor", "F", "<F>b__0#1_0#1", ".ctor", "<F>b__1#1", "<F>b__2#1");
+            CheckNames(new[] { reader0, reader1 }, reader1.GetFieldDefNames(), "<>9__0#1_0#1", "<>4__this", "a");
 
             diff1.VerifySynthesizedMembers(
-                "C: {<>c__DisplayClass0#1_0#1, <>c}",
+                "C: {<>c, <>c__DisplayClass0#1_0#1}",
                 "C.<>c__DisplayClass0#1_0#1: {<>4__this, a, <F>b__1#1, <F>b__2#1}",
                 "C.<>c: {<>9__0#1_0#1, <F>b__0#1_0#1}");
 
@@ -2357,8 +2357,8 @@ public class C
             var reader2 = diff2.GetMetadata().Reader;
 
             CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetTypeDefNames(), "<>c__DisplayClass1#2_0#2");
-            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetMethodDefNames(), ".ctor", "F", ".ctor", "<F>b__1#2", "<F>b__2#2", "<F>b__1#2_0#2");
-            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetFieldDefNames(), "<>4__this", "a", "<>9__1#2_0#2");
+            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetMethodDefNames(), ".ctor", "F", "<F>b__1#2_0#2", ".ctor", "<F>b__1#2", "<F>b__2#2");
+            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetFieldDefNames(), "<>9__1#2_0#2", "<>4__this", "a");
         }
 
         [Fact]
@@ -2445,9 +2445,9 @@ public class C
             var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
 
             var reader0 = md0.MetadataReader;
-            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "<>c__DisplayClass0_0`1", "<>c__0`1");
-            CheckNames(reader0, reader0.GetMethodDefNames(), "F", ".ctor", ".ctor", "<F>b__1", "<F>b__2", ".cctor", ".ctor", "<F>b__0_0");
-            CheckNames(reader0, reader0.GetFieldDefNames(), "<>4__this", "a", "<>9", "<>9__0_0");
+            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "<>c__0`1", "<>c__DisplayClass0_0`1");
+            CheckNames(reader0, reader0.GetMethodDefNames(), "F", ".ctor", ".cctor", ".ctor", "<F>b__0_0", ".ctor", "<F>b__1", "<F>b__2");
+            CheckNames(reader0, reader0.GetFieldDefNames(), "<>9", "<>9__0_0", "<>4__this", "a");
 
             var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
             var diff1 = compilation1.EmitDifference(
@@ -2457,13 +2457,13 @@ public class C
 
             var reader1 = diff1.GetMetadata().Reader;
 
-            CheckNames(new[] { reader0, reader1 }, reader1.GetTypeDefNames(), "<>c__DisplayClass0#1_0#1`1", "<>c__0#1`1");
-            CheckNames(new[] { reader0, reader1 }, reader1.GetMethodDefNames(), "F", ".ctor", "<F>b__1#1", "<F>b__2#1", ".cctor", ".ctor", "<F>b__0#1_0#1");
-            CheckNames(new[] { reader0, reader1 }, reader1.GetFieldDefNames(), "<>4__this", "a", "<>9", "<>9__0#1_0#1");
+            CheckNames(new[] { reader0, reader1 }, reader1.GetTypeDefNames(), "<>c__0#1`1", "<>c__DisplayClass0#1_0#1`1");
+            CheckNames(new[] { reader0, reader1 }, reader1.GetMethodDefNames(), "F", ".cctor", ".ctor", "<F>b__0#1_0#1", ".ctor", "<F>b__1#1", "<F>b__2#1");
+            CheckNames(new[] { reader0, reader1 }, reader1.GetFieldDefNames(), "<>9", "<>9__0#1_0#1", "<>4__this", "a");
 
             diff1.VerifySynthesizedMembers(
                 "C.<>c__0#1<T>: {<>9__0#1_0#1, <F>b__0#1_0#1}",
-                "C: {<>c__DisplayClass0#1_0#1, <>c__0#1}",
+                "C: {<>c__0#1, <>c__DisplayClass0#1_0#1}",
                 "C.<>c__DisplayClass0#1_0#1<T>: {<>4__this, a, <F>b__1#1, <F>b__2#1}");
 
             var diff2 = compilation2.EmitDifference(
@@ -2473,9 +2473,9 @@ public class C
 
             var reader2 = diff2.GetMetadata().Reader;
 
-            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetTypeDefNames(), "<>c__DisplayClass1#2_0#2`1", "<>c__1#2`1");
-            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetMethodDefNames(), "F", ".ctor", "<F>b__1#2", "<F>b__2#2", ".cctor", ".ctor", "<F>b__1#2_0#2");
-            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetFieldDefNames(), "<>4__this", "a", "<>9", "<>9__1#2_0#2");
+            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetTypeDefNames(), "<>c__1#2`1", "<>c__DisplayClass1#2_0#2`1");
+            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetMethodDefNames(), "F", ".cctor", ".ctor", "<F>b__1#2_0#2", ".ctor", "<F>b__1#2", "<F>b__2#2");
+            CheckNames(new[] { reader0, reader1, reader2 }, reader2.GetFieldDefNames(), "<>9", "<>9__1#2_0#2", "<>4__this", "a");
         }
 
         [Fact]
@@ -2592,7 +2592,7 @@ public class C
             diff1.VerifySynthesizedMembers(
                 "C.<>c: {<>9__1#1_0#1, <F>b__1#1_0#1}",
                 "C.<>c__DisplayClass1#1_0#1: {<>4__this, a, <F>b__1#1, <F>b__2#1}",
-                "C: {<>c__DisplayClass1#1_0#1, <>c}");
+                "C: {<>c, <>c__DisplayClass1#1_0#1}");
 
             var diff2 = compilation2.EmitDifference(
                 diff1.NextGeneration,
@@ -2602,7 +2602,7 @@ public class C
 
             diff2.VerifySynthesizedMembers(
                 "C.<>c__DisplayClass1#2_0#2: {<>4__this, a, <F>b__1#2, <F>b__2#2}",
-                "C: {<>c__DisplayClass1#2_0#2, <>c, <>c__DisplayClass1#1_0#1}",
+                "C: {<>c, <>c__DisplayClass1#2_0#2, <>c__DisplayClass1#1_0#1}",
                 "C.<>c: {<>9__1#2_0#2, <F>b__1#2_0#2, <>9__1#1_0#1, <F>b__1#1_0#1}",
                 "C.<>c__DisplayClass1#1_0#1: {<>4__this, a, <F>b__1#1, <F>b__2#1}");
 
@@ -2615,7 +2615,7 @@ public class C
                 "C.<>c__DisplayClass1#1_0#1: {<>4__this, a, <F>b__1#1, <F>b__2#1}",
                 "C.<>c: {<>9__1#2_0#2, <F>b__1#2_0#2, <>9__1#1_0#1, <F>b__1#1_0#1}",
                 "C.<>c__DisplayClass1#2_0#2: {<>4__this, a, <F>b__1#2, <F>b__2#2}",
-                "C: {<>c__DisplayClass1#2_0#2, <>c, <>c__DisplayClass1#1_0#1}");
+                "C: {<>c, <>c__DisplayClass1#2_0#2, <>c__DisplayClass1#1_0#1}");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -4493,7 +4493,7 @@ class Program
 
             diff1.VerifySynthesizedMembers(
                 "Program.<>o__1#1: {<>p__0, <>p__1}",
-                "Program: {<>o__1#1, <>c, <Iterator>d__1}",
+                "Program: {<>c, <>o__1#1, <Iterator>d__1}",
                 "Program.<>c: {<>9__1_0, <>9__1_1, <>9__1_2, <>9__1_3, <>9__1_4, <>9__1_5, <>9__1_6, <>9__1_7, <>9__1_8, <>9__1_9, <>9__1_10, <Iterator>b__1_0, <Iterator>b__1_1, <Iterator>b__1_2, <Iterator>b__1_3, <Iterator>b__1_4, <Iterator>b__1_5, <Iterator>b__1_6, <Iterator>b__1_7, <Iterator>b__1_8, <Iterator>b__1_9, <Iterator>b__1_10}",
                 "Program.<Iterator>d__1: {<>1__state, <>2__current, <>l__initialThreadId, <args>5__1, <list>5__2, <i>5__3, <result>5__4, <linked>5__5, <temp>5__7, <newArgs>5__6, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.String>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.String>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.String>.Current, System.Collections.IEnumerator.Current}",
                 "<>f__AnonymousType4<<a>j__TPar, <value>j__TPar>: {Equals, GetHashCode, ToString}",
@@ -4804,7 +4804,7 @@ class Program
             diff2.VerifySynthesizedMembers(
                 "Program.<>o__1#1: {<>p__0, <>p__1}",
                 "Program.<>o__1#2: {<>p__0, <>p__1, <>p__2}",
-                "Program: {<>o__1#2, <>c, <Iterator>d__1, <>o__1#1}",
+                "Program: {<>c, <>o__1#2, <Iterator>d__1, <>o__1#1}",
                 "Program.<>c: {<>9__1_0, <>9__1_1, <>9__1_2, <>9__1_3, <>9__1_4, <>9__1_5, <>9__1_6, <>9__1_7, <>9__1_8, <>9__1_9, <>9__1_10, <Iterator>b__1_0, <Iterator>b__1_1, <Iterator>b__1_2, <Iterator>b__1_3, <Iterator>b__1_4, <Iterator>b__1_5, <Iterator>b__1_6, <Iterator>b__1_7, <Iterator>b__1_8, <Iterator>b__1_9, <Iterator>b__1_10}",
                 "Program.<Iterator>d__1: {<>1__state, <>2__current, <>l__initialThreadId, <args>5__1, <list>5__2, <i>5__3, <result>5__4, <linked>5__5, <temp>5__7, <newArgs>5__6, System.IDisposable.Dispose, MoveNext, System.Collections.Generic.IEnumerator<System.String>.get_Current, System.Collections.IEnumerator.Reset, System.Collections.IEnumerator.get_Current, System.Collections.Generic.IEnumerable<System.String>.GetEnumerator, System.Collections.IEnumerable.GetEnumerator, System.Collections.Generic.IEnumerator<System.String>.Current, System.Collections.IEnumerator.Current}",
                 "<>f__AnonymousType4<<a>j__TPar, <value>j__TPar>: {Equals, GetHashCode, ToString}",

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -7620,7 +7620,7 @@ class C
 
             diff1.VerifySynthesizedMembers(
                 "C.<>o__0#1: {<>p__0}",
-                "C: {<>o__0#1, <>c}",
+                "C: {<>c, <>o__0#1}",
                 "C.<>c: {<>9__0_0, <>9__0_1, <>9__0_2, <>9__0_3#1, <>9__0_4#1, <>9__0_3, <>9__0_6#1, <>9__0_4, <>9__0_5, <>9__0_6, <>9__0_10#1, <F>b__0_0, <F>b__0_1, <F>b__0_2, <F>b__0_3#1, <F>b__0_4#1, <F>b__0_3, <F>b__0_6#1, <F>b__0_4, <F>b__0_5, <F>b__0_6, <F>b__0_10#1}",
                 "<>f__AnonymousType4<<<>h__TransparentIdentifier0>j__TPar, <length>j__TPar>: {Equals, GetHashCode, ToString}",
                 "<>f__AnonymousType2<<Value>j__TPar, <Length>j__TPar>: {Equals, GetHashCode, ToString}",
@@ -11921,7 +11921,7 @@ public class Program
                     SemanticEdit.Create(SemanticEditKind.Update, n0, n1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
 
             diff1.VerifySynthesizedMembers(
-                "Program: {<>c__DisplayClass2_0, <>c}",
+                "Program: {<>c, <>c__DisplayClass2_0}",
                 "Program.<>c__DisplayClass2_0: {x, <N>b__1}",
                 "Program.<>c: {<>9__2_0, <N>b__2_0}");
 
@@ -11993,7 +11993,7 @@ public class Program
 
             diff2.VerifySynthesizedMembers(
                 "Program.<>c__DisplayClass2_0: {x, <N>b__1}",
-                "Program: {<>c__DisplayClass2_0, <>c}",
+                "Program: {<>c, <>c__DisplayClass2_0}",
                 "Program.<>c: {<>9__2_0, <N>b__2_0}");
 
             diff2.VerifyIL("Program.N()", @"

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBIteratorTests.cs
@@ -650,23 +650,6 @@ public class Test
         <entry offset=""0x12e"" hidden=""true"" document=""1"" />
       </sequencePoints>
     </method>
-    <method containingType=""Test`1+&lt;get_IterProp&gt;d__3"" name=""MoveNext"">
-      <customDebugInfo>
-        <forward declaringType=""Test`1"" methodName=""System.Collections.IEnumerable.GetEnumerator"" />
-        <encLocalSlotMap>
-          <slot kind=""27"" offset=""0"" />
-        </encLocalSlotMap>
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x2a"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x2b"" startLine=""29"" startColumn=""13"" endLine=""29"" endColumn=""31"" document=""1"" />
-        <entry offset=""0x40"" hidden=""true"" document=""1"" />
-        <entry offset=""0x47"" startLine=""30"" startColumn=""13"" endLine=""30"" endColumn=""31"" document=""1"" />
-        <entry offset=""0x5c"" hidden=""true"" document=""1"" />
-        <entry offset=""0x63"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" document=""1"" />
-      </sequencePoints>
-    </method>
     <method containingType=""Test`1+&lt;IterMethod&gt;d__4"" name=""MoveNext"">
       <customDebugInfo>
         <forward declaringType=""Test`1"" methodName=""System.Collections.IEnumerable.GetEnumerator"" />
@@ -682,6 +665,23 @@ public class Test
         <entry offset=""0x47"" startLine=""37"" startColumn=""9"" endLine=""37"" endColumn=""27"" document=""1"" />
         <entry offset=""0x5c"" hidden=""true"" document=""1"" />
         <entry offset=""0x63"" startLine=""38"" startColumn=""9"" endLine=""38"" endColumn=""21"" document=""1"" />
+      </sequencePoints>
+    </method>
+    <method containingType=""Test`1+&lt;get_IterProp&gt;d__3"" name=""MoveNext"">
+      <customDebugInfo>
+        <forward declaringType=""Test`1"" methodName=""System.Collections.IEnumerable.GetEnumerator"" />
+        <encLocalSlotMap>
+          <slot kind=""27"" offset=""0"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2a"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x2b"" startLine=""29"" startColumn=""13"" endLine=""29"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x40"" hidden=""true"" document=""1"" />
+        <entry offset=""0x47"" startLine=""30"" startColumn=""13"" endLine=""30"" endColumn=""31"" document=""1"" />
+        <entry offset=""0x5c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x63"" startLine=""31"" startColumn=""9"" endLine=""31"" endColumn=""10"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -554,7 +554,7 @@ class C
             c.VerifyDiagnostics();
 
             c.VerifyPdb(@"
-<symbols>
+ <symbols>
   <files>
     <file id=""1"" name="""" language=""C#"" />
   </files>
@@ -589,14 +589,6 @@ class C
         <local name=""x"" il_index=""1"" il_start=""0x0"" il_end=""0x7a"" attributes=""0"" />
       </scope>
     </method>
-    <method containingType=""C+&lt;&gt;c__DisplayClass0_0"" name=""&lt;M&gt;b__0"" parameterNames=""a"">
-      <customDebugInfo>
-        <forward declaringType=""C"" methodName=""M"" />
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""30"" document=""1"" />
-      </sequencePoints>
-    </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;M&gt;b__0_1"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""M"" />
@@ -611,6 +603,14 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""12"" startColumn=""24"" endLine=""12"" endColumn=""30"" document=""1"" />
+      </sequencePoints>
+    </method>
+    <method containingType=""C+&lt;&gt;c__DisplayClass0_0"" name=""&lt;M&gt;b__0"" parameterNames=""a"">
+      <customDebugInfo>
+        <forward declaringType=""C"" methodName=""M"" />
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""30"" document=""1"" />
       </sequencePoints>
     </method>
   </methods>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -1090,7 +1090,7 @@ class C
 }");
             var c = CreateCompilationWithMscorlib40AndSystemCore(source, options: TestOptions.DebugDll);
             c.VerifyPdb(@"
-<symbols>
+ <symbols>
   <files>
     <file id=""1"" name="""" language=""C#"" />
   </files>
@@ -1115,14 +1115,6 @@ class C
       <scope startOffset=""0x0"" endOffset=""0x16"">
         <namespace name=""System"" />
       </scope>
-    </method>
-    <method containingType=""C+&lt;&gt;c__DisplayClass2_0"" name=""&lt;.cctor&gt;b__3"" parameterNames=""y"">
-      <customDebugInfo>
-        <forward declaringType=""C"" methodName="".cctor"" />
-      </customDebugInfo>
-      <sequencePoints>
-        <entry offset=""0x0"" startLine=""7"" startColumn=""66"" endLine=""7"" endColumn=""70"" document=""1"" />
-      </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;.cctor&gt;b__2_0"" parameterNames=""x"">
       <customDebugInfo>
@@ -1167,6 +1159,14 @@ class C
       <scope startOffset=""0x0"" endOffset=""0x1a"">
         <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0x1a"" attributes=""0"" />
       </scope>
+    </method>
+    <method containingType=""C+&lt;&gt;c__DisplayClass2_0"" name=""&lt;.cctor&gt;b__3"" parameterNames=""y"">
+      <customDebugInfo>
+        <forward declaringType=""C"" methodName="".cctor"" />
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""7"" startColumn=""66"" endLine=""7"" endColumn=""70"" document=""1"" />
+      </sequencePoints>
     </method>
   </methods>
 </symbols>");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -7746,7 +7746,9 @@ return;
   <methods>
     <method containingType=""{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointTypeName) }+&lt;{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointMethodName) }&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
-        <forward declaringType=""{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointTypeName) }+&lt;&gt;c"" methodName=""&lt;{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointMethodName) }&gt;b__0_0"" />
+        <using>
+          <namespace usingCount=""2"" />
+        </using>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""2"" />
           <slot kind=""33"" offset=""76"" />
@@ -7765,6 +7767,10 @@ return;
         <entry offset=""0xa9"" hidden=""true"" document=""1"" />
         <entry offset=""0xc1"" hidden=""true"" document=""1"" />
       </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0xd6"">
+        <namespace name=""System"" />
+        <namespace name=""System.Threading.Tasks"" />
+      </scope>
       <asyncInfo>
         <catchHandler offset=""0xa9"" />
         <kickoffMethod declaringType=""{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointTypeName) }"" methodName=""{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointMethodName) }"" parameterNames=""args"" />
@@ -7809,7 +7815,9 @@ return 11;
   <methods>
     <method containingType=""{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointTypeName) }+&lt;{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointMethodName) }&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
-        <forward declaringType=""{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointTypeName) }+&lt;&gt;c"" methodName=""&lt;{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointMethodName) }&gt;b__0_0"" />
+        <using>
+          <namespace usingCount=""2"" />
+        </using>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""2"" />
           <slot kind=""20"" offset=""2"" />
@@ -7829,6 +7837,10 @@ return 11;
         <entry offset=""0xac"" hidden=""true"" document=""1"" />
         <entry offset=""0xc6"" hidden=""true"" document=""1"" />
       </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0xdc"">
+        <namespace name=""System"" />
+        <namespace name=""System.Threading.Tasks"" />
+      </scope>
       <asyncInfo>
         <catchHandler offset=""0xac"" />
         <kickoffMethod declaringType=""{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointTypeName) }"" methodName=""{ EscapeForXML(WellKnownMemberNames.TopLevelStatementsEntryPointMethodName) }"" parameterNames=""args"" />

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -763,7 +763,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
                 if (NestedTypes != null)
                 {
-                    foreach (var type in NestedTypes)
+                    foreach (var type in NestedTypes.OrderBy(t => t.Name, StringComparer.Ordinal))
                     {
                         builder.Add(type.GetInternalSymbol());
                     }
@@ -790,7 +790,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
             if (_synthesizedTypeMembers.TryGetValue(container, out var defs))
             {
-                compileEmitTypes = defs.NestedTypes;
+                compileEmitTypes = defs.NestedTypes?.OrderBy(t => t.Name, StringComparer.Ordinal);
             }
 
             if (declareTypes == null)

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -736,7 +736,22 @@ namespace Microsoft.CodeAnalysis.Emit
             // Nested types may be queued from concurrent threads, but we need to emit them
             // in a deterministic order.
             internal IEnumerable<Cci.INestedTypeDefinition> DeterministicNestedTypes
-                => NestedTypes?.OrderBy(t => t.Name, StringComparer.Ordinal);
+            {
+                get
+                {
+#if DEBUG
+                    if (NestedTypes is not null)
+                    {
+                        foreach (var group in NestedTypes.GroupBy(t => t.Name, StringComparer.Ordinal))
+                        {
+                            var arities = group.Select(g => g.GenericParameters.Count());
+                            Debug.Assert(arities.All(a => a == arities.First()));
+                        }
+                    }
+#endif
+                    return NestedTypes?.OrderBy(t => t.Name, StringComparer.Ordinal);
+                }
+            }
 
             internal void AddNestedType(Cci.INestedTypeDefinition nestedType)
             {

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.vb
@@ -439,11 +439,11 @@ End Module
                 Row(6, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(7, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
                 Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
-                Row(11, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(8, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(6, TableIndex.Param, EditAndContinueOperation.Default),
                 Row(9, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
                 Row(10, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
-                Row(14, TableIndex.CustomAttribute, EditAndContinueOperation.Default))
+                Row(12, TableIndex.CustomAttribute, EditAndContinueOperation.Default))
         End Sub
 
         <WorkItem(1067140, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1067140")>
@@ -1456,9 +1456,9 @@ End Class
             Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
 
             Dim reader0 = md0.MetadataReader
-            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "_Closure$__1-0`1", "_Closure$__1`1")
-            CheckNames(reader0, reader0.GetMethodDefNames(), ".ctor", "F", "_Lambda$__1-1", ".ctor", "_Lambda$__2", ".ctor", ".cctor", "_Lambda$__1-0")
-            CheckNames(reader0, reader0.GetFieldDefNames(), "$VB$Local_a", "$I", "$I1-0")
+            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "_Closure$__1`1", "_Closure$__1-0`1")
+            CheckNames(reader0, reader0.GetMethodDefNames(), ".ctor", "F", "_Lambda$__1-1", ".ctor", ".cctor", "_Lambda$__1-0", ".ctor", "_Lambda$__2")
+            CheckNames(reader0, reader0.GetFieldDefNames(), "$I", "$I1-0", "$VB$Local_a")
 
             Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
 
@@ -1468,12 +1468,12 @@ End Class
 
             Dim reader1 = diff1.GetMetadata().Reader
 
-            CheckNames({reader0, reader1}, reader1.GetTypeDefNames(), "_Closure$__1#1-0#1`1", "_Closure$__1#1`1")
-            CheckNames({reader0, reader1}, reader1.GetMethodDefNames(), "F", "_Lambda$__1#1-1#1", ".ctor", "_Lambda$__2#1", ".ctor", ".cctor", "_Lambda$__1#1-0#1")
-            CheckNames({reader0, reader1}, reader1.GetFieldDefNames(), "$VB$Local_a", "$I", "$I1#1-0#1")
+            CheckNames({reader0, reader1}, reader1.GetTypeDefNames(), "_Closure$__1#1`1", "_Closure$__1#1-0#1`1")
+            CheckNames({reader0, reader1}, reader1.GetMethodDefNames(), "F", "_Lambda$__1#1-1#1", ".ctor", ".cctor", "_Lambda$__1#1-0#1", ".ctor", "_Lambda$__2#1")
+            CheckNames({reader0, reader1}, reader1.GetFieldDefNames(), "$I", "$I1#1-0#1", "$VB$Local_a")
 
             diff1.VerifySynthesizedMembers(
-                "C: {_Lambda$__1#1-1#1, _Closure$__1#1-0#1, _Closure$__1#1}",
+                "C: {_Lambda$__1#1-1#1, _Closure$__1#1, _Closure$__1#1-0#1}",
                 "C._Closure$__1#1(Of $CLS0): {$I1#1-0#1, _Lambda$__1#1-0#1}",
                 "C._Closure$__1#1-0#1(Of $CLS0): {_Lambda$__2#1}")
 
@@ -1483,9 +1483,9 @@ End Class
 
             Dim reader2 = diff2.GetMetadata().Reader
 
-            CheckNames({reader0, reader1, reader2}, reader2.GetTypeDefNames(), "_Closure$__2#2-0#2`1", "_Closure$__2#2`1")
-            CheckNames({reader0, reader1, reader2}, reader2.GetMethodDefNames(), "F", "_Lambda$__2#2-1#2", ".ctor", "_Lambda$__2#2", ".ctor", ".cctor", "_Lambda$__2#2-0#2")
-            CheckNames({reader0, reader1, reader2}, reader2.GetFieldDefNames(), "$VB$Local_a", "$I", "$I2#2-0#2")
+            CheckNames({reader0, reader1, reader2}, reader2.GetTypeDefNames(), "_Closure$__2#2`1", "_Closure$__2#2-0#2`1")
+            CheckNames({reader0, reader1, reader2}, reader2.GetMethodDefNames(), "F", "_Lambda$__2#2-1#2", ".ctor", ".cctor", "_Lambda$__2#2-0#2", ".ctor", "_Lambda$__2#2")
+            CheckNames({reader0, reader1, reader2}, reader2.GetFieldDefNames(), "$I", "$I2#2-0#2", "$VB$Local_a")
         End Sub
 
         <Fact>
@@ -1850,7 +1850,7 @@ End Class
                     New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
 
             diff1.VerifySynthesizedMembers(
-                "C: {_Closure$__1-0, _Closure$__}",
+                "C: {_Closure$__, _Closure$__1-0}",
                 "C._Closure$__: {$I1-0, _Lambda$__1-0}",
                 "C._Closure$__1-0: {_Lambda$__1}")
 
@@ -1891,7 +1891,7 @@ End Class
                     New SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables:=True)))
 
             diff2.VerifySynthesizedMembers(
-                "C: {_Closure$__1-0, _Closure$__}",
+                "C: {_Closure$__, _Closure$__1-0}",
                 "C._Closure$__: {$I1-0, _Lambda$__1-0}",
                 "C._Closure$__1-0: {_Lambda$__1}")
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -4367,7 +4367,7 @@ End Class
                     New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
 
             diff1.VerifySynthesizedMembers(
-                "C: {_Closure$__, VB$StateMachine_1_F}",
+                "C: {VB$StateMachine_1_F, _Closure$__}",
                 "C._Closure$__: {$I1-0, _Lambda$__1-0}",
                 "C.VB$StateMachine_1_F: {$State, $Builder, $VB$ResumableLocal_x$0, $VB$ResumableLocal_y$1, $A0, MoveNext, System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine}")
 
@@ -4380,7 +4380,7 @@ End Class
             ' Synthesized members collection still includes y field since members are only added to it and never deleted.
             ' The corresponding CLR field is also present.
             diff2.VerifySynthesizedMembers(
-                "C: {_Closure$__, VB$StateMachine_1_F}",
+                "C: {VB$StateMachine_1_F, _Closure$__}",
                 "C._Closure$__: {$I1-0, _Lambda$__1-0}",
                 "C.VB$StateMachine_1_F: {$State, $Builder, $VB$ResumableLocal_x$0, $A0, MoveNext, System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine, $VB$ResumableLocal_y$1}")
 
@@ -4391,7 +4391,7 @@ End Class
                     New SemanticEdit(SemanticEditKind.Update, f2, f3, GetSyntaxMapFromMarkers(source2, source3), preserveLocalVariables:=True)))
 
             diff3.VerifySynthesizedMembers(
-                "C: {_Closure$__, VB$StateMachine_1_F}",
+                "C: {VB$StateMachine_1_F, _Closure$__}",
                 "C._Closure$__: {$I1-0, _Lambda$__1-0}",
                 "C.VB$StateMachine_1_F: {$State, $Builder, $VB$ResumableLocal_x$0, $VB$ResumableLocal_y$2, $A0, MoveNext, System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine, $VB$ResumableLocal_y$1}")
 
@@ -4402,7 +4402,7 @@ End Class
                     New SemanticEdit(SemanticEditKind.Update, f3, f4, GetSyntaxMapFromMarkers(source3, source4), preserveLocalVariables:=True)))
 
             diff4.VerifySynthesizedMembers(
-                "C: {_Closure$__, VB$StateMachine_1_F}",
+                "C: {VB$StateMachine_1_F, _Closure$__}",
                 "C._Closure$__: {$I1-0, _Lambda$__1-0}",
                 "C.VB$StateMachine_1_F: {$State, $Builder, $VB$ResumableLocal_x$0, $A0, MoveNext, System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine, $VB$ResumableLocal_y$2, $VB$ResumableLocal_y$1}")
 
@@ -4413,7 +4413,7 @@ End Class
                     New SemanticEdit(SemanticEditKind.Update, f4, f5, GetSyntaxMapFromMarkers(source4, source5), preserveLocalVariables:=True)))
 
             diff5.VerifySynthesizedMembers(
-                "C: {_Closure$__, VB$StateMachine_1_F}",
+                "C: {VB$StateMachine_1_F, _Closure$__}",
                 "C._Closure$__: {$I1-0, _Lambda$__1-0}",
                 "C.VB$StateMachine_1_F: {$State, $Builder, $VB$ResumableLocal_x$0, $VB$ResumableLocal_y$3, $A0, MoveNext, System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine, $VB$ResumableLocal_y$2, $VB$ResumableLocal_y$1}")
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.vb
@@ -491,12 +491,12 @@ End Class
 
             Dim c = compilation1.GetMember(Of NamedTypeSymbol)("C")
             Dim displayClasses = peAssemblyBuilder.GetSynthesizedTypes(c).ToArray()
-            Assert.Equal("_Closure$__1-0", displayClasses(0).Name)
-            Assert.Equal("_Closure$__", displayClasses(1).Name)
+            Assert.Equal("_Closure$__", displayClasses(0).Name)
+            Assert.Equal("_Closure$__1-0", displayClasses(1).Name)
 
             Dim emitContext = New EmitContext(peAssemblyBuilder, Nothing, New DiagnosticBag(), metadataOnly:=False, includePrivateMembers:=True)
 
-            Dim fields = displayClasses(0).GetFields(emitContext).ToArray()
+            Dim fields = displayClasses(1).GetFields(emitContext).ToArray()
             Dim x1 = fields(0)
             Dim x2 = fields(1)
             Assert.Equal("$VB$Local_x1", x1.Name)

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBAsyncTests.vb
@@ -428,6 +428,7 @@ End Class
                     TestOptions.DebugDll)
 
             ' Goal: We're looking for "$VB$ResumableLocal_$VB$Closure_$0" and "$VB$ResumableLocal_a$1".
+            ' Note: since the method is first, it is recording the imports (rather than using an importsforward)
             compilation.VerifyPdb("C+VB$StateMachine_1_Async_Lambda.MoveNext",
 <symbols>
     <files>
@@ -467,7 +468,9 @@ End Class
                 <entry offset="0x12c" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x139">
-                <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
+                <namespace name="System" importlevel="file"/>
+                <namespace name="System.Threading.Tasks" importlevel="file"/>
+                <currentnamespace name=""/>
                 <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x0" il_end="0x139" attributes="0"/>
                 <local name="$VB$ResumableLocal_a$1" il_index="1" il_start="0x0" il_end="0x139" attributes="0"/>
             </scope>
@@ -509,6 +512,7 @@ End Class
                     TestOptions.ReleaseDll)
 
             ' Goal: We're looking for "$VB$ResumableLocal_$VB$Closure_$0" but not "$VB$ResumableLocal_a$1".
+            ' Note: since the method is first, it is recording the imports (rather than using an importsforward)
             compilation.VerifyPdb("C+VB$StateMachine_1_Async_Lambda.MoveNext",
 <symbols>
     <files>
@@ -538,7 +542,9 @@ End Class
                 <entry offset="0x103" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x10f">
-                <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
+                <namespace name="System" importlevel="file"/>
+                <namespace name="System.Threading.Tasks" importlevel="file"/>
+                <currentnamespace name=""/>
                 <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x0" il_end="0x10f" attributes="0"/>
             </scope>
             <asyncInfo>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBIteratorTests.vb
@@ -272,6 +272,7 @@ End Class
                     TestOptions.ReleaseDll)
 
             ' Goal: We're looking for the double-mangled name "$VB$ResumableLocal_$VB$Closure_$0".
+            ' Note: since the method is first, it is recording the imports (rather than using an importsforward)
             compilation.VerifyPdb("C+VB$StateMachine_1_Iterator_Lambda_Hoisted.MoveNext",
 <symbols>
     <files>
@@ -296,7 +297,9 @@ End Class
                 <entry offset="0x96" startLine="14" startColumn="5" endLine="14" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x98">
-                <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
+                <namespace name="System" importlevel="file"/>
+                <namespace name="System.Collections.Generic" importlevel="file"/>
+                <currentnamespace name=""/>
                 <scope startOffset="0x19" endOffset="0x97">
                     <local name="$VB$ResumableLocal_$VB$Closure_$0" il_index="0" il_start="0x19" il_end="0x97" attributes="0"/>
                 </scope>
@@ -349,7 +352,9 @@ End Class
                 <entry offset="0x54" startLine="12" startColumn="5" endLine="12" endColumn="17" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x56">
-                <importsforward declaringType="C+_Closure$__1-0" methodName="_Lambda$__0"/>
+                <namespace name="System" importlevel="file"/>
+                <namespace name="System.Collections.Generic" importlevel="file"/>
+                <currentnamespace name=""/>
                 <scope startOffset="0x19" endOffset="0x55">
                     <local name="$VB$Closure_0" il_index="1" il_start="0x19" il_end="0x55" attributes="0"/>
                 </scope>

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -3868,98 +3868,98 @@ End Module
             Dim compilation = CreateCompilationWithMscorlib40AndVBRuntime(source, TestOptions.DebugDll)
 
             compilation.VerifyPdb(
-<symbols>
-    <files>
-        <file id="1" name="" language="VB"/>
-    </files>
-    <methods>
-        <method containingType="M" name=".cctor">
-            <customDebugInfo>
-                <encLambdaMap>
-                    <methodOrdinal>0</methodOrdinal>
-                    <closure offset="-84"/>
-                    <lambda offset="-243"/>
-                    <lambda offset="-182"/>
-                    <lambda offset="-84"/>
-                    <lambda offset="-72" closure="0"/>
-                </encLambdaMap>
-            </customDebugInfo>
-            <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="13" endLine="7" endColumn="21" document="1"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x16">
-                <namespace name="System" importlevel="file"/>
-                <currentnamespace name=""/>
-            </scope>
-        </method>
-        <method containingType="M+_Closure$__0-0" name="_Lambda$__3" parameterNames="y">
-            <customDebugInfo>
-                <encLocalSlotMap>
-                    <slot kind="21" offset="-72"/>
-                </encLocalSlotMap>
-            </customDebugInfo>
-            <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="96" endLine="5" endColumn="107" document="1"/>
-                <entry offset="0x1" startLine="5" startColumn="108" endLine="5" endColumn="112" document="1"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x17">
-                <importsforward declaringType="M" methodName=".cctor"/>
-            </scope>
-        </method>
-        <method containingType="M+_Closure$__" name="_Lambda$__0-0" parameterNames="x">
-            <customDebugInfo>
-                <encLocalSlotMap>
-                    <slot kind="21" offset="-243"/>
-                    <slot kind="0" offset="-214"/>
-                    <slot kind="0" offset="-151"/>
-                </encLocalSlotMap>
-            </customDebugInfo>
-            <sequencePoints>
-                <entry offset="0x0" startLine="3" startColumn="46" endLine="3" endColumn="57" document="1"/>
-                <entry offset="0x1" startLine="4" startColumn="17" endLine="4" endColumn="62" document="1"/>
-                <entry offset="0x26" startLine="5" startColumn="17" endLine="5" endColumn="112" document="1"/>
-                <entry offset="0x4b" startLine="6" startColumn="13" endLine="6" endColumn="33" document="1"/>
-                <entry offset="0x5b" startLine="7" startColumn="9" endLine="7" endColumn="21" document="1"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x5d">
-                <importsforward declaringType="M" methodName=".cctor"/>
-                <local name="f" il_index="1" il_start="0x0" il_end="0x5d" attributes="0"/>
-                <local name="g" il_index="2" il_start="0x0" il_end="0x5d" attributes="0"/>
-            </scope>
-        </method>
-        <method containingType="M+_Closure$__" name="_Lambda$__0-1" parameterNames="o">
-            <customDebugInfo>
-                <encLocalSlotMap>
-                    <slot kind="21" offset="-182"/>
-                </encLocalSlotMap>
-            </customDebugInfo>
-            <sequencePoints>
-                <entry offset="0x0" startLine="4" startColumn="49" endLine="4" endColumn="60" document="1"/>
-                <entry offset="0x1" startLine="4" startColumn="61" endLine="4" endColumn="62" document="1"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x7">
-                <importsforward declaringType="M" methodName=".cctor"/>
-            </scope>
-        </method>
-        <method containingType="M+_Closure$__" name="_Lambda$__0-2" parameterNames="h">
-            <customDebugInfo>
-                <encLocalSlotMap>
-                    <slot kind="30" offset="-84"/>
-                    <slot kind="21" offset="-84"/>
-                </encLocalSlotMap>
-            </customDebugInfo>
-            <sequencePoints>
-                <entry offset="0x0" startLine="5" startColumn="84" endLine="5" endColumn="95" document="1"/>
-                <entry offset="0x1" hidden="true" document="1"/>
-                <entry offset="0xe" startLine="5" startColumn="96" endLine="5" endColumn="112" document="1"/>
-            </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x1f">
-                <importsforward declaringType="M" methodName=".cctor"/>
-                <local name="$VB$Closure_0" il_index="0" il_start="0x0" il_end="0x1f" attributes="0"/>
-            </scope>
-        </method>
-    </methods>
-</symbols>)
+ <symbols>
+     <files>
+         <file id="1" name="" language="VB"/>
+     </files>
+     <methods>
+         <method containingType="M" name=".cctor">
+             <customDebugInfo>
+                 <encLambdaMap>
+                     <methodOrdinal>0</methodOrdinal>
+                     <closure offset="-84"/>
+                     <lambda offset="-243"/>
+                     <lambda offset="-182"/>
+                     <lambda offset="-84"/>
+                     <lambda offset="-72" closure="0"/>
+                 </encLambdaMap>
+             </customDebugInfo>
+             <sequencePoints>
+                 <entry offset="0x0" startLine="3" startColumn="13" endLine="7" endColumn="21" document="1"/>
+             </sequencePoints>
+             <scope startOffset="0x0" endOffset="0x16">
+                 <namespace name="System" importlevel="file"/>
+                 <currentnamespace name=""/>
+             </scope>
+         </method>
+         <method containingType="M+_Closure$__" name="_Lambda$__0-0" parameterNames="x">
+             <customDebugInfo>
+                 <encLocalSlotMap>
+                     <slot kind="21" offset="-243"/>
+                     <slot kind="0" offset="-214"/>
+                     <slot kind="0" offset="-151"/>
+                 </encLocalSlotMap>
+             </customDebugInfo>
+             <sequencePoints>
+                 <entry offset="0x0" startLine="3" startColumn="46" endLine="3" endColumn="57" document="1"/>
+                 <entry offset="0x1" startLine="4" startColumn="17" endLine="4" endColumn="62" document="1"/>
+                 <entry offset="0x26" startLine="5" startColumn="17" endLine="5" endColumn="112" document="1"/>
+                 <entry offset="0x4b" startLine="6" startColumn="13" endLine="6" endColumn="33" document="1"/>
+                 <entry offset="0x5b" startLine="7" startColumn="9" endLine="7" endColumn="21" document="1"/>
+             </sequencePoints>
+             <scope startOffset="0x0" endOffset="0x5d">
+                 <importsforward declaringType="M" methodName=".cctor"/>
+                 <local name="f" il_index="1" il_start="0x0" il_end="0x5d" attributes="0"/>
+                 <local name="g" il_index="2" il_start="0x0" il_end="0x5d" attributes="0"/>
+             </scope>
+         </method>
+         <method containingType="M+_Closure$__" name="_Lambda$__0-1" parameterNames="o">
+             <customDebugInfo>
+                 <encLocalSlotMap>
+                     <slot kind="21" offset="-182"/>
+                 </encLocalSlotMap>
+             </customDebugInfo>
+             <sequencePoints>
+                 <entry offset="0x0" startLine="4" startColumn="49" endLine="4" endColumn="60" document="1"/>
+                 <entry offset="0x1" startLine="4" startColumn="61" endLine="4" endColumn="62" document="1"/>
+             </sequencePoints>
+             <scope startOffset="0x0" endOffset="0x7">
+                 <importsforward declaringType="M" methodName=".cctor"/>
+             </scope>
+         </method>
+         <method containingType="M+_Closure$__" name="_Lambda$__0-2" parameterNames="h">
+             <customDebugInfo>
+                 <encLocalSlotMap>
+                     <slot kind="30" offset="-84"/>
+                     <slot kind="21" offset="-84"/>
+                 </encLocalSlotMap>
+             </customDebugInfo>
+             <sequencePoints>
+                 <entry offset="0x0" startLine="5" startColumn="84" endLine="5" endColumn="95" document="1"/>
+                 <entry offset="0x1" hidden="true" document="1"/>
+                 <entry offset="0xe" startLine="5" startColumn="96" endLine="5" endColumn="112" document="1"/>
+             </sequencePoints>
+             <scope startOffset="0x0" endOffset="0x1f">
+                 <importsforward declaringType="M" methodName=".cctor"/>
+                 <local name="$VB$Closure_0" il_index="0" il_start="0x0" il_end="0x1f" attributes="0"/>
+             </scope>
+         </method>
+         <method containingType="M+_Closure$__0-0" name="_Lambda$__3" parameterNames="y">
+             <customDebugInfo>
+                 <encLocalSlotMap>
+                     <slot kind="21" offset="-72"/>
+                 </encLocalSlotMap>
+             </customDebugInfo>
+             <sequencePoints>
+                 <entry offset="0x0" startLine="5" startColumn="96" endLine="5" endColumn="107" document="1"/>
+                 <entry offset="0x1" startLine="5" startColumn="108" endLine="5" endColumn="112" document="1"/>
+             </sequencePoints>
+             <scope startOffset="0x0" endOffset="0x17">
+                 <importsforward declaringType="M" methodName=".cctor"/>
+             </scope>
+         </method>
+     </methods>
+ </symbols>)
         End Sub
 
         <WorkItem(846228, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/846228")>
@@ -4512,6 +4512,8 @@ Class C
     End Function
 End Class"
             Dim c = CreateCompilationWithMscorlib45AndVBRuntime({Parse(source)}, options:=TestOptions.DebugDll, references:={SystemCoreRef})
+
+            ' Note: since the method is first, it is recording the imports (rather than using an importsforward)
             c.VerifyPdb("C+VB$StateMachine_1_F.MoveNext",
 <symbols>
     <files>
@@ -4540,7 +4542,9 @@ End Class"
                 <entry offset="0x7e" hidden="true" document="1"/>
             </sequencePoints>
             <scope startOffset="0x0" endOffset="0x8b">
-                <importsforward declaringType="C+_Closure$__" methodName="_Lambda$__1-0" parameterNames="i"/>
+                <namespace name="System.Linq" importlevel="file"/>
+                <namespace name="System.Threading.Tasks" importlevel="file"/>
+                <currentnamespace name=""/>
                 <local name="$VB$ResumableLocal_c$0" il_index="0" il_start="0x0" il_end="0x8b" attributes="0"/>
             </scope>
             <asyncInfo>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/53865

The issue is that we're collecting synthesized nested types into concurrent queues but adding them in a non-deterministic order.
The two code paths below compete to add those nested types and include tasks/threads when not under a debugger (tests turn off concurrency when debugged).
The result was that those nested types didn't always appear in the same order in metadata.

```
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol.FixedImplementationType(PEModuleBuilder emitModule)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileNamedType(NamedTypeSymbol containingType)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.VisitNamedType(NamedTypeSymbol symbol, TypeCompilationState arg)
   at Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol.Accept[TArgument,TResult](CSharpSymbolVisitor`2 visitor, TArgument argument)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileNamespace(NamespaceSymbol symbol)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileMethodBodies(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuiltOpt, Boolean emittingPdb, Boolean emitTestCoverageData, Boolean hasDeclarationErrors, Boolean emitMethodBodies, BindingDiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.CompileMethods(CommonPEModuleBuilder moduleBuilder, Boolean emittingPdb, Boolean emitMetadataOnly, Boolean emitTestCoverageData, DiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Compilation.Emit(Stream peStream, Stream metadataPEStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, RebuildData rebuildData, CompilationTestData testData, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Compilation.Emit(Stream peStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, Stream metadataPEStream, RebuildData rebuildData, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Compilation.Emit(Stream peStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, Stream metadataPEStream, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.UnitTests.Emit.DeterministicTests.TODO2()
```

```
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceFixedFieldSymbol.FixedImplementationType(PEModuleBuilder emitModule)
   at Microsoft.CodeAnalysis.CSharp.Symbols.FieldSymbolAdapter.Microsoft.Cci.IFieldReference.GetType(EmitContext context)
   at Microsoft.CodeAnalysis.CodeGen.ReferenceDependencyWalker.VisitFieldReference(IFieldReference fieldReference, EmitContext context)
   at Microsoft.CodeAnalysis.CodeGen.ReferenceDependencyWalker.VisitReference(IReference reference, EmitContext context)
   at Microsoft.CodeAnalysis.Emit.CommonPEModuleBuilder.GetFakeSymbolTokenForIL(IReference symbol, SyntaxNode syntaxNode, DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CodeGen.ILBuilder.EmitToken(IReference value, SyntaxNode syntaxNode, DiagnosticBag diagnostics, Boolean encodeAsRawToken)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitSymbolToken(FieldSymbol symbol, SyntaxNode syntaxNode)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitInstanceFieldAddress(BoundFieldAccess fieldAccess, AddressKind addressKind)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitFieldAddress(BoundFieldAccess fieldAccess, AddressKind addressKind)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitAddress(BoundExpression expression, AddressKind addressKind)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitAddressOfExpression(BoundAddressOfOperator expression, Boolean used)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitExpressionCore(BoundExpression expression, Boolean used)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitExpression(BoundExpression expression, Boolean used)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitAssignmentPreamble(BoundAssignmentOperator assignmentOperator)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitAssignmentExpression(BoundAssignmentOperator assignmentOperator, UseKind useKind)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitExpressionCore(BoundExpression expression, Boolean used)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitExpressionCoreWithStackGuard(BoundExpression expression, Boolean used)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitExpression(BoundExpression expression, Boolean used)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitStatement(BoundStatement statement)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitStatementAndCountInstructions(BoundStatement statement)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitSequencePointStatement(BoundSequencePoint node)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitStatement(BoundStatement statement)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitStatements(ImmutableArray`1 statements)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitBlock(BoundBlock block)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitStatement(BoundStatement statement)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitStatementList(BoundStatementList list)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.EmitStatement(BoundStatement statement)
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.GenerateImpl()
   at Microsoft.CodeAnalysis.CSharp.CodeGen.CodeGenerator.Generate(Boolean& hasStackalloc)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.GenerateMethodBody(PEModuleBuilder moduleBuilder, MethodSymbol method, Int32 methodOrdinal, BoundStatement block, ImmutableArray`1 lambdaDebugInfo, ImmutableArray`1 closureDebugInfo, StateMachineTypeSymbol stateMachineTypeOpt, VariableSlotAllocator variableSlotAllocatorOpt, BindingDiagnosticBag diagnostics, DebugDocumentProvider debugDocumentProvider, ImportChain importChainOpt, Boolean emittingPdb, Boolean emitTestCoverageData, ImmutableArray`1 dynamicAnalysisSpans, AsyncForwardEntryPoint entryPointOpt)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileMethod(MethodSymbol methodSymbol, Int32 methodOrdinal, ProcessedFieldInitializers& processedInitializers, SynthesizedSubmissionFields previousSubmissionFields, TypeCompilationState compilationState)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileNamedType(NamedTypeSymbol containingType)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.VisitNamedType(NamedTypeSymbol symbol, TypeCompilationState arg)
   at Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol.Accept[TArgument,TResult](CSharpSymbolVisitor`2 visitor, TArgument argument)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileNamespace(NamespaceSymbol symbol)
   at Microsoft.CodeAnalysis.CSharp.MethodCompiler.CompileMethodBodies(CSharpCompilation compilation, PEModuleBuilder moduleBeingBuiltOpt, Boolean emittingPdb, Boolean emitTestCoverageData, Boolean hasDeclarationErrors, Boolean emitMethodBodies, BindingDiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.CSharpCompilation.CompileMethods(CommonPEModuleBuilder moduleBuilder, Boolean emittingPdb, Boolean emitMetadataOnly, Boolean emitTestCoverageData, DiagnosticBag diagnostics, Predicate`1 filterOpt, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Compilation.Emit(Stream peStream, Stream metadataPEStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, RebuildData rebuildData, CompilationTestData testData, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Compilation.Emit(Stream peStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, Stream metadataPEStream, RebuildData rebuildData, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Compilation.Emit(Stream peStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, Stream metadataPEStream, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.UnitTests.Emit.DeterministicTests.TODO2()
``` 