### PR TITLE
Move merge-conflict-fixes into the high-priority fix bucket.

### DIFF
--- a/src/Features/Core/Portable/ConflictMarkerResolution/AbstractConflictMarkerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/ConflictMarkerResolution/AbstractConflictMarkerCodeFixProvider.cs
@@ -36,6 +36,17 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; }
 
+        /// <summary>
+        /// 'Fix merge conflict markers' gets special privileges.  A core user scenario around them is that a user does
+        /// a source control merge, gets conflicts, and then wants to open and edit them in the IDE very quickly.
+        /// Forcing their fixes to be gated behind the set of normal fixes (which also involves semantic analysis) just
+        /// slows the user down.  As we can compute this syntactically, and the user is almost certainly trying to fix
+        /// them if they bring up the lightbulb on a <c>&lt;&lt;&lt;&lt;&lt;&lt;&lt;</c> line, it should run ahead of
+        /// normal fix providers else so the user can quickly fix the conflict and move onto the next conflict.
+        /// </summary>
+        private protected override CodeActionRequestPriority ComputeRequestPriority()
+            => CodeActionRequestPriority.High;
+
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var cancellationToken = context.CancellationToken;


### PR DESCRIPTION
Reason explained in the doc comment in the PR.