### PR TITLE
Add solution sync time telemetry

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -90,6 +90,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
             timer.Stop();
 
+            // report telemetry to help correlate slow solution sync with UI delays
             if (timer.ElapsedMilliseconds > 1000)
             {
                 Logger.Log(FunctionId.AssetService_Perf, KeyValueLogMessage.Create(map => map["SolutionSyncTime"] = timer.ElapsedMilliseconds));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -529,8 +529,9 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         InheritanceMargin_GetInheritanceMemberItems = 493,
 
         LSP_FindDocumentInWorkspace = 494,
-        AssetService_Perf = 495,
 
         SuggestedActions_GetSuggestedActionsAsync = 500,
+
+        AssetService_Perf = 520,
     }
 }


### PR DESCRIPTION
Report `vs.ide.vbcs.assetservice.perf` event with property `solutionsynctime` when solution synchronization to OOP takes more than 1s.
Fixes: [AB#1423479](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1423479)