### PR TITLE
Remove branch-checking from storage subsystem

### DIFF
--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
 
             var persistentService = previewWorkspace.Services.GetPersistentStorageService(previewWorkspace.CurrentSolution.Options);
 
-            await using var storage = await persistentService.GetStorageAsync(SolutionKey.ToSolutionKey(previewWorkspace.CurrentSolution), checkBranchId: true, CancellationToken.None);
+            await using var storage = await persistentService.GetStorageAsync(SolutionKey.ToSolutionKey(previewWorkspace.CurrentSolution), CancellationToken.None);
             Assert.IsType<NoOpPersistentStorage>(storage);
         }
 

--- a/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
+++ b/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
@@ -55,7 +55,7 @@ namespace AnalyzerRunner
             if (usePersistentStorage)
             {
                 var persistentStorageService = _workspace.Services.GetPersistentStorageService(_workspace.CurrentSolution.Options);
-                await using var persistentStorage = await persistentStorageService.GetStorageAsync(SolutionKey.ToSolutionKey(_workspace.CurrentSolution), checkBranchId: true, cancellationToken).ConfigureAwait(false);
+                await using var persistentStorage = await persistentStorageService.GetStorageAsync(SolutionKey.ToSolutionKey(_workspace.CurrentSolution), cancellationToken).ConfigureAwait(false);
                 if (persistentStorage is NoOpPersistentStorage)
                 {
                     throw new InvalidOperationException("Benchmark is not configured to use persistent storage.");

--- a/src/Tools/IdeCoreBenchmarks/FindReferencesBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/FindReferencesBenchmarks.cs
@@ -75,7 +75,7 @@ namespace IdeCoreBenchmarks
                 if (storageService == null)
                     throw new ArgumentException("Couldn't get storage service");
 
-                using (var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(workspace.CurrentSolution), checkBranchId: true, CancellationToken.None))
+                using (var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(workspace.CurrentSolution), CancellationToken.None))
                 {
                     Console.WriteLine();
                 }

--- a/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
@@ -77,7 +77,7 @@ namespace IdeCoreBenchmarks
                 if (storageService == null)
                     throw new ArgumentException("Couldn't get storage service");
 
-                using (var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(workspace.CurrentSolution), checkBranchId: true, CancellationToken.None))
+                using (var storage = await storageService.GetStorageAsync(SolutionKey.ToSolutionKey(workspace.CurrentSolution), CancellationToken.None))
                 {
                     Console.WriteLine();
                 }

--- a/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
+++ b/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
@@ -947,7 +947,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             var configuration = new MockPersistentStorageConfiguration(solution.Id, _persistentFolder.Path, throwOnFailure);
 
             _storageService = GetStorageService((IMefHostExportProvider)solution.Workspace.Services.HostServices, configuration, faultInjector, _persistentFolder.Path);
-            var storage = await _storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), checkBranchId: true, CancellationToken.None);
+            var storage = await _storageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), CancellationToken.None);
 
             // If we're injecting faults, we expect things to be strange
             if (faultInjector == null)
@@ -966,7 +966,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             var configuration = new MockPersistentStorageConfiguration(solutionKey.Id, _persistentFolder.Path, throwOnFailure: true);
 
             _storageService = GetStorageService((IMefHostExportProvider)workspace.Services.HostServices, configuration, faultInjector, _persistentFolder.Path);
-            var storage = await _storageService.GetStorageAsync(solutionKey, checkBranchId: true, CancellationToken.None);
+            var storage = await _storageService.GetStorageAsync(solutionKey, CancellationToken.None);
 
             // If we're injecting faults, we expect things to be strange
             if (faultInjector == null)

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 // Ok, we can use persistence.  First try to load from the persistence service.
                 var persistentStorageService = services.GetPersistentStorageService(database);
 
-                var storage = await persistentStorageService.GetStorageAsync(solutionKey, checkBranchId: false, cancellationToken).ConfigureAwait(false);
+                var storage = await persistentStorageService.GetStorageAsync(solutionKey, cancellationToken).ConfigureAwait(false);
                 await using var _ = storage.ConfigureAwait(false);
 
                 // Get the unique key to identify our data.

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 var persistentStorageService = services.GetPersistentStorageService(database);
 
