### PR TITLE
List-patterns: fix build break

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -313,6 +313,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Call(receiverOpt, accessor);
         }
 
+        public BoundExpression Indexer(BoundExpression? receiverOpt, PropertySymbol property, BoundExpression arg0)
+        {
+            Debug.Assert((receiverOpt is null) == property.IsStatic);
+            var accessor = property.GetOwnOrInheritedGetMethod();
+            Debug.Assert(accessor is not null);
+            return Call(receiverOpt, accessor, arg0);
+        }
+
         public NamedTypeSymbol SpecialType(SpecialType st)
         {
             NamedTypeSymbol specialType = Compilation.GetSpecialType(st);


### PR DESCRIPTION
Restoring overload we'd [removed](https://github.com/dotnet/roslyn/pull/56586) in `main` branch
Relates to test plan https://github.com/dotnet/roslyn/issues/51289