### PR TITLE
Only pass the lsp misc files workspace for non-VS scenarios.  

### DIFF
--- a/src/EditorFeatures/Core/Implementation/LanguageServer/VisualStudioInProcLanguageServer.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/VisualStudioInProcLanguageServer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             string? clientName,
             string userVisibleServerName,
             string telemetryServerTypeName)
-            : base(requestDispatcherFactory, jsonRpc, capabilitiesProvider, workspaceRegistrationService, globalOptions, listenerProvider, logger, supportedLanguages, clientName, userVisibleServerName, telemetryServerTypeName)
+            : base(requestDispatcherFactory, jsonRpc, capabilitiesProvider, workspaceRegistrationService, lspMiscellaneousFilesWorkspace: null, globalOptions, listenerProvider, logger, supportedLanguages, clientName, userVisibleServerName, telemetryServerTypeName)
         {
             _supportedLanguages = supportedLanguages;
             _diagnosticService = diagnosticService;

--- a/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
@@ -38,11 +38,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             ILspWorkspaceRegistrationService workspaceRegistrationService,
             ILspLogger logger)
         {
+            var lspMiscellaneousFilesWorkspace = new LspMiscellaneousFilesWorkspace(logger);
+
             return new LanguageServerTarget(
                 _dispatcherFactory,
                 jsonRpc,
                 capabilitiesProvider,
                 workspaceRegistrationService,
+                lspMiscellaneousFilesWorkspace,
                 _globalOptions,
                 _listenerProvider,
                 logger,

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             RequestTelemetryLogger telemetryLogger,
             ClientCapabilities clientCapabilities,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
-            LspMiscellaneousFilesWorkspace lspMiscellaneousFilesWorkspace,
+            LspMiscellaneousFilesWorkspace? lspMiscellaneousFilesWorkspace,
             Dictionary<Workspace, (Solution workspaceSolution, Solution lspSolution)>? solutionCache,
             IDocumentChangeTracker? documentChangeTracker,
             ImmutableArray<string> supportedLanguages,
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             ILspLogger logger,
             RequestTelemetryLogger telemetryLogger,
             ILspWorkspaceRegistrationService lspWorkspaceRegistrationService,
-            LspMiscellaneousFilesWorkspace lspMiscFilesWorkspace,
+            LspMiscellaneousFilesWorkspace? lspMiscFilesWorkspace,
             TextDocumentIdentifier textDocument,
             string? clientName)
         {
@@ -155,7 +155,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             // If the document was not in a registered workspace, try to retrieve from the LSP misc files workspace.
-            document = TryGetDocumentFromWorkspace(textDocument, clientName, lspMiscFilesWorkspace);
+            if (lspMiscFilesWorkspace is not null)
+            {
+                document = TryGetDocumentFromWorkspace(textDocument, clientName, lspMiscFilesWorkspace);
+            }
+
             return document;
 
             static Document? TryGetDocumentFromRegisteredWorkspaces(

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.DocumentChangeTracker.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.DocumentChangeTracker.cs
@@ -70,10 +70,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         internal class DocumentChangeTracker : IWorkspaceService, IDocumentChangeTracker
         {
             private readonly Dictionary<Uri, SourceText> _trackedDocuments = new();
-            private readonly LspMiscellaneousFilesWorkspace _lspMiscellaneousFilesWorkspace;
+            private readonly LspMiscellaneousFilesWorkspace? _lspMiscellaneousFilesWorkspace;
             private readonly ILspWorkspaceRegistrationService _lspWorkspaceRegistrationService;
 
-            public DocumentChangeTracker(LspMiscellaneousFilesWorkspace lspMiscellaneousFilesWorkspace, ILspWorkspaceRegistrationService lspWorkspaceRegistrationService)
+            public DocumentChangeTracker(LspMiscellaneousFilesWorkspace? lspMiscellaneousFilesWorkspace, ILspWorkspaceRegistrationService lspWorkspaceRegistrationService)
             {
                 _lspMiscellaneousFilesWorkspace = lspMiscellaneousFilesWorkspace;
                 _lspWorkspaceRegistrationService = lspWorkspaceRegistrationService;
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 // If we can't find the document in any of the registered workspaces, add it to our loose files workspace.
                 if (!IsPresentInRegisteredWorkspaces(documentUri, _lspWorkspaceRegistrationService))
                 {
-                    _lspMiscellaneousFilesWorkspace.AddMiscellaneousDocument(documentUri);
+                    _lspMiscellaneousFilesWorkspace?.AddMiscellaneousDocument(documentUri);
                 }
             }
 
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 // If we see the document has been moved to a registered workspace, remove it from our loose files workspace.
                 if (IsPresentInRegisteredWorkspaces(documentUri, _lspWorkspaceRegistrationService))
                 {
-                    _lspMiscellaneousFilesWorkspace.TryRemoveMiscellaneousDocument(documentUri);
+                    _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(documentUri);
                 }
             }
 
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 _trackedDocuments.Remove(documentUri);
 
                 // Remove from the lsp misc files workspace if it was added there.
-                _lspMiscellaneousFilesWorkspace.TryRemoveMiscellaneousDocument(documentUri);
+                _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(documentUri);
             }
 
             public IEnumerable<(Uri DocumentUri, SourceText Text)> GetTrackedDocuments()
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             public List<SourceText> GetTrackedTexts()
                 => _queue._documentChangeTracker.GetTrackedDocuments().Select(i => i.Text).ToList();
 
-            public LspMiscellaneousFilesWorkspace GetLspMiscellaneousFilesWorkspace() => _queue._lspMiscellaneousFilesWorkspace;
+            public LspMiscellaneousFilesWorkspace? GetLspMiscellaneousFilesWorkspace() => _queue._lspMiscellaneousFilesWorkspace;
 
             public bool IsComplete() => _queue._queue.IsCompleted && _queue._queue.IsEmpty;
         }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly DocumentChangeTracker _documentChangeTracker;
         private readonly RequestTelemetryLogger _requestTelemetryLogger;
         private readonly IGlobalOptionService _globalOptions;
-        private readonly LspMiscellaneousFilesWorkspace _lspMiscellaneousFilesWorkspace;
+        private readonly LspMiscellaneousFilesWorkspace? _lspMiscellaneousFilesWorkspace;
 
         // This dictionary is used to cache our forked LSP solution so we don't have to
         // recompute it for each request. We don't need to worry about threading because they are only
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public RequestExecutionQueue(
             ILspLogger logger,
             ILspWorkspaceRegistrationService workspaceRegistrationService,
-            LspMiscellaneousFilesWorkspace lspMiscellaneousFilesWorkspace,
+            LspMiscellaneousFilesWorkspace? lspMiscellaneousFilesWorkspace,
             IGlobalOptionService globalOptions,
             ImmutableArray<string> supportedLanguages,
             string serverName,

--- a/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
+++ b/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
@@ -55,6 +55,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             JsonRpc jsonRpc,
             ICapabilitiesProvider capabilitiesProvider,
             ILspWorkspaceRegistrationService workspaceRegistrationService,
+            LspMiscellaneousFilesWorkspace? lspMiscellaneousFilesWorkspace,
             IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspLogger logger,
@@ -80,7 +81,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             _userVisibleServerName = userVisibleServerName;
             TelemetryServerName = telemetryServerTypeName;
 
-            var lspMiscellaneousFilesWorkspace = new LspMiscellaneousFilesWorkspace(logger);
             Queue = new RequestExecutionQueue(logger, workspaceRegistrationService, lspMiscellaneousFilesWorkspace, globalOptions, supportedLanguages, userVisibleServerName, TelemetryServerName);
             Queue.RequestServerShutdown += RequestExecutionQueue_Errored;
         }

--- a/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
@@ -92,6 +92,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
                 serverJsonRpc,
                 capabilitiesProvider,
                 lspWorkspaceRegistrationService,
+                new LspMiscellaneousFilesWorkspace(NoOpLspLogger.Instance),
                 globalOptions,
                 listenerProvider,
                 NoOpLspLogger.Instance,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
@@ -181,7 +181,7 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
 
     private static Document? GetMiscellaneousDocument(TestLspServer testLspServer)
     {
-        return testLspServer.GetQueueAccessor().GetLspMiscellaneousFilesWorkspace().CurrentSolution.Projects.SingleOrDefault()?.Documents.Single();
+        return testLspServer.GetQueueAccessor().GetLspMiscellaneousFilesWorkspace()!.CurrentSolution.Projects.SingleOrDefault()?.Documents.Single();
     }
 
     private static async Task<LSP.Hover> RunGetHoverAsync(TestLspServer testLspServer, LSP.Location caret)


### PR DESCRIPTION
Misc files in VSwill be handled by the VS misc files workspace instead of the lsp misc files workspace

https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/356545

The previous misc files change broke RPS because we started loading dlls needed by the default mef host which was used by the LSP misc files workspace.  We don't have access to the VS workspace mef composition (and it might not even exist when this is created).  And we don't necessarily have a host workspace.  So we just avoid creating it in VS