### PR TITLE
Stop including codebase for LSP protocol packages

### DIFF
--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -105,9 +105,6 @@
       These are separate from the _Dependency list as we do not need to always add the package dependency (e.g. private dependencies)
     -->
     <ItemGroup>
-      <_AssemblyVersionVariable Include="RoslynLanguageServerProtocol" Condition="'%(_Dependency.Identity)' == 'Microsoft.VisualStudio.LanguageServer.Protocol'">
-        <Version>%(_Dependency._AssemblyVersion)</Version>
-      </_AssemblyVersionVariable>
       <_AssemblyVersionVariable  Include="Roslyn" Version="$(AssemblyVersion)"/>
     </ItemGroup>
 

--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -315,9 +315,10 @@
     <NuGetPackageToIncludeInVsix Include="System.Composition.Convention" PkgDefEntry="CodeBase" />
     <NuGetPackageToIncludeInVsix Include="System.Composition.Hosting" PkgDefEntry="CodeBase" />
     <NuGetPackageToIncludeInVsix Include="ICSharpCode.Decompiler" PkgDefEntry="CodeBase" />
-    <NuGetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol" PkgDefEntry="CodeBase" />
-    <NugetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" PkgDefEntry="CodeBase" />
-    <NugetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" PkgDefEntry="CodeBase" />
+    <!-- Code base is provided by the LSP client for released VS versions in order to ensure only 1 version of these assemblies are loaded. -->
+    <NuGetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol" />
+    <NugetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" />
+    <NugetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(NuGetPackageRoot)\sqlitepclraw.lib.e_sqlite3\$(SQLitePCLRawbundle_greenVersion)\runtimes\win-x86\native\e_sqlite3.dll">


### PR DESCRIPTION
As requested by the LSP client team, we need to remove the codebase from LSP packages.  On VS release they are trying to consolidate all teams to the same version of these assemblies (to avoid each team loading 3 dlls).  However, this caused perf issues when there were multiple codebases for the same version, leading VS to potentially load a non ngen'd version of the dlls.

To fix this for the dev17 release, we remove our codebase entries in favor of the ones provided by the LSP client team (since we're on the same version already).  

In 17.1 before the protocol libraries get updated again, the LSP client team have committed to figuring out how to resolve this issue without codebases so we can all load our own copies during development.

https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/354605