### PR TITLE
Correctly reparse generated files when parse options change

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis
             return Create(
                 Identity,
                 sourceText,
-                ParseOptions,
+                parseOptions,
                 this.LanguageServices,
                 this.solutionServices);
         }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -363,6 +363,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var generatedTreeAfterChange = await Assert.Single(await project.GetSourceGeneratedDocumentsAsync()).GetSyntaxTreeAsync();
 
             Assert.NotSame(generatedTreeBeforeChange, generatedTreeAfterChange);
+            Assert.Equal(DocumentationMode.Diagnose, generatedTreeAfterChange!.Options.DocumentationMode);
         }
 
         [Theory, CombinatorialData]


### PR DESCRIPTION
A typo meant we'd still reparse with the old options; the test designed to catch this didn't because the test only asserted the tree changed, not that the new option actually took effect.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1409124