### PR TITLE
Always set BuildingInsideVisualStudio when loading MSBuild workspace

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
@@ -31,13 +31,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
             { PropertyNames.DesignTimeBuild, bool.TrueString },
 
             // this will force CoreCompile task to execute even if all inputs and outputs are up to date
-#if NETCOREAPP
-            { PropertyNames.NonExistentFile, "__NonExistentSubDir__\\__NonExistentFile__" },
-#else
-            // Setting `BuildingInsideVisualStudio` indirectly sets NonExistentFile:
-            // https://github.com/microsoft/msbuild/blob/ab9b2f36a5ff7a85f842b205d5529e77fdc9d7ab/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3462-L3470
             { PropertyNames.BuildingInsideVisualStudio, bool.TrueString },
-#endif
 
             { PropertyNames.BuildProjectReferences, bool.FalseString },
             { PropertyNames.BuildingProject, bool.FalseString },


### PR DESCRIPTION
It was reported that dotnet-format was failing to load WPF project with the MSBuildWorkspace (See https://github.com/dotnet/format/issues/1337). The necessary change to fix this was to pass `BuildingInsideVisualStudio` to `true` which we were already doing for Full Framework. This change makes the behavior the same regardless of which TFM the MSBuild.Workspace library was built for.