### PR TITLE
Fix null type argument inference with T?

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -618,7 +618,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     ExactOrBoundsInference(kind, argumentType, target, ref useSiteInfo);
                 }
-                else if (IsUnfixedTypeParameter(target) && kind is ExactOrBoundsKind.LowerBound)
+                else if (IsUnfixedTypeParameter(target) && !target.NullableAnnotation.IsAnnotated() && kind is ExactOrBoundsKind.LowerBound)
                 {
                     var ordinal = ((TypeParameterSymbol)target.Type).Ordinal;
                     _nullableAnnotationLowerBounds[ordinal] = _nullableAnnotationLowerBounds[ordinal].Join(argumentType.NullableAnnotation);


### PR DESCRIPTION
Fixes #56788

When a type parameter is annotated, you can always read null from it and/or write null to it. We only want `null` to contribute its nullability if there is a possibility that the type parameter could be substituted for a non-nullable reference type.
