### PR TITLE
[Async lightbulb performance] Move suppression fixes to 'Low' priority bucket

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -467,7 +467,7 @@ class Class
                     var diagnostics = await diagnosticService.GetDiagnosticsForSpanAsync(document, span);
                     Assert.Equal(2, diagnostics.Where(d => d.Id == "CS0219").Count());
 
-                    var allFixes = (await fixService.GetFixesAsync(document, span, includeConfigurationFixes: true, cancellationToken: CancellationToken.None))
+                    var allFixes = (await fixService.GetFixesAsync(document, span, cancellationToken: CancellationToken.None))
                         .SelectMany(fixCollection => fixCollection.Fixes);
 
                     var cs0219Fixes = allFixes.Where(fix => fix.PrimaryDiagnostic.Id == "CS0219").ToArray();

--- a/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
@@ -106,20 +106,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         {
                             VisualStudio.Utilities.DefaultOrderings.Highest => CodeActionRequestPriority.High,
                             VisualStudio.Utilities.DefaultOrderings.Default => CodeActionRequestPriority.Normal,
-                            VisualStudio.Utilities.DefaultOrderings.Lowest => CodeActionRequestPriority.Low,
+                            VisualStudio.Utilities.DefaultOrderings.Lowest => CodeActionRequestPriority.Lowest,
                             _ => (CodeActionRequestPriority?)null,
                         };
 
                         if (priority != null)
                         {
-                            // Only request suppression fixes if we're in the lowest priority group.  The other groups
-                            // should not show suppressions them as that would cause them to not appear at the end.
-
                             var allSets = GetCodeFixesAndRefactoringsAsync(
                                 state, requestedActionCategories, document,
                                 range, selection,
                                 addOperationScope: _ => null,
-                                includeSuppressionFixes: priority.Value == CodeActionRequestPriority.Low,
                                 priority.Value,
                                 currentActionCount, cancellationToken).WithCancellation(cancellationToken).ConfigureAwait(false);
 
@@ -165,7 +161,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 SnapshotSpan range,
                 TextSpan? selection,
                 Func<string, IDisposable?> addOperationScope,
-                bool includeSuppressionFixes,
                 CodeActionRequestPriority priority,
                 int currentActionCount,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -175,7 +170,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 var fixesTask = GetCodeFixesAsync(
                     state, supportsFeatureService, requestedActionCategories, workspace, document, range,
-                    addOperationScope, includeSuppressionFixes, priority, isBlocking: false, cancellationToken);
+                    addOperationScope, priority, isBlocking: false, cancellationToken);
                 var refactoringsTask = GetRefactoringsAsync(
                     state, supportsFeatureService, requestedActionCategories, GlobalOptions, workspace, document, selection,
                     addOperationScope, priority, isBlocking: false, cancellationToken);

--- a/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
@@ -106,6 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         {
                             VisualStudio.Utilities.DefaultOrderings.Highest => CodeActionRequestPriority.High,
                             VisualStudio.Utilities.DefaultOrderings.Default => CodeActionRequestPriority.Normal,
+                            VisualStudio.Utilities.DefaultOrderings.Lowest => CodeActionRequestPriority.Low,
                             _ => (CodeActionRequestPriority?)null,
                         };
 
@@ -118,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                                 state, requestedActionCategories, document,
                                 range, selection,
                                 addOperationScope: _ => null,
-                                includeSuppressionFixes: priority.Value == CodeActionRequestPriority.Normal,
+                                includeSuppressionFixes: priority.Value == CodeActionRequestPriority.Low,
                                 priority.Value,
                                 currentActionCount, cancellationToken).WithCancellation(cancellationToken).ConfigureAwait(false);
 

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -321,6 +321,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
                 }
 
+                // 'CodeActionRequestPriority.Low' is reserved for suppression/configuration code fixes.
+                // No code refactoring should have this request priority.
+                if (priority == CodeActionRequestPriority.Low)
+                {
+                    return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
+                }
+
                 // If we are computing refactorings outside the 'Refactoring' context, i.e. for example, from the lightbulb under a squiggle or selection,
                 // then we want to filter out refactorings outside the selection span.
                 var filterOutsideSelection = !requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring);

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     // SuggestedActionSets so that we can share logic between local Roslyn and LSP.
                     var fixesTask = GetCodeFixesAsync(
                         state, supportsFeatureService, requestedActionCategories, workspace, document, range,
-                        addOperationScope, includeSuppressionFixes: true, CodeActionRequestPriority.None,
+                        addOperationScope, CodeActionRequestPriority.None,
                         isBlocking: true, cancellationToken);
                     var refactoringsTask = GetRefactoringsAsync(
                         state, supportsFeatureService, requestedActionCategories, GlobalOptions, workspace, document, selection,
@@ -262,7 +262,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 Document document,
                 SnapshotSpan range,
                 Func<string, IDisposable?> addOperationScope,
-                bool includeSuppressionFixes,
                 CodeActionRequestPriority priority,
                 bool isBlocking,
                 CancellationToken cancellationToken)
