### PR TITLE
Handle operators when rewriting expression trees

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -146,8 +146,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we use this method to patch up the conversion method only in two cases - 
             // 1) when rewriting MethodGroup conversions and the method gets substituted.
             // 2) when lowering IntPtr conversion (a compat-related conversion which becomes a kind of a user-defined conversion)
+            // 3) when rewriting user-defined conversions and the method gets substituted
             // in those cases it is ok to ignore existing _uncommonData.
-            Debug.Assert(_kind == ConversionKind.MethodGroup || _kind == ConversionKind.IntPtr);
+            Debug.Assert(_kind is ConversionKind.MethodGroup or ConversionKind.IntPtr or ConversionKind.ImplicitUserDefined or ConversionKind.ExplicitUserDefined);
 
             return new Conversion(this.Kind, conversionMethod, isExtensionMethod: IsExtensionMethod);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundTreeRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundTreeRewriter.cs
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected int RecursionDepth => _recursionDepth;
 
+        [return: NotNullIfNotNull("node")]
         public override BoundNode? Visit(BoundNode? node)
         {
             var expression = node as BoundExpression;

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -1,12 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable disable
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -76,15 +75,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             foreach (var local in locals)
             {
-                LocalSymbol newLocal;
-                if (TryRewriteLocal(local, out newLocal))
+                if (TryRewriteLocal(local, out LocalSymbol? newLocal))
                 {
                     newLocals.Add(newLocal);
                 }
             }
         }
 
-        protected bool TryRewriteLocal(LocalSymbol local, out LocalSymbol newLocal)
+        protected bool TryRewriteLocal(LocalSymbol local, [NotNullWhen(true)] out LocalSymbol? newLocal)
         {
             if (NeedsProxy(local))
             {
@@ -130,15 +128,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 return node.Update(
                     newLocals,
-                    (BoundExpression)this.Visit(node.ExceptionSourceOpt),
+                    (BoundExpression?)this.Visit(node.ExceptionSourceOpt),
                     this.VisitType(node.ExceptionTypeOpt),
-                    (BoundStatementList)this.Visit(node.ExceptionFilterPrologueOpt),
-                    (BoundExpression)this.Visit(node.ExceptionFilterOpt),
-                    (BoundBlock)this.Visit(node.Body),
+                    (BoundStatementList?)this.Visit(node.ExceptionFilterPrologueOpt),
+                    (BoundExpression?)this.Visit(node.ExceptionFilterOpt),
+                    (BoundBlock?)this.Visit(node.Body)!,
                     node.IsSynthesizedAsyncCatchAll);
             }
 
-            return base.VisitCatchBlock(node);
+            return base.VisitCatchBlock(node)!;
         }
 
         public override BoundNode VisitBlock(BoundBlock node)
@@ -163,11 +161,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override BoundNode VisitForStatement(BoundForStatement node)
         {
             var newOuterLocals = RewriteLocals(node.OuterLocals);
-            BoundStatement initializer = (BoundStatement)this.Visit(node.Initializer);
+            var initializer = (BoundStatement?)this.Visit(node.Initializer);
             var newInnerLocals = RewriteLocals(node.InnerLocals);
-            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
-            BoundStatement increment = (BoundStatement)this.Visit(node.Increment);
-            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            var condition = (BoundExpression?)this.Visit(node.Condition);
+            var increment = (BoundStatement?)this.Visit(node.Increment);
+            var body = (BoundStatement)this.Visit(node.Body);
             return node.Update(newOuterLocals, initializer, newInnerLocals, condition, increment, body, node.BreakLabel, node.ContinueLabel);
         }
 
@@ -190,11 +188,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override BoundNode VisitUsingStatement(BoundUsingStatement node)
         {
             var newLocals = RewriteLocals(node.Locals);
-            BoundMultipleLocalDeclarations declarationsOpt = (BoundMultipleLocalDeclarations)this.Visit(node.DeclarationsOpt);
-            BoundExpression expressionOpt = (BoundExpression)this.Visit(node.ExpressionOpt);
-            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            var declarations = (BoundMultipleLocalDeclarations?)this.Visit(node.DeclarationsOpt);
+            var expression = (BoundExpression?)this.Visit(node.ExpressionOpt);
+            var body = (BoundStatement)this.Visit(node.Body);
             Conversion disposableConversion = RewriteConversion(node.IDisposableConversion);
-            return node.Update(newLocals, declarationsOpt, expressionOpt, disposableConversion, body, node.AwaitOpt, node.PatternDisposeInfoOpt);
+            return node.Update(newLocals, declarations, expression, disposableConversion, body, node.AwaitOpt, node.PatternDisposeInfoOpt);
         }
 
         private Conversion RewriteConversion(Conversion conversion)
@@ -204,6 +202,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case ConversionKind.ExplicitUserDefined:
                 case ConversionKind.ImplicitUserDefined:
                     Debug.Assert(conversion.ConstrainedToTypeOpt is null);
+                    Debug.Assert(conversion.Method is not null);
                     return new Conversion(conversion.Kind, VisitMethodSymbol(conversion.Method), conversion.IsExtensionMethod);
                 case ConversionKind.MethodGroup:
                     throw ExceptionUtilities.UnexpectedValue(conversion.Kind);
