### PR TITLE
[Lightbulb Perf] Only force compute document diagnostics for the requ…

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.CSharp;
@@ -693,6 +694,44 @@ class C3
             var diagnostics = await compilationWithAnalyzers.GetAnalyzerSyntaxDiagnosticsAsync(tree, CancellationToken.None);
             var diagnostic = Assert.Single(diagnostics);
             Assert.Equal(RegisterSyntaxTreeCancellationAnalyzer.DiagnosticId, diagnostic.Id);
+        }
+
+        [Fact]
+        public async Task TestEventQueuePartialCompletionForSpanBasedQuery()
+        {
+            var source = @"
+class C
+{
+    void M1()
+    {
+        int x1 = 0;
+    }
+
+    void M2()
+    {
+        int x2 = 0;
+    }
+}";
+            var compilation = CreateCompilation(source);
+            var syntaxTree = compilation.SyntaxTrees[0];
+            var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+            // Get analyzer diagnostics for a span within "M1".
+            var localDecl = syntaxTree.GetRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().First();
+            var span = localDecl.Span;
+            var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new CSharpCompilerDiagnosticAnalyzer());
+            var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, AnalyzerOptions.Empty);
+            _ = await compilationWithAnalyzers.GetAnalysisResultAsync(semanticModel, span, CancellationToken.None);
+
+            // Verify only required compilation events are generated in the event queue.
+            // Event queue should not be completed as we are requesting diagnostics for a span within "M1"
+            // and no compilation event should be generated for "M2".
+            var eventQueue = compilationWithAnalyzers.Compilation.EventQueue;
+            Assert.False(eventQueue.IsCompleted);
+
+            // Now fetch diagnostics for entire tree and verify event queue is completed.
+            _ = await compilationWithAnalyzers.GetAnalysisResultAsync(semanticModel, filterSpan: null, CancellationToken.None);
+            Assert.True(eventQueue.IsCompleted);
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -884,6 +884,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
             else if (!analysisScope.IsSyntacticSingleFileAnalysis)
             {
+                // Get the mapped model and invoke GetDiagnostics for the given filter span, if any.
+                // Limiting the GetDiagnostics scope to the filter span ensures we only generate compilation events
+                // for the required symbols whose delcaration intersects with this span, instead of all symbols in the tree.
                 var mappedModel = _compilation.GetSemanticModel(analysisScope.FilterFileOpt!.Value.SourceTree!);
                 _ = mappedModel.GetDiagnostics(analysisScope.FilterSpanOpt, cancellationToken);
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -886,7 +886,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // Get the mapped model and invoke GetDiagnostics for the given filter span, if any.
                 // Limiting the GetDiagnostics scope to the filter span ensures we only generate compilation events
-                // for the required symbols whose delcaration intersects with this span, instead of all symbols in the tree.
+                // for the required symbols whose declaration intersects with this span, instead of all symbols in the tree.
                 var mappedModel = _compilation.GetSemanticModel(analysisScope.FilterFileOpt!.Value.SourceTree!);
                 _ = mappedModel.GetDiagnostics(analysisScope.FilterSpanOpt, cancellationToken);
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -885,7 +885,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             else if (!analysisScope.IsSyntacticSingleFileAnalysis)
             {
                 var mappedModel = _compilation.GetSemanticModel(analysisScope.FilterFileOpt!.Value.SourceTree!);
-                _ = mappedModel.GetDiagnostics(cancellationToken: cancellationToken);
+                _ = mappedModel.GetDiagnostics(analysisScope.FilterSpanOpt, cancellationToken);
             }
         }
 


### PR DESCRIPTION
…ested span

In the IDE, while determining in the background whether or not lightbulb should be shown for the current line, we only request compiler + analyzer diagnostics for the current line span.
Prior logic in CompilationWithAnalyzers was force computing compiler semantic diagnostics for the entire document, which not only meant unnecessary overhead for computing compiler diagnostics, but also generated compilation events for the entire document and hence an unnecessary overhead for computing analyzer diagnostics.

Verified that added unit test fails prior to this change.