### PR TITLE
Report UseSite diagnostics on user-defined conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -90,6 +90,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Obsolete diagnostics for method group are reported as part of creating the method group conversion.
             ReportDiagnosticsIfObsolete(diagnostics, conversion, syntax, hasBaseReceiver: false);
+            if (conversion.Method is not null)
+            {
+                ReportUseSite(conversion.Method, diagnostics, syntax.Location);
+            }
             CheckConstraintLanguageVersionAndRuntimeSupportForConversion(syntax, conversion, diagnostics);
 
             if (conversion.IsAnonymousFunction && source.Kind == BoundKind.UnboundLambda)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConversionTests.cs
@@ -1214,5 +1214,49 @@ class C
 ";
             CompileAndVerify(source).VerifyDiagnostics();
         }
+
+        [Fact]
+        [WorkItem(54113, "https://github.com/dotnet/roslyn/issues/54113")]
+        public void DisallowedModreqOnConversion()
+        {
+            var il = @"
+.class public auto ansi beforefieldinit C
+    extends [mscorlib]System.Object
+{
+    .method public hidebysig specialname static 
+        int32 modreq([mscorlib]System.Runtime.CompilerServices.OutAttribute) op_Implicit (
+            class C i
+        ) cil managed 
+    {
+        IL_0000: ldc.i4.0
+        IL_0001: ret
+    }
+
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor () cil managed 
+    {
+        IL_0000: ldarg.0
+        IL_0001: call instance void [mscorlib]System.Object::.ctor()
+        IL_0006: nop
+        IL_0007: ret
+    }
+}
+";
+            var comp = CreateCompilationWithIL(@"
+class Test
+{
+    void M(C x)
+    {
+        _ = (int)x;
+    }
+}
+", il);
+
+            comp.VerifyDiagnostics(
+                    // (6,13): error CS0570: 'C.implicit operator int(C)' is not supported by the language
+                    //         _ = (int)x;
+                    Diagnostic(ErrorCode.ERR_BindToBogus, "(int)x").WithArguments("C.implicit operator int(C)").WithLocation(6, 13)
+            );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
@@ -26661,7 +26661,10 @@ class Test
                 Diagnostic(ErrorCode.ERR_BindToBogus, "+x").WithArguments("I1.operator +(I1)").WithLocation(7, 13),
                 // (8,13): error CS0570: 'I1.operator +(I1, I1)' is not supported by the language
                 //         _ = x + y;
-                Diagnostic(ErrorCode.ERR_BindToBogus, "x + y").WithArguments("I1.operator +(I1, I1)").WithLocation(8, 13)
+                Diagnostic(ErrorCode.ERR_BindToBogus, "x + y").WithArguments("I1.operator +(I1, I1)").WithLocation(8, 13),
+                // (14,16): error CS0570: 'I2<T>.implicit operator int(T)' is not supported by the language
+                //         return x;
+                Diagnostic(ErrorCode.ERR_BindToBogus, "x").WithArguments("I2<T>.implicit operator int(T)").WithLocation(14, 16)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
@@ -26651,7 +26651,6 @@ class Test
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            // Conversions aren't flagged due to https://github.com/dotnet/roslyn/issues/54113.
             compilation1.VerifyDiagnostics(
                 // (6,11): error CS0570: 'I1.M1()' is not supported by the language
                 //         T.M1();


### PR DESCRIPTION
We weren't reporting use site diagnostics on user-defined conversion operators, meaning that we would miss things like UnmanagedCallersOnly or invalid modreq reporting. Fixes https://github.com/dotnet/roslyn/issues/54113.