@@ -212,7 +211,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public sealed override TypeSymbol VisitType(TypeSymbol type)
+        [return: NotNullIfNotNull("type")]
+        public sealed override TypeSymbol? VisitType(TypeSymbol? type)
         {
             return TypeMap.SubstituteType(type).Type;
         }
@@ -227,14 +227,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override BoundNode VisitPropertyAccess(BoundPropertyAccess node)
         {
             var rewrittenPropertySymbol = VisitPropertySymbol(node.PropertySymbol);
-            var rewrittenReceiver = (BoundExpression)Visit(node.ReceiverOpt);
+            var rewrittenReceiver = (BoundExpression?)Visit(node.ReceiverOpt);
             return node.Update(rewrittenReceiver, rewrittenPropertySymbol, node.ResultKind, VisitType(node.Type));
         }
 
         public override BoundNode VisitCall(BoundCall node)
         {
             var rewrittenMethodSymbol = VisitMethodSymbol(node.Method);
-            var rewrittenReceiver = (BoundExpression)this.Visit(node.ReceiverOpt);
+            var rewrittenReceiver = (BoundExpression?)this.Visit(node.ReceiverOpt);
             var rewrittenArguments = (ImmutableArray<BoundExpression>)this.VisitList(node.Arguments);
             var rewrittenType = this.VisitType(node.Type);
 
@@ -288,8 +288,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             methodBeingWrapped = methodBeingWrapped.ConstructedFrom;
 
-            MethodSymbol wrapper = this.CompilationState.GetMethodWrapper(methodBeingWrapped);
-            if ((object)wrapper != null)
+            MethodSymbol? wrapper = this.CompilationState.GetMethodWrapper(methodBeingWrapped);
+            if (wrapper is not null)
             {
                 return wrapper;
             }
@@ -311,10 +311,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return wrapper;
         }
 
