### PR TITLE
Allow newlines in the holes inside interpolated strings

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1308,7 +1308,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DictionaryInitializerInExpressionTree = 8074,
         ERR_ExtensionCollectionElementInitializerInExpressionTree = 8075,
         ERR_UnclosedExpressionHole = 8076,
-        ERR_SingleLineCommentInExpressionHole = 8077,
+        // It is now legal to have single line comments in expression holes.
+        // ERR_SingleLineCommentInExpressionHole = 8077,
         ERR_InsufficientStack = 8078,
         ERR_UseDefViolationProperty = 8079,
         ERR_AutoPropertyMustOverrideSet = 8080,
@@ -1990,7 +1991,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadCallerArgumentExpressionParamWithoutDefaultValue = 8964,
         WRN_CallerArgumentExpressionAttributeSelfReferential = 8965,
         WRN_CallerArgumentExpressionParamForUnconsumedLocation = 8966,
-        ERR_NewlinesAreNotAllowedInsideANonVerbatimInterpolatedString = 8967,
+        // It is now legal to have newlines in expression holes.
+        // ERR_NewlinesAreNotAllowedInsideANonVerbatimInterpolatedString = 8967,
         ERR_AttrTypeArgCannotBeTypeVar = 8968,
         // WRN_AttrDependentTypeNotAllowed = 8969, // Backed out of of warning wave 6, may be reintroduced later
         ERR_AttrDependentTypeNotAllowed = 8970,

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -764,7 +764,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case '@':
                     if (TextWindow.PeekChar(1) == '"')
                     {
-                        var errorCode = this.ScanVerbatimStringLiteral(ref info, allowNewlines: true);
+                        var errorCode = this.ScanVerbatimStringLiteral(ref info);
                         if (errorCode is ErrorCode code)
                             this.AddError(code);
                     }

--- a/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer_StringLiteral.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         /// <summary>
         /// Returns an appropriate error code if scanning this verbatim literal ran into an error.
         /// </summary>
-        private ErrorCode? ScanVerbatimStringLiteral(ref TokenInfo info, bool allowNewlines)
+        private ErrorCode? ScanVerbatimStringLiteral(ref TokenInfo info)
         {
             _builder.Length = 0;
 
@@ -178,14 +178,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     // starting point. And finish lexing this string.
                     error ??= ErrorCode.ERR_UnterminatedStringLit;
                     break;
-                }
-
-                // If we hit a new line when it's not allowed.  Give an error at that new line, but keep on consuming
-                // the verbatim literal to the end to avoid the contents of the string being lexed as C# (which will
-                // cause a ton of cascaded errors).  Only need to do this on the first newline we hit.
-                if (!allowNewlines && SyntaxFacts.IsNewLine(ch))
-                {
-                    error ??= ErrorCode.ERR_NewlinesAreNotAllowedInsideANonVerbatimInterpolatedString;
                 }
 
                 TextWindow.AdvanceChar();
@@ -272,7 +264,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             private readonly Lexer _lexer;
             private bool _isVerbatim;
-            private bool _allowNewlines;
 
             /// <summary>
             /// There are two types of errors we can encounter when trying to scan out an interpolated string (and its
@@ -285,18 +276,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             public SyntaxDiagnosticInfo? Error;
             private bool EncounteredUnrecoverableError;
 
-            public InterpolatedStringScanner(
-                Lexer lexer,
-                bool isVerbatim)
+            public InterpolatedStringScanner(Lexer lexer, bool isVerbatim)
             {
                 _lexer = lexer;
                 _isVerbatim = isVerbatim;
-                _allowNewlines = isVerbatim;
             }
 
             private bool IsAtEnd()
             {
-                return IsAtEnd(_isVerbatim && _allowNewlines);
+                return IsAtEnd(_isVerbatim);
             }
 
             private bool IsAtEnd(bool allowNewline)
@@ -529,15 +517,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     char ch = _lexer.TextWindow.PeekChar();
 
