### PR TITLE
Add context.default.vs.core.version shared property to OOP telemetry session

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -1032,68 +1032,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private static void ReportTelemetry(DebuggingSessionTelemetry.Data data)
         {
             // report telemetry (fire and forget):
-            _ = Task.Run(() => LogTelemetry(data, Logger.Log, LogAggregator.GetNextId));
-        }
-
-        private static void LogTelemetry(DebuggingSessionTelemetry.Data debugSessionData, Action<FunctionId, LogMessage> log, Func<int> getNextId)
-        {
-            const string SessionId = nameof(SessionId);
-            const string EditSessionId = nameof(EditSessionId);
-
-            var debugSessionId = getNextId();
-
-            log(FunctionId.Debugging_EncSession, KeyValueLogMessage.Create(map =>
-            {
-                map[SessionId] = debugSessionId;
-                map["SessionCount"] = debugSessionData.EditSessionData.Count(session => session.InBreakState);
-                map["EmptySessionCount"] = debugSessionData.EmptyEditSessionCount;
-                map["HotReloadSessionCount"] = debugSessionData.EditSessionData.Count(session => !session.InBreakState);
-                map["EmptyHotReloadSessionCount"] = debugSessionData.EmptyHotReloadEditSessionCount;
-            }));
-
-            foreach (var editSessionData in debugSessionData.EditSessionData)
-            {
-                var editSessionId = getNextId();
-
-                log(FunctionId.Debugging_EncSession_EditSession, KeyValueLogMessage.Create(map =>
-                {
-                    map[SessionId] = debugSessionId;
-                    map[EditSessionId] = editSessionId;
-
-                    map["HadCompilationErrors"] = editSessionData.HadCompilationErrors;
-                    map["HadRudeEdits"] = editSessionData.HadRudeEdits;
-                    map["HadValidChanges"] = editSessionData.HadValidChanges;
-                    map["HadValidInsignificantChanges"] = editSessionData.HadValidInsignificantChanges;
-
-                    map["RudeEditsCount"] = editSessionData.RudeEdits.Length;
-                    map["EmitDeltaErrorIdCount"] = editSessionData.EmitErrorIds.Length;
-                    map["InBreakState"] = editSessionData.InBreakState;
-                    map["Capabilities"] = (int)editSessionData.Capabilities;
-                }));
-
-                foreach (var errorId in editSessionData.EmitErrorIds)
-                {
-                    log(FunctionId.Debugging_EncSession_EditSession_EmitDeltaErrorId, KeyValueLogMessage.Create(map =>
-                    {
-                        map[SessionId] = debugSessionId;
-                        map[EditSessionId] = editSessionId;
-                        map["ErrorId"] = errorId;
-                    }));
-                }
-
-                foreach (var (editKind, syntaxKind) in editSessionData.RudeEdits)
-                {
-                    log(FunctionId.Debugging_EncSession_EditSession_RudeEdit, KeyValueLogMessage.Create(map =>
-                    {
-                        map[SessionId] = debugSessionId;
-                        map[EditSessionId] = editSessionId;
-
-                        map["RudeEditKind"] = editKind;
-                        map["RudeEditSyntaxKind"] = syntaxKind;
-                        map["RudeEditBlocking"] = editSessionData.HadRudeEdits;
-                    }));
-                }
-            }
+            _ = Task.Run(() => DebuggingSessionTelemetry.Log(data, Logger.Log, LogAggregator.GetNextId));
         }
 
         internal TestAccessor GetTestAccessor()
@@ -1129,7 +1068,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 => _instance._pendingUpdate;
 
             public void SetTelemetryLogger(Action<FunctionId, LogMessage> logger, Func<int> getNextId)
