### PR TITLE
Resolve Microsoft.DotNet prebuilts for source-build

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <!--
       This package would normally be restored by the Arcade SDK, but it is not included during restore operations
       if the -package flag is not also provided during the build. Roslyn separates the restore operation from the


### PR DESCRIPTION
This should have no effect on the normal roslyn build, but allows us to stop catching these Microsoft.DotNet packages as prebuilts in source build. Looking at the file history, these were excluded from source build previously, and source build CI is passing with this change. See https://github.com/dotnet/installer/pull/12268