### PR TITLE
Switch to a JTF blocking wait in lightbulbs

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
@@ -161,13 +161,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (options != null)
                 {
                     // Note: we want to block the UI thread here so the user cannot modify anything while the codefix applies
-                    operations = GetOperationsAsync(actionWithOptions, options, cancellationToken).WaitAndGetResult(cancellationToken);
+                    operations = this.ThreadingContext.JoinableTaskFactory.Run(
+                        () => GetOperationsAsync(actionWithOptions, options, cancellationToken));
                 }
             }
             else
             {
                 // Note: we want to block the UI thread here so the user cannot modify anything while the codefix applies
-                operations = GetOperationsAsync(progressTracker, cancellationToken).WaitAndGetResult(cancellationToken);
+                operations = this.ThreadingContext.JoinableTaskFactory.Run(
+                    () => GetOperationsAsync(progressTracker, cancellationToken));
             }
 
             if (operations != null)


### PR DESCRIPTION
This prevents a deadlock for people in the CloudCache A/B experiment as that component has a UI dependency, and so we cannot safely do a roslyn-blocking wait on the UI thread for it.

Note that this blocking goes away entirely in 17.1 thanks to https://github.com/dotnet/roslyn/pull/55687.  In 17.1 the entire invocation path for lightbulbs is entirely async (which makes it a non-issue if cloudcache needs the UI thread).