### PR TITLE
Backport 56569 to 17.0

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -179,14 +179,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                     // We convert the code fixes and refactorings to UnifiedSuggestedActionSets instead of
                     // SuggestedActionSets so that we can share logic between local Roslyn and LSP.
-                    var fixes = GetCodeFixesAsync(
+                    var fixesTask = GetCodeFixesAsync(
                         state, supportsFeatureService, requestedActionCategories, workspace, document, range,
-                        addOperationScope, CodeActionRequestPriority.None, isBlocking: true, cancellationToken).WaitAndGetResult(cancellationToken);
-                    var refactorings = GetRefactoringsAsync(
+                        addOperationScope, includeSuppressionFixes: true, CodeActionRequestPriority.None,
+                        isBlocking: true, cancellationToken);
+                    var refactoringsTask = GetRefactoringsAsync(
                         state, supportsFeatureService, requestedActionCategories, GlobalOptions, workspace, document, selection,
-                        addOperationScope, CodeActionRequestPriority.None, isBlocking: true, cancellationToken).WaitAndGetResult(cancellationToken);
+                        addOperationScope, CodeActionRequestPriority.None, isBlocking: true, cancellationToken);
 
-                    return ConvertToSuggestedActionSets(state, selection, fixes, refactorings);
+                    Task.WhenAll(fixesTask, refactoringsTask).WaitAndGetResult(cancellationToken);
+
+                    return ConvertToSuggestedActionSets(state, selection,
+                        fixesTask.WaitAndGetResult(cancellationToken),
+                        refactoringsTask.WaitAndGetResult(cancellationToken));
                 }
             }
 
@@ -258,6 +263,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 Document document,
                 SnapshotSpan range,
                 Func<string, IDisposable?> addOperationScope,
+                bool includeSuppressionFixes,
                 CodeActionRequestPriority priority,
                 bool isBlocking,
                 CancellationToken cancellationToken)
@@ -271,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
                     workspace, state.Target.Owner._codeFixService, document, range.Span.ToTextSpan(),
-                    priority, isBlocking, addOperationScope, cancellationToken).AsTask();
+                    includeSuppressionFixes, priority, isBlocking, addOperationScope, cancellationToken).AsTask();
             }
 
             private static string GetFixCategory(DiagnosticSeverity severity)

--- a/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             ICodeFixService codeFixService,
             Document document,
             TextSpan selection,
+            bool includeSuppressionFixes,
             CodeActionRequestPriority priority,
             bool isBlocking,
             Func<string, IDisposable?> addOperationScope,
@@ -42,7 +43,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             // Intentionally switch to a threadpool thread to compute fixes.  We do not want to accidentally
             // run any of this on the UI thread and potentially allow any code to take a dependency on that.
             var fixes = await Task.Run(() => codeFixService.GetFixesAsync(
-                document, selection, includeSuppressionFixes: true, priority, isBlocking, addOperationScope, cancellationToken), cancellationToken).ConfigureAwait(false);
+                document, selection, includeSuppressionFixes, priority, isBlocking, addOperationScope, cancellationToken), cancellationToken).ConfigureAwait(false);
 
             var filteredFixes = fixes.WhereAsArray(c => c.Fixes.Length > 0);
             var organizedFixes = OrganizeFixes(workspace, filteredFixes);

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionHelpers.cs
@@ -222,7 +222,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
             var textSpan = ProtocolConversions.RangeToTextSpan(selection, text);
 
             var codeFixes = await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
-                document.Project.Solution.Workspace, codeFixService, document, textSpan, CodeActionRequestPriority.None,
+                document.Project.Solution.Workspace, codeFixService, document, textSpan,
+                includeSuppressionFixes: true, CodeActionRequestPriority.None,
                 isBlocking: false, addOperationScope: _ => null, cancellationToken).ConfigureAwait(false);
 
             var codeRefactorings = await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(


### PR DESCRIPTION
This ensures suppression/config fixes always go at the end of the lightbulb list.