### PR TITLE
Allow fixing valid unused variables nested inside bad local declarations

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedVariable/RemoveUnusedVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedVariable/RemoveUnusedVariableTests.cs
@@ -769,5 +769,32 @@ class C
     }
 }");
         }
+
+        [WorkItem(56924, "https://github.com/dotnet/roslyn/issues/56924")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedVariable)]
+        public async Task RemoveUnusedVariableInCatchInsideBadLocalDeclaration()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    void Method(bool test)
+    {
+        if (test) var x = () => {
+            try { }
+            catch (Exception [|ex|]) { }
+        };
+    }
+}",
+@"class Class
+{
+    void Method(bool test)
+    {
+        if (test) var x = () => {
+            try { }
+            catch (Exception) { }
+        };
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/RemoveUnusedVariable/CSharpRemoveUnusedVariableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedVariable/CSharpRemoveUnusedVariableCodeFixProvider.cs
@@ -70,8 +70,15 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedVariable
         protected override SeparatedSyntaxList<SyntaxNode> GetVariables(LocalDeclarationStatementSyntax localDeclarationStatement)
             => localDeclarationStatement.Declaration.Variables;
 
-        protected override bool ShouldOfferFixForLocalDeclaration(ISyntaxFactsService syntaxFacts, LocalDeclarationStatementSyntax localDeclaration)
+        protected override bool ShouldOfferFixForLocalDeclaration(ISyntaxFactsService syntaxFacts, SyntaxNode node)
         {
+            var localDeclaration = node.Parent?.Parent as LocalDeclarationStatementSyntax;
+
+            // If the fix location is not for a local declaration then we can allow it (eg, when inside a for
+            // or catch).
+            if (localDeclaration is null)
+                return true;
+
             // Local declarations must be parented by an executable block, or global statement, otherwise
             // removing them would be invalid (and more than likely crash the fixer)
             return localDeclaration.Parent is GlobalStatementSyntax ||

--- a/src/Features/VisualBasic/Portable/RemoveUnusedVariable/VisualBasicRemoveUnusedVariableCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/RemoveUnusedVariable/VisualBasicRemoveUnusedVariableCodeFixProvider.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedVariable
             Return localDeclarationStatement.Declarators
         End Function
 
-        Protected Overrides Function ShouldOfferFixForLocalDeclaration(syntaxFactsService As ISyntaxFactsService, localDeclaration As LocalDeclarationStatementSyntax) As Boolean
+        Protected Overrides Function ShouldOfferFixForLocalDeclaration(syntaxFactsService As ISyntaxFactsService, node As SyntaxNode) As Boolean
             Return True
         End Function
     End Class


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/56924

A suggestion in https://github.com/dotnet/roslyn/pull/56902 made the local declaration lookup too broad. This reverts to the state before the suggestion, and adds a test.