-        private bool TryReplaceWithProxy(Symbol parameterOrLocal, SyntaxNode syntax, out BoundNode replacement)
+        private bool TryReplaceWithProxy(Symbol parameterOrLocal, SyntaxNode syntax, [NotNullWhen(true)] out BoundNode? replacement)
         {
-            CapturedSymbolReplacement proxy;
-            if (proxies.TryGetValue(parameterOrLocal, out proxy))
+            if (proxies.TryGetValue(parameterOrLocal, out CapturedSymbolReplacement? proxy))
             {
                 replacement = proxy.Replacement(syntax, frameType => FramePointer(syntax, frameType));
                 return true;
@@ -326,8 +325,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override BoundNode VisitParameter(BoundParameter node)
         {
-            BoundNode replacement;
-            if (TryReplaceWithProxy(node.ParameterSymbol, node.Syntax, out replacement))
+            if (TryReplaceWithProxy(node.ParameterSymbol, node.Syntax, out BoundNode? replacement))
             {
                 return replacement;
             }
@@ -338,13 +336,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected virtual BoundNode VisitUnhoistedParameter(BoundParameter node)
         {
-            return base.VisitParameter(node);
+            return base.VisitParameter(node)!;
         }
 
         public sealed override BoundNode VisitLocal(BoundLocal node)
         {
-            BoundNode replacement;
-            if (TryReplaceWithProxy(node.LocalSymbol, node.Syntax, out replacement))
+            if (TryReplaceWithProxy(node.LocalSymbol, node.Syntax, out BoundNode? replacement))
             {
                 return replacement;
             }
@@ -357,13 +354,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private BoundNode VisitUnhoistedLocal(BoundLocal node)
         {
-            LocalSymbol replacementLocal;
-            if (this.localMap.TryGetValue(node.LocalSymbol, out replacementLocal))
+            if (this.localMap.TryGetValue(node.LocalSymbol, out LocalSymbol? replacementLocal))
             {
                 return new BoundLocal(node.Syntax, replacementLocal, node.ConstantValueOpt, replacementLocal.Type, node.HasErrors);
             }
 
-            return base.VisitLocal(node);
+            return base.VisitLocal(node)!;
         }
 
         public override BoundNode VisitAwaitableInfo(BoundAwaitableInfo node)
@@ -377,7 +373,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var rewrittenPlaceholder = awaitablePlaceholder.Update(awaitablePlaceholder.ValEscape, VisitType(awaitablePlaceholder.Type));
             _placeholderMap.Add(awaitablePlaceholder, rewrittenPlaceholder);
 
-            var getAwaiter = (BoundExpression)this.Visit(node.GetAwaiter);
+            var getAwaiter = (BoundExpression?)this.Visit(node.GetAwaiter);
             var isCompleted = VisitPropertySymbol(node.IsCompleted);
             var getResult = VisitMethodSymbol(node.GetResult);
 
@@ -397,7 +393,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (originalLeft.Kind != BoundKind.Local)
             {
-                return base.VisitAssignmentOperator(node);
+                return base.VisitAssignmentOperator(node)!;
             }
 
             var leftLocal = (BoundLocal)originalLeft;
@@ -465,7 +461,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override BoundNode VisitFieldAccess(BoundFieldAccess node)
         {
-            BoundExpression receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
+            var receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             TypeSymbol type = this.VisitType(node.Type);
             var fieldSymbol = ((FieldSymbol)node.FieldSymbol.OriginalDefinition)
                 .AsMember((NamedTypeSymbol)this.VisitType(node.FieldSymbol.ContainingType));
@@ -474,7 +470,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node)
         {
-            var rewritten = (BoundObjectCreationExpression)base.VisitObjectCreationExpression(node);
+            var rewritten = (BoundObjectCreationExpression?)base.VisitObjectCreationExpression(node);
+            Debug.Assert(rewritten != null);
             if (!TypeSymbol.Equals(rewritten.Type, node.Type, TypeCompareKind.ConsiderEverything2) && (object)node.Constructor != null)
             {
                 MethodSymbol ctor = VisitMethodSymbol(node.Constructor);
@@ -498,11 +495,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             BoundExpression originalArgument = node.Argument;
             BoundExpression rewrittenArgument = (BoundExpression)this.Visit(originalArgument);
-            MethodSymbol method = node.MethodOpt;
+            MethodSymbol? method = node.MethodOpt;
 
             // if the original receiver was BoundKind.BaseReference (i.e. from a method group)
             // and the receiver is overridden, change the method to point to a wrapper method
-            if (BaseReferenceInReceiverWasRewritten(originalArgument, rewrittenArgument) && method.IsMetadataVirtual())
+            if (BaseReferenceInReceiverWasRewritten(originalArgument, rewrittenArgument) && method!.IsMetadataVirtual())
             {
                 method = GetMethodWrapperForBaseNonVirtualCall(method, originalArgument.Syntax);
             }
@@ -518,16 +515,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
         {
-            BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
-            BoundExpression whenNotNull = (BoundExpression)this.Visit(node.WhenNotNull);
-            BoundExpression whenNullOpt = (BoundExpression)this.Visit(node.WhenNullOpt);
+            var receiver = (BoundExpression)this.Visit(node.Receiver);
+            var whenNotNull = (BoundExpression)this.Visit(node.WhenNotNull);
+            var whenNullOpt = (BoundExpression?)this.Visit(node.WhenNullOpt);
             TypeSymbol type = this.VisitType(node.Type);
             return node.Update(receiver, VisitMethodSymbol(node.HasValueMethodOpt), whenNotNull, whenNullOpt, node.Id, type);
         }
 
-        protected MethodSymbol VisitMethodSymbol(MethodSymbol method)
+        [return: NotNullIfNotNull("method")]
+        protected MethodSymbol? VisitMethodSymbol(MethodSymbol? method)
         {
-            if ((object)method == null)
+            if (method is null)
             {
                 return null;
             }
@@ -562,9 +560,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private PropertySymbol VisitPropertySymbol(PropertySymbol property)
+        [return: NotNullIfNotNull("property")]
+        private PropertySymbol? VisitPropertySymbol(PropertySymbol? property)
         {
-            if ((object)property == null)
+            if (property is null)
             {
                 return null;
             }
@@ -610,6 +609,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbol receiverType = this.VisitType(node.ReceiverType);
 
             var member = node.MemberSymbol;
+            Debug.Assert(member is not null);
 
             switch (member.Kind)
             {
@@ -632,10 +632,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return node.Update(operand, method, type);
         }
 
-        private static bool BaseReferenceInReceiverWasRewritten(BoundExpression originalReceiver, BoundExpression rewrittenReceiver)
+        private static bool BaseReferenceInReceiverWasRewritten([NotNullWhen(true)] BoundExpression? originalReceiver, [NotNullWhen(true)] BoundExpression? rewrittenReceiver)
         {
-            return originalReceiver != null && originalReceiver.Kind == BoundKind.BaseReference &&
-                   rewrittenReceiver != null && rewrittenReceiver.Kind != BoundKind.BaseReference;
+            return originalReceiver is { Kind: BoundKind.BaseReference } &&
+                   rewrittenReceiver is { Kind: not BoundKind.BaseReference };
         }
 
         /// <summary>
@@ -651,12 +651,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(ReferenceEquals(methodBeingWrapped, methodBeingWrapped.ConstructedFrom));
                 Debug.Assert(!methodBeingWrapped.IsStatic);
 
-                TypeMap typeMap = null;
+                TypeMap? typeMap = methodBeingWrapped.ContainingType is SubstitutedNamedTypeSymbol substitutedType ? substitutedType.TypeSubstitution : TypeMap.Empty;
+
                 ImmutableArray<TypeParameterSymbol> typeParameters;
-
-                var substitutedType = methodBeingWrapped.ContainingType as SubstitutedNamedTypeSymbol;
-                typeMap = ((object)substitutedType == null ? TypeMap.Empty : substitutedType.TypeSubstitution);
-
                 if (!methodBeingWrapped.IsGenericMethod)
                 {
                     typeParameters = ImmutableArray<TypeParameterSymbol>.Empty;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -6002,5 +6002,662 @@ public class C
     }
 ");
         }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_01()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        private readonly struct Wrapper<T>
+        {
+            public static bool operator ==(T t, Wrapper<T> wrapper)
+            {
+                Console.WriteLine(t.ToString());
+                return true;
+            }
+
+            public static bool operator !=(T t, Wrapper<T> wrapper) => false;
+        }
+
+        static void Main()
+        {
+            GenericMethod(""Run"");
+        }
+
+        private static void GenericMethod<T>(T t) where T : class
+        {
+            Func<Expression<Func<T, Wrapper<T>, bool>>> func = () => (x, y) => x == y;
+
+            func().Compile()(t, default);
+        }
+    }
+}";
+
+            var verifier = CompileAndVerify(code, expectedOutput: "Run");
+            verifier.VerifyDiagnostics(
+                // (9,33): warning CS0660: 'Program.Wrapper<T>' defines operator == or operator != but does not override Object.Equals(object o)
+                //         private readonly struct Wrapper<T>
+                Diagnostic(ErrorCode.WRN_EqualityOpWithoutEquals, "Wrapper").WithArguments("BadImageFormatExceptionRepro.Program.Wrapper<T>").WithLocation(9, 33),
+                // (9,33): warning CS0661: 'Program.Wrapper<T>' defines operator == or operator != but does not override Object.GetHashCode()
+                //         private readonly struct Wrapper<T>
+                Diagnostic(ErrorCode.WRN_EqualityOpWithoutGetHashCode, "Wrapper").WithArguments("BadImageFormatExceptionRepro.Program.Wrapper<T>").WithLocation(9, 33)
+            );
+            verifier.VerifyIL("BadImageFormatExceptionRepro.Program.<>c__2<T>.<GenericMethod>b__2_0()", @"
+{
+  // Code size       90 (0x5a)
+  .maxstack  5
+  .locals init (System.Linq.Expressions.ParameterExpression V_0,
+                System.Linq.Expressions.ParameterExpression V_1)
+  IL_0000:  ldtoken    ""T""
+  IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_000a:  ldstr      ""x""
+  IL_000f:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0014:  stloc.0
+  IL_0015:  ldtoken    ""BadImageFormatExceptionRepro.Program.Wrapper<T>""
+  IL_001a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_001f:  ldstr      ""y""
+  IL_0024:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0029:  stloc.1
+  IL_002a:  ldloc.0
+  IL_002b:  ldloc.1
+  IL_002c:  ldc.i4.0
+  IL_002d:  ldtoken    ""bool BadImageFormatExceptionRepro.Program.Wrapper<T>.op_Equality(T, BadImageFormatExceptionRepro.Program.Wrapper<T>)""
+  IL_0032:  ldtoken    ""BadImageFormatExceptionRepro.Program.Wrapper<T>""
+  IL_0037:  call       ""System.Reflection.MethodBase System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle)""
+  IL_003c:  castclass  ""System.Reflection.MethodInfo""
+  IL_0041:  call       ""System.Linq.Expressions.BinaryExpression System.Linq.Expressions.Expression.Equal(System.Linq.Expressions.Expression, System.Linq.Expressions.Expression, bool, System.Reflection.MethodInfo)""
+  IL_0046:  ldc.i4.2
+  IL_0047:  newarr     ""System.Linq.Expressions.ParameterExpression""
+  IL_004c:  dup
+  IL_004d:  ldc.i4.0
+  IL_004e:  ldloc.0
+  IL_004f:  stelem.ref
+  IL_0050:  dup
+  IL_0051:  ldc.i4.1
+  IL_0052:  ldloc.1
+  IL_0053:  stelem.ref
+  IL_0054:  call       ""System.Linq.Expressions.Expression<System.Func<T, BadImageFormatExceptionRepro.Program.Wrapper<T>, bool>> System.Linq.Expressions.Expression.Lambda<System.Func<T, BadImageFormatExceptionRepro.Program.Wrapper<T>, bool>>(System.Linq.Expressions.Expression, params System.Linq.Expressions.ParameterExpression[])""
+  IL_0059:  ret
+}");
+        }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_02()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        private readonly struct Wrapper<T>
+        {
+            public static Wrapper<T> operator +(Wrapper<T> wrapper)
+            {
+                Console.WriteLine(""Run"");
+                return wrapper;
+            }
+        }
+
+        static void Main()
+        {
+            GenericMethod<string>();
+        }
+
+        private static void GenericMethod<T>() where T : class
+        {
+            Func<Expression<Func<Wrapper<T>, Wrapper<T>>>> func = () => (x) => +x;
+
+            func().Compile()(default);
+        }
+    }
+}";
+
+            var verifier = CompileAndVerify(code, expectedOutput: "Run");
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("BadImageFormatExceptionRepro.Program.<>c__2<T>.<GenericMethod>b__2_0()", @"
+{
+  // Code size       63 (0x3f)
+  .maxstack  5
+  .locals init (System.Linq.Expressions.ParameterExpression V_0)
+  IL_0000:  ldtoken    ""BadImageFormatExceptionRepro.Program.Wrapper<T>""
+  IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_000a:  ldstr      ""x""
+  IL_000f:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0014:  stloc.0
+  IL_0015:  ldloc.0
+  IL_0016:  ldtoken    ""BadImageFormatExceptionRepro.Program.Wrapper<T> BadImageFormatExceptionRepro.Program.Wrapper<T>.op_UnaryPlus(BadImageFormatExceptionRepro.Program.Wrapper<T>)""
+  IL_001b:  ldtoken    ""BadImageFormatExceptionRepro.Program.Wrapper<T>""
+  IL_0020:  call       ""System.Reflection.MethodBase System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle)""
+  IL_0025:  castclass  ""System.Reflection.MethodInfo""
+  IL_002a:  call       ""System.Linq.Expressions.UnaryExpression System.Linq.Expressions.Expression.UnaryPlus(System.Linq.Expressions.Expression, System.Reflection.MethodInfo)""
+  IL_002f:  ldc.i4.1
+  IL_0030:  newarr     ""System.Linq.Expressions.ParameterExpression""
+  IL_0035:  dup
+  IL_0036:  ldc.i4.0
+  IL_0037:  ldloc.0
+  IL_0038:  stelem.ref
+  IL_0039:  call       ""System.Linq.Expressions.Expression<System.Func<BadImageFormatExceptionRepro.Program.Wrapper<T>, BadImageFormatExceptionRepro.Program.Wrapper<T>>> System.Linq.Expressions.Expression.Lambda<System.Func<BadImageFormatExceptionRepro.Program.Wrapper<T>, BadImageFormatExceptionRepro.Program.Wrapper<T>>>(System.Linq.Expressions.Expression, params System.Linq.Expressions.ParameterExpression[])""
+  IL_003e:  ret
+}");
+        }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_03()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        static void Main()
+        {
+            GenericMethod<C>();
+        }
+
+        private static void GenericMethod<T>() where T : I<T>
+        {
+            Func<Expression<Func<T, T, bool>>> func = () => (x, y) => x == y;
+
+            func();
+            Console.WriteLine(""Run"");
+        }
+    }
+
+    interface I<T> where T : I<T>
+    {
+        public static abstract bool operator==(T t1, T t2);
+        public static abstract bool operator!=(T t1, T t2);
+    }
+
+    class C : I<C>
+    {
+        public static bool operator ==(C c1, C c2) => true;
+        public static bool operator !=(C c1, C c2) => false;
+    }
+}";
+
+            var comp = CreateCompilation(code, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.Net60);
+            comp.VerifyDiagnostics(
+                // (16,71): error CS8927: An expression tree may not contain an access of static abstract interface member
+                //             Func<Expression<Func<T, T, bool>>> func = () => (x, y) => x == y;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsAbstractStaticMemberAccess, "x == y").WithLocation(16, 71),
+                // (29,11): warning CS0660: 'C' defines operator == or operator != but does not override Object.Equals(object o)
+                //     class C : I<C>
+                Diagnostic(ErrorCode.WRN_EqualityOpWithoutEquals, "C").WithArguments("BadImageFormatExceptionRepro.C").WithLocation(29, 11),
+                // (29,11): warning CS0661: 'C' defines operator == or operator != but does not override Object.GetHashCode()
+                //     class C : I<C>
+                Diagnostic(ErrorCode.WRN_EqualityOpWithoutGetHashCode, "C").WithArguments("BadImageFormatExceptionRepro.C").WithLocation(29, 11)
+            );
+        }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_04()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        static void Main()
+        {
+            GenericMethod<C>();
+        }
+
+        private static void GenericMethod<T>() where T : I<T>
+        {
+            Func<Expression<Func<T, T>>> func = () => (x) => +x;
+
+            func();
+            Console.WriteLine(""Run"");
+        }
+    }
+
+    interface I<T> where T : I<T>
+    {
+        public static abstract T operator+(T t);
+    }
+
+    class C : I<C>
+    {
+        public static C operator +(C c) => c;
+    }
+}";
+
+            var comp = CreateCompilation(code, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.Net60);
+            comp.VerifyDiagnostics(
+                // (16,62): error CS8927: An expression tree may not contain an access of static abstract interface member
+                //             Func<Expression<Func<T, T>>> func = () => (x) => +x;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsAbstractStaticMemberAccess, "+x").WithLocation(16, 62)
+            );
+        }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_05()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        static void Main()
+        {
+            GenericMethod(""Run"");
+        }
+
+        private static void GenericMethod<T>(T t)
+        {
+            Func<Expression<Func<T, C<T>>>> func = () => x => x;
+
+            func().Compile()(t);
+        }
+    }
+
+    class C<T>
+    {
+        public static implicit operator C<T>(T t)
+        {
+            Console.WriteLine(t);
+            return default;
+        }
+    }
+}
+";
+
+            var verifier = CompileAndVerify(code, expectedOutput: "Run");
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("BadImageFormatExceptionRepro.Program.<>c__1<T>.<GenericMethod>b__1_0()", @"
+{
+  // Code size       73 (0x49)
+  .maxstack  5
+  .locals init (System.Linq.Expressions.ParameterExpression V_0)
+  IL_0000:  ldtoken    ""T""
+  IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_000a:  ldstr      ""x""
+  IL_000f:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0014:  stloc.0
+  IL_0015:  ldloc.0
+  IL_0016:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_001b:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0020:  ldtoken    ""BadImageFormatExceptionRepro.C<T> BadImageFormatExceptionRepro.C<T>.op_Implicit(T)""
+  IL_0025:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_002a:  call       ""System.Reflection.MethodBase System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle)""
+  IL_002f:  castclass  ""System.Reflection.MethodInfo""
+  IL_0034:  call       ""System.Linq.Expressions.UnaryExpression System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type, System.Reflection.MethodInfo)""
+  IL_0039:  ldc.i4.1
+  IL_003a:  newarr     ""System.Linq.Expressions.ParameterExpression""
+  IL_003f:  dup
+  IL_0040:  ldc.i4.0
+  IL_0041:  ldloc.0
+  IL_0042:  stelem.ref
+  IL_0043:  call       ""System.Linq.Expressions.Expression<System.Func<T, BadImageFormatExceptionRepro.C<T>>> System.Linq.Expressions.Expression.Lambda<System.Func<T, BadImageFormatExceptionRepro.C<T>>>(System.Linq.Expressions.Expression, params System.Linq.Expressions.ParameterExpression[])""
+  IL_0048:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_06()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        static void Main()
+        {
+            GenericMethod(""Run"");
+        }
+
+        private static void GenericMethod<T>(T t)
+        {
+            Func<Expression<Func<T, C<T>>>> func = () => x => (C<T>)x;
+
+            func().Compile()(t);
+        }
+    }
+
+    class C<T>
+    {
+        public static explicit operator C<T>(T t)
+        {
+            Console.WriteLine(t);
+            return default;
+        }
+    }
+}
+";
+
+            var verifier = CompileAndVerify(code, expectedOutput: "Run");
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("BadImageFormatExceptionRepro.Program.<>c__1<T>.<GenericMethod>b__1_0()", @"
+{
+  // Code size       73 (0x49)
+  .maxstack  5
+  .locals init (System.Linq.Expressions.ParameterExpression V_0)
+  IL_0000:  ldtoken    ""T""
+  IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_000a:  ldstr      ""x""
+  IL_000f:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0014:  stloc.0
+  IL_0015:  ldloc.0
+  IL_0016:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_001b:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0020:  ldtoken    ""BadImageFormatExceptionRepro.C<T> BadImageFormatExceptionRepro.C<T>.op_Explicit(T)""
+  IL_0025:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_002a:  call       ""System.Reflection.MethodBase System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle)""
+  IL_002f:  castclass  ""System.Reflection.MethodInfo""
+  IL_0034:  call       ""System.Linq.Expressions.UnaryExpression System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, System.Type, System.Reflection.MethodInfo)""
+  IL_0039:  ldc.i4.1
+  IL_003a:  newarr     ""System.Linq.Expressions.ParameterExpression""
+  IL_003f:  dup
+  IL_0040:  ldc.i4.0
+  IL_0041:  ldloc.0
+  IL_0042:  stelem.ref
+  IL_0043:  call       ""System.Linq.Expressions.Expression<System.Func<T, BadImageFormatExceptionRepro.C<T>>> System.Linq.Expressions.Expression.Lambda<System.Func<T, BadImageFormatExceptionRepro.C<T>>>(System.Linq.Expressions.Expression, params System.Linq.Expressions.ParameterExpression[])""
+  IL_0048:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_07()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        static void Main()
+        {
+            GenericMethod<string>();
+        }
+
+        private static void GenericMethod<T>()
+        {
+            Func<Expression<Func<C<T>, C<T>, C<T>>>> func = () => (x, y) => x && y;
+
+            func().Compile()(default, default);
+        }
+    }
+
+    class C<T>
+    {
+        public static bool operator false(C<T> c)
+        {
+            Console.Write(""1"");
+            return false;
+        }
+        public static bool operator true(C<T> c) => false;
+        public static C<T> operator &(C<T> c1, C<T> c2)
+        {
+            Console.Write(""2"");
+            return c1;
+        }
+    }
+}
+";
+
+            var verifier = CompileAndVerify(code, expectedOutput: "12");
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("BadImageFormatExceptionRepro.Program.<>c__1<T>.<GenericMethod>b__1_0()", @"
+{
+  // Code size       89 (0x59)
+  .maxstack  5
+  .locals init (System.Linq.Expressions.ParameterExpression V_0,
+                System.Linq.Expressions.ParameterExpression V_1)
+  IL_0000:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_000a:  ldstr      ""x""
+  IL_000f:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0014:  stloc.0
+  IL_0015:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_001a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_001f:  ldstr      ""y""
+  IL_0024:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0029:  stloc.1
+  IL_002a:  ldloc.0
+  IL_002b:  ldloc.1
+  IL_002c:  ldtoken    ""BadImageFormatExceptionRepro.C<T> BadImageFormatExceptionRepro.C<T>.op_BitwiseAnd(BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>)""
+  IL_0031:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_0036:  call       ""System.Reflection.MethodBase System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle)""
+  IL_003b:  castclass  ""System.Reflection.MethodInfo""
+  IL_0040:  call       ""System.Linq.Expressions.BinaryExpression System.Linq.Expressions.Expression.AndAlso(System.Linq.Expressions.Expression, System.Linq.Expressions.Expression, System.Reflection.MethodInfo)""
+  IL_0045:  ldc.i4.2
+  IL_0046:  newarr     ""System.Linq.Expressions.ParameterExpression""
+  IL_004b:  dup
+  IL_004c:  ldc.i4.0
+  IL_004d:  ldloc.0
+  IL_004e:  stelem.ref
+  IL_004f:  dup
+  IL_0050:  ldc.i4.1
+  IL_0051:  ldloc.1
+  IL_0052:  stelem.ref
+  IL_0053:  call       ""System.Linq.Expressions.Expression<System.Func<BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>>> System.Linq.Expressions.Expression.Lambda<System.Func<BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>>>(System.Linq.Expressions.Expression, params System.Linq.Expressions.ParameterExpression[])""
+  IL_0058:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_08()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        static void Main()
+        {
+            GenericMethod<string>();
+        }
+
+        private static void GenericMethod<T>()
+        {
+            Func<Expression<Func<C<T>, C<T>, C<T>>>> func = () => (x, y) => x || y;
+
+            func().Compile()(default, default);
+        }
+    }
+
+    class C<T>
+    {
+        public static bool operator true(C<T> c)
+        {
+            Console.Write(""1"");
+            return false;
+        }
+        public static bool operator false(C<T> c) => false;
+        public static C<T> operator |(C<T> c1, C<T> c2)
+        {
+            Console.Write(""2"");
+            return c1;
+        }
+    }
+}
+";
+
+            var verifier = CompileAndVerify(code, expectedOutput: "12");
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("BadImageFormatExceptionRepro.Program.<>c__1<T>.<GenericMethod>b__1_0()", @"
+{
+  // Code size       89 (0x59)
+  .maxstack  5
+  .locals init (System.Linq.Expressions.ParameterExpression V_0,
+                System.Linq.Expressions.ParameterExpression V_1)
+  IL_0000:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_000a:  ldstr      ""x""
+  IL_000f:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0014:  stloc.0
+  IL_0015:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_001a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_001f:  ldstr      ""y""
+  IL_0024:  call       ""System.Linq.Expressions.ParameterExpression System.Linq.Expressions.Expression.Parameter(System.Type, string)""
+  IL_0029:  stloc.1
+  IL_002a:  ldloc.0
+  IL_002b:  ldloc.1
+  IL_002c:  ldtoken    ""BadImageFormatExceptionRepro.C<T> BadImageFormatExceptionRepro.C<T>.op_BitwiseOr(BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>)""
+  IL_0031:  ldtoken    ""BadImageFormatExceptionRepro.C<T>""
+  IL_0036:  call       ""System.Reflection.MethodBase System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle)""
+  IL_003b:  castclass  ""System.Reflection.MethodInfo""
+  IL_0040:  call       ""System.Linq.Expressions.BinaryExpression System.Linq.Expressions.Expression.OrElse(System.Linq.Expressions.Expression, System.Linq.Expressions.Expression, System.Reflection.MethodInfo)""
+  IL_0045:  ldc.i4.2
+  IL_0046:  newarr     ""System.Linq.Expressions.ParameterExpression""
+  IL_004b:  dup
+  IL_004c:  ldc.i4.0
+  IL_004d:  ldloc.0
+  IL_004e:  stelem.ref
+  IL_004f:  dup
+  IL_0050:  ldc.i4.1
+  IL_0051:  ldloc.1
+  IL_0052:  stelem.ref
+  IL_0053:  call       ""System.Linq.Expressions.Expression<System.Func<BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>>> System.Linq.Expressions.Expression.Lambda<System.Func<BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>, BadImageFormatExceptionRepro.C<T>>>(System.Linq.Expressions.Expression, params System.Linq.Expressions.ParameterExpression[])""
+  IL_0058:  ret
+}
+");
+        }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_09()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        static void Main()
+        {
+            GenericMethod<C>();
+        }
+
+        private static void GenericMethod<T>() where T : I<T>
+        {
+            Func<Expression<Func<T, T, T>>> func = () => (x, y) => x && y;
+
+            func().Compile()(default, default);
+        }
+    }
+
+    public interface I<T> where T : I<T>
+    {
+        public static abstract bool operator true(T t);
+        public static abstract bool operator false(T t);
+        public static abstract T operator &(T t1, T t2);
+    }
+
+    class C : I<C>
+    {
+        public static bool operator false(C c)
+        {
+            Console.Write(""1"");
+            return false;
+        }
+        public static bool operator true(C c) => false;
+        public static C operator &(C c1, C c2)
+        {
+            Console.Write(""2"");
+            return c1;
+        }
+    }
+}
+";
+
+            var comp = CreateCompilation(code, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.Net60);
+            comp.VerifyDiagnostics(
+                // (16,68): error CS8927: An expression tree may not contain an access of static abstract interface member
+                //             Func<Expression<Func<T, T, T>>> func = () => (x, y) => x && y;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsAbstractStaticMemberAccess, "x && y").WithLocation(16, 68)
+            );
+        }
+
+        [Fact, WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")]
+        public void UserDefinedOperatorInGenericExpressionTree_10()
+        {
+            var code = @"
+using System;
+using System.Linq.Expressions;
+
+namespace BadImageFormatExceptionRepro
+{
+    class Program
+    {
+        static void Main()
+        {
+            GenericMethod<C>();
+        }
+
+        private static void GenericMethod<T>() where T : I<T>
+        {
+            Func<Expression<Func<T, T, T>>> func = () => (x, y) => x || y;
+
+            func().Compile()(default, default);
+        }
+    }
+
+    public interface I<T> where T : I<T>
+    {
+        public static abstract bool operator true(T t);
+        public static abstract bool operator false(T t);
+        public static abstract T operator |(T t1, T t2);
+    }
+
+    class C : I<C>
+    {
+        public static bool operator true(C c)
+        {
+            Console.Write(""1"");
+            return false;
+        }
+        public static bool operator false(C c) => false;
+        public static C operator |(C c1, C c2)
+        {
+            Console.Write(""2"");
+            return c1;
+        }
+    }
+}
+";
+
+            var comp = CreateCompilation(code, parseOptions: TestOptions.RegularPreview, targetFramework: TargetFramework.Net60);
+            comp.VerifyDiagnostics(
+                // (16,68): error CS8927: An expression tree may not contain an access of static abstract interface member
+                //             Func<Expression<Func<T, T, T>>> func = () => (x, y) => x || y;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsAbstractStaticMemberAccess, "x || y").WithLocation(16, 68)
+            );
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundUserDefinedUnaryOperator.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundUserDefinedUnaryOperator.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #If DEBUG Then
         Private Sub Validate()
-            Debug.Assert(Type Is UnderlyingExpression.Type)
+            Debug.Assert(TypeSymbol.Equals(Type, UnderlyingExpression.Type, TypeCompareKind.ConsiderEverything))
             Debug.Assert((OperatorKind And UnaryOperatorKind.UserDefined) <> 0)
             Debug.Assert(UnderlyingExpression.Kind = BoundKind.BadExpression OrElse UnderlyingExpression.Kind = BoundKind.Call)
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/UserDefinedConversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/UserDefinedConversions.vb
@@ -4540,6 +4540,84 @@ BC42106: Operator 'CType' doesn't return a value on all code paths. A null refer
 </expected>)
         End Sub
 
+        <WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")>
+        <Fact>
+        Public Sub UserDefinedConversionOperatorInGenericExpressionTree_01()
+            Dim compilationDef =
+<compilation name="OperatorsWithDefaultValuesAreNotBound">
+    <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Linq.Expressions
+Public Class Program
+    Public Shared Sub Main()
+        GenericMethod(Of String)()
+    End Sub
+    
+    Private Shared Sub GenericMethod(Of T)()
+        Dim func As Func(Of Expression(Of Func(Of T, C(Of T)))) =
+            Function ()
+                Return Function(x) x 
+            End Function
+            
+        func().Compile()(Nothing)
+    End Sub
+End Class
+
+Class C(Of T)
+    Public Shared Widening Operator CType(t1 As T) As C(Of T)
+        Console.Write("Run")
+        Return Nothing 
+    End Operator
+End Class
+    ]]></file>
+</compilation>
+
+            Dim compilation = CreateCompilation(compilationDef, options:=TestOptions.ReleaseExe)
+
+            compilation.AssertTheseDiagnostics()
+
+            CompileAndVerify(compilation, expectedOutput:="Run")
+        End Sub
+
+        <WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")>
+        <Fact>
+        Public Sub UserDefinedConversionOperatorInGenericExpressionTree_02()
+            Dim compilationDef =
+<compilation name="OperatorsWithDefaultValuesAreNotBound">
+    <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Linq.Expressions
+Public Class Program
+    Public Shared Sub Main()
+        GenericMethod(Of String)()
+    End Sub
+    
+    Private Shared Sub GenericMethod(Of T)()
+        Dim func As Func(Of Expression(Of Func(Of T, C(Of T)))) =
+            Function ()
+                Return Function(x) CType(x, C(Of T))
+            End Function
+            
+        func().Compile()(Nothing)
+    End Sub
+End Class
+
+Class C(Of T)
+    Public Shared Narrowing Operator CType(t1 As T) As C(Of T)
+        Console.Write("Run")
+        Return Nothing 
+    End Operator
+End Class
+    ]]></file>
+</compilation>
+
+            Dim compilation = CreateCompilation(compilationDef, options:=TestOptions.ReleaseExe)
+
+            compilation.AssertTheseDiagnostics()
+
+            CompileAndVerify(compilation, expectedOutput:="Run")
+        End Sub
+
 #End Region
     End Class
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/UserDefinedUnaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/UserDefinedUnaryOperators.vb
@@ -736,6 +736,45 @@ S4_TakeWhileBaseClass S4_Select
 
         End Sub
 
