### PR TITLE
Delete unnecessary code

### DIFF
--- a/src/VisualStudio/Core/Def/Interactive/VsResetInteractive.cs
+++ b/src/VisualStudio/Core/Def/Interactive/VsResetInteractive.cs
@@ -161,36 +161,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
         }
 
         internal Project GetProjectFromHierarchy(IVsHierarchy hierarchy)
-            => _workspace.CurrentSolution.Projects.FirstOrDefault(proj => ProjectIdMatchesHierarchy(_workspace, proj.Id, hierarchy));
-
-        private static bool ProjectIdMatchesHierarchy(VisualStudioWorkspace workspace, ProjectId projectId, IVsHierarchy hierarchy)
-        {
-            var hierarchyForProject = workspace.GetHierarchy(projectId);
-
-            if (hierarchyForProject == null)
-            {
-                return false;
-            }
-
-            if (hierarchyForProject == hierarchy)
-            {
-                return true;
-            }
-
-            // For CPS, the hierarchy for the Roslyn project isn't the same as the one
-            // we get from Solution Explorer (it's a wrapper implementation), so we'll
-            // have to compare properties.
-
-            hierarchyForProject.GetProperty((uint)VSConstants.VSITEMID.Root, (int)__VSHPROPID.VSHPROPID_Name, out var rawValue);
-
-            if (rawValue is string projectName)
-            {
-                hierarchy.GetProperty((uint)VSConstants.VSITEMID.Root, (int)__VSHPROPID.VSHPROPID_Name, out rawValue);
-                return projectName == (rawValue as string);
-            }
-
-            return false;
-        }
+            => _workspace.CurrentSolution.Projects.FirstOrDefault(proj => _workspace.GetHierarchy(proj.Id) == hierarchy);
 
         private static InteractiveHostPlatform? GetInteractiveHostPlatform(string targetFrameworkMoniker, Platform platform)
         {


### PR DESCRIPTION
This was working around the old CPS wrapper IVsHierarchies which we simply don't do anymore.

I was looking at some code in the Live Unit Testing repository, and discovered this code that wasn't necessary. When @shyamnamboodiripad deleted it from there, he told me it was copied from here. So time for it to go.