### PR TITLE
Hook up NFW in OOP

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.Telemetry;
 using Microsoft.CodeAnalysis.Notification;
 using RoslynLogger = Microsoft.CodeAnalysis.Internal.Log.Logger;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -53,6 +54,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 telemetryService.InitializeTelemetrySession(telemetrySession);
                 telemetryService.RegisterUnexpectedExceptionLogger(TraceLogger);
+                WatsonReporter.InitializeFatalErrorHandlers();
 
                 // log telemetry that service hub started
                 RoslynLogger.Log(FunctionId.RemoteHost_Connect, KeyValueLogMessage.Create(m => m["Host"] = hostProcessId));


### PR DESCRIPTION
Report exceptions from IServiceHubServiceFactory.CreateService since they are not propagated to the client due to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1410923.
Hook up NFW reporting in OOP. Exceptions will be reported to ProcessTelemetry ServiceHub log file.