### PR TITLE
Handle 'out'. Add some metadata decoding.

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
@@ -2082,7 +2082,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
     }
 
-    /// <summary>The ref modifier of a method's return value or a local.</summary>
+    /// <summary>The ref modifier of a method's return value, a local, or a type argument.</summary>
     internal sealed partial class RefTypeSyntax : TypeSyntax
     {
         internal readonly SyntaxToken refKeyword;
@@ -2135,6 +2135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             this.type = type;
         }
 
+        /// <summary>SyntaxToken representing the 'ref', 'in' or 'out' keyword.</summary>
         public SyntaxToken RefKeyword => this.refKeyword;
         /// <summary>Gets the optional "readonly" keyword.</summary>
         public SyntaxToken? ReadOnlyKeyword => this.readOnlyKeyword;
@@ -35481,7 +35482,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
 #if DEBUG
             if (refKeyword == null) throw new ArgumentNullException(nameof(refKeyword));
-            if (refKeyword.Kind != SyntaxKind.RefKeyword) throw new ArgumentException(nameof(refKeyword));
+            switch (refKeyword.Kind)
+            {
+                case SyntaxKind.RefKeyword:
+                case SyntaxKind.InKeyword:
+                case SyntaxKind.OutKeyword: break;
+                default: throw new ArgumentException(nameof(refKeyword));
+            }
             if (readOnlyKeyword != null)
             {
                 switch (readOnlyKeyword.Kind)
@@ -40454,7 +40461,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
 #if DEBUG
             if (refKeyword == null) throw new ArgumentNullException(nameof(refKeyword));
-            if (refKeyword.Kind != SyntaxKind.RefKeyword) throw new ArgumentException(nameof(refKeyword));
+            switch (refKeyword.Kind)
+            {
+                case SyntaxKind.RefKeyword:
+                case SyntaxKind.InKeyword:
+                case SyntaxKind.OutKeyword: break;
+                default: throw new ArgumentException(nameof(refKeyword));
+            }
             if (readOnlyKeyword != null)
             {
                 switch (readOnlyKeyword.Kind)

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -2390,7 +2390,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Creates a new RefTypeSyntax instance.</summary>
         public static RefTypeSyntax RefType(SyntaxToken refKeyword, SyntaxToken readOnlyKeyword, TypeSyntax type)
         {
-            if (refKeyword.Kind() != SyntaxKind.RefKeyword) throw new ArgumentException(nameof(refKeyword));
+            switch (refKeyword.Kind())
+            {
+                case SyntaxKind.RefKeyword:
+                case SyntaxKind.InKeyword:
+                case SyntaxKind.OutKeyword: break;
+                default: throw new ArgumentException(nameof(refKeyword));
+            }
             switch (readOnlyKeyword.Kind())
             {
                 case SyntaxKind.ReadOnlyKeyword:
@@ -2402,8 +2408,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>Creates a new RefTypeSyntax instance.</summary>
-        public static RefTypeSyntax RefType(TypeSyntax type)
-            => SyntaxFactory.RefType(SyntaxFactory.Token(SyntaxKind.RefKeyword), default, type);
+        public static RefTypeSyntax RefType(SyntaxToken refKeyword, TypeSyntax type)
+            => SyntaxFactory.RefType(refKeyword, default, type);
 
         /// <summary>Creates a new ParenthesizedExpressionSyntax instance.</summary>
         public static ParenthesizedExpressionSyntax ParenthesizedExpression(SyntaxToken openParenToken, ExpressionSyntax expression, SyntaxToken closeParenToken)

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
@@ -982,7 +982,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public OmittedTypeArgumentSyntax WithOmittedTypeArgumentToken(SyntaxToken omittedTypeArgumentToken) => Update(omittedTypeArgumentToken);
     }
 
-    /// <summary>The ref modifier of a method's return value or a local.</summary>
+    /// <summary>The ref modifier of a method's return value, a local, or a type argument.</summary>
     /// <remarks>
     /// <para>This node is associated with the following syntax kinds:</para>
     /// <list type="bullet">
@@ -998,6 +998,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
         }
 
+        /// <summary>SyntaxToken representing the 'ref', 'in' or 'out' keyword.</summary>
         public SyntaxToken RefKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.RefTypeSyntax)this.Green).refKeyword, Position, 0);
 
         /// <summary>Gets the optional "readonly" keyword.</summary>

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6060,11 +6060,12 @@ tryAgain:
             SyntaxToken varianceToken = null;
             if (this.CurrentToken.Kind == SyntaxKind.InKeyword || this.CurrentToken.Kind == SyntaxKind.OutKeyword)
             {
+                // PROTOTYPE(delegate-type-args): give a more accurate LangVersion error?
                 // Recognize the variance syntax, but give an error as it's
                 // only appropriate in a type parameter list.
-                varianceToken = this.EatToken();
-                varianceToken = CheckFeatureAvailability(varianceToken, MessageID.IDS_FeatureTypeVariance);
-                varianceToken = this.AddError(varianceToken, ErrorCode.ERR_IllegalVarianceSyntax);
+                // varianceToken = this.EatToken();
+                // varianceToken = CheckFeatureAvailability(varianceToken, MessageID.IDS_FeatureTypeVariance);
+                // varianceToken = this.AddError(varianceToken, ErrorCode.ERR_IllegalVarianceSyntax);
             }
 
             var result = this.ParseType();
