### PR TITLE
Add external access for vscode telemetry

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "6.0.100-rc.1.21463.6",
     "allowPrerelease": true,
-    "rollForward": "major"
+    "rollForward": "disable"
   },
   "tools": {
     "dotnet": "6.0.100-rc.1.21463.6",

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/VSCode/API/VSCodeTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/VSCode/API/VSCodeTelemetryLogger.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CodeAnalysis.Internal.Log;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.VSCode.API;
+
+/// <summary>
+/// Allows VSCode to implement a telemetry logger for <see cref="ILogger"/> events.
+/// </summary>
+internal abstract class VSCodeTelemetryLogger : ILogger
+{
+    bool ILogger.IsEnabled(FunctionId functionId)
+    {
+        return IsEnabled(functionId.ToString());
+    }
+
+    void ILogger.Log(FunctionId functionId, LogMessage logMessage)
+    {
+        Log(functionId.ToString(), GetProperties(logMessage), CancellationToken.None);
+    }
+
+    void ILogger.LogBlockStart(FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
+    {
+        LogBlockStart(functionId.ToString(), GetProperties(logMessage), cancellationToken);
+    }
+
+    void ILogger.LogBlockEnd(FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
+    {
+        LogBlockEnd(functionId.ToString(), GetProperties(logMessage), cancellationToken);
+    }
+
+    public void Register()
+    {
+        Logger.SetLogger(this);
+    }
+
+    public abstract bool IsEnabled(string functionId);
+
+    public abstract void Log(string functionId, IEnumerable<KeyValuePair<string, object>>? properties, CancellationToken cancellationToken);
+
+    public abstract void LogBlockStart(string functionId, IEnumerable<KeyValuePair<string, object>>? properties, CancellationToken cancellationToken);
+
+    public abstract void LogBlockEnd(string functionId, IEnumerable<KeyValuePair<string, object>>? properties, CancellationToken cancellationToken);
+
+    private static IEnumerable<KeyValuePair<string, object>>? GetProperties(LogMessage logMessage)
+    {
+        return logMessage is KeyValueLogMessage kvMessage ? kvMessage.Properties : null;
+    }
+}

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/VSCode/API/VSCodeTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/VSCode/API/VSCodeTelemetryLogger.cs
@@ -13,40 +13,24 @@ namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.VSCode.API;
 /// </summary>
 internal abstract class VSCodeTelemetryLogger : ILogger
 {
-    private readonly Dictionary<FunctionId, string> _functionIdToString = new Dictionary<FunctionId, string>();
-
-    private string GetFunctionIdAsString(FunctionId functionId)
-    {
-        if (_functionIdToString.ContainsKey(functionId))
-        {
-            return _functionIdToString[functionId];
-        }
-        else
-        {
-            var functionIdAsString = functionId.ToString();
-            _functionIdToString.Add(functionId, functionIdAsString);
-            return functionIdAsString;
-        }
-    }
-
     bool ILogger.IsEnabled(FunctionId functionId)
     {
-        return IsEnabled(GetFunctionIdAsString(functionId));
+        return IsEnabled(functionId.Convert());
     }
 
     void ILogger.Log(FunctionId functionId, LogMessage logMessage)
     {
-        Log(GetFunctionIdAsString(functionId), GetProperties(logMessage), CancellationToken.None);
+        Log(functionId.Convert(), GetProperties(logMessage), CancellationToken.None);
     }
 
     void ILogger.LogBlockStart(FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
     {
-        LogBlockStart(GetFunctionIdAsString(functionId), GetProperties(logMessage), cancellationToken);
+        LogBlockStart(functionId.Convert(), GetProperties(logMessage), cancellationToken);
     }
 
     void ILogger.LogBlockEnd(FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
     {
-        LogBlockEnd(GetFunctionIdAsString(functionId), GetProperties(logMessage), cancellationToken);
+        LogBlockEnd(functionId.Convert(), GetProperties(logMessage), cancellationToken);
     }
 
     public void Register()

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/VSCode/API/VSCodeTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/VSCode/API/VSCodeTelemetryLogger.cs
@@ -13,24 +13,40 @@ namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.VSCode.API;
 /// </summary>
 internal abstract class VSCodeTelemetryLogger : ILogger
 {
+    private readonly Dictionary<FunctionId, string> _functionIdToString = new Dictionary<FunctionId, string>();
+
+    private string GetFunctionIdAsString(FunctionId functionId)
+    {
+        if (_functionIdToString.ContainsKey(functionId))
+        {
+            return _functionIdToString[functionId];
+        }
+        else
+        {
+            var functionIdAsString = functionId.ToString();
+            _functionIdToString.Add(functionId, functionIdAsString);
+            return functionIdAsString;
+        }
+    }
+
     bool ILogger.IsEnabled(FunctionId functionId)
     {
-        return IsEnabled(functionId.ToString());
+        return IsEnabled(GetFunctionIdAsString(functionId));
     }
 
     void ILogger.Log(FunctionId functionId, LogMessage logMessage)
     {
-        Log(functionId.ToString(), GetProperties(logMessage), CancellationToken.None);
+        Log(GetFunctionIdAsString(functionId), GetProperties(logMessage), CancellationToken.None);
     }
 
     void ILogger.LogBlockStart(FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
     {
-        LogBlockStart(functionId.ToString(), GetProperties(logMessage), cancellationToken);
+        LogBlockStart(GetFunctionIdAsString(functionId), GetProperties(logMessage), cancellationToken);
     }
 
     void ILogger.LogBlockEnd(FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
     {
-        LogBlockEnd(functionId.ToString(), GetProperties(logMessage), cancellationToken);
+        LogBlockEnd(GetFunctionIdAsString(functionId), GetProperties(logMessage), cancellationToken);
     }
 
     public void Register()

--- a/src/VisualStudio/Core/Def/RoslynActivityLogger.cs
+++ b/src/VisualStudio/Core/Def/RoslynActivityLogger.cs
@@ -55,16 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             private const int StartEventId = 1;
             private const int EndEventId = 2;
 
-            private static readonly ImmutableDictionary<FunctionId, string> s_functionIdCache;
-
             public readonly TraceSource TraceSource;
-
-            static TraceSourceLogger()
-            {
-                // build enum to string cache
-                s_functionIdCache =
-                    Enum.GetValues(typeof(FunctionId)).Cast<FunctionId>().ToImmutableDictionary(f => f, f => f.ToString());
-            }
 
             public TraceSourceLogger(TraceSource traceSource)
                 => TraceSource = traceSource;
@@ -76,13 +67,13 @@ namespace Microsoft.VisualStudio.LanguageServices
             }
 
             public void Log(FunctionId functionId, LogMessage logMessage)
-                => TraceSource.TraceData(TraceEventType.Verbose, LogEventId, s_functionIdCache[functionId], logMessage.GetMessage());
+                => TraceSource.TraceData(TraceEventType.Verbose, LogEventId, functionId.Convert(), logMessage.GetMessage());
 
             public void LogBlockStart(FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
-                => TraceSource.TraceData(TraceEventType.Verbose, StartEventId, s_functionIdCache[functionId], uniquePairId);
+                => TraceSource.TraceData(TraceEventType.Verbose, StartEventId, functionId.Convert(), uniquePairId);
 
             public void LogBlockEnd(FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
-                => TraceSource.TraceData(TraceEventType.Verbose, EndEventId, s_functionIdCache[functionId], uniquePairId, cancellationToken.IsCancellationRequested, delta, logMessage.GetMessage());
+                => TraceSource.TraceData(TraceEventType.Verbose, EndEventId, functionId.Convert(), uniquePairId, cancellationToken.IsCancellationRequested, delta, logMessage.GetMessage());
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Log/FunctionIdExtensions.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionIdExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Internal.Log
+{
+    internal static class FunctionIdExtensions
+    {
+        private static readonly Lazy<ImmutableDictionary<FunctionId, string>> s_functionIdsToString = new(
+            () => Enum.GetValues(typeof(FunctionId)).Cast<FunctionId>().ToImmutableDictionary(f => f, f => f.ToString()));
+
+        public static string Convert(this FunctionId functionId) => s_functionIdsToString.Value[functionId];
+    }
+}


### PR DESCRIPTION
Adds external access so that VSCode can report telemetry when we fire telemetry events.

Since all the logger bits are internal to the workspaces project, this seemed like the most appropriate approach.  However, an alternative is making ILogger and friends public, but not sure if there are other problems with doing that.