-                => _instance._reportTelemetry = data => LogTelemetry(data, logger, getNextId);
+                => _instance._reportTelemetry = data => DebuggingSessionTelemetry.Log(data, logger, getNextId);
         }
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSessionTelemetry.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSessionTelemetry.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Internal.Log;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
@@ -55,6 +57,79 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 else
                 {
                     _editSessionData.Add(editSessionTelemetryData);
+                }
+            }
+        }
+
+        // Example query:
+        //
+        // RawEventsVS
+        // | where EventName == "vs/ide/vbcs/debugging/encsession/editsession"
+        // | project EventId, EventName, Properties, Measures, MacAddressHash
+        // | where Measures["vs.ide.vbcs.debugging.encsession.editsession.emitdeltaerroridcount"] == 0
+        // | extend HasValidChanges = Properties["vs.ide.vbcs.debugging.encsession.editsession.hadvalidchanges"] == "True"
+        // | where HasValidChanges
+        // | extend IsHotReload = Properties["vs.ide.vbcs.debugging.encsession.editsession.inbreakstate"] == "False"
+        // | extend IsEnC = not(IsHotReload)
+        // | summarize HotReloadUsers = dcountif(MacAddressHash, IsHotReload),
+        //             EncUsers = dcountif(MacAddressHash, IsEnC)
+        public static void Log(Data data, Action<FunctionId, LogMessage> log, Func<int> getNextId)
+        {
+            const string SessionId = nameof(SessionId);
+            const string EditSessionId = nameof(EditSessionId);
+
+            var debugSessionId = getNextId();
+
+            log(FunctionId.Debugging_EncSession, KeyValueLogMessage.Create(map =>
+            {
+                map[SessionId] = debugSessionId;
+                map["SessionCount"] = data.EditSessionData.Count(session => session.InBreakState);
+                map["EmptySessionCount"] = data.EmptyEditSessionCount;
+                map["HotReloadSessionCount"] = data.EditSessionData.Count(session => !session.InBreakState);
+                map["EmptyHotReloadSessionCount"] = data.EmptyHotReloadEditSessionCount;
+            }));
+
+            foreach (var editSessionData in data.EditSessionData)
+            {
+                var editSessionId = getNextId();
+
+                log(FunctionId.Debugging_EncSession_EditSession, KeyValueLogMessage.Create(map =>
+                {
+                    map[SessionId] = debugSessionId;
+                    map[EditSessionId] = editSessionId;
+
+                    map["HadCompilationErrors"] = editSessionData.HadCompilationErrors;
+                    map["HadRudeEdits"] = editSessionData.HadRudeEdits;
+                    map["HadValidChanges"] = editSessionData.HadValidChanges;
+                    map["HadValidInsignificantChanges"] = editSessionData.HadValidInsignificantChanges;
+
+                    map["RudeEditsCount"] = editSessionData.RudeEdits.Length;
+                    map["EmitDeltaErrorIdCount"] = editSessionData.EmitErrorIds.Length;
+                    map["InBreakState"] = editSessionData.InBreakState;
+                    map["Capabilities"] = (int)editSessionData.Capabilities;
+                }));
+
+                foreach (var errorId in editSessionData.EmitErrorIds)
+                {
+                    log(FunctionId.Debugging_EncSession_EditSession_EmitDeltaErrorId, KeyValueLogMessage.Create(map =>
+                    {
+                        map[SessionId] = debugSessionId;
+                        map[EditSessionId] = editSessionId;
+                        map["ErrorId"] = errorId;
+                    }));
+                }
+
+                foreach (var (editKind, syntaxKind) in editSessionData.RudeEdits)
+                {
+                    log(FunctionId.Debugging_EncSession_EditSession_RudeEdit, KeyValueLogMessage.Create(map =>
+                    {
+                        map[SessionId] = debugSessionId;
+                        map[EditSessionId] = editSessionId;
+
+                        map["RudeEditKind"] = editKind;
+                        map["RudeEditSyntaxKind"] = syntaxKind;
+                        map["RudeEditBlocking"] = editSessionData.HadRudeEdits;
+                    }));
                 }
             }
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
@@ -51,6 +51,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 var telemetrySession = new TelemetrySession(serializedSession);
                 telemetrySession.Start();
 
+                // adds property to each event reported from this session
+                telemetrySession.SetSharedProperty("VS.Core.Version", Environment.GetEnvironmentVariable("VisualStudioVersion"));
+
                 telemetryService.InitializeTelemetrySession(telemetrySession);
                 telemetryService.RegisterUnexpectedExceptionLogger(TraceLogger);
 


### PR DESCRIPTION
The version number is currently not available in OOP. Having it makes it easier to write telemetry queries.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1410759 tracks ask on VS platform to add this property, at which point we can stop setting it.