### PR TITLE
Fix crash lowering property pattern where override lacks a get accessor

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -308,13 +308,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression Property(BoundExpression? receiverOpt, PropertySymbol property)
         {
             Debug.Assert((receiverOpt is null) == property.IsStatic);
-            return Call(receiverOpt, property.GetMethod); // TODO: should we use property.GetBaseProperty().GetMethod to ensure we generate a call to the overridden method?
+            var accessor = property.GetOwnOrInheritedGetMethod();
+            Debug.Assert(accessor is not null);
+            return Call(receiverOpt, accessor);
         }
 
         public BoundExpression Indexer(BoundExpression? receiverOpt, PropertySymbol property, BoundExpression arg0)
         {
             Debug.Assert((receiverOpt is null) == property.IsStatic);
-            return Call(receiverOpt, property.GetMethod, arg0); // TODO: should we use property.GetBaseProperty().GetMethod to ensure we generate a call to the overridden method?
+            var accessor = property.GetOwnOrInheritedGetMethod();
+            Debug.Assert(accessor is not null);
+            return Call(receiverOpt, accessor, arg0);
         }
 
         public NamedTypeSymbol SpecialType(SpecialType st)

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -313,14 +313,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Call(receiverOpt, accessor);
         }
 
-        public BoundExpression Indexer(BoundExpression? receiverOpt, PropertySymbol property, BoundExpression arg0)
-        {
-            Debug.Assert((receiverOpt is null) == property.IsStatic);
-            var accessor = property.GetOwnOrInheritedGetMethod();
-            Debug.Assert(accessor is not null);
-            return Call(receiverOpt, accessor, arg0);
-        }
-
         public NamedTypeSymbol SpecialType(SpecialType st)
         {
             NamedTypeSymbol specialType = Compilation.GetSpecialType(st);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/ITuplePatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/ITuplePatternTests.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
@@ -192,6 +193,104 @@ public class C : ITuple
   IL_0060:  ldc.i4.0
   IL_0061:  ret
 }");
+        }
+
+        [Fact, WorkItem(51801, "https://github.com/dotnet/roslyn/issues/51801")]
+        public void IndexerOverrideLacksAccessor()
+        {
+            var source = @"
+#nullable enable
+using System.Runtime.CompilerServices;
+
+class Base
+{
+  public virtual object this[int i] { get { return 1; } set { } }
+}
+
+class C : Base, ITuple
+{
+  public override object this[int i] { set { } }
+  public int Length => 2;
+
+  public string? Value { get; }
+
+  public string M()
+  {
+    switch (this)
+    {
+      case (1, 1):
+        return Value;
+      default:
+        return Value;
+    }
+  }
+}
+";
+            var verifier = CompileAndVerify(CreatePatternCompilation(source, TestOptions.DebugDll));
+            verifier.VerifyIL("C.M", @"
+  {
+      // Code size      110 (0x6e)
+      .maxstack  2
+      .locals init (C V_0,
+                    int V_1,
+                    object V_2,
+                    int V_3,
+                    object V_4,
+                    int V_5,
+                    C V_6,
+                    string V_7)
+      IL_0000:  nop
+      IL_0001:  ldarg.0
+      IL_0002:  stloc.s    V_6
+      IL_0004:  ldloc.s    V_6
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  isinst     ""System.Runtime.CompilerServices.ITuple""
+      IL_000d:  brfalse.s  IL_0061
+      IL_000f:  ldloc.0
+      IL_0010:  callvirt   ""int System.Runtime.CompilerServices.ITuple.Length.get""
+      IL_0015:  stloc.1
+      IL_0016:  ldloc.1
+      IL_0017:  ldc.i4.2
+      IL_0018:  bne.un.s   IL_0061
+      IL_001a:  ldloc.0
+      IL_001b:  ldc.i4.0
+      IL_001c:  callvirt   ""object System.Runtime.CompilerServices.ITuple.this[int].get""
+      IL_0021:  stloc.2
+      IL_0022:  ldloc.2
+      IL_0023:  isinst     ""int""
+      IL_0028:  brfalse.s  IL_0061
+      IL_002a:  ldloc.2
+      IL_002b:  unbox.any  ""int""
+      IL_0030:  stloc.3
+      IL_0031:  ldloc.3
+      IL_0032:  ldc.i4.1
+      IL_0033:  bne.un.s   IL_0061
+      IL_0035:  ldloc.0
+      IL_0036:  ldc.i4.1
+      IL_0037:  callvirt   ""object System.Runtime.CompilerServices.ITuple.this[int].get""
+      IL_003c:  stloc.s    V_4
+      IL_003e:  ldloc.s    V_4
+      IL_0040:  isinst     ""int""
+      IL_0045:  brfalse.s  IL_0061
+      IL_0047:  ldloc.s    V_4
+      IL_0049:  unbox.any  ""int""
+      IL_004e:  stloc.s    V_5
+      IL_0050:  ldloc.s    V_5
+      IL_0052:  ldc.i4.1
+      IL_0053:  beq.s      IL_0057
+      IL_0055:  br.s       IL_0061
+      IL_0057:  ldarg.0
+      IL_0058:  call       ""string C.Value.get""
+      IL_005d:  stloc.s    V_7
+      IL_005f:  br.s       IL_006b
+      IL_0061:  ldarg.0
+      IL_0062:  call       ""string C.Value.get""
+      IL_0067:  stloc.s    V_7
+      IL_0069:  br.s       IL_006b
+      IL_006b:  ldloc.s    V_7
+      IL_006d:  ret
+    }");
         }
 
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -2007,6 +2007,56 @@ public class C {
 }");
         }
 
+        [Fact, WorkItem(51801, "https://github.com/dotnet/roslyn/issues/51801")]
+        public void PropertyOverrideLacksAccessor()
+        {
+            var source = @"
+#nullable enable
+
+class Base
+{
+  public virtual bool IsOk { get { return true; } set { } }
+}
+
+class C : Base
+{
+  public override bool IsOk { set { } }
+  public string? Value { get; }
+
+  public string M()
+  {
+    switch (this)
+    {
+      case { IsOk: true }:
+        return Value;
+      default:
+        return Value;
+    }
+  }
+}
+";
+            var verifier = CompileAndVerify(source);
+            verifier.VerifyIL("C.M", @"
+{
+  // Code size       26 (0x1a)
+  .maxstack  1
+  .locals init (C V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  brfalse.s  IL_0013
+  IL_0005:  ldloc.0
+  IL_0006:  callvirt   ""bool Base.IsOk.get""
+  IL_000b:  pop
+  IL_000c:  ldarg.0
+  IL_000d:  call       ""string C.Value.get""
+  IL_0012:  ret
+  IL_0013:  ldarg.0
+  IL_0014:  call       ""string C.Value.get""
+  IL_0019:  ret
+}");
+        }
+
         [Fact, WorkItem(20641, "https://github.com/dotnet/roslyn/issues/20641")]
         public void PatternsVsAs01()
         {


### PR DESCRIPTION
Closes #51801.

I added an item to #51289 to ensure we cover an analogous scenario with indexer accesses.

I think this change is analogous to lowering of "conventional" property accesses:

https://github.com/dotnet/roslyn/blob/2eddced21a8d9dcfea0509dec368be07644b4302/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PropertyAccess.cs#L89