### PR TITLE
Fix a race condition in CompilationWithAnalyzers

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -761,6 +761,14 @@ class C
                 //         int x1 = 0; // CS0219 (unused variable)
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x1").WithArguments("x1").WithLocation(6, 13));
 
+            // Verify compiler analyzer diagnostics for entire tree
+            result = await compilationWithAnalyzers.GetAnalysisResultAsync(semanticModel, filterSpan: null, CancellationToken.None);
+            diagnostics = result.SemanticDiagnostics[syntaxTree][compilerAnalyzer];
+            diagnostics.Verify(
+                // (6,13): warning CS0219: The variable 'x1' is assigned but its value is never used
+                //         int x1 = 0; // CS0219 (unused variable)
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x1").WithArguments("x1").WithLocation(6, 13));
+
             // Verify no diagnostics with a span outside the local decl
             span = localDecl.GetLastToken().GetNextToken().Span;
             result = await compilationWithAnalyzers.GetAnalysisResultAsync(semanticModel, span, CancellationToken.None);


### PR DESCRIPTION
#56844 (merged a day ago) introduced a race condition wherein if we reuse the same CompilationWithAnalyzers instance for computing compiler semantic diagnostics for both line span (lightbulb) and full file span (background analysis for squiggles and error list), we end up reporting duplicate diagnostics from CompilationWithAnalyzers. This leads to seeing these duplicates in the error list. This change fixes that by ensuring we dedupe the reported compiler semantic diagnostics from CompilationWithAnalyzers.

Added unit test scenario in this PR fails due to duplicate diagnostics prior to the product fix and should act as a regression test for this issue.
