### PR TITLE
Unskip AttributeTests.GenericAttributeParameter_01

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -10291,7 +10291,7 @@ class Outer<T2>
                 Diagnostic(ErrorCode.ERR_BadAttributeArgument, "default(T2)").WithLocation(10, 22));
         }
 
-        [ConditionalFact(typeof(CoreClrOnly), AlwaysSkip = "https://github.com/dotnet/roslyn/issues/56664"), WorkItem(55190, "https://github.com/dotnet/roslyn/issues/55190")]
+        [ConditionalFact(typeof(CoreClrOnly)), WorkItem(55190, "https://github.com/dotnet/roslyn/issues/55190")]
         public void GenericAttributeParameter_01()
         {
             var source = @"
@@ -10325,9 +10325,7 @@ class Program
     }
 }
 ";
-            // The expected output here will change once we consume a runtime
-            // which has a fix for https://github.com/dotnet/runtime/issues/56492
-            var verifier = CompileAndVerify(source, sourceSymbolValidator: verify, symbolValidator: verifyMetadata, expectedOutput: "CustomAttributeFormatException");
+            var verifier = CompileAndVerify(source, sourceSymbolValidator: verify, symbolValidator: verifyMetadata, expectedOutput: "a");
 
             verifier.VerifyTypeIL("Holder", @"
 .class private auto ansi beforefieldinit Holder


### PR DESCRIPTION
Closes #56664

This does not resolve the entire issue: the runtime library is now able to retrieve the argument correctly, but the compiler doesn't yet do the same for the metadata symbols. I did experiment locally with updating the System.Reflection.Metadata dependency but it did not produce the correct behavior. It's possible the behavior is solely the result of a bug in the compiler and it's also possible that both the dependency update and a compiler change is needed for correct behavior.