-                    // See if we ran into a disallowed new line.  If so, this is recoverable, so just skip past it but
-                    // give a good message about the issue.  This will prevent a lot of cascading issues with the
-                    // remainder of the interpolated string that comes on the following lines.
-                    var allowNewLines = _isVerbatim && _allowNewlines;
-                    if (!allowNewLines && SyntaxFacts.IsNewLine(ch))
-                    {
-                        TrySetRecoverableError(_lexer.MakeError(_lexer.TextWindow.Position, width: 0, ErrorCode.ERR_NewlinesAreNotAllowedInsideANonVerbatimInterpolatedString));
-                    }
-
+                    // Note: within a hole new-lines are always allowed.  The retriction on if new-lines are allowed or not
+                    // is only within a text-portion of the interpolated stirng.
                     if (IsAtEnd(allowNewline: true))
                     {
                         // the caller will complain
@@ -558,17 +539,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 var interpolations = (ArrayBuilder<Interpolation>?)null;
                                 var info = default(TokenInfo);
                                 bool wasVerbatim = _isVerbatim;
-                                bool wasAllowNewlines = _allowNewlines;
                                 try
                                 {
                                     _isVerbatim = isVerbatimSubstring;
-                                    _allowNewlines &= _isVerbatim;
                                     ScanInterpolatedStringLiteralTop(interpolations, ref info, closeQuoteMissing: out _);
                                 }
                                 finally
                                 {
                                     _isVerbatim = wasVerbatim;
-                                    _allowNewlines = wasAllowNewlines;
                                 }
                                 continue;
                             }
@@ -618,7 +596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 // to be a normal verbatim string, so we can continue on an attempt to understand the
                                 // outer interpolated string properly.
                                 var discarded = default(TokenInfo);
-                                var errorCode = _lexer.ScanVerbatimStringLiteral(ref discarded, _allowNewlines);
+                                var errorCode = _lexer.ScanVerbatimStringLiteral(ref discarded);
                                 if (errorCode is ErrorCode code)
                                 {
                                     TrySetRecoverableError(_lexer.MakeError(nestedStringPosition, width: 2, code));
@@ -632,17 +610,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 var interpolations = (ArrayBuilder<Interpolation>?)null;
                                 var info = default(TokenInfo);
                                 bool wasVerbatim = _isVerbatim;
-                                bool wasAllowNewlines = _allowNewlines;
                                 try
                                 {
                                     _isVerbatim = true;
-                                    _allowNewlines = true;
                                     ScanInterpolatedStringLiteralTop(interpolations, ref info, closeQuoteMissing: out _);
                                 }
                                 finally
                                 {
                                     _isVerbatim = wasVerbatim;
-                                    _allowNewlines = wasAllowNewlines;
                                 }
                                 continue;
                             }
@@ -652,15 +627,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                             switch (_lexer.TextWindow.PeekChar(1))
                             {
                                 case '/':
-                                    if (!_isVerbatim || !_allowNewlines)
-                                    {
-                                        // error: single-line comment not allowed in an interpolated string.
-                                        // report the error but keep going for good error recovery.
-                                        TrySetRecoverableError(_lexer.MakeError(_lexer.TextWindow.Position, 2, ErrorCode.ERR_SingleLineCommentInExpressionHole));
-                                    }
+                                    _lexer.TextWindow.AdvanceChar(); // skip /
+                                    _lexer.TextWindow.AdvanceChar(); // skip /
 
-                                    _lexer.TextWindow.AdvanceChar(); // skip /
-                                    _lexer.TextWindow.AdvanceChar(); // skip /
+                                    // read up to the end of the line.
                                     while (!IsAtEnd(allowNewline: false))
                                     {
                                         _lexer.TextWindow.AdvanceChar(); // skip // comment character
@@ -710,26 +680,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 _lexer.TextWindow.AdvanceChar();
                 while (true)
                 {
-                    var ch = _lexer.TextWindow.PeekChar();
-
-                    // See if we ran into a disallowed new line.  If so, this is recoverable, so just skip past it but
-                    // give a good message about the issue.  This will prevent a lot of cascading issues with the remainder
-                    // of the interpolated string that comes on the following lines.
-                    var allowNewLines = _isVerbatim && _allowNewlines;
-                    if (!allowNewLines && SyntaxFacts.IsNewLine(ch))
-                    {
-                        TrySetRecoverableError(_lexer.MakeError(_lexer.TextWindow.Position, width: 0, ErrorCode.ERR_NewlinesAreNotAllowedInsideANonVerbatimInterpolatedString));
-                    }
-
                     if (IsAtEnd(allowNewline: true))
                     {
-                        return; // let the caller complain about the unterminated quote
+                        this.TrySetUnrecoverableError(_lexer.MakeError(_lexer.TextWindow.Position, 1, ErrorCode.ERR_OpenEndedComment));
+                        return;
                     }
 
+                    var ch = _lexer.TextWindow.PeekChar();
                     _lexer.TextWindow.AdvanceChar();
                     if (ch == '*' && _lexer.TextWindow.PeekChar() == '/')
                     {
-                        _lexer.TextWindow.AdvanceChar(); // skip */
+                        _lexer.TextWindow.AdvanceChar();
                         return;
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/csharplang/issues/4935 (approved by LDM).