+        <WorkItem(56376, "https://github.com/dotnet/roslyn/issues/56376")>
+        <Fact>
+        Public Sub UserDefinedUnaryOperatorInGenericExpressionTree()
+            Dim compilationDef =
+<compilation name="OperatorsWithDefaultValuesAreNotBound">
+    <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Linq.Expressions
+Public Class Program
+    Public Shared Sub Main()
+        GenericMethod(Of String)()
+    End Sub
+    
+    Private Shared Sub GenericMethod(Of T)()
+        Dim func As Func(Of Expression(Of Func(Of C(Of T), C(Of T)))) =
+            Function ()
+                Return Function(x) +x 
+            End Function
+            
+        func().Compile()(Nothing)
+    End Sub
+End Class
+
+Class C(Of T)
+    Public Shared Operator +(c1 As C(Of T)) As C(Of T)
+        Console.Write("Run")
+        Return c1
+    End Operator
+End Class
+    ]]></file>
+</compilation>
+
+            Dim compilation = CreateCompilation(compilationDef, options:=TestOptions.ReleaseExe)
+
+            compilation.AssertTheseDiagnostics()
+
+            CompileAndVerify(compilation, expectedOutput:="Run")
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Currently, we're not handling binary operators in the MethodToClass rewriter, which causes user-defined operators to be missed when we lift things to closures. Fixes https://github.com/dotnet/roslyn/issues/56376. Recommend reviewing each commit separately: commit 1 nullable-enables MethodToClassRewriter, and commit 2 actually fixes the bug.