### PR TITLE
Emit compiler version to Windows PDB

### DIFF
--- a/src/Compilers/Core/Portable/DiaSymReader/Metadata/IMetadataEmit.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/Metadata/IMetadataEmit.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 #pragma warning disable 436 // SuppressUnmanagedCodeSecurityAttribute defined in source and mscorlib 
 
 using System;

--- a/src/Compilers/Core/Portable/DiaSymReader/Writer/ISymUnmanagedCompilerInfoWriter.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/Writer/ISymUnmanagedCompilerInfoWriter.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.DiaSymReader
+{
+    [ComImport]
+    [Guid("2ae6a06a-92ba-4c2d-a64e-7e9fa421a330")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [ComVisible(false)]
+    internal interface ISymUnmanagedCompilerInfoWriter
+    {
+        /// <summary>
+        /// Adds compiler version number and name.
+        /// </summary>
+        [PreserveSig]
+        int AddCompilerInfo(ushort major, ushort minor, ushort build, ushort revision, [MarshalAs(UnmanagedType.LPWStr)] string name);
+    }
+}

--- a/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriter.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriter.cs
@@ -208,5 +208,20 @@ namespace Microsoft.DiaSymReader
         /// <exception cref="InvalidOperationException">Writes are not allowed to the underlying stream.</exception>
         /// <exception cref="SymUnmanagedWriterException">Error occurred while writing PDB data.</exception>
         public abstract void CloseTokensToSourceSpansMap();
+
+        /// <summary>
+        /// Writes compiler version and name to the PDB.
+        /// </summary>
+        /// <param name="major">Major version</param>
+        /// <param name="minor">Minor version</param>
+        /// <param name="build">Build</param>
+        /// <param name="revision">Revision</param>
+        /// <param name="name">Compiler name</param>
+        /// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+        /// <exception cref="SymUnmanagedWriterException">Error occurred while writing PDB data.</exception>
+        /// <exception cref="NotSupportedException">The PDB writer does not support adding compiler info.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+        public virtual void AddCompilerInfo(ushort major, ushort minor, ushort build, ushort revision, string name)
+            => throw new NotSupportedException();
     }
 }

--- a/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriterImpl.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriterImpl.cs
@@ -749,5 +749,28 @@ namespace Microsoft.DiaSymReader
             // we need to go through IPdbWriter interface to get it.
             ((IPdbWriter)symWriter).GetSignatureAge(out stamp, out age);
         }
+
+        public override void AddCompilerInfo(ushort major, ushort minor, ushort build, ushort revision, string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            var symWriter = GetSymWriter();
+            if (symWriter is not ISymUnmanagedCompilerInfoWriter infoWriter)
+            {
+                return;
+            }
+
+            try
+            {
+                infoWriter.AddCompilerInfo(major, minor, build, revision, name);
+            }
+            catch (Exception ex)
+            {
+                throw PdbWritingException(ex);
+            }
+        }
     }
 }

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Security.Cryptography;
@@ -767,6 +768,14 @@ namespace Microsoft.Cci
             {
                 AddDocumentIndex(kvp.Value);
             }
+        }
+
+        public void WriteCompilerVersion(string language)
+        {
+            var compilerAssembly = typeof(Compilation).Assembly;
+            var fileVersion = Version.Parse(compilerAssembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version);
+            var versionString = compilerAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            _symWriter.AddCompilerInfo((ushort)fileVersion.Major, (ushort)fileVersion.Minor, (ushort)fileVersion.Build, (ushort)fileVersion.Revision, $"{language} - {versionString}");
         }
     }
 }

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -108,6 +108,8 @@ namespace Microsoft.Cci
                 }
 
                 nativePdbWriterOpt.WriteRemainingDebugDocuments(mdWriter.Module.DebugDocumentsBuilder.DebugDocuments);
+
+                nativePdbWriterOpt.WriteCompilerVersion(context.Module.CommonCompilation.Language);
             }
 
             Stream peStream = getPeStream();

--- a/src/Test/PdbUtilities/Writer/MockSymUnmanagedWriter.cs
+++ b/src/Test/PdbUtilities/Writer/MockSymUnmanagedWriter.cs
@@ -126,5 +126,10 @@ namespace Roslyn.Test.Utilities
         {
             throw MakeException();
         }
+
+        public override void AddCompilerInfo(ushort major, ushort minor, ushort build, ushort revision, string name)
+        {
+            throw MakeException();
+        }
     }
 }


### PR DESCRIPTION
Uses new SymReader API to write compiler version info to Windows PDB.
No op if the SymReader does not implement the API.

The new API will be added to Microsoft.DiaSymReader.Native.*.dll (not available yet). On .NET Core the library is loaded from the CLR runtime so this will require the runtime to be updated first before we can test on Core.

Similar change in Crossgen: https://github.com/dotnet/runtime/pull/59686

The compiler emits the following Windows PDB S_COMPILE3 record:

```
** Module: "* CompilerInfo *" from "86F52079"


(000004) S_COMPILE3:
         Language: MSIL
         Target processor: Pentium III
         Compiled for edit and continue: no
         Compiled without debugging info: no
         Compiled with LTCG: no
         Compiled with /bzalign: no
         Managed code present: no
         Compiled with /GS: no
         Compiled with /hotpatch: no
         Converted by CVTCIL: no
         MSIL module: no
         Compiled with /sdl: no
         Compiled with pgo: no
         .EXP module: no
         Pad bits = 0x0000
         Frontend Version: Major = 0, Minor = 0, Build = 0, QFE = 0
         Backend Version: Major = 42, Minor = 42, Build = 42, QFE = 42424
         Version string: C# - 4.0.0-dev
```