### PR TITLE
Disable roll-forward to newer SDK versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "6.0.100-rc.1.21463.6",
     "allowPrerelease": true,
-    "rollForward": "major"
+    "rollForward": "disable"
   },
   "tools": {
     "dotnet": "6.0.100-rc.1.21463.6",


### PR DESCRIPTION
Right now we can't run with some unreleased SDK versions so disable this for now.