### PR TITLE
Add anonymous method example to breaking changes document

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 6.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 6.md
@@ -69,14 +69,15 @@ These are _function_type_conversions_.
     }
     ```
 
-    c. Method group conversion to `Expression` or `LambdaExpression`
+    c. Method group or anonymous method conversion to `Expression` or `LambdaExpression`
 
     ```csharp
     using System;
     using System.Linq.Expressions;
 
     var c = new C();
-    c.M(F); // error CS0428: Cannot convert method group 'F' to non-delegate type 'Expression'
+    c.M(F);                         // error CS0428: Cannot convert method group 'F' to non-delegate type 'Expression'
+    c.M(delegate () { return 1; }); // error CS1946: An anonymous method expression cannot be converted to an expression tree
 
     static int F() => 0;
 

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -7807,6 +7807,65 @@ class A {
                 "delegate*<in Int32, ref readonly String>");
         }
 
+        private static readonly SymbolDisplayFormat s_fullDelegateFormat = new SymbolDisplayFormat(
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+            delegateStyle: SymbolDisplayDelegateStyle.NameAndSignature,
+            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeVariance | SymbolDisplayGenericsOptions.IncludeTypeConstraints,
+            parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeParamsRefOut,
+            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes,
+            kindOptions: SymbolDisplayKindOptions.IncludeNamespaceKeyword | SymbolDisplayKindOptions.IncludeTypeKeyword);
+
+        [Fact]
+        public void TestInferredDelegateType()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        var v = (int i) => i.ToString();
+    }
+}
+";
+
+            var comp = CreateCompilation(source);
+            var semanticModel = comp.GetSemanticModel(comp.SyntaxTrees.Single());
+            var syntaxTree = semanticModel.SyntaxTree;
+            var declaration = (LocalDeclarationStatementSyntax)semanticModel.SyntaxTree.GetRoot().DescendantNodes().Single(n => n.Kind() == SyntaxKind.LocalDeclarationStatement);
+            var type = semanticModel.GetTypeInfo(declaration.Declaration.Type).Type;
+
+            Verify(type.ToDisplayParts(), "System.Func<int, string>",
+                SymbolDisplayPartKind.NamespaceName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.DelegateName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation);
+
+            Verify(type.ToDisplayParts(s_fullDelegateFormat), "delegate string System.Func<int, string>(int arg)",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NamespaceName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.DelegateName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation);
+        }
+
         [Fact]
         public void TestSynthesizedAnonymousDelegateType1()
         {
@@ -7821,25 +7880,15 @@ class C
 ";
 
             var comp = CreateCompilation(source);
-
             var semanticModel = comp.GetSemanticModel(comp.SyntaxTrees.Single());
             var syntaxTree = semanticModel.SyntaxTree;
-
             var declaration = (LocalDeclarationStatementSyntax)semanticModel.SyntaxTree.GetRoot().DescendantNodes().Single(n => n.Kind() == SyntaxKind.LocalDeclarationStatement);
             var type = semanticModel.GetTypeInfo(declaration.Declaration.Type).Type;
 
             Verify(type.ToDisplayParts(), "<anonymous delegate>",
                 SymbolDisplayPartKind.DelegateName);
 
-            var format = new SymbolDisplayFormat(
-                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
-                delegateStyle: SymbolDisplayDelegateStyle.NameAndSignature,
-                genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeVariance | SymbolDisplayGenericsOptions.IncludeTypeConstraints,
-                parameterOptions: SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeName | SymbolDisplayParameterOptions.IncludeParamsRefOut,
-                miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes,
-                kindOptions: SymbolDisplayKindOptions.IncludeNamespaceKeyword | SymbolDisplayKindOptions.IncludeTypeKeyword);
-
-            Verify(type.ToDisplayParts(format), "delegate string <anonymous delegate>(ref int)",
+            Verify(type.ToDisplayParts(s_fullDelegateFormat), "delegate string <anonymous delegate>(ref int)",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
@@ -7850,7 +7899,33 @@ class C
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Punctuation);
+        }
 
+        [Fact]
+        public void TestSynthesizedAnonymousDelegateType2()
+        {
+            var source =
+@"Class Program
+    Shared Sub Main
+        Dim f = Function(ByRef i As Integer) i.ToString()
+    End Sub
+End Class";
+
+            var comp = CreateVisualBasicCompilation(source);
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var name = tree.GetRoot().DescendantNodes().OfType<VisualBasic.Syntax.VariableDeclaratorSyntax>().Single();
+            var type = ((ILocalSymbol)model.GetDeclaredSymbol(name.Names[0])).Type;
+
+            Verify(SymbolDisplay.ToDisplayParts(type), "<empty anonymous type>",
+                SymbolDisplayPartKind.ClassName);
+
+            Verify(SymbolDisplay.ToDisplayParts(type, s_fullDelegateFormat), "AnonymousType string <empty anonymous type>",
+                SymbolDisplayPartKind.AnonymousTypeIndicator,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ClassName);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaAttributeParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaAttributeParsingTests.cs
@@ -3452,5 +3452,143 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             EOF();
         }
+
+        [Fact]
+        public void AnonymousMethod_01()
+        {
+            string source = "[A] delegate () { }";
+            verify(source, TestOptions.Regular9);
+            verify(source);
+
+            void verify(string source, ParseOptions parseOptions = null)
+            {
+                UsingExpression(source, parseOptions,
+                    // (1,1): error CS1073: Unexpected token 'delegate'
+                    // [A] delegate () { }
+                    Diagnostic(ErrorCode.ERR_UnexpectedToken, "[A]").WithArguments("delegate").WithLocation(1, 1),
+                    // (1,1): error CS1525: Invalid expression term '['
+                    // [A] delegate () { }
+                    Diagnostic(ErrorCode.ERR_InvalidExprTerm, "[").WithArguments("[").WithLocation(1, 1));
+
+                N(SyntaxKind.ElementAccessExpression);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.BracketedArgumentList);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Argument);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                            }
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void AnonymousMethod_02()
+        {
+            string source = "[return: A] delegate () { return null; }";
+            verify(source, TestOptions.Regular9);
+            verify(source);
+
+            void verify(string source, ParseOptions parseOptions = null)
+            {
+                UsingExpression(source, parseOptions,
+                    // (1,1): error CS1073: Unexpected token 'delegate'
+                    // [return: A] delegate () { return null; }
+                    Diagnostic(ErrorCode.ERR_UnexpectedToken, "[return: A]").WithArguments("delegate").WithLocation(1, 1),
+                    // (1,1): error CS1525: Invalid expression term '['
+                    // [return: A] delegate () { return null; }
+                    Diagnostic(ErrorCode.ERR_InvalidExprTerm, "[").WithArguments("[").WithLocation(1, 1),
+                    // (1,2): error CS1041: Identifier expected; 'return' is a keyword
+                    // [return: A] delegate () { return null; }
+                    Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "return").WithArguments("", "return").WithLocation(1, 2));
+
+                N(SyntaxKind.ElementAccessExpression);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.BracketedArgumentList);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Argument);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                            }
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                }
+                EOF();
+            }
+        }
+
+        [Fact]
+        public void AnonymousMethod_03()
+        {
+            string source = "d = [A] delegate () { };";
+            verify(source, TestOptions.Regular9);
+            verify(source);
+
+            void verify(string source, ParseOptions parseOptions = null)
+            {
+                UsingStatement(source, parseOptions,
+                    // (1,1): error CS1073: Unexpected token 'delegate'
+                    // d = [A] delegate () { };
+                    Diagnostic(ErrorCode.ERR_UnexpectedToken, "d = [A] ").WithArguments("delegate").WithLocation(1, 1),
+                    // (1,5): error CS1525: Invalid expression term '['
+                    // d = [A] delegate () { };
+                    Diagnostic(ErrorCode.ERR_InvalidExprTerm, "[").WithArguments("[").WithLocation(1, 5),
+                    // (1,9): error CS1002: ; expected
+                    // d = [A] delegate () { };
+                    Diagnostic(ErrorCode.ERR_SemicolonExpected, "delegate").WithLocation(1, 9));
+
+                N(SyntaxKind.ExpressionStatement);
+                {
+                    N(SyntaxKind.SimpleAssignmentExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "d");
+                        }
+                        N(SyntaxKind.EqualsToken);
+                        N(SyntaxKind.ElementAccessExpression);
+                        {
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                            N(SyntaxKind.BracketedArgumentList);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                N(SyntaxKind.Argument);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "A");
+                                    }
+                                }
+                                N(SyntaxKind.CloseBracketToken);
+                            }
+                        }
+                    }
+                    M(SyntaxKind.SemicolonToken);
+                }
+                EOF();
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaAttributeParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaAttributeParsingTests.cs
@@ -3460,7 +3460,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             verify(source, TestOptions.Regular9);
             verify(source);
 
