### PR TITLE
Set JsonRpc.ExceptionStrategy to ExceptionProcessing.ISerializable

### DIFF
--- a/src/Workspaces/Remote/Core/ServiceDescriptor.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptor.cs
@@ -58,8 +58,10 @@ namespace Microsoft.CodeAnalysis.Remote
         protected override JsonRpcConnection CreateConnection(JsonRpc jsonRpc)
         {
             jsonRpc.CancelLocallyInvokedMethodsWhenConnectionIsClosed = true;
+            jsonRpc.ExceptionStrategy = ExceptionProcessing.ISerializable;
             var connection = base.CreateConnection(jsonRpc);
             connection.LocalRpcTargetOptions = s_jsonRpcTargetOptions;
+
             return connection;
         }
 


### PR DESCRIPTION
Should propagate exception info to the client.