@@ -276,7 +275,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
                     workspace, state.Target.Owner._codeFixService, document, range.Span.ToTextSpan(),
-                    includeSuppressionFixes, priority, isBlocking, addOperationScope, cancellationToken).AsTask();
+                    priority, isBlocking, addOperationScope, cancellationToken).AsTask();
             }
 
             private static string GetFixCategory(DiagnosticSeverity severity)
@@ -321,9 +320,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
                 }
 
-                // 'CodeActionRequestPriority.Low' is reserved for suppression/configuration code fixes.
+                // 'CodeActionRequestPriority.Lowest' is reserved for suppression/configuration code fixes.
                 // No code refactoring should have this request priority.
-                if (priority == CodeActionRequestPriority.Low)
+                if (priority == CodeActionRequestPriority.Lowest)
                 {
                     return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
                 }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSourceProvider.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
     [Order]
     [SuggestedActionPriority(DefaultOrderings.Highest)]
     [SuggestedActionPriority(DefaultOrderings.Default)]
+    [SuggestedActionPriority(DefaultOrderings.Lowest)]
     internal partial class SuggestedActionsSourceProvider : ISuggestedActionsSourceProvider
     {
         private static readonly Guid s_CSharpSourceGuid = new Guid("b967fea8-e2c3-4984-87d4-71a38f49e16a");

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
 
             var codeFixes = await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
                 document.Project.Solution.Workspace, codeFixService, document, textSpan,
-                includeSuppressionFixes: true, CodeActionRequestPriority.None,
+                CodeActionRequestPriority.None,
                 isBlocking: false, addOperationScope: _ => null, cancellationToken).ConfigureAwait(false);
 
             var codeRefactorings = await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(

--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager, analyzerReference);
 
             // Verify that we do not crash when computing fixes.
-            _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), includeConfigurationFixes: false, cancellationToken: CancellationToken.None);
+            _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), cancellationToken: CancellationToken.None);
 
             // Verify that code fix is invoked with both the diagnostics in the context,
             // i.e. duplicate diagnostics are not silently discarded by the CodeFixService.
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager, analyzerReference);
 
             // Verify registered configuration code actions do not have duplicates.
-            var fixCollections = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), includeConfigurationFixes: true, cancellationToken: CancellationToken.None);
+            var fixCollections = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), cancellationToken: CancellationToken.None);
             var codeActions = fixCollections.SelectMany(c => c.Fixes.Select(f => f.Action)).ToImmutableArray();
             Assert.Equal(7, codeActions.Length);
             var uniqueTitles = new HashSet<string>();
@@ -145,14 +145,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
             // Verify only analyzerWithFix is executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Normal'.
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                includeConfigurationFixes: false, priority: CodeActionRequestPriority.Normal, isBlocking: false,
+                priority: CodeActionRequestPriority.Normal, isBlocking: false,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(analyzerWithFix.ReceivedCallback);
             Assert.False(analyzerWithoutFix.ReceivedCallback);
 
-            // Verify both analyzerWithFix and analyzerWithoutFix are executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Low'.
+            // Verify both analyzerWithFix and analyzerWithoutFix are executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Lowest'.
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                includeConfigurationFixes: true, priority: CodeActionRequestPriority.Low, isBlocking: false,
+                priority: CodeActionRequestPriority.Lowest, isBlocking: false,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(analyzerWithFix.ReceivedCallback);
             Assert.True(analyzerWithoutFix.ReceivedCallback);
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var reference = new MockAnalyzerReference(codefix, ImmutableArray.Create(diagnosticAnalyzer));
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
             document = project.Documents.Single();
-            var fixes = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), includeConfigurationFixes: true, cancellationToken: CancellationToken.None);
+            var fixes = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), cancellationToken: CancellationToken.None);
 
             if (exception)
             {
@@ -619,7 +619,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
 
             var document = project.Documents.Single();
-            return await fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), includeConfigurationFixes: false, cancellationToken: CancellationToken.None);
+            return await fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), cancellationToken: CancellationToken.None);
         }
 
         private sealed class NuGetCodeFixProvider : AbstractNuGetOrVsixCodeFixProvider