@@ -6640,7 +6641,7 @@ tryAgain:
             ScanTypeFlags result;
             bool isFunctionPointer = false;
 
-            if (this.CurrentToken.Kind == SyntaxKind.RefKeyword)
+            if (this.CurrentToken.Kind is SyntaxKind.RefKeyword or SyntaxKind.InKeyword or SyntaxKind.OutKeyword)
             {
                 // in a ref local or ref return, we treat "ref" and "ref readonly" as part of the type
                 this.EatToken();
@@ -7011,11 +7012,13 @@ done:
 
         private TypeSyntax ParseType(ParseTypeMode mode = ParseTypeMode.Normal)
         {
-            if (this.CurrentToken.Kind == SyntaxKind.RefKeyword)
+            if (this.CurrentToken.Kind is SyntaxKind.RefKeyword or SyntaxKind.OutKeyword or SyntaxKind.InKeyword)
             {
                 var refKeyword = this.EatToken();
                 refKeyword = this.CheckFeatureAvailability(refKeyword, MessageID.IDS_FeatureRefLocalsReturns);
 
+                // PROTOTYPE(delegate-type-args): prevent combining 'in' with 'readonly'?
+                // should 'out'/'in' be stored in a different syntax node than 'readonly'?
                 SyntaxToken readonlyKeyword = null;
                 if (this.CurrentToken.Kind == SyntaxKind.ReadOnlyKeyword)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
@@ -46,6 +46,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return new PointerTypeSymbol(CreateType(type, customModifiers));
         }
 
+        internal override TypeSymbol MakeRefTypeSymbol(PEModuleSymbol moduleSymbol, TypeSymbol type, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers)
+        {
+            if (type is UnsupportedMetadataTypeSymbol)
+            {
+                return type;
+            }
+
+            var refKind = RefKind.Ref;
+            // PROTOTYPE(delegate-type-args): it's not clear how to decode OutAttribute etc
+
+            return new RefTypeSymbol(refKind, CreateType(type, customModifiers));
+        }
+
         internal override TypeSymbol MakeFunctionPointerTypeSymbol(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
         {
             return FunctionPointerTypeSymbol.CreateFromMetadata(callingConvention, retAndParamTypes);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -170,6 +170,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 case SymbolKind.PointerType:
                     return DecodePointerType((PointerTypeSymbol)type);
 
+                case SymbolKind.RefType:
+                    return DecodeRefType((RefTypeSymbol)type);
+
                 case SymbolKind.NamedType:
                     // We may have a tuple type from a substituted type symbol,
                     // but it will be missing names from metadata, so we'll
@@ -204,6 +207,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         private PointerTypeSymbol DecodePointerType(PointerTypeSymbol type)
         {
             return type.WithPointedAtType(DecodeTypeInternal(type.PointedAtTypeWithAnnotations));
+        }
+
+        private RefTypeSymbol DecodeRefType(RefTypeSymbol type)
+        {
+            return type.WithReferencedType(DecodeTypeInternal(type.ReferencedTypeWithAnnotations));
         }
 
         private FunctionPointerTypeSymbol DecodeFunctionPointerType(FunctionPointerTypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/RefTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/RefTypeSymbol.cs
@@ -24,6 +24,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ReferencedTypeWithAnnotations = referencedTypeWithAnnotations;
         }
 
+        internal RefTypeSymbol WithReferencedType(TypeWithAnnotations newReferencedType)
+        {
+            return ReferencedTypeWithAnnotations.IsSameAs(newReferencedType) ? this : new RefTypeSymbol(RefKind, newReferencedType);
+        }
+
         public override bool IsReferenceType => false;
         public override bool IsValueType => false;
 

--- a/src/Compilers/CSharp/Portable/Syntax/RefTypeSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/RefTypeSyntax.cs
@@ -19,10 +19,5 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     public partial class SyntaxFactory
     {
-        /// <summary>Creates a new RefTypeSyntax instance.</summary>
-        public static RefTypeSyntax RefType(SyntaxToken refKeyword, TypeSyntax type)
-        {
-            return RefType(refKeyword, readOnlyKeyword: default, type);
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -400,11 +400,16 @@
   </Node>
   <Node Name="RefTypeSyntax" Base="TypeSyntax">
     <TypeComment>
-      <summary>The ref modifier of a method's return value or a local.</summary>
+      <summary>The ref modifier of a method's return value, a local, or a type argument.</summary>
     </TypeComment>
     <Kind Name="RefType"/>
     <Field Name="RefKeyword" Type="SyntaxToken">
       <Kind Name="RefKeyword"/>
+      <Kind Name="InKeyword"/>
+      <Kind Name="OutKeyword"/>
+      <PropertyComment>
+        <summary>SyntaxToken representing the 'ref', 'in' or 'out' keyword.</summary>
+      </PropertyComment>
     </Field>
     <Field Name="ReadOnlyKeyword" Type="SyntaxToken" Optional="true">
       <Kind Name="ReadOnlyKeyword"/>

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -107,6 +107,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         TypeWithAnnotations pointedAtType = pointer.PointedAtTypeWithAnnotations;
                         return checkTypeWithAnnotations(pointedAtType, flagNonDefaultArraySizesOrLowerBounds);
                     }
+                case SymbolKind.RefType:
+                    {
+                        var refType = (RefTypeSymbol)type;
+                        TypeWithAnnotations referencedType = refType.ReferencedTypeWithAnnotations;
+                        return checkTypeWithAnnotations(referencedType, flagNonDefaultArraySizesOrLowerBounds);
+                    }
                 case SymbolKind.FunctionPointerType:
                     {
                         var funcPtr = (FunctionPointerTypeSymbol)type;

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -7938,7 +7938,43 @@ b { }";
                             N(SyntaxKind.LessThanToken);
                             N(SyntaxKind.RefType);
                             {
-                                N(SyntaxKind.RefKeyword);
+                                N(SyntaxKind.InKeyword);
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                }
+                            }
+                            N(SyntaxKind.GreaterThanToken);
+                        }
+                    }
+                    N(SyntaxKind.VariableDeclarator);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                }
+                N(SyntaxKind.SemicolonToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void DelegateOutTypeArg()
+        {
+            UsingStatement("Action<out int> x;");
+
+            N(SyntaxKind.LocalDeclarationStatement);
+            {
+                N(SyntaxKind.VariableDeclaration);
+                {
+                    N(SyntaxKind.GenericName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Action");
+                        N(SyntaxKind.TypeArgumentList);
+                        {
+                            N(SyntaxKind.LessThanToken);
+                            N(SyntaxKind.RefType);
+                            {
+                                N(SyntaxKind.OutKeyword);
                                 N(SyntaxKind.PredefinedType);
                                 {
                                     N(SyntaxKind.IntKeyword);

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -319,6 +319,12 @@ namespace Microsoft.CodeAnalysis
                     typeSymbol = MakePointerTypeSymbol(typeSymbol, modifiers);
                     break;
 
+                case SignatureTypeCode.ByReference:
+                    modifiers = DecodeModifiersOrThrow(ref ppSig, out typeCode);
+                    typeSymbol = DecodeTypeOrThrow(ref ppSig, typeCode, out refersToNoPiaLocalType);
+                    typeSymbol = MakeRefTypeSymbol(typeSymbol, modifiers);
+                    break;
+
                 case SignatureTypeCode.GenericTypeParameter:
                     if (!ppSig.TryReadCompressedInteger(out paramPosition))
                     {

--- a/src/Compilers/Core/Portable/MetadataReader/SymbolFactory.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/SymbolFactory.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis
         internal abstract TypeSymbol SubstituteTypeParameters(ModuleSymbol moduleSymbol, TypeSymbol generic, ImmutableArray<KeyValuePair<TypeSymbol, ImmutableArray<ModifierInfo<TypeSymbol>>>> arguments, ImmutableArray<bool> refersToNoPiaLocalType);
 
         internal abstract TypeSymbol MakePointerTypeSymbol(ModuleSymbol moduleSymbol, TypeSymbol type, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers);
+        internal abstract TypeSymbol MakeRefTypeSymbol(ModuleSymbol moduleSymbol, TypeSymbol type, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers);
         internal abstract TypeSymbol MakeFunctionPointerTypeSymbol(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> returnAndParamTypes);
         internal abstract TypeSymbol GetSpecialType(ModuleSymbol moduleSymbol, SpecialType specialType);
         internal abstract TypeSymbol GetSystemTypeSymbol(ModuleSymbol moduleSymbol);

--- a/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
@@ -77,6 +77,11 @@ namespace Microsoft.CodeAnalysis
             return _factory.MakePointerTypeSymbol(this.moduleSymbol, type, customModifiers);
         }
 
+        protected TypeSymbol MakeRefTypeSymbol(TypeSymbol type, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers)
+        {
+            return _factory.MakeRefTypeSymbol(this.moduleSymbol, type, customModifiers);
+        }
+
         protected TypeSymbol MakeFunctionPointerTypeSymbol(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamInfos)
         {
             return _factory.MakeFunctionPointerTypeSymbol(callingConvention, retAndParamInfos);

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
@@ -148,6 +148,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Friend Overrides Function MakeFunctionPointerTypeSymbol(callingConvention As Cci.CallingConvention, retAndParamTypes As ImmutableArray(Of ParamInfo(Of TypeSymbol))) As TypeSymbol
             Return New UnsupportedMetadataTypeSymbol()
         End Function
+
+        Friend Overrides Function MakeRefTypeSymbol(moduleSymbol As PEModuleSymbol, type As TypeSymbol, customModifiers As ImmutableArray(Of ModifierInfo(Of TypeSymbol))) As TypeSymbol
+            Return New UnsupportedMetadataTypeSymbol()
+        End Function
     End Class
 
 End Namespace


### PR DESCRIPTION
More functionality for the "delegate type arguments" work.