### PR TITLE
Fix generator caching in compiler server

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -14240,7 +14240,7 @@ public class Generator : ISourceGenerator
             CleanupAllGeneratedFiles(srcDirectory.Path);
         }
 
-        [ConditionalTheory(typeof(WindowsOrMacOsOnly))]
+        [ConditionalTheory(typeof(WindowsOnly))]
         [InlineData("abc/a.txt", "abc\\a.txt", 1)]
         [InlineData("abc\\a.txt", "abc\\a.txt", 1)]
         [InlineData("abc/a.txt", "abc\\..\\a.txt", 2)]
@@ -14251,7 +14251,7 @@ public class Generator : ISourceGenerator
         [InlineData("a.txt", "A.txt", 1)]
         [InlineData("abc/a.txt", "ABC\\a.txt", 1)]
         [InlineData("abc/a.txt", "ABC\\A.txt", 1)]
-        public void TestDuplicateAdditionalFiles_WindowsAndMac(string additionalFilePath1, string additionalFilePath2, int expectedCount) => TestDuplicateAdditionalFiles(additionalFilePath1, additionalFilePath2, expectedCount);
+        public void TestDuplicateAdditionalFiles_Windows(string additionalFilePath1, string additionalFilePath2, int expectedCount) => TestDuplicateAdditionalFiles(additionalFilePath1, additionalFilePath2, expectedCount);
 
         [ConditionalTheory(typeof(LinuxOnly))]
         [InlineData("a.txt", "A.txt", 2)]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -14195,6 +14195,7 @@ public class Generator : ISourceGenerator
         [Theory]
         [InlineData("a.txt", "b.txt", 2)]
         [InlineData("a.txt", "a.txt", 1)]
+        [InlineData("a.txt", "A.txt", 1)]
         [InlineData("abc/a.txt", "def/a.txt", 2)]
         [InlineData("abc/a.txt", "abc/a.txt", 1)]
         [InlineData("abc/a.txt", "abc\\a.txt", 1)]
@@ -14245,6 +14246,15 @@ public class Generator : ISourceGenerator
 
             CleanupAllGeneratedFiles(srcDirectory.Path);
         }
+
+        [ConditionalTheory(typeof(UnixLikeOnly))]
+        [InlineData("a.txt", "A.txt", 2)]
+        [InlineData("abc/a.txt", "abc/A.txt", 2)]
+        [InlineData("abc/a.txt", "ABC/a.txt", 2)]
+        [InlineData("abc/a.txt", "./../abc/A.txt", 2)]
+        [InlineData("abc/a.txt", "./../ABC/a.txt", 2)]
+        public void TestDuplicateAdditionalFiles_Linux(string additionalFilePath1, string additionalFilePath2, int expectedCount) => TestDuplicateAdditionalFiles(additionalFilePath1, additionalFilePath2, expectedCount);
+
     }
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -14195,23 +14195,16 @@ public class Generator : ISourceGenerator
         [Theory]
         [InlineData("a.txt", "b.txt", 2)]
         [InlineData("a.txt", "a.txt", 1)]
-        [InlineData("a.txt", "A.txt", 1)]
         [InlineData("abc/a.txt", "def/a.txt", 2)]
         [InlineData("abc/a.txt", "abc/a.txt", 1)]
-        [InlineData("abc/a.txt", "abc\\a.txt", 1)]
         [InlineData("abc/a.txt", "abc/../a.txt", 2)]
         [InlineData("abc/a.txt", "abc/./a.txt", 1)]
         [InlineData("abc/a.txt", "abc/../abc/a.txt", 1)]
         [InlineData("abc/a.txt", "abc/.././abc/a.txt", 1)]
-        [InlineData("abc/a.txt", "abc\\..\\a.txt", 2)]
-        [InlineData("abc/a.txt", "abc\\..\\abc\\a.txt", 1)]
         [InlineData("abc/a.txt", "./abc/a.txt", 1)]
         [InlineData("abc/a.txt", "../abc/../abc/a.txt", 2)]
         [InlineData("abc/a.txt", "./abc/../abc/a.txt", 1)]
         [InlineData("../abc/a.txt", "../abc/../abc/a.txt", 1)]