--- a/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
@@ -41,9 +41,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, DocumentId? documentId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, string? diagnosticId = null, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
-
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 

--- a/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
@@ -44,6 +44,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, string? diagnosticId = null, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
         public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 

--- a/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
+++ b/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
@@ -75,7 +75,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 ' Verify available codefix with a global fixer
                 Dim fixes = Await codefixService.GetFixesAsync(document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                    includeConfigurationFixes:=True, cancellationToken:=CancellationToken.None)
+                    cancellationToken:=CancellationToken.None)
                 Assert.Equal(0, fixes.Count())
 
                 ' Verify available codefix with a global fixer + a project fixer
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 document = project.Documents.Single()
                 fixes = Await codefixService.GetFixesAsync(document,
                                                      (Await document.GetSyntaxRootAsync()).FullSpan,
-                                                     includeConfigurationFixes:=True, cancellationToken:=CancellationToken.None)
+                                                     cancellationToken:=CancellationToken.None)
                 Assert.Equal(1, fixes.Count())
 
                 ' Remove a project analyzer
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 document = project.Documents.Single()
                 fixes = Await codefixService.GetFixesAsync(document,
                                                      (Await document.GetSyntaxRootAsync()).FullSpan,
-                                                     includeConfigurationFixes:=True, cancellationToken:=CancellationToken.None)
+                                                     cancellationToken:=CancellationToken.None)
                 Assert.Equal(0, fixes.Count())
             End Using
         End Function
@@ -143,7 +143,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 ' Verify no codefix with a global fixer
                 Dim fixes = Await codefixService.GetFixesAsync(document,
                                                          (Await document.GetSyntaxRootAsync()).FullSpan,
-                                                         includeConfigurationFixes:=True, cancellationToken:=CancellationToken.None)
+                                                         cancellationToken:=CancellationToken.None)
                 Assert.Equal(0, fixes.Count())
 
                 ' Verify no codefix with a global fixer + a project fixer
@@ -156,7 +156,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 document = project.Documents.Single()
                 fixes = Await codefixService.GetFixesAsync(document,
                                                      (Await document.GetSyntaxRootAsync()).FullSpan,
-                                                     includeConfigurationFixes:=True, cancellationToken:=CancellationToken.None)
+                                                     cancellationToken:=CancellationToken.None)
                 Assert.Equal(0, fixes.Count())
             End Using
         End Function

--- a/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
@@ -177,6 +177,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             // those fixes have a dedicated request priority 'CodeActionPriorityRequest.Lowest'.
             // Hence, for Normal or Low priority, we only need to execute analyzers which can report at least one fixable diagnostic
             // that can have a non-suppression/configuration fix.
+            // Note that for 'CodeActionPriorityRequest.High', we only run compiler analyzer, which always has fixable diagnostics,
+            // so we can pass in null. 
             var shouldIncludeDiagnostic = priority is CodeActionRequestPriority.Normal or CodeActionRequestPriority.Low
                 ? GetFixableDiagnosticFilter(document)
                 : null;
@@ -254,8 +256,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 var hasWorkspaceFixers = TryGetWorkspaceFixersMap(document, out var workspaceFixersMap);
                 var projectFixersMap = GetProjectFixers(document.Project);
 
-                return id => (hasWorkspaceFixers && workspaceFixersMap!.Value.ContainsKey(id))
-                    || projectFixersMap.ContainsKey(id);
+                return id =>
+                {
+                    if (hasWorkspaceFixers && workspaceFixersMap!.Value.ContainsKey(id))
+                        return true;
+
+                    return projectFixersMap.ContainsKey(id);
+                };
             }
         }
 

--- a/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 {
     internal interface ICodeFixService
     {
-        Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, bool includeSuppressionFixes, CodeActionRequestPriority priority, bool isBlocking, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
+        Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, bool isBlocking, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
         Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CancellationToken cancellationToken);
         Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, IProgressTracker progressTracker, CancellationToken cancellationToken);
         CodeFixProvider? GetSuppressionFixer(string language, IEnumerable<string> diagnosticIds);
