### PR TITLE
Add more completion External Access APIs for F# and TS

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionProvider.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionProvider.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
+{
+    internal abstract class VSTypeScriptCompletionProvider : CompletionProvider
+    {
+        public sealed override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
+        {
+            var triggerOnTypingLetters = options.GetOption(CompletionOptions.TriggerOnTypingLetters2, InternalLanguageNames.TypeScript);
+            return ShouldTriggerCompletionImpl(text, caretPosition, trigger, triggerOnTypingLetters);
+        }
+
+        protected abstract bool ShouldTriggerCompletionImpl(SourceText text, int caretPosition, CompletionTrigger trigger, bool triggerOnTypingLetters);
+    }
+}

--- a/src/Tools/ExternalAccess/FSharp/Completion/FSharpCommonCompletionProvider.cs
+++ b/src/Tools/ExternalAccess/FSharp/Completion/FSharpCommonCompletionProvider.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Completion;
 
@@ -11,9 +12,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
 {
     internal static class FSharpCommonCompletionProvider
     {
+        [Obsolete]
         public static CompletionProvider Create(IFSharpCommonCompletionProvider fsharpCommonCompletionProvider)
-        {
-            return new FSharpInternalCommonCompletionProvider(fsharpCommonCompletionProvider);
-        }
+            => new FSharpInternalCommonCompletionProvider(fsharpCommonCompletionProvider);
+
+        public static CompletionProvider Create(FSharpCommonCompletionProviderBase fsharpCommonCompletionProvider)
+            => new FSharpInternalCommonCompletionProvider(fsharpCommonCompletionProvider);
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Completion/FSharpCompletionProviderBase.cs
+++ b/src/Tools/ExternalAccess/FSharp/Completion/FSharpCompletionProviderBase.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
+{
+    internal abstract class FSharpCompletionProviderBase : CompletionProvider
+    {
+        public sealed override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
+            => ShouldTriggerCompletionImpl(text, caretPosition, trigger);
+
+        protected abstract bool ShouldTriggerCompletionImpl(SourceText text, int caretPosition, CompletionTrigger trigger);
+    }
+}

--- a/src/Tools/ExternalAccess/FSharp/Completion/IFSharpCommonCompletionProvider.cs
+++ b/src/Tools/ExternalAccess/FSharp/Completion/IFSharpCommonCompletionProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
 {
+    [Obsolete]
     internal interface IFSharpCommonCompletionProvider
     {
         Task ProvideCompletionsAsync(CompletionContext context);
@@ -24,5 +25,23 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
             CompletionItem selectedItem,
             char? ch,
             CancellationToken cancellationToken);
+    }
+
+#pragma warning disable CS0612 // Type or member is obsolete
+    internal abstract class FSharpCommonCompletionProviderBase : IFSharpCommonCompletionProvider
+#pragma warning restore CS0612 // Type or member is obsolete
+    {
+        public abstract Task ProvideCompletionsAsync(CompletionContext context);
+
+        public abstract bool IsInsertionTrigger(SourceText text, int insertedCharacterPosition);
+
+        public abstract Task<TextChange?> GetTextChangeAsync(
+            Func<CompletionItem, char?, CancellationToken, Task<TextChange?>> baseGetTextChangeAsync,
+            CompletionItem selectedItem,
+            char? ch,
+            CancellationToken cancellationToken);
+
+        bool IFSharpCommonCompletionProvider.IsInsertionTrigger(SourceText text, int insertedCharacterPosition, OptionSet options)
+            => IsInsertionTrigger(text, insertedCharacterPosition);
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Completion/FSharpInternalCommonCompletionProvider.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Completion/FSharpInternalCommonCompletionProvider.cs
@@ -16,12 +16,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Completion
 {
     internal sealed class FSharpInternalCommonCompletionProvider : CommonCompletionProvider
     {
+#pragma warning disable CS0612 // Switch to FSharpCommonCompletionProviderBase after F# switches
         private readonly IFSharpCommonCompletionProvider _provider;
 
         public FSharpInternalCommonCompletionProvider(IFSharpCommonCompletionProvider provider)
         {
             _provider = provider;
         }
+#pragma warning restore CS0612 // Type or member is obsolete
 
         public override Task ProvideCompletionsAsync(CompletionContext context)
         {


### PR DESCRIPTION
These will be used to avoid accessing OptionSet.