### PR TITLE
Remove unnecessary Symbol type checks

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1323,7 +1323,7 @@ symIsHidden:;
                 : symbol;
 
             // Check for symbols marked with 'Microsoft.CodeAnalysis.Embedded' attribute
-            if (!this.Compilation.SourceModule.Equals(unwrappedSymbol.ContainingModule, SymbolEqualityComparer.Default.CompareKind) && unwrappedSymbol.IsHiddenByCodeAnalysisEmbeddedAttribute())
+            if (!this.Compilation.SourceModule.Equals(unwrappedSymbol.ContainingModule) && unwrappedSymbol.IsHiddenByCodeAnalysisEmbeddedAttribute())
             {
                 return LookupResult.Empty();
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -628,7 +628,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // this part is expected to disappear when inlining "someSymbol == null"
-            return (object)left == (object)right || right.Equals(left, SymbolEqualityComparer.Default.CompareKind);
+            return (object)left == (object)right || right.Equals(left);
         }
 
         /// <summary>
@@ -653,12 +653,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // this part is expected to disappear when inlining "someSymbol != null"
-            return (object)left != (object)right && !right.Equals(left, SymbolEqualityComparer.Default.CompareKind);
+            return (object)left != (object)right && !right.Equals(left);
         }
 
         public sealed override bool Equals(object obj)
         {
             return this.Equals(obj as Symbol, SymbolEqualityComparer.Default.CompareKind);
+        }
+
+        public bool Equals(Symbol other)
+        {
+            return this.Equals(other, SymbolEqualityComparer.Default.CompareKind);
         }
 
         bool ISymbolInternal.Equals(ISymbolInternal other, TypeCompareKind compareKind)


### PR DESCRIPTION
Calls to `Symbol.Equals(object)` require a dynamic type check on the argument. Directly calling the overload which takes a `Symbol` parameter avoids this type check. The changes in this commit target hot paths revealed in [AB#1421526](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1421526).