### PR TITLE
Ensure ReferenceCountedDisposable<T>.WeakReference is pointer-sized

### DIFF
--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/ReferenceCountedDisposableTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/ReferenceCountedDisposableTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Reflection;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -133,6 +134,61 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestDefaultWeakReference()
             => Assert.Null(default(ReferenceCountedDisposable<IDisposable>.WeakReference).TryAddReference());
+
+        /// <summary>
+        /// This test verifies that a weak reference cannot be created from a disposed reference, even if another strong
+        /// reference to the same object is still alive. It specifically covers the case where a weak reference HAS NOT
+        /// been created prior to the assertion.
+        /// </summary>
+        [Fact]
+        public void TestWeakReferenceCannotBeCreatedFromDisposedReference_NoPriorWeakReference()
+        {
+            var target = new DisposableObject();
+            var reference = new ReferenceCountedDisposable<DisposableObject>(target);
+
+            var secondReference = reference.TryAddReference();
+            Assert.NotNull(secondReference);
+
+            reference.Dispose();
+
+            var weakReference = new ReferenceCountedDisposable<DisposableObject>.WeakReference(reference);
+            Assert.Null(weakReference.TryAddReference());
+        }
+
+        /// <summary>
+        /// This test verifies that a weak reference cannot be created from a disposed reference, even if another strong
+        /// reference to the same object is still alive. It specifically covers the case where a weak reference HAS been
+        /// created prior to the assertion.
+        /// </summary>
+        [Fact]
+        public void TestWeakReferenceCannotBeCreatedFromDisposedReference_WithPriorWeakReference()
+        {
+            var target = new DisposableObject();
+            var reference = new ReferenceCountedDisposable<DisposableObject>(target);
+
+            // Create an initial weak reference at a point where the reference is alive. This ensures the internal
+            // shared WeakReference<T> is initialized.
+            var weakReference = new ReferenceCountedDisposable<DisposableObject>.WeakReference(reference);
+            Assert.NotNull(weakReference.TryAddReference());
+
+            var secondReference = reference.TryAddReference();
+            Assert.NotNull(secondReference);
+
+            reference.Dispose();
+
+            var secondWeakReference = new ReferenceCountedDisposable<DisposableObject>.WeakReference(reference);
+            Assert.Null(secondWeakReference.TryAddReference());
+        }
+
+        [Fact]
+        public void TestWeakReferenceCannotTear()
+        {
+            // WeakReference contains a single field which is a reference type, so reads/writes cannot tear
+            var field = Assert.Single(typeof(ReferenceCountedDisposable<>.WeakReference)
+                .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+
+            Assert.True(field.FieldType.IsClass);
+        }
 
         private sealed class DisposableObject : IDisposable
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposable.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposable.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -315,6 +316,7 @@ namespace Roslyn.Utilities
             /// <remarks>
             /// DO NOT DISPOSE OF THE TARGET.
             /// </remarks>
+            [DisallowNull]
             public WeakReference<T>? _weakInstance;
 
             public int _referenceCount;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposable.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/ReferenceCountedDisposable.cs
@@ -226,7 +226,7 @@ namespace Roslyn.Utilities
         /// <remarks>
         /// This value type holds a single field, which is not subject to torn reads/writes.
         /// </remarks>
-        public struct WeakReference
+        public readonly struct WeakReference
         {
             private readonly BoxedReferenceCount? _boxedReferenceCount;
 


### PR DESCRIPTION
This change ensures torn reads are not possible, even in cases where access to a `ReferenceCountedDisposable<T>.WeakReference` is not synchronized.

The first commit addresses a potential torn read by synchronizing access to a field. The last commit reverts this change because it is no longer necessary.