-                var storage = await persistentStorageService.GetStorageAsync(documentKey.Project.Solution, checkBranchId: false, cancellationToken).ConfigureAwait(false);
+                var storage = await persistentStorageService.GetStorageAsync(documentKey.Project.Solution, cancellationToken).ConfigureAwait(false);
                 await using var _ = storage.ConfigureAwait(false);
 
                 // attempt to load from persisted state
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             try
             {
-                var storage = await persistentStorageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), checkBranchId: false, cancellationToken).ConfigureAwait(false);
+                var storage = await persistentStorageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
                 await using var _ = storage.ConfigureAwait(false);
                 using var stream = SerializableBytes.CreateWritableStream();
 
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // check whether we already have info for this document
             try
             {
-                var storage = await persistentStorageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), checkBranchId: false, cancellationToken).ConfigureAwait(false);
+                var storage = await persistentStorageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
                 await using var _ = storage.ConfigureAwait(false);
                 // Check if we've already stored a checksum and it matches the checksum we 
                 // expect.  If so, we're already precalculated and don't have to recompute

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IChecksummedPersistentStorageService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IChecksummedPersistentStorageService.cs
@@ -10,6 +10,6 @@ namespace Microsoft.CodeAnalysis.Host
 {
     internal interface IChecksummedPersistentStorageService
     {
-        ValueTask<IChecksummedPersistentStorage> GetStorageAsync(SolutionKey solutionKey, bool checkBranchId, CancellationToken cancellationToken);
+        ValueTask<IChecksummedPersistentStorage> GetStorageAsync(SolutionKey solutionKey, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/NoOpPersistentStorageService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/NoOpPersistentStorageService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Host
                 ? throw new InvalidOperationException("Database was not supported")
                 : Instance;
 
-        public ValueTask<IChecksummedPersistentStorage> GetStorageAsync(SolutionKey solutionKey, bool checkBranchId, CancellationToken cancellationToken)
+        public ValueTask<IChecksummedPersistentStorage> GetStorageAsync(SolutionKey solutionKey, CancellationToken cancellationToken)
             => new(NoOpPersistentStorage.GetOrThrow(throwOnFailure: false));
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/SolutionKey.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/SolutionKey.cs
@@ -22,20 +22,16 @@ namespace Microsoft.CodeAnalysis.Storage
         [DataMember(Order = 1)]
         public readonly string? FilePath;
 
-        [DataMember(Order = 2)]
-        public readonly bool IsPrimaryBranch;
-
-        public SolutionKey(SolutionId id, string? filePath, bool isPrimaryBranch)
+        public SolutionKey(SolutionId id, string? filePath)
         {
             Id = id;
             FilePath = filePath;
-            IsPrimaryBranch = isPrimaryBranch;
         }
 
         public static SolutionKey ToSolutionKey(Solution solution)
             => ToSolutionKey(solution.State);
 
         public static SolutionKey ToSolutionKey(SolutionState solutionState)
-            => new(solutionState.Id, solutionState.FilePath, solutionState.BranchId == solutionState.Workspace.PrimaryBranchId);
+            => new(solutionState.Id, solutionState.FilePath);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassificationCache/RemoteSemanticClassificationCacheService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassificationCache/RemoteSemanticClassificationCacheService.cs
@@ -76,9 +76,8 @@ namespace Microsoft.CodeAnalysis.Remote
         private static async Task CacheSemanticClassificationsAsync(Document document, CancellationToken cancellationToken)
         {
             var solution = document.Project.Solution;
-            var services = solution.Workspace.Services;
-            var persistenceService = services.GetPersistentStorageService(solution.Options);
-            var storage = await persistenceService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), checkBranchId: true, cancellationToken).ConfigureAwait(false);
+            var persistenceService = solution.Workspace.Services.GetPersistentStorageService(solution.Options);
+            var storage = await persistenceService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
             await using var _1 = storage.ConfigureAwait(false);
             if (storage == null)
                 return;
@@ -240,9 +239,8 @@ namespace Microsoft.CodeAnalysis.Remote
             StorageDatabase database,
             CancellationToken cancellationToken)
         {
-            var services = GetWorkspaceServices();
-            var persistenceService = services.GetPersistentStorageService(database);
-            var storage = await persistenceService.GetStorageAsync(documentKey.Project.Solution, checkBranchId: false, cancellationToken).ConfigureAwait(false);
+            var persistenceService = GetWorkspaceServices().GetPersistentStorageService(database);
+            var storage = await persistenceService.GetStorageAsync(documentKey.Project.Solution, cancellationToken).ConfigureAwait(false);
             await using var _ = storage.ConfigureAwait(false);
             if (storage == null)
                 return default;


### PR DESCRIPTION
Almost all usages in product code passed the 'false' value.  So just updating the code for that to be the only executed codepaths.