### PR TITLE
Ensure that OOP feature calls read from the right DB.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/DocumentKey.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/DocumentKey.cs
@@ -48,5 +48,8 @@ namespace Microsoft.CodeAnalysis.Storage
 
         public int GetHashCode(DocumentKey obj)
             => obj.Id.GetHashCode();
+
+        public DocumentKey WithWorkspaceKind(string workspaceKind)
+            => new(Project.WithWorkspaceKind(workspaceKind), Id, FilePath, Name);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/ProjectKey.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/ProjectKey.cs
@@ -48,5 +48,8 @@ namespace Microsoft.CodeAnalysis.Storage
 
         public static ProjectKey ToProjectKey(SolutionKey solutionKey, ProjectState projectState)
             => new(solutionKey, projectState.Id, projectState.FilePath, projectState.Name, projectState.GetParseOptionsChecksum());
+
+        public ProjectKey WithWorkspaceKind(string workspaceKind)
+            => new(Solution.WithWorkspaceKind(workspaceKind), Id, FilePath, Name, ParseOptionsChecksum);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/SolutionKey.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/SolutionKey.cs
@@ -41,5 +41,8 @@ namespace Microsoft.CodeAnalysis.Storage
 
         public static SolutionKey ToSolutionKey(SolutionState solutionState)
             => new(solutionState.Workspace.Kind, solutionState.Id, solutionState.FilePath, solutionState.BranchId == solutionState.Workspace.PrimaryBranchId);
+
+        public SolutionKey WithWorkspaceKind(string workspaceKind)
+            => new(workspaceKind, Id, FilePath, IsPrimaryBranch);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
@@ -98,9 +98,15 @@ namespace Microsoft.CodeAnalysis.Remote
                 // synchronizing the solution over to the remote side.  Instead, we just directly
                 // check whatever cached data we have from the previous vs session.
                 var callback = GetCallback(callbackId, cancellationToken);
+                var workspace = GetWorkspace();
+
+                // We translated a call from the host over to the OOP side.  We need to look up
+                // the data in OOP's storage system, not the host's storage system.
+                documentKeys = documentKeys.SelectAsArray(d => d.WithWorkspaceKind(workspace.Kind!));
+                priorityDocumentKeys = priorityDocumentKeys.SelectAsArray(d => d.WithWorkspaceKind(workspace.Kind!));
 
                 await AbstractNavigateToSearchService.SearchCachedDocumentsInCurrentProcessAsync(
-                    GetWorkspaceServices(), documentKeys, priorityDocumentKeys, database, searchPattern, kinds.ToImmutableHashSet(), callback, cancellationToken).ConfigureAwait(false);
+                    workspace.Services, documentKeys, priorityDocumentKeys, database, searchPattern, kinds.ToImmutableHashSet(), callback, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassificationCache/RemoteSemanticClassificationCacheService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassificationCache/RemoteSemanticClassificationCacheService.cs
@@ -163,6 +163,11 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             return RunServiceAsync(async cancellationToken =>
             {
+                // We translated a call from the host over to the OOP side.  We need to look up
+                // the data in OOP's storage system, not the host's storage system.
+                var workspace = GetWorkspace();
+                documentKey = documentKey.WithWorkspaceKind(workspace.Kind!);
+
                 var classifiedSpans = await TryGetOrReadCachedSemanticClassificationsAsync(
                     documentKey, checksum, database, cancellationToken).ConfigureAwait(false);
                 if (classifiedSpans.IsDefault)


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/56237 made a change where a storage DB was not chosen ambiently, but based on the solution the caller was operating on.  This is sensible in isolation, but it broke a pair of features that depended on the prior behavior.  Specifically, 'navigate to' and 'classification caching' both call into OOP with keys associated with the 'VS Host' workspace, but we still want to lookup information in the 'Remote OOP' workspace.

This change fixes things so that on the OOP side we translate these calls over to lookup in the OOP workspace's storage system instead.

We intend to make deeper changes in 17.1.  There will also be tests/telemetry added there to validate that things are working and that we catch regressions.