### PR TITLE
Don't inline lightbulb actions if the total count would be too high

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -192,13 +192,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     return ConvertToSuggestedActionSets(
                         state, selection,
                         fixesTask.WaitAndGetResult(cancellationToken),
-                        refactoringsTask.WaitAndGetResult(cancellationToken));
+                        refactoringsTask.WaitAndGetResult(cancellationToken),
+                        currentActionCount: 0);
                 }
             }
 
-            protected IEnumerable<SuggestedActionSet> ConvertToSuggestedActionSets(ReferenceCountedDisposable<State> state, TextSpan? selection, ImmutableArray<UnifiedSuggestedActionSet> fixes, ImmutableArray<UnifiedSuggestedActionSet> refactorings)
+            protected IEnumerable<SuggestedActionSet> ConvertToSuggestedActionSets(
+                ReferenceCountedDisposable<State> state,
+                TextSpan? selection,
+                ImmutableArray<UnifiedSuggestedActionSet> fixes,
+                ImmutableArray<UnifiedSuggestedActionSet> refactorings,
+                int currentActionCount)
             {
-                var filteredSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(fixes, refactorings, selection);
+                var filteredSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(fixes, refactorings, selection, currentActionCount);
                 return filteredSets.SelectAsArray(s => ConvertToSuggestedActionSet(s, state.Target.Owner, state.Target.SubjectBuffer)).WhereNotNull();
             }
 

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
@@ -233,7 +233,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
                 document.Project.Solution.Workspace, codeRefactoringService, document, textSpan, CodeActionRequestPriority.None, isBlocking: false,
                 addOperationScope: _ => null, filterOutsideSelection: false, cancellationToken).ConfigureAwait(false);
 
-            var actionSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(codeFixes, codeRefactorings, textSpan);
+            var actionSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(
+                codeFixes, codeRefactorings, textSpan, currentActionCount: 0);
             return actionSets;
         }
 

--- a/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -593,15 +593,15 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             => new(set.CategoryName, set.Actions, set.Title, priority, set.ApplicableToSpan);
 
         private static ImmutableArray<UnifiedSuggestedActionSet> InlineActionSetsIfDesirable(
-            ImmutableArray<UnifiedSuggestedActionSet> allActionSets,
+            ImmutableArray<UnifiedSuggestedActionSet> actionSets,
             int currentActionCount)
         {
             // If we only have a single set of items, and that set only has three max suggestion
             // offered. Then we can consider inlining any nested actions into the top level list.
             // (but we only do this if the parent of the nested actions isn't invokable itself).
-            return currentActionCount + allActionSets.Sum(a => a.Actions.Count()) > 3
-                ? allActionSets
-                : allActionSets.SelectAsArray(InlineActions);
+            return currentActionCount + actionSets.Sum(a => a.Actions.Count()) > 3
+                ? actionSets
+                : actionSets.SelectAsArray(InlineActions);
         }
 
         private static UnifiedSuggestedActionSet InlineActions(UnifiedSuggestedActionSet actionSet)

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -464,6 +464,7 @@ public class P2 { }");
             {
                 "using System.IO;",
                 "Rename 'P2' to 'Stream'",
+                "Generate type 'Foober'",
                 "System.IO.Stream",
                 "Generate class 'Stream' in new file",
                 "Generate class 'Stream'",

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -464,7 +464,6 @@ public class P2 { }");
             {
                 "using System.IO;",
                 "Rename 'P2' to 'Stream'",
-                "Generate type 'Foober'",
                 "System.IO.Stream",
                 "Generate class 'Stream' in new file",
                 "Generate class 'Stream'",
@@ -513,6 +512,7 @@ namespace NS
             {
                 "Rename 'P2' to 'Foober'",
                 "Goober - using N;",
+                "Generate type 'Foober'",
                 "Generate class 'Foober' in new file",
                 "Generate class 'Foober'",
                 "Generate nested class 'Foober'",


### PR DESCRIPTION
I found this while i was dogfooding async lightbulbs.  Something was often not feeling 'right', but i couldn't put my finger on it.  I eventually compared the lightbulb i was seeing with async lightbulbs with the normal sync lightbulbs.  It then hit me, the async lightbulb was showing *too many* items in the list***.  This was because it had chosen to inline nested actions to the top level, despite our heuristic that we shouldn't do that if it would make things too cluttered.

The problem here was that hte sync lightbulb had all the items to look out when making this decision.  However, the async lightbulb shows items for a particular priority group once it is complete, and when it inlines items it is only looking at the number of items in that priority class.

The simple fix here is to keep a running counter of how many items have been added in total, and use that to make a determination if a group should still inline items.  

--

*** In my case it was that "generate type" items were being inlined with async-lightbulbs when they hadn't been before.  This was adding a net 3 additional items to the list making it feel 'heavier' than normal.