-        [InlineData("abc/a.txt", "../abc\\../abc\\a.txt", 2)]
-        [InlineData("abc/a.txt", "./abc\\../abc\\a.txt", 1)]
-        [InlineData("../abc/a.txt", "../abc\\../abc\\a.txt", 1)]
         [InlineData("../abc/a.txt", "../abc/a.txt", 1)]
         [InlineData("./abc/a.txt", "abc/a.txt", 1)]
         public void TestDuplicateAdditionalFiles(string additionalFilePath1, string additionalFilePath2, int expectedCount)
@@ -14246,6 +14239,19 @@ public class Generator : ISourceGenerator
 
             CleanupAllGeneratedFiles(srcDirectory.Path);
         }
+
+        [ConditionalTheory(typeof(WindowsOnly))]
+        [InlineData("abc/a.txt", "abc\\a.txt", 1)]
+        [InlineData("abc\\a.txt", "abc\\a.txt", 1)]
+        [InlineData("abc/a.txt", "abc\\..\\a.txt", 2)]
+        [InlineData("abc/a.txt", "abc\\..\\abc\\a.txt", 1)]
+        [InlineData("abc/a.txt", "../abc\\../abc\\a.txt", 2)]
+        [InlineData("abc/a.txt", "./abc\\../abc\\a.txt", 1)]
+        [InlineData("../abc/a.txt", "../abc\\../abc\\a.txt", 1)]
+        [InlineData("a.txt", "A.txt", 1)]
+        [InlineData("abc/a.txt", "ABC\\a.txt", 1)]
+        [InlineData("abc/a.txt", "ABC\\A.txt", 1)]
+        public void TestDuplicateAdditionalFiles_Windows(string additionalFilePath1, string additionalFilePath2, int expectedCount) => TestDuplicateAdditionalFiles(additionalFilePath1, additionalFilePath2, expectedCount);
 
         [ConditionalTheory(typeof(UnixLikeOnly))]
         [InlineData("a.txt", "A.txt", 2)]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -14240,7 +14240,7 @@ public class Generator : ISourceGenerator
             CleanupAllGeneratedFiles(srcDirectory.Path);
         }
 
-        [ConditionalTheory(typeof(WindowsOnly))]
+        [ConditionalTheory(typeof(WindowsOrMacOsOnly))]
         [InlineData("abc/a.txt", "abc\\a.txt", 1)]
         [InlineData("abc\\a.txt", "abc\\a.txt", 1)]
         [InlineData("abc/a.txt", "abc\\..\\a.txt", 2)]
@@ -14251,9 +14251,9 @@ public class Generator : ISourceGenerator
         [InlineData("a.txt", "A.txt", 1)]
         [InlineData("abc/a.txt", "ABC\\a.txt", 1)]
         [InlineData("abc/a.txt", "ABC\\A.txt", 1)]
-        public void TestDuplicateAdditionalFiles_Windows(string additionalFilePath1, string additionalFilePath2, int expectedCount) => TestDuplicateAdditionalFiles(additionalFilePath1, additionalFilePath2, expectedCount);
+        public void TestDuplicateAdditionalFiles_WindowsAndMac(string additionalFilePath1, string additionalFilePath2, int expectedCount) => TestDuplicateAdditionalFiles(additionalFilePath1, additionalFilePath2, expectedCount);
 
-        [ConditionalTheory(typeof(UnixLikeOnly))]
+        [ConditionalTheory(typeof(LinuxOnly))]
         [InlineData("a.txt", "A.txt", 2)]
         [InlineData("abc/a.txt", "abc/A.txt", 2)]
         [InlineData("abc/a.txt", "ABC/a.txt", 2)]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -14205,8 +14205,12 @@ public class Generator : ISourceGenerator
         [InlineData("abc/a.txt", "abc\\..\\a.txt", 2)]
         [InlineData("abc/a.txt", "abc\\..\\abc\\a.txt", 1)]
         [InlineData("abc/a.txt", "./abc/a.txt", 1)]
-        [InlineData("abc/a.txt", "../abc/../abc/a.txt", 1)]
-        [InlineData("abc/a.txt", "../abc\\../abc\\a.txt", 1)]
+        [InlineData("abc/a.txt", "../abc/../abc/a.txt", 2)]
+        [InlineData("abc/a.txt", "./abc/../abc/a.txt", 1)]
+        [InlineData("../abc/a.txt", "../abc/../abc/a.txt", 1)]
+        [InlineData("abc/a.txt", "../abc\\../abc\\a.txt", 2)]
+        [InlineData("abc/a.txt", "./abc\\../abc\\a.txt", 1)]
+        [InlineData("../abc/a.txt", "../abc\\../abc\\a.txt", 1)]
         [InlineData("../abc/a.txt", "../abc/a.txt", 1)]
         [InlineData("./abc/a.txt", "abc/a.txt", 1)]
         public void TestDuplicateAdditionalFiles(string additionalFilePath1, string additionalFilePath2, int expectedCount)
