### PR TITLE
Ensure low-pri fixes go in the right async lightbulb bucket.

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -4,8 +4,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -19,7 +17,6 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
-using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -486,7 +483,7 @@ public class P2 { }");
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
-        public void GFUFuzzyMatchAfterRenameTracking()
+        public void GFUFuzzyMatchAfterRenameTrackingAndAfterGenerateType()
         {
             SetUpEditor(@"
 namespace N
@@ -511,12 +508,12 @@ namespace NS
             var expectedItems = new[]
             {
                 "Rename 'P2' to 'Foober'",
-                "Goober - using N;",
                 "Generate type 'Foober'",
                 "Generate class 'Foober' in new file",
                 "Generate class 'Foober'",
                 "Generate nested class 'Foober'",
                 "Generate new type...",
+                "Goober - using N;",
                 "Suppress or Configure issues",
                 "Suppress CS0168",
                 "in Source",


### PR DESCRIPTION
Fixes #57157

This is targetting 17.0 to address the async lightbulb regression there. The core issue here is that prior to 'async lightbulbs' 'add using' already had two priority classes. Normal 'exact match' fixes that would show up at the top of the lightbulb, and 'normal pri' 'fuzzy matching' fixes that would show up at the bottom.

When we switched to async lightbulbs this broke as we'd compute all add-using fixes and put them before everything else. The fix here is to not immediately add all lightbulb sets to the bucket we're in.  If they're low pri items, we wait until later to add them.

High pri add using fixes
Normal pri other fixes
Normal pri add using fixes