### PR TITLE
Addresses the first bullet point in #56843.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -733,5 +733,33 @@ class C
             _ = await compilationWithAnalyzers.GetAnalysisResultAsync(semanticModel, filterSpan: null, CancellationToken.None);
             Assert.True(eventQueue.IsCompleted);
         }
+
+        [Fact, WorkItem(56843, "https://github.com/dotnet/roslyn/issues/56843")]
+        public async Task TestCompilerAnalyzerForSpanBasedSemanticDiagnostics()
+        {
+            var source = @"
+class C
+{
+    void M1()
+    {
+        int x1 = 0; // CS0219 (unused variable)
+    }
+}";
+            var compilation = CreateCompilation(source);
+            var syntaxTree = compilation.SyntaxTrees[0];
+            var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+            // Get compiler analyzer diagnostics for a span within "M1".
+            var localDecl = syntaxTree.GetRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().First();
+            var span = localDecl.Span;
+            var compilerAnalyzer = new CSharpCompilerDiagnosticAnalyzer();
+            var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(compilerAnalyzer), AnalyzerOptions.Empty);
+            var result = await compilationWithAnalyzers.GetAnalysisResultAsync(semanticModel, span, CancellationToken.None);
+            var diagnostics = result.SemanticDiagnostics[syntaxTree][compilerAnalyzer];
+            diagnostics.Verify(
+                // (6,13): warning CS0219: The variable 'x1' is assigned but its value is never used
+                //         int x1 = 0; // CS0219 (unused variable)
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x1").WithArguments("x1").WithLocation(6, 13));
+        }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1516,7 +1516,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     break;
 
-                case CompilationUnitCompletedEvent compilationUnitCompletedEvent:
+                case CompilationUnitCompletedEvent compilationUnitCompletedEvent when !compilationUnitCompletedEvent.FilterSpan.HasValue:
                     SemanticModelProvider.ClearCache(compilationUnitCompletedEvent.CompilationUnit, compilationUnitCompletedEvent.Compilation);
                     break;
 
