### PR TITLE
Enable async lightbulbs in 17.0

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSourceProvider.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             if (textBuffer.IsInLspEditorContext())
                 return null;
 
-            var asyncEnabled = _globalOptions.GetOption(SuggestionsOptions.Asynchronous) ?? _globalOptions.GetOption(SuggestionsOptions.AsynchronousFeatureFlag);
+            var asyncEnabled = _globalOptions.GetOption(SuggestionsOptions.Asynchronous) ?? !_globalOptions.GetOption(SuggestionsOptions.AsynchronousQuickActionsDisableFeatureFlag);
 
             return asyncEnabled
                 ? new AsyncSuggestedActionsSource(_threadingContext, _globalOptions, this, textView, textBuffer, _suggestedActionCategoryRegistry)

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestionsOptions.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestionsOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
         public static readonly Option2<bool?> Asynchronous = new(FeatureName, nameof(Asynchronous), defaultValue: null,
             new RoamingProfileStorageLocation("TextEditor.Specific.Suggestions.Asynchronous2"));
 
-        public static readonly Option2<bool> AsynchronousFeatureFlag = new(FeatureName, nameof(AsynchronousFeatureFlag), defaultValue: false,
-            new FeatureFlagStorageLocation("Roslyn.AsynchronousQuickActions2"));
+        public static readonly Option2<bool> AsynchronousQuickActionsDisableFeatureFlag = new(FeatureName, nameof(AsynchronousQuickActionsDisableFeatureFlag), defaultValue: false,
+            new FeatureFlagStorageLocation("Roslyn.AsynchronousQuickActionsDisable"));
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestionsOptionsProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestionsOptionsProvider.cs
@@ -22,6 +22,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
         public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
             SuggestionsOptions.Asynchronous,
-            SuggestionsOptions.AsynchronousFeatureFlag);
+            SuggestionsOptions.AsynchronousQuickActionsDisableFeatureFlag);
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -92,9 +92,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             // Quick Actions
             BindToOption(ComputeQuickActionsAsynchronouslyExperimental, SuggestionsOptions.Asynchronous, () =>
             {
-                // If the option has not been set by the user, check if the option is enabled from experimentation.
-                // If so, default to that.
-                return optionStore.GetOption(SuggestionsOptions.AsynchronousFeatureFlag);
+                // If the option has not been set by the user, check if the option is disabled from experimentation.
+                return !optionStore.GetOption(SuggestionsOptions.AsynchronousQuickActionsDisableFeatureFlag);
             });
 
             // Highlighting

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -511,12 +511,12 @@ namespace NS
             var expectedItems = new[]
             {
                 "Rename 'P2' to 'Foober'",
+                "Goober - using N;",
                 "Generate type 'Foober'",
                 "Generate class 'Foober' in new file",
                 "Generate class 'Foober'",
                 "Generate nested class 'Foober'",
                 "Generate new type...",
-                "Goober - using N;",
                 "Suppress or Configure issues",
                 "Suppress CS0168",
                 "in Source",

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TextViewWindow_InProc.cs
@@ -356,17 +356,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             }
 
             var activeSession = broker.GetSession(view);
-            if (activeSession == null || !activeSession.IsExpanded)
+            if (activeSession == null)
             {
                 var bufferType = view.TextBuffer.ContentType.DisplayName;
                 throw new InvalidOperationException(string.Format("No expanded light bulb session found after View.ShowSmartTag.  Buffer content type={0}", bufferType));
             }
 
-            if (activeSession.TryGetSuggestedActionSets(out var actionSets) != QuerySuggestedActionCompletionStatus.Completed)
-            {
-                actionSets = Array.Empty<SuggestedActionSet>();
-            }
-
+            var actionSets = await LightBulbHelper.WaitForItemsAsync(broker, view);
             return await SelectActionsAsync(actionSets);
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/LightBulbHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/LightBulbHelper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text.Editor;
@@ -11,11 +12,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 {
     public static class LightBulbHelper
     {
-        public static Task<bool> WaitForLightBulbSessionAsync(ILightBulbBroker broker, IWpfTextView view)
+        public static async Task<bool> WaitForLightBulbSessionAsync(ILightBulbBroker broker, IWpfTextView view)
         {
             var startTime = DateTimeOffset.Now;
 
-            return Helper.RetryAsync(async () =>
+            var active = await Helper.RetryAsync(async () =>
             {
                 if (broker.IsLightBulbSessionActive(view))
                 {
@@ -33,6 +34,42 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 return broker.IsLightBulbSessionActive(view);
             }, TimeSpan.Zero);
+
+            if (!active)
+                return false;
+
+            await WaitForItemsAsync(broker, view);
+            return true;
+        }
+
+        public static async Task<IEnumerable<SuggestedActionSet>> WaitForItemsAsync(ILightBulbBroker broker, IWpfTextView view)
+        {
+            var activeSession = broker.GetSession(view);
+            if (activeSession == null)
+            {
+                var bufferType = view.TextBuffer.ContentType.DisplayName;
+                throw new InvalidOperationException(string.Format("No expanded light bulb session found after View.ShowSmartTag.  Buffer content type={0}", bufferType));
+            }
+
+            var start = DateTime.Now;
+            IEnumerable<SuggestedActionSet> actionSets = Array.Empty<SuggestedActionSet>();
+            while (DateTime.Now - start < Helper.HangMitigatingTimeout)
+            {
+                var status = activeSession.TryGetSuggestedActionSets(out actionSets);
+                if (status is not QuerySuggestedActionCompletionStatus.Completed and
+                              not QuerySuggestedActionCompletionStatus.Canceled)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                    continue;
+                }
+
+                if (status != QuerySuggestedActionCompletionStatus.Completed)
+                    actionSets = Array.Empty<SuggestedActionSet>();
+
+                break;
+            }
+
+            return actionSets;
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/TestUtilities.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/TestUtilities.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         {
             var shouldThrow = false;
             var sb = new StringBuilder();
-            sb.Append("The following expected item(s) not found:\r\n");
+            sb.AppendLine("The following expected item(s) not found:");
 
             foreach (var item in expected)
             {
@@ -39,6 +39,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
             if (shouldThrow)
             {
+                sb.AppendLine("Actual items:");
+                foreach (var item in actual)
+                    sb.AppendLine(item.ToString());
+
                 throw new Exception(sb.ToString());
             }
         }

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -70,8 +70,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             ' Quick Actions
             BindToOption(ComputeQuickActionsAsynchronouslyExperimental, SuggestionsOptions.Asynchronous,
                          Function()
-                             ' If the option has Not been set by the user, check if the option is enabled from experimentation.
-                             Return optionStore.GetOption(SuggestionsOptions.AsynchronousFeatureFlag)
+                             ' If the option has Not been set by the user, check if the option is disabled from experimentation.
+                             Return Not optionStore.GetOption(SuggestionsOptions.AsynchronousQuickActionsDisableFeatureFlag)
                          End Function)
 
             ' Highlighting


### PR DESCRIPTION
The plan here is that we are going to turn this on in 17.0 but both have a control-tower flag to disable this if we run into anything unforseen, and we'll still have an Tools|Option value to disable this (for people that control-tower might not reach).

This differs from what we're doing in 17.1 where async lightbulbs are just on by default, but there's no user facing way to go back.  This balances our desire to get this out now in the hope that we can make 17.0, with the need for a fallback in case external usage reveals something we missed.