### PR TITLE
Add property to errors in errorlist to prevent the error service from…

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -30,6 +30,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
     internal abstract partial class VisualStudioBaseDiagnosticListTable
     {
         /// <summary>
+        /// Used by the editor to signify that errors added to the error list
+        /// should not be copied to the guest.  Instead they will be published via LSP.
+        /// </summary>
+        private const string DoNotPropogateToGuestProperty = "DoNotPropagateToGuests";
+
+        /// <summary>
         /// Error list diagnostic source for "Build + Intellisense" setting.
         /// See <see cref="VisualStudioDiagnosticListTableWorkspaceEventListener.VisualStudioDiagnosticListTable.BuildTableDataSource"/>
         /// for error list diagnostic source for "Build only" setting.
@@ -388,6 +394,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                             return guids.Length > 0;
                         case StandardTableKeyNames.SuppressionState:
                             content = data.IsSuppressed ? SuppressionState.Suppressed : SuppressionState.Active;
+                            return true;
+                        case DoNotPropogateToGuestProperty:
+                            content = true;
                             return true;
                         default:
                             content = null;


### PR DESCRIPTION
… duplicating them to the guest in LiveShare

Errors for the liveshare guest are either produced via LSP publish diagnostics directly to the guest or, when pull diagnostics are enabled on the host, via LSP pull.  Host error list errors should never be propagated to the guest.

Fixes - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1378186 (introduced when the platform switched to using the diagnostics brokered service for LSP publish).