### PR TITLE
Add documentation and unit test

### DIFF
--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -7,12 +7,14 @@ Imports System.IO
 Imports System.Reflection
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.SolutionCrawler
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.UnitTests.Diagnostics
@@ -2222,5 +2224,101 @@ class MyClass
                 Assert.Equal(0, diagnostics.Count())
             End Using
         End Function
+
+        <WpfTheory>
+        <InlineData(DiagnosticAnalyzerCategory.SemanticSpanAnalysis, True)>
+        <InlineData(DiagnosticAnalyzerCategory.SemanticDocumentAnalysis, False)>
+        <InlineData(DiagnosticAnalyzerCategory.ProjectAnalysis, False)>
+        Friend Async Function TestTryAppendDiagnosticsForSpanAsync(category As DiagnosticAnalyzerCategory, isSpanBasedAnalyzer As Boolean) As Task
+            Dim test = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document><![CDATA[
+class MyClass
+{
+    void M()
+    {
+        int x = 0;
+    }
+}]]>
+                               </Document>
+                           </Project>
+                       </Workspace>
+
+            Using workspace = TestWorkspace.CreateWorkspace(test, composition:=s_compositionWithMockDiagnosticUpdateSourceRegistrationService)
+                Dim solution = workspace.CurrentSolution
+                Dim project = solution.Projects.Single()
+
+                ' Add analyzer
+                Dim analyzer = New AnalyzerWithCustomDiagnosticCategory(category)
+                Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
+                project = project.AddAnalyzerReference(analyzerReference)
+                Assert.False(analyzer.ReceivedOperationCallback)
+
+                ' Get span to analyze
+                Dim document = project.Documents.Single()
+                Dim root = Await document.GetSyntaxRootAsync(CancellationToken.None)
+                Dim localDecl = root.DescendantNodes().OfType(Of CodeAnalysis.CSharp.Syntax.LocalDeclarationStatementSyntax).Single()
+                Dim span = localDecl.Span
+
+                Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
+                Assert.IsType(Of MockDiagnosticUpdateSourceRegistrationService)(workspace.GetService(Of IDiagnosticUpdateSourceRegistrationService)())
+                Dim diagnosticService = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
+                Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
+
+                ' Verify available diagnostic descriptors
+                Dim descriptorsMap = solution.State.Analyzers.GetDiagnosticDescriptorsPerReference(diagnosticService.AnalyzerInfoCache, project)
+                Assert.Equal(1, descriptorsMap.Count)
+                Dim descriptors = descriptorsMap.First().Value
+                Assert.Equal(1, descriptors.Length)
+                Assert.Equal(analyzer.Descriptor.Id, descriptors.Single().Id)
+
+                ' Try get diagnostics for span
+                Dim diagnostics As New PooledObjects.ArrayBuilder(Of DiagnosticData)
+                Await diagnosticService.TryAppendDiagnosticsForSpanAsync(document, span, diagnostics)
+
+                ' Verify only span-based analyzer is invoked with TryAppendDiagnosticsForSpanAsync
+                Assert.Equal(isSpanBasedAnalyzer, analyzer.ReceivedOperationCallback)
+            End Using
+        End Function
+
+        <DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)>
+        Private NotInheritable Class AnalyzerWithCustomDiagnosticCategory
+            Inherits DiagnosticAnalyzer
+            Implements IBuiltInAnalyzer
+
+            Private ReadOnly _category As DiagnosticAnalyzerCategory
+            Public Property Descriptor As New DiagnosticDescriptor("ID0001", "Title", "Message", "Category", DiagnosticSeverity.Warning, isEnabledByDefault:=True)
+            Public Property ReceivedOperationCallback As Boolean
+
+            Public Sub New(category As DiagnosticAnalyzerCategory)
+                _category = category
+            End Sub
+
+            Public ReadOnly Property RequestPriority As CodeActionRequestPriority Implements IBuiltInAnalyzer.RequestPriority
+                Get
+                    Return CodeActionRequestPriority.Normal
+                End Get
+            End Property
+
+            Public Function GetAnalyzerCategory() As DiagnosticAnalyzerCategory Implements IBuiltInAnalyzer.GetAnalyzerCategory
+                Return _category
+            End Function
+
+            Public Function OpenFileOnly(options As OptionSet) As Boolean Implements IBuiltInAnalyzer.OpenFileOnly
+                Return False
+            End Function
+
+            Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
+                Get
+                    Return ImmutableArray.Create(Descriptor)
+                End Get
+            End Property
+
+            Public Overrides Sub Initialize(context As AnalysisContext)
+                context.RegisterOperationAction(Sub(operationContext As OperationAnalysisContext)
+                                                    ReceivedOperationCallback = True
+                                                End Sub, OperationKind.VariableDeclaration)
+            End Sub
+        End Class
     End Class
 End Namespace

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -68,6 +68,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         ///
         /// It will return true if it was able to return all up-to-date diagnostics.
         ///  otherwise, false indicating there are some missing diagnostics in the diagnostic list
+        ///  
+        /// This API will only force complete analyzers that support span based analysis, i.e. compiler analyzer and
+        /// <see cref="IBuiltInAnalyzer"/>s that support <see cref="DiagnosticAnalyzerCategory.SemanticSpanAnalysis"/>.
+        /// For the rest of the analyzers, it will only return diagnostics if the analyzer has already been executed.
+        /// Use <see cref="GetDiagnosticsForSpanAsync(Document, TextSpan?, string?, bool, CodeActionRequestPriority, Func{string, IDisposable?}?, CancellationToken)"/>
+        /// if you want to force complete all analyzers and get up-to-date diagnostics for all analyzers for the given span.
         /// </summary>
         Task<bool> TryAppendDiagnosticsForSpanAsync(Document document, TextSpan range, ArrayBuilder<DiagnosticData> diagnostics, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
Follow-up to #56696

Add documentation and unit test for `IDiagnosticAnalyzerService.TryAppendDiagnosticsForSpanAsync` API that is used by the editor in background to determine whether or not lightbulb should be shown on the current line.