@@ -24,10 +24,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
     internal static class ICodeFixServiceExtensions
     {
-        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, bool includeConfigurationFixes, CancellationToken cancellationToken)
-            => service.GetFixesAsync(document, range, includeConfigurationFixes, isBlocking: false, cancellationToken);
+        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, CancellationToken cancellationToken)
+            => service.GetFixesAsync(document, range, isBlocking: false, cancellationToken);
 
-        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, bool includeConfigurationFixes, bool isBlocking, CancellationToken cancellationToken)
-            => service.GetFixesAsync(document, range, includeConfigurationFixes, CodeActionRequestPriority.None, isBlocking, addOperationScope: _ => null, cancellationToken);
+        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, bool isBlocking, CancellationToken cancellationToken)
+            => service.GetFixesAsync(document, range, CodeActionRequestPriority.None, isBlocking, addOperationScope: _ => null, cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
@@ -80,20 +80,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(
             Document document,
             TextSpan? range,
-            string? diagnosticId,
-            bool includeSuppressedDiagnostics,
-            CodeActionRequestPriority priority,
-            Func<string, IDisposable?>? addOperationScope,
-            CancellationToken cancellationToken)
-        {
-            Func<string, bool>? shouldIncludeDiagnostic = diagnosticId != null ? id => id == diagnosticId : null;
-            return GetDiagnosticsForSpanAsync(document, range, shouldIncludeDiagnostic,
-                includeSuppressedDiagnostics, priority, addOperationScope, cancellationToken);
-        }
-
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(
-            Document document,
-            TextSpan? range,
             Func<string, bool>? shouldIncludeDiagnostic,
             bool includeSuppressedDiagnostics,
             CodeActionRequestPriority priority,

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // always make sure that analyzer is called on background thread.
                 return Task.Run(() => analyzer.TryAppendDiagnosticsForSpanAsync(
-                    document, range, diagnostics, diagnosticId: null, includeSuppressedDiagnostics, CodeActionRequestPriority.None, blockForData: false, addOperationScope: null, cancellationToken), cancellationToken);
+                    document, range, diagnostics, shouldIncludeDiagnostic: null, includeSuppressedDiagnostics, CodeActionRequestPriority.None, blockForData: false, addOperationScope: null, cancellationToken), cancellationToken);
             }
 
             return SpecializedTasks.False;
