### PR TITLE
CompletionService: remove public constructor

### DIFF
--- a/docs/Breaking API Changes.md
+++ b/docs/Breaking API Changes.md
@@ -46,3 +46,10 @@ The change affects compatibility in two ways:
 - DateTimeConstant(-1) will still count when we check that you don’t specify two default values. The compiler will produce an error, instead of succeeding (and producing IL with two attributes).
 
 PR: https://github.com/dotnet/roslyn/pull/11536
+
+# Version 4.1.0
+
+### Can no longer inherit from CompletionService and CompletionServiceWithProviders
+
+The constructors of Microsoft.CodeAnalysis.Completion and Microsoft.CodeAnalysis.Completion.CompletionServiceWithProviders are now internal.
+Roslyn does not support implementing completion for arbitrary languages.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -246,6 +246,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 }
                 else
                 {
+                    Contract.ThrowIfNull(document);
                     filterMethod = (itemsWithPatternMatches, text) => completionService.FilterItems(document, itemsWithPatternMatches, text);
                 }
 

--- a/src/Features/Core/Portable/Completion/CompletionContext.cs
+++ b/src/Features/Core/Portable/Completion/CompletionContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -19,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Completion
     {
         private readonly List<CompletionItem> _items;
 
-        internal IReadOnlyList<CompletionItem> Items => _items;
+        private CompletionItem? _suggestionModeItem;
 
         internal CompletionProvider Provider { get; }
 
@@ -104,6 +102,8 @@ namespace Microsoft.CodeAnalysis.Completion
             _items = new List<CompletionItem>();
         }
 
+        internal IReadOnlyList<CompletionItem> Items => _items;
+
         public void AddItem(CompletionItem item)
         {
             if (item == null)
@@ -128,8 +128,6 @@ namespace Microsoft.CodeAnalysis.Completion
             }
         }
 
-        private CompletionItem _suggestionModeItem;
-
         /// <summary>
         /// An optional <see cref="CompletionItem"/> that appears selected in the list presented to the user during suggestion mode.
         /// 
@@ -140,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// 
         /// No text is ever inserted when this item is completed, leaving the text the user typed instead.
         /// </summary>
-        public CompletionItem SuggestionModeItem
+        public CompletionItem? SuggestionModeItem
         {
             get
             {
@@ -149,12 +147,12 @@ namespace Microsoft.CodeAnalysis.Completion
 
             set
             {
-                _suggestionModeItem = value;
-
-                if (_suggestionModeItem != null)
+                if (value != null)
                 {
-                    _suggestionModeItem = FixItem(_suggestionModeItem);
+                    value = FixItem(value);
                 }
+
+                _suggestionModeItem = value;
             }
         }
 

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -22,6 +22,11 @@ namespace Microsoft.CodeAnalysis.Completion
     /// </summary>
     public abstract class CompletionService : ILanguageService
     {
+        // Prevent inheritance outside of Roslyn.
+        internal CompletionService()
+        {
+        }
+
         /// <summary>
         /// Gets the service corresponding to the specified document.
         /// </summary>

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -27,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <summary>
         /// Gets the service corresponding to the specified document.
         /// </summary>
-        public static CompletionService GetService(Document document)
+        public static CompletionService? GetService(Document? document)
             => document?.GetLanguageService<CompletionService>();
 
         /// <summary>
@@ -55,8 +53,8 @@ namespace Microsoft.CodeAnalysis.Completion
             SourceText text,
             int caretPosition,
             CompletionTrigger trigger,
-            ImmutableHashSet<string> roles = null,
-            OptionSet options = null)
+            ImmutableHashSet<string>? roles = null,
+            OptionSet? options = null)
         {
             return false;
         }
@@ -80,8 +78,8 @@ namespace Microsoft.CodeAnalysis.Completion
             SourceText text,
             int caretPosition,
             CompletionTrigger trigger,
-            ImmutableHashSet<string> roles = null,
-            OptionSet options = null)
+            ImmutableHashSet<string>? roles = null,
+            OptionSet? options = null)
         {
             return ShouldTriggerCompletion(text, caretPosition, trigger, roles, options);
         }
@@ -111,12 +109,12 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="roles">Optional set of roles associated with the editor state.</param>
         /// <param name="options">Optional options that override the default options.</param>
         /// <param name="cancellationToken"></param>
