### PR TITLE
Log gold bars to the activity log

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/CommandHandlers/RenameCommandHandler.cs
@@ -114,6 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                 errorReportingService.ShowGlobalErrorInfo(
                     string.Format(EditorFeaturesWpfResources.Error_performing_rename_0, ex.Message),
+                    ex,
                     new InfoBarUI(
                         WorkspacesResources.Show_Stack_Trace,
                         InfoBarUI.UIKind.HyperLink,

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -353,6 +353,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                 errorReportingService.ShowGlobalErrorInfo(
                     string.Format(EditorFeaturesWpfResources.Error_performing_rename_0, ex.Message),
+                    ex,
                     new InfoBarUI(
                         WorkspacesResources.Show_Stack_Trace,
                         InfoBarUI.UIKind.HyperLink,

--- a/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
+++ b/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
@@ -74,7 +74,8 @@ namespace Microsoft.CodeAnalysis.Editor
                     {
                         base.HandleException(provider, exception);
 
-                        _errorReportingService?.ShowGlobalErrorInfo(String.Format(WorkspacesResources._0_encountered_an_error_and_has_been_disabled, provider.GetType().Name),
+                        _errorReportingService?.ShowGlobalErrorInfo(string.Format(WorkspacesResources._0_encountered_an_error_and_has_been_disabled, provider.GetType().Name),
+                            exception,
                             new InfoBarUI(WorkspacesResources.Show_Stack_Trace, InfoBarUI.UIKind.HyperLink, () => ShowDetailedErrorInfo(exception), closeAfterAction: false),
                             new InfoBarUI(WorkspacesResources.Enable, InfoBarUI.UIKind.Button, () =>
                             {

--- a/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
         public void ShowDetailedErrorInfo(Exception exception)
             => Logger.Log(FunctionId.Extension_Exception, exception.StackTrace);
 
-        public void ShowGlobalErrorInfo(string message, params InfoBarUI[] items)
+        public void ShowGlobalErrorInfo(string message, Exception? exception, params InfoBarUI[] items)
             => Logger.Log(FunctionId.Extension_Exception, message);
 
         public void ShowFeatureNotAvailableErrorInfo(string message, Exception? exception)

--- a/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
@@ -313,6 +313,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
                     errorReportingService.ShowGlobalErrorInfo(
                         message,
+                        ex,
                         new InfoBarUI(
                             WorkspacesResources.Show_Stack_Trace,
                             InfoBarUI.UIKind.HyperLink,

--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioSuppressionFixServiceAccessor.cs
@@ -43,6 +43,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis
             {
                 errorReportingService.ShowGlobalErrorInfo(
                     string.Format(ServicesVSResources.Error_updating_suppressions_0, ex.Message),
+                    ex,
                     new InfoBarUI(
                         WorkspacesResources.Show_Stack_Trace,
                         InfoBarUI.UIKind.HyperLink,
@@ -63,6 +64,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis
             {
                 errorReportingService.ShowGlobalErrorInfo(
                     string.Format(ServicesVSResources.Error_updating_suppressions_0, ex.Message),
+                    ex,
                     new InfoBarUI(
                         WorkspacesResources.Show_Stack_Trace,
                         InfoBarUI.UIKind.HyperLink,
@@ -83,6 +85,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis
             {
                 errorReportingService.ShowGlobalErrorInfo(
                     string.Format(ServicesVSResources.Error_updating_suppressions_0, ex.Message),
+                    ex,
                     new InfoBarUI(
                         WorkspacesResources.Show_Stack_Trace,
                         InfoBarUI.UIKind.HyperLink,

--- a/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
@@ -153,6 +153,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             // Show info bar.
             _workspace.Services.GetRequiredService<IErrorReportingService>()
                 .ShowGlobalErrorInfo(ServicesVSResources.Visual_Studio_has_suspended_some_advanced_features_to_improve_performance,
+                    exception: null,
                     new InfoBarUI(ServicesVSResources.Re_enable, InfoBarUI.UIKind.Button, RenableBackgroundAnalysis),
                     new InfoBarUI(ServicesVSResources.Learn_more, InfoBarUI.UIKind.HyperLink,
                         () => VisualStudioNavigateToLinkService.StartBrowser(new Uri(LowVMMoreInfoLink)), closeAfterAction: false));

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
@@ -5,22 +5,40 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
     internal partial class VisualStudioErrorReportingService : IErrorReportingService
     {
+        private readonly IThreadingContext _threadingContext;
+        private readonly IAsynchronousOperationListener _listener;
         private readonly IInfoBarService _infoBarService;
+        private readonly SVsServiceProvider _serviceProvider;
 
-        public VisualStudioErrorReportingService(IInfoBarService infoBarService)
-            => _infoBarService = infoBarService;
+        public VisualStudioErrorReportingService(
+            IThreadingContext threadingContext,
+            IAsynchronousOperationListenerProvider listenerProvider,
+            IInfoBarService infoBarService,
+            SVsServiceProvider serviceProvider)
+        {
+            _threadingContext = threadingContext;
+            _listener = listenerProvider.GetListener(FeatureAttribute.Workspace);
+            _infoBarService = infoBarService;
+            _serviceProvider = serviceProvider;
+        }
 
         public string HostDisplayName => "Visual Studio";
 
-        public void ShowGlobalErrorInfo(string message, params InfoBarUI[] items)
+        public void ShowGlobalErrorInfo(string message, Exception? exception, params InfoBarUI[] items)
         {
+            var detailedMessage = exception is null ? "" : GetFormattedExceptionStack(exception);
+            LogGlobalErrorToActivityLog(message, detailedMessage);
             _infoBarService.ShowInfoBar(message, items);
 
             // Have to use KeyValueLogMessage so it gets reported in telemetry
@@ -46,7 +64,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     closeAfterAction: true));
             }
 
-            ShowGlobalErrorInfo(message, infoBarUIs.ToArray());
+            ShowGlobalErrorInfo(message, exception, infoBarUIs.ToArray());
+        }
+
+        private void LogGlobalErrorToActivityLog(string message, string? detailedError)
+        {
+            _ = _threadingContext.JoinableTaskFactory.RunAsync(async () =>
+            {
+                using var _ = _listener.BeginAsyncOperation(nameof(LogGlobalErrorToActivityLog));
+
+                await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(_threadingContext.DisposalToken);
+
+                var activityLog = await ((IAsyncServiceProvider)_serviceProvider).GetServiceAsync<SVsActivityLog, IVsActivityLog>().ConfigureAwait(true);
+                activityLog.LogEntry(
+                    (uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR,
+                    nameof(VisualStudioErrorReportingService),
+                    string.Join(Environment.NewLine, message, detailedError));
+            });
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingServiceFactory.cs
@@ -2,32 +2,47 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
     [ExportWorkspaceServiceFactory(typeof(IErrorReportingService), ServiceLayer.Host), Shared]
     internal sealed class VisualStudioErrorReportingServiceFactory : IWorkspaceServiceFactory
     {
-        private IErrorReportingService _singleton;
+        private readonly IThreadingContext _threadingContext;
+        private readonly IAsynchronousOperationListenerProvider _listenerProvider;
+        private readonly SVsServiceProvider _serviceProvider;
+
+        private IErrorReportingService? _singleton;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VisualStudioErrorReportingServiceFactory()
+        public VisualStudioErrorReportingServiceFactory(
+            IThreadingContext threadingContext,
+            IAsynchronousOperationListenerProvider listenerProvider,
+            SVsServiceProvider serviceProvider)
         {
+            _threadingContext = threadingContext;
+            _listenerProvider = listenerProvider;
+            _serviceProvider = serviceProvider;
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
             if (_singleton == null)
             {
-                _singleton = new VisualStudioErrorReportingService(workspaceServices.GetRequiredService<IInfoBarService>());
+                _singleton = new VisualStudioErrorReportingService(
+                    _threadingContext,
+                    _listenerProvider,
+                    workspaceServices.GetRequiredService<IInfoBarService>(),
+                    _serviceProvider);
             }
 
             return _singleton;

--- a/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Extensions
         /// this kind error info should be something that affects whole roslyn such as
         /// background compilation is disabled due to memory issue and etc
         /// </summary>
-        void ShowGlobalErrorInfo(string message, params InfoBarUI[] items);
+        void ShowGlobalErrorInfo(string message, Exception? exception, params InfoBarUI[] items);
 
         void ShowDetailedErrorInfo(Exception exception);
 

--- a/src/Workspaces/CoreTestUtilities/TestErrorReportingService.cs
+++ b/src/Workspaces/CoreTestUtilities/TestErrorReportingService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public void ShowDetailedErrorInfo(Exception exception)
             => OnError(exception.Message);
 
-        public void ShowGlobalErrorInfo(string message, params InfoBarUI[] items)
+        public void ShowGlobalErrorInfo(string message, Exception? exception, params InfoBarUI[] items)
             => OnError(message);
 
         public void ShowFeatureNotAvailableErrorInfo(string message, Exception? exception)


### PR DESCRIPTION
This will help with feedback investigations, since the stack trace will now always be available.