-            void verify(string source, ParseOptions parseOptions = null)
+            void verify(string source, ParseOptions? parseOptions = null)
             {
                 UsingExpression(source, parseOptions,
                     // (1,1): error CS1073: Unexpected token 'delegate'
@@ -3500,7 +3500,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             verify(source, TestOptions.Regular9);
             verify(source);
 
-            void verify(string source, ParseOptions parseOptions = null)
+            void verify(string source, ParseOptions? parseOptions = null)
             {
                 UsingExpression(source, parseOptions,
                     // (1,1): error CS1073: Unexpected token 'delegate'
@@ -3543,7 +3543,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             verify(source, TestOptions.Regular9);
             verify(source);
 
-            void verify(string source, ParseOptions parseOptions = null)
+            void verify(string source, ParseOptions? parseOptions = null)
             {
                 UsingStatement(source, parseOptions,
                     // (1,1): error CS1073: Unexpected token 'delegate'

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
@@ -5179,6 +5179,72 @@ End Class")
             Verify(description, "A.B", SymbolDisplayPartKind.AliasName, SymbolDisplayPartKind.Operator, SymbolDisplayPartKind.ClassName)
         End Sub
 
+        <Fact()>
+        Public Sub AnonymousDelegateType()
+            Dim source =
+"Class Program
+    Shared Sub Main()
+        Dim f = Function(ByRef x as Integer) x.ToString()
+    End Sub
+End Class"
+            Dim comp = CreateCompilation(source)
+            comp.VerifyDiagnostics()
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim declarator = tree.GetCompilationUnitRoot().DescendantNodes().OfType(Of VariableDeclaratorSyntax)().Single()
+            Dim type = DirectCast(model.GetDeclaredSymbol(declarator.Names(0)), ILocalSymbol).Type
+
+            Verify(
+                type.ToDisplayParts(),
+                "Function <generated method>(ByRef x As Integer) As String",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.DelegateName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword)
+
+            Dim format = New SymbolDisplayFormat(
+                typeQualificationStyle:=SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+                delegateStyle:=SymbolDisplayDelegateStyle.NameAndSignature,
+                genericsOptions:=SymbolDisplayGenericsOptions.IncludeTypeParameters Or SymbolDisplayGenericsOptions.IncludeVariance Or SymbolDisplayGenericsOptions.IncludeTypeConstraints,
+                parameterOptions:=SymbolDisplayParameterOptions.IncludeType Or SymbolDisplayParameterOptions.IncludeName Or SymbolDisplayParameterOptions.IncludeParamsRefOut,
+                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers Or SymbolDisplayMiscellaneousOptions.UseSpecialTypes,
+                kindOptions:=SymbolDisplayKindOptions.IncludeNamespaceKeyword Or SymbolDisplayKindOptions.IncludeTypeKeyword)
+
+            Verify(
+                type.ToDisplayParts(format),
+                "AnonymousType Function <generated method>(ByRef x As Integer) As String",
+                SymbolDisplayPartKind.AnonymousTypeIndicator,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.DelegateName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword)
+        End Sub
+
 #Region "Helpers"
 
         Private Shared Sub TestSymbolDescription(


### PR DESCRIPTION
Add anonymous method example to breaking changes document and add synthesized anonymous delegate tests for `SymbolDisplay`.