-        public abstract Task<CompletionList> GetCompletionsAsync(
+        public abstract Task<CompletionList?> GetCompletionsAsync(
             Document document,
             int caretPosition,
             CompletionTrigger trigger = default,
-            ImmutableHashSet<string> roles = null,
-            OptionSet options = null,
+            ImmutableHashSet<string>? roles = null,
+            OptionSet? options = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -126,12 +124,12 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <remarks>
         /// expandItemsAvailable is true when expanded items are returned or can be provided upon request.
         /// </remarks>
-        internal virtual async Task<(CompletionList completionList, bool expandItemsAvailable)> GetCompletionsInternalAsync(
+        internal virtual async Task<(CompletionList? completionList, bool expandItemsAvailable)> GetCompletionsInternalAsync(
              Document document,
              int caretPosition,
              CompletionTrigger trigger = default,
-             ImmutableHashSet<string> roles = null,
-             OptionSet options = null,
+             ImmutableHashSet<string>? roles = null,
+             OptionSet? options = null,
              CancellationToken cancellationToken = default)
         {
             var completionList = await GetCompletionsAsync(document, caretPosition, trigger, roles, options, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -528,7 +528,7 @@ namespace Microsoft.CodeAnalysis.Completion
             Document document,
             int position,
             CompletionTrigger triggerInfo,
-            OptionSet options,
+            OptionSet? options,
             TextSpan? defaultSpan,
             CancellationToken cancellationToken)
         {
@@ -752,7 +752,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 Document document,
                 int position,
                 CompletionTrigger triggerInfo,
-                OptionSet options,
+                OptionSet? options,
                 CancellationToken cancellationToken)
             {
                 return _completionServiceWithProviders.GetContextAsync(

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -41,14 +40,14 @@ namespace Microsoft.CodeAnalysis.Completion
         private readonly ConditionalWeakTable<AnalyzerReference, ProjectCompletionProvider>.CreateValueCallback _createProjectCompletionProvidersProvider
             = new(r => new ProjectCompletionProvider(r));
 
-        private readonly Dictionary<string, CompletionProvider> _nameToProvider = new();
+        private readonly Dictionary<string, CompletionProvider?> _nameToProvider = new();
         private readonly Dictionary<ImmutableHashSet<string>, ImmutableArray<CompletionProvider>> _rolesToProviders;
         private readonly Func<ImmutableHashSet<string>, ImmutableArray<CompletionProvider>> _createRoleProviders;
-        private readonly Func<string, CompletionProvider> _getProviderByName;
+        private readonly Func<string, CompletionProvider?> _getProviderByName;
 
         private readonly Workspace _workspace;
 
-        private IEnumerable<Lazy<CompletionProvider, CompletionProviderMetadata>> _importedProviders;
+        private IEnumerable<Lazy<CompletionProvider, CompletionProviderMetadata>>? _lazyImportedProviders;
 
         protected CompletionServiceWithProviders(Workspace workspace)
         {
@@ -71,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Completion
 
         internal IEnumerable<Lazy<CompletionProvider, CompletionProviderMetadata>> GetImportedProviders()
         {
-            if (_importedProviders == null)
+            if (_lazyImportedProviders == null)
             {
                 var language = Language;
                 var mefExporter = (IMefHostExportProvider)_workspace.Services.HostServices;
@@ -81,10 +80,10 @@ namespace Microsoft.CodeAnalysis.Completion
                         .Where(lz => lz.Metadata.Language == language)
                         ).ToList();
 
-                Interlocked.CompareExchange(ref _importedProviders, providers, null);
+                Interlocked.CompareExchange(ref _lazyImportedProviders, providers, null);
             }
 
-            return _importedProviders;
+            return _lazyImportedProviders;
         }
 
         private ImmutableArray<CompletionProvider> CreateRoleProviders(ImmutableHashSet<string> roles)
@@ -114,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Completion
             return imported.Concat(builtin).ToImmutableArray();
         }
 
-        protected ImmutableArray<CompletionProvider> GetProviders(ImmutableHashSet<string> roles)
+        protected ImmutableArray<CompletionProvider> GetProviders(ImmutableHashSet<string>? roles)
         {
             roles ??= ImmutableHashSet<string>.Empty;
 
@@ -125,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         private ConcatImmutableArray<CompletionProvider> GetFilteredProviders(
-            Project project, ImmutableHashSet<string> roles, CompletionTrigger trigger, OptionSet options)
+            Project? project, ImmutableHashSet<string>? roles, CompletionTrigger trigger, OptionSet options)
         {
             var allCompletionProviders = FilterProviders(GetProviders(roles, trigger), trigger, options);
             var projectCompletionProviders = FilterProviders(GetProjectCompletionProviders(project), trigger, options);
@@ -133,12 +132,12 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         protected virtual ImmutableArray<CompletionProvider> GetProviders(
-            ImmutableHashSet<string> roles, CompletionTrigger trigger)
+            ImmutableHashSet<string>? roles, CompletionTrigger trigger)
         {
             return GetProviders(roles);
         }
 
-        private ImmutableArray<CompletionProvider> GetProjectCompletionProviders(Project project)
+        private ImmutableArray<CompletionProvider> GetProjectCompletionProviders(Project? project)
         {
             if (project is null)
             {
@@ -222,9 +221,9 @@ namespace Microsoft.CodeAnalysis.Completion
             return ImmutableArray<CompletionProvider>.Empty;
         }
 
-        protected internal CompletionProvider GetProvider(CompletionItem item)
+        protected internal CompletionProvider? GetProvider(CompletionItem item)
         {
-            CompletionProvider provider = null;
+            CompletionProvider? provider = null;
 
             if (item.ProviderName != null)
             {
@@ -237,18 +236,18 @@ namespace Microsoft.CodeAnalysis.Completion
             return provider;
         }
 
-        private CompletionProvider GetProviderByName(string providerName)
+        private CompletionProvider? GetProviderByName(string providerName)
         {
             var providers = GetAllProviders(roles: ImmutableHashSet<string>.Empty);
             return providers.FirstOrDefault(p => p.Name == providerName);
         }
 
-        public override async Task<CompletionList> GetCompletionsAsync(
+        public override async Task<CompletionList?> GetCompletionsAsync(
             Document document,
             int caretPosition,
             CompletionTrigger trigger,
-            ImmutableHashSet<string> roles,
-            OptionSet options,
+            ImmutableHashSet<string>? roles,
+            OptionSet? options,
             CancellationToken cancellationToken)
         {
             var (completionList, _) = await GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, trigger, roles, options, cancellationToken).ConfigureAwait(false);
@@ -261,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// In most cases we'd still end up with complete document, but we'd consider it an acceptable trade-off even when 
         /// we get into this transient state.
         /// </summary>
-        private async Task<(Document document, SemanticModel semanticModel)> GetDocumentWithFrozenPartialSemanticsAsync(Document document, CancellationToken cancellationToken)
+        private async Task<(Document document, SemanticModel? semanticModel)> GetDocumentWithFrozenPartialSemanticsAsync(Document document, CancellationToken cancellationToken)
         {
             var usePartialSemantic = _workspace.Options.GetOption(CompletionServiceOptions.UsePartialSemanticForCompletion);
             if (usePartialSemantic)
@@ -272,12 +271,12 @@ namespace Microsoft.CodeAnalysis.Completion
             return (document, await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false));
         }
 
-        private protected async Task<(CompletionList completionList, bool expandItemsAvailable)> GetCompletionsWithAvailabilityOfExpandedItemsAsync(
+        private protected async Task<(CompletionList? completionList, bool expandItemsAvailable)> GetCompletionsWithAvailabilityOfExpandedItemsAsync(
             Document document,
             int caretPosition,
             CompletionTrigger trigger,
-            ImmutableHashSet<string> roles,
-            OptionSet options,
+            ImmutableHashSet<string>? roles,
+            OptionSet? options,
             CancellationToken cancellationToken)
         {
             // We don't need SemanticModel here, just want to make sure it won't get GC'd before CompletionProviders are able to get it.
@@ -458,7 +457,7 @@ namespace Microsoft.CodeAnalysis.Completion
             // list.  If no contexts changed it, then just use the default span provided by the service.
             var finalCompletionListSpan = completionContexts.FirstOrDefault(c => c.CompletionListSpan != defaultSpan)?.CompletionListSpan ?? defaultSpan;
             using var displayNameToItemsMap = new DisplayNameToItemsMap(this);
-            CompletionItem suggestionModeItem = null;
+            CompletionItem? suggestionModeItem = null;
 
             foreach (var context in completionContexts)
             {
@@ -559,14 +558,14 @@ namespace Microsoft.CodeAnalysis.Completion
             return description;
         }
 
-        public override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, ImmutableHashSet<string> roles = null, OptionSet options = null)
+        public override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, ImmutableHashSet<string>? roles = null, OptionSet? options = null)
         {
             var document = text.GetOpenDocumentInCurrentContextWithChanges();
             return ShouldTriggerCompletion(document?.Project, text, caretPosition, trigger, roles, options);
         }
 
         internal override bool ShouldTriggerCompletion(
-            Project project, SourceText text, int caretPosition, CompletionTrigger trigger, ImmutableHashSet<string> roles = null, OptionSet options = null)
+            Project? project, SourceText text, int caretPosition, CompletionTrigger trigger, ImmutableHashSet<string>? roles = null, OptionSet? options = null)
         {
             options ??= _workspace.Options;
             if (!options.GetOption(CompletionOptions.TriggerOnTyping, Language))
@@ -576,7 +575,7 @@ namespace Microsoft.CodeAnalysis.Completion
 
             if (trigger.Kind == CompletionTriggerKind.Deletion && SupportsTriggerOnDeletion(options))
             {
-                return Char.IsLetterOrDigit(trigger.Character) || trigger.Character == '.';
+                return char.IsLetterOrDigit(trigger.Character) || trigger.Character == '.';
             }
 
             var providers = GetFilteredProviders(project, roles, trigger, options);
@@ -607,14 +606,14 @@ namespace Microsoft.CodeAnalysis.Completion
             }
         }
 
-        bool IEqualityComparer<ImmutableHashSet<string>>.Equals(ImmutableHashSet<string> x, ImmutableHashSet<string> y)
+        bool IEqualityComparer<ImmutableHashSet<string>>.Equals([AllowNull] ImmutableHashSet<string> x, [AllowNull] ImmutableHashSet<string> y)
         {
             if (x == y)
             {
                 return true;
             }
 
-            if (x.Count != y.Count)
+            if (x == null || y == null || x.Count != y.Count)
             {
                 return false;
             }
@@ -630,7 +629,7 @@ namespace Microsoft.CodeAnalysis.Completion
             return true;
         }
 
-        int IEqualityComparer<ImmutableHashSet<string>>.GetHashCode(ImmutableHashSet<string> obj)
+        int IEqualityComparer<ImmutableHashSet<string>>.GetHashCode([DisallowNull] ImmutableHashSet<string> obj)
         {
             var hash = 0;
             foreach (var o in obj)

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionServiceWithProviders.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Completion;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
+{
+    internal abstract class VSTypeScriptCompletionServiceWithProviders : CompletionServiceWithProviders
+    {
+        internal VSTypeScriptCompletionServiceWithProviders(Workspace workspace)
+            : base(workspace)
+        {
+        }
+    }
+}

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptOptions.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptOptions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
     internal static class VSTypeScriptOptions
     {
         public static PerLanguageOption<bool> BlockForCompletionItems { get; } = (PerLanguageOption<bool>)CompletionOptions.BlockForCompletionItems2;
+        public static PerLanguageOption<bool> TriggerOnTypingLetters { get; } = (PerLanguageOption<bool>)CompletionOptions.TriggerOnTypingLetters2;
 
         public static OptionSet WithBackgroundAnalysisScope(this OptionSet options, bool openFilesOnly)
             => options.WithChangedOption(

--- a/src/Features/Core/Portable/PublicAPI.Shipped.txt
+++ b/src/Features/Core/Portable/PublicAPI.Shipped.txt
@@ -180,7 +180,6 @@ Microsoft.CodeAnalysis.Completion.CompletionRules.WithDismissIfEmpty(bool dismis
 Microsoft.CodeAnalysis.Completion.CompletionRules.WithDismissIfLastCharacterDeleted(bool dismissIfLastCharacterDeleted) -> Microsoft.CodeAnalysis.Completion.CompletionRules
 Microsoft.CodeAnalysis.Completion.CompletionRules.WithSnippetsRule(Microsoft.CodeAnalysis.Completion.SnippetsRule snippetsRule) -> Microsoft.CodeAnalysis.Completion.CompletionRules
 Microsoft.CodeAnalysis.Completion.CompletionService
-Microsoft.CodeAnalysis.Completion.CompletionService.CompletionService() -> void
 Microsoft.CodeAnalysis.Completion.CompletionServiceWithProviders
 Microsoft.CodeAnalysis.Completion.CompletionServiceWithProviders.CompletionServiceWithProviders(Microsoft.CodeAnalysis.Workspace workspace) -> void
 Microsoft.CodeAnalysis.Completion.CompletionServiceWithProviders.GetProvider(Microsoft.CodeAnalysis.Completion.CompletionItem item) -> Microsoft.CodeAnalysis.Completion.CompletionProvider

--- a/src/Tools/ExternalAccess/FSharp/Completion/FSharpCompletionServiceWithProviders.cs
+++ b/src/Tools/ExternalAccess/FSharp/Completion/FSharpCompletionServiceWithProviders.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Completion;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
+{
+    internal abstract class FSharpCompletionServiceWithProviders : CompletionServiceWithProviders
+    {
+        internal FSharpCompletionServiceWithProviders(Workspace workspace)
+            : base(workspace)
+        {
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Completion
 {
     internal static class OmniSharpCompletionService
     {
-        public static Task<(CompletionList completionList, bool expandItemsAvailable)> GetCompletionsAsync(
+        public static Task<(CompletionList? completionList, bool expandItemsAvailable)> GetCompletionsAsync(
             this CompletionService completionService,
             Document document,
             int caretPosition,


### PR DESCRIPTION
Adds nullable annotations.
Removes public constructor of CompletionService. Adds external access types for TS and F#.