@@ -14222,7 +14226,7 @@ public class Generator : ISourceGenerator
             var additionalFile2 = expectedCount == 2 ? srcDirectory.CreateFile(additionalFilePath2) : null;
 
             string path1 = additionalFile1.Path;
-            string path2 = additionalFile2?.Path ?? path1;
+            string path2 = additionalFile2?.Path ?? Path.Combine(srcDirectory.Path, additionalFilePath2);
 
             int count = 0;
             var generator = new PipelineCallbackGenerator(ctx =>

--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/AdditionalTextComparerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/AdditionalTextComparerTests.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Roslyn.Test.Utilities.TestGenerators;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
+{
+    public class AdditionalTextComparerTests
+    {
+        [Fact]
+        public void Compares_Equal_When_Path_And_Content_Are_The_Same()
+        {
+            AdditionalText text1 = new InMemoryAdditionalText(@"c:\a\b\c.txt", "abc");
+            AdditionalText text2 = new InMemoryAdditionalText(@"c:\a\b\c.txt", "abc");
+
+            Assert.NotEqual(text1, text2);
+            Assert.Equal(text1, text2, AdditionalTextComparer.Instance);
+        }
+
+        [Fact]
+        public void HashCodes_Match_When_Path_And_Content_Are_The_Same()
+        {
+            AdditionalText text1 = new InMemoryAdditionalText(@"c:\a\b\c.txt", "abc");
+            AdditionalText text2 = new InMemoryAdditionalText(@"c:\a\b\c.txt", "abc");
+
+            var hash1 = text1.GetHashCode();
+            var hash2 = text2.GetHashCode();
+            Assert.NotEqual(hash1, hash2);
+
+            var comparerHash1 = AdditionalTextComparer.Instance.GetHashCode(text1);
+            var comparerHash2 = AdditionalTextComparer.Instance.GetHashCode(text2);
+            Assert.Equal(comparerHash1, comparerHash2);
+        }
+
+        [Fact]
+        public void Not_Equal_When_Paths_Differ()
+        {
+            AdditionalText text1 = new InMemoryAdditionalText(@"c:\a\b\c.txt", "abc");
+            AdditionalText text2 = new InMemoryAdditionalText(@"c:\d\e\f.txt", "abc");
+
+            Assert.NotEqual(text1, text2, AdditionalTextComparer.Instance);
+
+            var comparerHash1 = AdditionalTextComparer.Instance.GetHashCode(text1);
+            var comparerHash2 = AdditionalTextComparer.Instance.GetHashCode(text2);
+            Assert.NotEqual(comparerHash1, comparerHash2);
+        }
+
+        [Fact]
+        public void Not_Equal_When_Contents_Differ()
+        {
+            AdditionalText text1 = new InMemoryAdditionalText(@"c:\a\b\c.txt", "abc");
+            AdditionalText text2 = new InMemoryAdditionalText(@"c:\a\b\c.txt", "def");
+
+            Assert.NotEqual(text1, text2, AdditionalTextComparer.Instance);
+
+            var comparerHash1 = AdditionalTextComparer.Instance.GetHashCode(text1);
+            var comparerHash2 = AdditionalTextComparer.Instance.GetHashCode(text2);
+            Assert.NotEqual(comparerHash1, comparerHash2);
+        }
+
+        [Fact]
+        public void Comparison_With_Different_Path_Casing()
+        {
+            AdditionalText text1 = new InMemoryAdditionalText(@"c:\a\b\c.txt", "abc");
+            AdditionalText text2 = new InMemoryAdditionalText(@"c:\a\B\c.txt", "abc");
+
+            // hash codes are path case insensitive
+            var comparerHash1 = AdditionalTextComparer.Instance.GetHashCode(text1);
+            var comparerHash2 = AdditionalTextComparer.Instance.GetHashCode(text2);
+            Assert.Equal(comparerHash1, comparerHash2);
+
+            // but we correctly compare
+            if (PathUtilities.IsUnixLikePlatform)
+            {
+                Assert.NotEqual(text1, text2, AdditionalTextComparer.Instance);
+            }
+            else
+            {
+                Assert.Equal(text1, text2, AdditionalTextComparer.Instance);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -744,7 +744,10 @@ namespace Microsoft.CodeAnalysis
             if (this.GeneratorDriverCache is object && !disableCache)
             {
                 cacheKey = deriveCacheKey();
-                driver = this.GeneratorDriverCache.TryGetDriver(cacheKey);
+                driver = this.GeneratorDriverCache.TryGetDriver(cacheKey)?
+                                                  .WithUpdatedParseOptions(parseOptions)
+                                                  .WithUpdatedAnalyzerConfigOptions(analyzerConfigOptionsProvider)
+                                                  .ReplaceAdditionalTexts(additionalTexts);
             }
 
             driver ??= CreateGeneratorDriver(parseOptions, generators, analyzerConfigOptionsProvider, additionalTexts);

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1448,14 +1448,18 @@ namespace Microsoft.CodeAnalysis
 
         protected virtual ImmutableArray<AdditionalTextFile> ResolveAdditionalFilesFromArguments(List<DiagnosticInfo> diagnostics, CommonMessageProvider messageProvider, TouchedFileLogger? touchedFilesLogger)
         {
-            var builder = ImmutableArray.CreateBuilder<AdditionalTextFile>();
+            var builder = ArrayBuilder<AdditionalTextFile>.GetInstance();
+            var filePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var file in Arguments.AdditionalFiles)
             {
-                builder.Add(new AdditionalTextFile(file, this));
+                if (filePaths.Add(file.Path))
+                {
+                    builder.Add(new AdditionalTextFile(file, this));
+                }
             }
 
-            return builder.ToImmutableArray();
+            return builder.ToImmutableAndFree();
         }
 
         private static void ReportAnalyzerExecutionTime(TextWriter consoleOutput, AnalyzerDriver analyzerDriver, CultureInfo culture, bool isConcurrentBuild)

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1449,7 +1449,7 @@ namespace Microsoft.CodeAnalysis
         protected virtual ImmutableArray<AdditionalTextFile> ResolveAdditionalFilesFromArguments(List<DiagnosticInfo> diagnostics, CommonMessageProvider messageProvider, TouchedFileLogger? touchedFilesLogger)
         {
             var builder = ArrayBuilder<AdditionalTextFile>.GetInstance();
-            var filePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var filePaths = new HashSet<string>(PathUtilities.Comparer);
 
             foreach (var file in Arguments.AdditionalFiles)
             {

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1453,7 +1453,8 @@ namespace Microsoft.CodeAnalysis
 
             foreach (var file in Arguments.AdditionalFiles)
             {
-                if (filePaths.Add(file.Path))
+                Debug.Assert(PathUtilities.IsAbsolute(file.Path));
+                if (filePaths.Add(PathUtilities.ExpandAbsolutePathWithRelativeParts(file.Path)))
                 {
                     builder.Add(new AdditionalTextFile(file, this));
                 }

--- a/src/Compilers/Core/Portable/InternalUtilities/AdditionalTextComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/AdditionalTextComparer.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal class AdditionalTextComparer : IEqualityComparer<AdditionalText>
+    {
+        public static readonly AdditionalTextComparer Instance = new AdditionalTextComparer();
+
+        public bool Equals([AllowNull] AdditionalText x, [AllowNull] AdditionalText y)
+        {
+            if (object.ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            if (!PathUtilities.Comparer.Equals(x.Path, y.Path))
+            {
+                return false;
+            }
+
+            var xText = x.GetText();
+            var yText = y.GetText();
+
+            if (xText is null || yText is null || xText.Length != yText.Length)
+            {
+                return false;
+            }
+
+            return ByteSequenceComparer.Equals(xText.GetChecksum(), yText.GetChecksum());
+        }
+
+        public int GetHashCode([DisallowNull] AdditionalText obj)
+        {
+            return Hash.Combine(PathUtilities.Comparer.GetHashCode(obj.Path),
+                                ByteSequenceComparer.GetHashCode(obj.GetText()?.GetChecksum() ?? ImmutableArray<byte>.Empty));
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/AdditionalTextComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/AdditionalTextComparer.cs
@@ -11,11 +11,11 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal class AdditionalTextComparer : IEqualityComparer<AdditionalText>
+    internal sealed class AdditionalTextComparer : IEqualityComparer<AdditionalText>
     {
         public static readonly AdditionalTextComparer Instance = new AdditionalTextComparer();
 
-        public bool Equals([AllowNull] AdditionalText x, [AllowNull] AdditionalText y)
+        public bool Equals(AdditionalText? x, AdditionalText? y)
         {
             if (object.ReferenceEquals(x, y))
             {
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis
             return ByteSequenceComparer.Equals(xText.GetChecksum(), yText.GetChecksum());
         }
 
-        public int GetHashCode([DisallowNull] AdditionalText obj)
+        public int GetHashCode(AdditionalText obj)
         {
             return Hash.Combine(PathUtilities.Comparer.GetHashCode(obj.Path),
                                 ByteSequenceComparer.GetHashCode(obj.GetText()?.GetChecksum() ?? ImmutableArray<byte>.Empty));

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -16,6 +16,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureReferenceOperation.IsInitializat
 Microsoft.CodeAnalysis.GeneratorAttribute.GeneratorAttribute(string! firstLanguage, params string![]! additionalLanguages) -> void
 Microsoft.CodeAnalysis.GeneratorAttribute.Languages.get -> string![]!
 Microsoft.CodeAnalysis.GeneratorDriver.ReplaceAdditionalText(Microsoft.CodeAnalysis.AdditionalText! oldText, Microsoft.CodeAnalysis.AdditionalText! newText) -> Microsoft.CodeAnalysis.GeneratorDriver!
+Microsoft.CodeAnalysis.GeneratorDriver.ReplaceAdditionalTexts(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.AdditionalText!> newTexts) -> Microsoft.CodeAnalysis.GeneratorDriver!
 Microsoft.CodeAnalysis.GeneratorDriver.WithUpdatedAnalyzerConfigOptions(Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider! newOptions) -> Microsoft.CodeAnalysis.GeneratorDriver!
 Microsoft.CodeAnalysis.GeneratorDriver.WithUpdatedParseOptions(Microsoft.CodeAnalysis.ParseOptions! newOptions) -> Microsoft.CodeAnalysis.GeneratorDriver!
 Microsoft.CodeAnalysis.GeneratorDriverOptions

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -120,6 +120,8 @@ namespace Microsoft.CodeAnalysis
             return FromState(newState);
         }
 
+        public GeneratorDriver ReplaceAdditionalTexts(ImmutableArray<AdditionalText> newTexts) => FromState(_state.With(additionalTexts: newTexts));
+
         public GeneratorDriver WithUpdatedParseOptions(ParseOptions newOptions) => newOptions is object
                                                                                    ? FromState(_state.With(parseOptions: newOptions))
                                                                                    : throw new ArgumentNullException(nameof(newOptions));

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -94,11 +94,11 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
-        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_getInput, _registerOutput, comparer, _name);
+        public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_getInput, _registerOutput, _inputComparer, comparer, _name);
 
-        public IIncrementalGeneratorNode<T> WithTrackingName(string name) => new InputNode<T>(_getInput, _registerOutput, _comparer, name);
+        public IIncrementalGeneratorNode<T> WithTrackingName(string name) => new InputNode<T>(_getInput, _registerOutput, _inputComparer, _comparer, name);
 
-        public InputNode<T> WithRegisterOutput(Action<IIncrementalGeneratorOutputNode> registerOutput) => new InputNode<T>(_getInput, registerOutput, _inputComparer, _comparer);
+        public InputNode<T> WithRegisterOutput(Action<IIncrementalGeneratorOutputNode> registerOutput) => new InputNode<T>(_getInput, registerOutput, _inputComparer, _comparer, _name);
 
         public void RegisterOutput(IIncrementalGeneratorOutputNode output) => _registerOutput(output);
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/InputNode.cs
@@ -20,18 +20,20 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly Func<DriverStateTable.Builder, ImmutableArray<T>> _getInput;
         private readonly Action<IIncrementalGeneratorOutputNode> _registerOutput;
+        private readonly IEqualityComparer<T> _inputComparer;
         private readonly IEqualityComparer<T> _comparer;
         private readonly string? _name;
 
-        public InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput)
-            : this(getInput, registerOutput: null, comparer: null)
+        public InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput, IEqualityComparer<T>? inputComparer = null)
+            : this(getInput, registerOutput: null, inputComparer: inputComparer, comparer: null)
         {
         }
 
-        private InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput, Action<IIncrementalGeneratorOutputNode>? registerOutput, IEqualityComparer<T>? comparer = null, string? name = null)
+        private InputNode(Func<DriverStateTable.Builder, ImmutableArray<T>> getInput, Action<IIncrementalGeneratorOutputNode>? registerOutput, IEqualityComparer<T>? inputComparer = null, IEqualityComparer<T>? comparer = null, string? name = null)
         {
             _getInput = getInput;
             _comparer = comparer ?? EqualityComparer<T>.Default;
+            _inputComparer = inputComparer ?? EqualityComparer<T>.Default;
             _registerOutput = registerOutput ?? (o => throw ExceptionUtilities.Unreachable);
             _name = name;
         }
@@ -43,7 +45,7 @@ namespace Microsoft.CodeAnalysis
             TimeSpan elapsedTime = stopwatch.Elapsed;
 
             // create a mutable hashset of the new items we can check against
-            HashSet<T> itemsSet = new HashSet<T>();
+            HashSet<T> itemsSet = new HashSet<T>(_inputComparer);
             foreach (var item in inputItems)
             {
                 var added = itemsSet.Add(item);
@@ -93,9 +95,10 @@ namespace Microsoft.CodeAnalysis
         }
 
         public IIncrementalGeneratorNode<T> WithComparer(IEqualityComparer<T> comparer) => new InputNode<T>(_getInput, _registerOutput, comparer, _name);
+
         public IIncrementalGeneratorNode<T> WithTrackingName(string name) => new InputNode<T>(_getInput, _registerOutput, _comparer, name);
 
-        public InputNode<T> WithRegisterOutput(Action<IIncrementalGeneratorOutputNode> registerOutput) => new InputNode<T>(_getInput, registerOutput, _comparer);
+        public InputNode<T> WithRegisterOutput(Action<IIncrementalGeneratorOutputNode> registerOutput) => new InputNode<T>(_getInput, registerOutput, _inputComparer, _comparer);
 
         public void RegisterOutput(IIncrementalGeneratorOutputNode output) => _registerOutput(output);
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SharedInputNodes.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SharedInputNodes.cs
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -19,7 +16,7 @@ namespace Microsoft.CodeAnalysis
 
         public static readonly InputNode<ParseOptions> ParseOptions = new InputNode<ParseOptions>(b => ImmutableArray.Create(b.DriverState.ParseOptions));
 
-        public static readonly InputNode<AdditionalText> AdditionalTexts = new InputNode<AdditionalText>(b => b.DriverState.AdditionalTexts);
+        public static readonly InputNode<AdditionalText> AdditionalTexts = new InputNode<AdditionalText>(b => b.DriverState.AdditionalTexts, AdditionalTextComparer.Instance);
 
         public static readonly InputNode<SyntaxTree> SyntaxTrees = new InputNode<SyntaxTree>(b => b.Compilation.SyntaxTrees.ToImmutableArray());
 

--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -312,12 +312,6 @@ namespace Roslyn.Test.Utilities
         public override string SkipReason => "Test not supported on macOS";
     }
 
-    public class WindowsOrMacOsOnly : ExecutionCondition
-    {
-        public override bool ShouldSkip => ExecutionConditionUtil.IsLinux;
-        public override string SkipReason => "Test not supported on Linux";
-    }
-
     public class LinuxOnly : ExecutionCondition
     {
         public override bool ShouldSkip => !ExecutionConditionUtil.IsLinux;

--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -312,6 +312,18 @@ namespace Roslyn.Test.Utilities
         public override string SkipReason => "Test not supported on macOS";
     }
 
+    public class WindowsOrMacOsOnly : ExecutionCondition
+    {
+        public override bool ShouldSkip => ExecutionConditionUtil.IsLinux;
+        public override string SkipReason => "Test not supported on Linux";
+    }
+
+    public class LinuxOnly : ExecutionCondition
+    {
+        public override bool ShouldSkip => !ExecutionConditionUtil.IsLinux;
+        public override string SkipReason => "Test not supported on Windows or macOS";
+    }
+
     public class ClrOnly : ExecutionCondition
     {
         public override bool ShouldSkip => MonoHelpers.IsRunningOnMono();


### PR DESCRIPTION
- Correctly restore additional files and config providers
- Enables driver inputs to supply comparers
- Adds an additional text comparer that allows the driver to determine if two texts are equal
- Adds tests for the cache inputs

**Note** We're not comparing the config provider: this means every invocation we'll think it was modified even when it wasn't. I'm thinking about putting in a separate cache for the configs anyway, which would actually fix this, but for now it doesn't matter too much. Although the config provider has changed, the values that come out of it will be the same, so downstream nodes will likely be considered cached as it just produces strings.