@@ -1796,6 +1796,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 foreach (var (analyzer, semanticModelActions) in _lazySemanticModelActions)
                 {
                     if (!analysisScope.Contains(analyzer))
+                    {
+                        continue;
+                    }
+
+                    // Only compiler analyzer supports span-based semantic model action callbacks.
+                    if (completedEvent.FilterSpan.HasValue && !IsCompilerAnalyzer(analyzer))
                     {
                         continue;
                     }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -676,18 +676,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<SemanticModelAnalyzerAction> semanticModelActions,
             DiagnosticAnalyzer analyzer,
             SemanticModel semanticModel,
-            CompilationEvent compilationUnitCompletedEvent,
+            CompilationUnitCompletedEvent compilationUnitCompletedEvent,
             AnalysisScope analysisScope,
             AnalysisState? analysisState,
             bool isGeneratedCode)
         {
+            Debug.Assert(!compilationUnitCompletedEvent.FilterSpan.HasValue || _isCompilerAnalyzer!(analyzer), "Only compiler analyzer supports span-based semantic model action callbacks");
+
             AnalyzerStateData? analyzerState = null;
 
             try
             {
                 if (TryStartProcessingEvent(compilationUnitCompletedEvent, analyzer, analysisScope, analysisState, out analyzerState))
                 {
-                    ExecuteSemanticModelActionsCore(semanticModelActions, analyzer, semanticModel, analyzerState, isGeneratedCode);
+                    ExecuteSemanticModelActionsCore(semanticModelActions, analyzer, semanticModel, analyzerState, analysisScope, isGeneratedCode);
                     analysisState?.MarkEventComplete(compilationUnitCompletedEvent, analyzer);
                     return true;
                 }
@@ -705,6 +707,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticAnalyzer analyzer,
             SemanticModel semanticModel,
             AnalyzerStateData? analyzerState,
+            AnalysisScope analysisScope,
             bool isGeneratedCode)
         {
             if (isGeneratedCode && _shouldSkipAnalysisOnGeneratedCode(analyzer) ||
@@ -724,7 +727,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     _cancellationToken.ThrowIfCancellationRequested();
 
                     var context = new SemanticModelAnalysisContext(semanticModel, AnalyzerOptions, diagReporter.AddDiagnosticAction,
-                        isSupportedDiagnostic, _cancellationToken);
+                        isSupportedDiagnostic, analysisScope.FilterSpanOpt, _cancellationToken);
 
                     // Catch Exception from action.
                     ExecuteAndCatchIfThrows(

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationUnitCompletedEvent.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationUnitCompletedEvent.cs
@@ -2,20 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.Text;
+
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal sealed class CompilationUnitCompletedEvent : CompilationEvent
     {
-        public CompilationUnitCompletedEvent(Compilation compilation, SyntaxTree compilationUnit) : base(compilation)
+        public CompilationUnitCompletedEvent(Compilation compilation, SyntaxTree compilationUnit, TextSpan? filterSpan = null)
+            : base(compilation)
         {
             this.CompilationUnit = compilationUnit;
+            this.FilterSpan = filterSpan;
         }
 
         public SyntaxTree CompilationUnit { get; }
 
+        /// <summary>
+        /// Optional filter span for a synthesized CompilationUnitCompletedEvent generated for span-based semantic diagnostic computation.
+        /// See https://github.com/dotnet/roslyn/issues/56843 for details.
+        /// </summary>
+        public TextSpan? FilterSpan { get; }
+
         public override string ToString()
         {
-            return "CompilationUnitCompletedEvent(" + CompilationUnit.FilePath + ")";
+            var str = "CompilationUnitCompletedEvent(" + CompilationUnit.FilePath + ")";
+            if (FilterSpan.HasValue)
+            {
+                str += FilterSpan.Value.ToString();
+            }
+
+            return str;
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
@@ -38,8 +38,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             public static void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
             {
-                var declDiagnostics = context.SemanticModel.GetDeclarationDiagnostics(cancellationToken: context.CancellationToken);
-                var bodyDiagnostics = context.SemanticModel.GetMethodBodyDiagnostics(cancellationToken: context.CancellationToken);
+                var declDiagnostics = context.SemanticModel.GetDeclarationDiagnostics(context.FilterSpan, context.CancellationToken);
+                var bodyDiagnostics = context.SemanticModel.GetMethodBodyDiagnostics(context.FilterSpan, context.CancellationToken);
 
                 ReportDiagnostics(declDiagnostics, context.ReportDiagnostic, IsSourceLocation, s_declaration);
                 ReportDiagnostics(bodyDiagnostics, context.ReportDiagnostic, IsSourceLocation);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
@@ -648,12 +648,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken { get { return _cancellationToken; } }
 
+        /// <summary>
+        /// Optional filter span for which to compute diagnostics.
+        /// </summary>
+        internal TextSpan? FilterSpan { get; set; }
+
         public SemanticModelAnalysisContext(SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
+            : this(semanticModel, options, reportDiagnostic, isSupportedDiagnostic, filterSpan: null, cancellationToken)
+        {
+        }
+
+        internal SemanticModelAnalysisContext(SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, TextSpan? filterSpan, CancellationToken cancellationToken)
         {
             _semanticModel = semanticModel;
             _options = options;
             _reportDiagnostic = reportDiagnostic;
             _isSupportedDiagnostic = isSupportedDiagnostic;
+            FilterSpan = filterSpan;
             _cancellationToken = cancellationToken;
         }
 

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -2186,6 +2186,50 @@ class MyClass
         End Function
 
         <WpfFact>
+        Friend Async Function TestCompilerAnalyzerForSpanBasedQuery() As Task
+            Dim test = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document><![CDATA[
+class C
+{
+    void M1()
+    {
+        int x1 = 0;
+    }
+}]]>
+                               </Document>
+                           </Project>
+                       </Workspace>
+
+            Using workspace = TestWorkspace.CreateWorkspace(test, composition:=s_compositionWithMockDiagnosticUpdateSourceRegistrationService)
+                Dim solution = workspace.CurrentSolution
+                Dim project = solution.Projects.Single()
+
+                ' Add compiler analyzer
+                Dim analyzer = DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp)
+                Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(analyzer))
+                project = project.AddAnalyzerReference(analyzerReference)
+
+                ' Get span to analyze
+                Dim document = project.Documents.Single()
+                Dim root = Await document.GetSyntaxRootAsync(CancellationToken.None)
+                Dim localDecl = root.DescendantNodes().OfType(Of CodeAnalysis.CSharp.Syntax.LocalDeclarationStatementSyntax).Single()
+                Dim span = localDecl.Span
+
+                Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
+                Assert.IsType(Of MockDiagnosticUpdateSourceRegistrationService)(workspace.GetService(Of IDiagnosticUpdateSourceRegistrationService)())
+                Dim diagnosticService = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
+                Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
+
+                ' Verify diagnostics for span
+                Dim diagnostics As New PooledObjects.ArrayBuilder(Of DiagnosticData)
+                Await diagnosticService.TryAppendDiagnosticsForSpanAsync(document, span, diagnostics)
+                Dim diagnostic = Assert.Single(diagnostics)
+                Assert.Equal("CS0219", diagnostic.Id)
+            End Using
+        End Function
+
+        <WpfFact>
         Public Async Function TestEnsureNoMergedNamespaceSymbolAnalyzerAsync() As Task
             Dim test = <Workspace>
                            <Project Language="C#" AssemblyName="BaseAssembly" CommonReferences="true">

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerExtensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerExtensions.cs
@@ -16,25 +16,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 ProjectDiagnosticAnalyzer _ => DiagnosticAnalyzerCategory.ProjectAnalysis,
                 IBuiltInAnalyzer builtInAnalyzer => builtInAnalyzer.GetAnalyzerCategory(),
 
-                // It is not possible to know the categorization for a public analyzer, so return a worst-case categorization.
-                _ => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis
+                // Compiler analyzer supports syntax diagnostics, span-based semantic diagnostics and project level diagnostics.
+                // For a public analyzer it is not possible to know the diagnostic categorization, so return a worst-case categorization.
+                _ => analyzer.IsCompilerAnalyzer()
+                    ? DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis | DiagnosticAnalyzerCategory.SemanticSpanAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis
+                    : DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis
             };
 
         public static bool SupportAnalysisKind(this DiagnosticAnalyzer analyzer, AnalysisKind kind)
-        {
-            // compiler diagnostic analyzer always supports all kinds:
-            if (analyzer.IsCompilerAnalyzer())
-            {
-                return true;
-            }
-
-            return kind switch
+            => kind switch
             {
                 AnalysisKind.Syntax => analyzer.SupportsSyntaxDiagnosticAnalysis(),
                 AnalysisKind.Semantic => analyzer.SupportsSemanticDiagnosticAnalysis(),
                 _ => throw ExceptionUtilities.UnexpectedValue(kind)
             };
-        }
 
         public static bool SupportsSyntaxDiagnosticAnalysis(this DiagnosticAnalyzer analyzer)
         {


### PR DESCRIPTION
Addresses the first bullet point in #56843.

Prior to this change, compiler diagnostic analyzer could only be run from the IDE for entire document span. This is primarily due to lack of an analyzer API that allows the analyzer to register a span-based semantic diagnostic callback. Though we can consider designing and adding such an analyzer API, it would be purely an IDE-only analyzer action, as analyzers are never executed for a span in batch compilation mode - this would make it difficult to justify adding such an API.

With this PR, we add a workaround in the analyzer driver to allow executing compiler analyzer's semantic model action scoped to a filter span. This should speed up executing the compiler analyzer for lightbulb scenarios in the IDE, which are always scoped to current line span.

Verified that both the compiler and IDE tests added with this PR fail prior to the product changes.

**NOTE:** This change would not give us any perceivable improvement in non-async lightbulb scenario, as we are extremely likely to have at least one other analyzer that needs to run on the entire document. The performance improvement should be perceivable in async lightbulb scenario as the high priority code fixes bucket (add usings and merge conflict resolution) only run the compiler analyzer.