### PR TITLE
Set the width of Inheritance Margin to 18

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceGlyphManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceGlyphManager.cs
@@ -67,7 +67,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             _heightAndWidthOfTheGlyph = heightAndWidthOfTheGlyph;
             _editorFormatMap.FormatMappingChanged += FormatMappingChanged;
 
-            // _glyphToTaggedSpan = new Dictionary<InheritanceMarginGlyph, SnapshotSpan>();
             _glyphDataTree = new SimpleIntervalTree<GlyphData, GlyphDataIntrospector>(new GlyphDataIntrospector(), values: null);
             UpdateBackgroundColor();
         }

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginViewMargin.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/InheritanceMarginViewMargin.cs
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
 {
     internal class InheritanceMarginViewMargin : ForegroundThreadAffinitizedObject, IWpfTextViewMargin
     {
-        // Same size as the Glyph Margin
-        private const double HeightAndWidthOfMargin = 17;
+        // 16 (width of the crisp image) + 2 * 1 (width of the border) = 18
+        private const double HeightAndWidthOfMargin = 18;
         private readonly IWpfTextView _textView;
         private readonly ITagAggregator<InheritanceMarginTag> _tagAggregator;
         private readonly IOptionService _optionService;

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml.cs
@@ -28,7 +28,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         private readonly IStreamingFindUsagesPresenter _streamingFindUsagesPresenter;
         private readonly IUIThreadOperationExecutor _operationExecutor;
         private readonly Workspace _workspace;
-        private readonly IWpfTextView _textView;
         private readonly IAsynchronousOperationListener _listener;
 
         public InheritanceMarginContextMenu(
@@ -36,14 +35,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             IStreamingFindUsagesPresenter streamingFindUsagesPresenter,
             IUIThreadOperationExecutor operationExecutor,
             Workspace workspace,
-            IWpfTextView textView,
             IAsynchronousOperationListener listener)
         {
             _threadingContext = threadingContext;
             _streamingFindUsagesPresenter = streamingFindUsagesPresenter;
             _workspace = workspace;
             _operationExecutor = operationExecutor;
-            _textView = textView;
             _listener = listener;
             InitializeComponent();
         }

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginGlyph.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginGlyph.cs
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             {
                 var viewModel = (InheritanceMarginGlyphViewModel)DataContext;
 
-                ContextMenu = new InheritanceMarginContextMenu(_threadingContext, _streamingFindUsagesPresenter, _operationExecutor, _workspace, _textView, _listener);
+                ContextMenu = new InheritanceMarginContextMenu(_threadingContext, _streamingFindUsagesPresenter, _operationExecutor, _workspace, _listener);
                 ContextMenu.DataContext = viewModel;
                 ContextMenu.ItemsSource = viewModel.MenuItemViewModels;
                 ContextMenu.Opened += ContextMenu_OnOpen;


### PR DESCRIPTION
When C#/VB -> Advanced -> Combine Inheritance Margin with Indicator margin is off
![image](https://user-images.githubusercontent.com/24360909/134725379-506fa5d4-f91c-4470-8f0d-8f198af9209c.png)

It is caused because the width is set to 17.

Change this value to 1 * 2 + 16 (2 * border + crisp image) = 18

![image](https://user-images.githubusercontent.com/24360909/134727201-78ac9926-6ebc-466e-a12b-b9261cde42af.png)

Also do some code cleaning.
