### PR TITLE
Fix 'use pattern combinators' so it won't generate nullable pattern checks

### DIFF
--- a/src/EditorFeatures/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzerTests.cs
@@ -125,7 +125,7 @@ class C
         }
 
         [InlineData("nullable == 1 || 2 == nullable", "nullable is 1 or 2")]
-        [Theory(Skip = "https://github.com/dotnet/roslyn/issues/56938"), Trait(Traits.Feature, Traits.Features.CodeActionsUsePatternCombinators)]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUsePatternCombinators)]
         public async Task TestOnNullableExpression(string expression, string expected)
         {
             await TestAllOnExpressionAsync(expression, expected);

--- a/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
+++ b/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Simplification
             CancellationToken cancellationToken)
         {
             // Debug flag to help processing things serially instead of parallel.
-            var executeSerially = false;
+            var executeSerially = Debugger.IsAttached;
 
             Contract.ThrowIfFalse(nodesAndTokensToReduce.Any());
 


### PR DESCRIPTION
The original code for this feature would generate checks like `x is (int?)0 or (int?)1`.  This is not legal code, but it's what was generated anyways.  However, this was ok in the original code as the cast simplifier would simplify this to `x is 0 or 1`.  however, the new cast simplifier won't simplify this leading to broken generated code.

The fix here is to actually fix the code-generator to generate this as `x is (int)0 or (int)1` which is legal and can actually be simplified in the later pass.