@@ -86,11 +86,25 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Func<string, IDisposable?>? addOperationScope,
             CancellationToken cancellationToken)
         {
+            Func<string, bool>? shouldIncludeDiagnostic = diagnosticId != null ? id => id == diagnosticId : null;
+            return GetDiagnosticsForSpanAsync(document, range, shouldIncludeDiagnostic,
+                includeSuppressedDiagnostics, priority, addOperationScope, cancellationToken);
+        }
+
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(
+            Document document,
+            TextSpan? range,
+            Func<string, bool>? shouldIncludeDiagnostic,
+            bool includeSuppressedDiagnostics,
+            CodeActionRequestPriority priority,
+            Func<string, IDisposable?>? addOperationScope,
+            CancellationToken cancellationToken)
+        {
             if (_map.TryGetValue(document.Project.Solution.Workspace, out var analyzer))
             {
                 // always make sure that analyzer is called on background thread.
                 return Task.Run(() => analyzer.GetDiagnosticsForSpanAsync(
-                    document, range, diagnosticId, includeSuppressedDiagnostics, priority,
+                    document, range, shouldIncludeDiagnostic, includeSuppressedDiagnostics, priority,
                     blockForData: true, addOperationScope, cancellationToken), cancellationToken);
             }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.ProjectAndCompilationWithAnalyzers.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.ProjectAndCompilationWithAnalyzers.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
+{
+    internal partial class DiagnosticIncrementalAnalyzer
+    {
+        private sealed class ProjectAndCompilationWithAnalyzers
+        {
+            public Project Project { get; }
+            public CompilationWithAnalyzers? CompilationWithAnalyzers { get; }
+
+            public ProjectAndCompilationWithAnalyzers(Project project, CompilationWithAnalyzers? compilationWithAnalyzers)
+            {
+                Project = project;
+                CompilationWithAnalyzers = compilationWithAnalyzers;
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -21,20 +21,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
     internal partial class DiagnosticIncrementalAnalyzer
     {
         public async Task<bool> TryAppendDiagnosticsForSpanAsync(
-            Document document, TextSpan? range, ArrayBuilder<DiagnosticData> result, string? diagnosticId,
+            Document document, TextSpan? range, ArrayBuilder<DiagnosticData> result, Func<string, bool>? shouldIncludeDiagnostic,
             bool includeSuppressedDiagnostics, CodeActionRequestPriority priority, bool blockForData,
             Func<string, IDisposable?>? addOperationScope, CancellationToken cancellationToken)
         {
             var getter = await LatestDiagnosticsForSpanGetter.CreateAsync(
                 this, document, range, blockForData, addOperationScope, includeSuppressedDiagnostics,
-                priority, diagnosticId, cancellationToken).ConfigureAwait(false);
+                priority, shouldIncludeDiagnostic, cancellationToken).ConfigureAwait(false);
             return await getter.TryGetAsync(result, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(
             Document document,
             TextSpan? range,
-            string? diagnosticId,
+            Func<string, bool>? shouldIncludeDiagnostic,
             bool includeSuppressedDiagnostics,
             CodeActionRequestPriority priority,
             bool blockForData,
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var list);
             var result = await TryAppendDiagnosticsForSpanAsync(
-                document, range, list, diagnosticId, includeSuppressedDiagnostics,
+                document, range, list, shouldIncludeDiagnostic, includeSuppressedDiagnostics,
                 priority, blockForData, addOperationScope, cancellationToken).ConfigureAwait(false);
             Debug.Assert(result);
             return list.ToImmutable();
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private readonly bool _blockForData;
             private readonly bool _includeSuppressedDiagnostics;
             private readonly CodeActionRequestPriority _priority;
-            private readonly string? _diagnosticId;
+            private readonly Func<string, bool>? _shouldIncludeDiagnostic;
             private readonly Func<string, IDisposable?>? _addOperationScope;
 
             private delegate Task<IEnumerable<DiagnosticData>> DiagnosticsGetterAsync(DiagnosticAnalyzer analyzer, DocumentAnalysisExecutor executor, CancellationToken cancellationToken);
@@ -77,22 +77,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                  Func<string, IDisposable?>? addOperationScope,
                  bool includeSuppressedDiagnostics,
                  CodeActionRequestPriority priority,
-                 string? diagnosticId,
+                 Func<string, bool>? shouldIncludeDiagnostic,
                  CancellationToken cancellationToken)
             {
                 var stateSets = owner._stateManager
                                      .GetOrCreateStateSets(document.Project).Where(s => !owner.DiagnosticAnalyzerInfoCache.IsAnalyzerSuppressed(s.Analyzer, document.Project));
 
                 // filter to specific diagnostic it is looking for
-                if (diagnosticId != null)
+                if (shouldIncludeDiagnostic != null)
                 {
-                    stateSets = stateSets.Where(s => owner.DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(s.Analyzer).Any(d => d.Id == diagnosticId)).ToList();
+                    stateSets = stateSets.Where(s => owner.DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(s.Analyzer).Any(d => shouldIncludeDiagnostic(d.Id))).ToList();
                 }
 
                 var compilationWithAnalyzers = await CreateCompilationWithAnalyzersAsync(document.Project, stateSets, includeSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 
                 return new LatestDiagnosticsForSpanGetter(
-                    owner, compilationWithAnalyzers, document, stateSets, diagnosticId, range,
+                    owner, compilationWithAnalyzers, document, stateSets, shouldIncludeDiagnostic, range,
                     blockForData, addOperationScope, includeSuppressedDiagnostics, priority);
             }
 
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 CompilationWithAnalyzers? compilationWithAnalyzers,
                 Document document,
                 IEnumerable<StateSet> stateSets,
-                string? diagnosticId,
+                Func<string, bool>? shouldIncludeDiagnostic,
                 TextSpan? range,
                 bool blockForData,
                 Func<string, IDisposable?>? addOperationScope,
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _compilationWithAnalyzers = compilationWithAnalyzers;
                 _document = document;
                 _stateSets = stateSets;
-                _diagnosticId = diagnosticId;
+                _shouldIncludeDiagnostic = shouldIncludeDiagnostic;
                 _range = range;
                 _blockForData = blockForData;
                 _addOperationScope = addOperationScope;
@@ -243,6 +243,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 if (_priority == CodeActionRequestPriority.None)
                     return true;
 
+                // 'CodeActionRequestPriority.Low' is used for suppression/configuration fixes,
+                // which requires all analyzer diagnostics.
+                if (_priority == CodeActionRequestPriority.Low)
+                    return true;
+
                 // The compiler analyzer always counts for any priority.  It's diagnostics may be fixed
                 // by high pri or normal pri fixers.
                 if (analyzer.IsCompilerAnalyzer())
@@ -259,7 +264,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return diagnostic.DocumentId == _document.Id &&
                     (_range == null || _range.Value.IntersectsWith(diagnostic.GetTextSpan()))
                     && (_includeSuppressedDiagnostics || !diagnostic.IsSuppressed)
-                    && (_diagnosticId == null || _diagnosticId == diagnostic.Id);
+                    && (_shouldIncludeDiagnostic == null || _shouldIncludeDiagnostic(diagnostic.Id));
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -54,6 +54,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         /// </summary>
         private sealed class LatestDiagnosticsForSpanGetter
         {
+            // PERF: Cache the last Project and corresponding CompilationWithAnalyzers used to compute analyzer diagnostics for span.
+            //       This is now required as async lightbulb will query and execute different priority buckets of analyzers with multiple
+            //       calls, and we want to reuse CompilationWithAnalyzers instance if possible. 
             private static readonly WeakReference<ProjectAndCompilationWithAnalyzers?> _lastProjectAndCompilationWithAnalyzers = new(null);
 
             private readonly DiagnosticIncrementalAnalyzer _owner;

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -72,20 +72,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// This API will only force complete analyzers that support span based analysis, i.e. compiler analyzer and
         /// <see cref="IBuiltInAnalyzer"/>s that support <see cref="DiagnosticAnalyzerCategory.SemanticSpanAnalysis"/>.
         /// For the rest of the analyzers, it will only return diagnostics if the analyzer has already been executed.
-        /// Use <see cref="GetDiagnosticsForSpanAsync(Document, TextSpan?, string?, bool, CodeActionRequestPriority, Func{string, IDisposable?}?, CancellationToken)"/>
+        /// Use <see cref="GetDiagnosticsForSpanAsync(Document, TextSpan?, Func{string, bool}?, bool, CodeActionRequestPriority, Func{string, IDisposable?}?, CancellationToken)"/>
         /// if you want to force complete all analyzers and get up-to-date diagnostics for all analyzers for the given span.
         /// </summary>
         Task<bool> TryAppendDiagnosticsForSpanAsync(Document document, TextSpan range, ArrayBuilder<DiagnosticData> diagnostics, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Return up to date diagnostics for the given span for the document
-        /// <para>
-        /// This can be expensive since it is force analyzing diagnostics if it doesn't have up-to-date one yet. If
-        /// <paramref name="diagnosticId"/> is not null, it gets diagnostics only for this given <paramref
-        /// name="diagnosticId"/> value.
-        /// </para>
-        /// </summary>
-        Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, string? diagnosticId = null, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Return up to date diagnostics for the given span for the document
@@ -102,5 +92,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         public static Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(this IDiagnosticAnalyzerService service, Document document, TextSpan range, string? diagnosticId = null, bool includeSuppressedDiagnostics = false, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
             => service.GetDiagnosticsForSpanAsync(document, range, diagnosticId, includeSuppressedDiagnostics, CodeActionRequestPriority.None, addOperationScope, cancellationToken);
+
+        /// <summary>
+        /// Return up to date diagnostics for the given span for the document
+        /// <para>
+        /// This can be expensive since it is force analyzing diagnostics if it doesn't have up-to-date one yet. If
+        /// <paramref name="diagnosticId"/> is not null, it gets diagnostics only for this given <paramref
+        /// name="diagnosticId"/> value.
+        /// </para>
+        /// </summary>
+        public static Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(this IDiagnosticAnalyzerService service, Document document, TextSpan? range, string? diagnosticId = null, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
+        {
+            Func<string, bool>? shouldIncludeDiagnostic = diagnosticId != null ? id => id == diagnosticId : null;
+            return service.GetDiagnosticsForSpanAsync(document, range, shouldIncludeDiagnostic,
+                includeSuppressedDiagnostics, priority, addOperationScope, cancellationToken);
+        }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -86,6 +86,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </para>
         /// </summary>
         Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, string? diagnosticId = null, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Return up to date diagnostics for the given span for the document
+        /// <para>
+        /// This can be expensive since it is force analyzing diagnostics if it doesn't have up-to-date one yet.
+        /// Predicate <paramref name="shouldIncludeDiagnostic"/> filters out analyzers from execution if 
+        /// none of its reported diagnostics should be included in the result.
+        /// </para>
+        /// </summary>
+        Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default);
     }
 
     internal static class IDiagnosticAnalyzerServiceExtensions

--- a/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -34,7 +34,6 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             ICodeFixService codeFixService,
             Document document,
             TextSpan selection,
-            bool includeSuppressionFixes,
             CodeActionRequestPriority priority,
             bool isBlocking,
             Func<string, IDisposable?> addOperationScope,
@@ -45,7 +44,6 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             var fixes = await Task.Run(() => codeFixService.GetFixesAsync(
                 document,
                 selection,
-                includeSuppressionFixes,
                 priority,
                 isBlocking,
                 addOperationScope,

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -525,6 +525,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)
             End Function
 
+            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), Optional includeSuppressedDiagnostics As Boolean = False, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional addOperationScope As Func(Of String, IDisposable) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
+                Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)
+            End Function
+
             Public Function TryAppendDiagnosticsForSpanAsync(document As Document, range As TextSpan, diagnostics As ArrayBuilder(Of DiagnosticData), Optional includeSuppressedDiagnostics As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As Task(Of Boolean) Implements IDiagnosticAnalyzerService.TryAppendDiagnosticsForSpanAsync
                 Return Task.FromResult(False)
             End Function

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -521,10 +521,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Public Sub Reanalyze(workspace As Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing, Optional highPriority As Boolean = False) Implements IDiagnosticAnalyzerService.Reanalyze
             End Sub
 
-            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan?, Optional diagnosticId As String = Nothing, Optional includeSuppressedDiagnostics As Boolean = False, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional addOperationScope As Func(Of String, IDisposable) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
-                Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)
-            End Function
-
             Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), Optional includeSuppressedDiagnostics As Boolean = False, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional addOperationScope As Func(Of String, IDisposable) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
                 Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)
             End Function

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -523,7 +523,6 @@ namespace NS
             var expectedItems = new[]
             {
                 "Rename 'P2' to 'Foober'",
-                "Generate type 'Foober'",
                 "Generate class 'Foober' in new file",
                 "Generate class 'Foober'",
                 "Generate nested class 'Foober'",

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixProvider.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             get
             {
                 var priority = ComputeRequestPriority();
+                // Note: CodeActionRequestPriority.Low is reserved for IConfigurationFixProvider.
                 Contract.ThrowIfFalse(priority is CodeActionRequestPriority.Normal or CodeActionRequestPriority.High);
                 return priority;
             }

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixProvider.cs
@@ -45,8 +45,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             get
             {
                 var priority = ComputeRequestPriority();
-                // Note: CodeActionRequestPriority.Low is reserved for IConfigurationFixProvider.
-                Contract.ThrowIfFalse(priority is CodeActionRequestPriority.Normal or CodeActionRequestPriority.High);
+                // Note: CodeActionRequestPriority.Lowest is reserved for IConfigurationFixProvider.
+                Contract.ThrowIfFalse(priority is CodeActionRequestPriority.Low or CodeActionRequestPriority.Normal or CodeActionRequestPriority.High);
                 return priority;
             }
         }

--- a/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringProvider.cs
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             get
             {
                 var priority = ComputeRequestPriority();
-                // Note: CodeActionRequestPriority.Low is reserved for IConfigurationFixProvider.
-                Contract.ThrowIfFalse(priority is CodeActionRequestPriority.Normal or CodeActionRequestPriority.High);
+                // Note: CodeActionRequestPriority.Lowest is reserved for IConfigurationFixProvider.
+                Contract.ThrowIfFalse(priority is CodeActionRequestPriority.Low or CodeActionRequestPriority.Normal or CodeActionRequestPriority.High);
                 return priority;
             }
         }

--- a/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringProvider.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             get
             {
                 var priority = ComputeRequestPriority();
+                // Note: CodeActionRequestPriority.Low is reserved for IConfigurationFixProvider.
                 Contract.ThrowIfFalse(priority is CodeActionRequestPriority.Normal or CodeActionRequestPriority.High);
                 return priority;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeActions/CodeActionRequestPriority.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeActions/CodeActionRequestPriority.cs
@@ -11,17 +11,24 @@ namespace Microsoft.CodeAnalysis.CodeActions
     {
         /// <summary>
         /// No priority specified, all refactoring, code fixes, and analyzers should be run.  This is equivalent
-        /// to <see cref="Normal"/> and <see cref="High"/> combined.
+        /// to <see cref="Low"/>, <see cref="Normal"/> and <see cref="High"/> combined.
         /// </summary>
         None = 0,
+
+        /// <summary>
+        /// Only low priority suppression and configuration fix providers should be run.  Specifically,
+        /// <see cref="T:IConfigurationFixProvider"/> providers will be run.
+        /// </summary>
+        Low = 1,
 
         /// <summary>
         /// Only normal priority refactoring, code fix providers should be run.  Specifically,
         /// providers will be run when <see cref="T:CodeRefactoringProvider.RequestPriority"/> or
         /// <see cref="T:CodeFixProvider.RequestPriority"/> is <see cref="Normal"/>.  <see cref="DiagnosticAnalyzer"/>s
-        /// will be run except for <see cref="DiagnosticAnalyzerExtensions.IsCompilerAnalyzer"/>.
+        /// which can report at least one fixable diagnostic will be run.
         /// </summary>
-        Normal = 1,
+        Normal = 2,
+
         /// <summary>
         /// Only high priority refactoring, code fix providers should be run.  Specifically,
         /// providers will be run when <see cref="T:CodeRefactoringProvider.RequestPriority"/> or
@@ -29,6 +36,6 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// The <see cref="DiagnosticAnalyzerExtensions.IsCompilerAnalyzer"/> <see cref="DiagnosticAnalyzer"/>
         /// will be run.
         /// </summary>
-        High = 2,
+        High = 3,
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeActions/CodeActionRequestPriority.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeActions/CodeActionRequestPriority.cs
@@ -11,15 +11,23 @@ namespace Microsoft.CodeAnalysis.CodeActions
     {
         /// <summary>
         /// No priority specified, all refactoring, code fixes, and analyzers should be run.  This is equivalent
-        /// to <see cref="Low"/>, <see cref="Normal"/> and <see cref="High"/> combined.
+        /// to <see cref="Lowest"/>, <see cref="Low"/>, <see cref="Normal"/> and <see cref="High"/> combined.
         /// </summary>
         None = 0,
 
         /// <summary>
-        /// Only low priority suppression and configuration fix providers should be run.  Specifically,
+        /// Only lowest priority suppression and configuration fix providers should be run.  Specifically,
         /// <see cref="T:IConfigurationFixProvider"/> providers will be run.
         /// </summary>
-        Low = 1,
+        Lowest = 1,
+
+        /// <summary>
+        /// Only low priority refactoring, code fix providers should be run.  Specifically,
+        /// providers will be run when <see cref="T:CodeRefactoringProvider.RequestPriority"/> or
+        /// <see cref="T:CodeFixProvider.RequestPriority"/> is <see cref="Low"/>.  <see cref="DiagnosticAnalyzer"/>s
+        /// which can report at least one fixable diagnostic will be run.
+        /// </summary>
+        Low = 2,
 
         /// <summary>
         /// Only normal priority refactoring, code fix providers should be run.  Specifically,
@@ -27,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// <see cref="T:CodeFixProvider.RequestPriority"/> is <see cref="Normal"/>.  <see cref="DiagnosticAnalyzer"/>s
         /// which can report at least one fixable diagnostic will be run.
         /// </summary>
-        Normal = 2,
+        Normal = 3,
 
         /// <summary>
         /// Only high priority refactoring, code fix providers should be run.  Specifically,
@@ -36,6 +44,6 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// The <see cref="DiagnosticAnalyzerExtensions.IsCompilerAnalyzer"/> <see cref="DiagnosticAnalyzer"/>
         /// will be run.
         /// </summary>
-        High = 3,
+        High = 4,
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeActions/CodeActionRequestPriority.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeActions/CodeActionRequestPriority.cs
@@ -18,6 +18,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// <summary>
         /// Only lowest priority suppression and configuration fix providers should be run.  Specifically,
         /// <see cref="T:IConfigurationFixProvider"/> providers will be run.
+        /// NOTE: This priority is reserved for suppression and configuration fix providers and should not be
+        /// used by regular code fix providers and refactoring providers.
         /// </summary>
         Lowest = 1,
 


### PR DESCRIPTION
Addresses second item in #56843

Prior to this change, all the analyzers that are not high-pri are added to the normal priority bucket and executed at once. This PR further breaks down the normal priority bucket into two buckets as follow:

1. `Normal`: Analyzers that produce at least one fixable diagnostic, i.e. have a corresponding code fixer.
2. `Low`: Analyzers without any fixable diagnostics, i.e. have no corresponding code fixer. These diagnostics will only have Suppression/Configuration quick actions, which are lower priority and always show up at the bottom of the light bulb.

This new bucketing allows us to reduce the number of analyzers that are executed in the Normal priority bucket and hence generate all the non-suppression/configuration code fixes faster in async light bulb.