### PR TITLE
[hackathon] Support nice syntax for ValueArray in most type contexts.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1318,7 +1318,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // ignore receiver when symbol is static
                 receiverOpt = null;
             }
-            else if (symbol.ContainingType?.IsValueArrayType() == true)
+            else if (symbol.ContainingType?.IsValueArrayType(symbol.DeclaringCompilation ) == true)
             {
                 // all the references that can be obtained from ValueArray instance accessors/methods
                 // point back to the instance
@@ -1434,7 +1434,7 @@ moreArguments:
                 // ignore receiver when symbol is static
                 receiverOpt = null;
             }
-            else if (symbol.ContainingType?.IsValueArrayType() == true)
+            else if (symbol.ContainingType?.IsValueArrayType(symbol.DeclaringCompilation) == true)
             {
                 // all the references that can be obtained from ValueArray instance accessors/methods
                 // point back to the instance

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -660,9 +660,44 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var dimension = rankSpecifier.Sizes;
                 if (!permitDimensions && dimension.Count != 0 && dimension[0].Kind() != SyntaxKind.OmittedArraySizeExpression)
                 {
-                    // https://github.com/dotnet/roslyn/issues/32464
-                    // Should capture invalid dimensions for use in `SemanticModel` and `IOperation`.
-                    Error(diagnostics, ErrorCode.ERR_ArraySizeInDeclaration, rankSpecifier);
+                    var size0 = dimension[0];
+                    if (dimension.Count == 1)
+                    {
+                        // TODO: VS better errors
+                        if (rankSpecifier.Rank > 1)
+                        {
+                            Error(diagnostics, ErrorCode.ERR_ArraySizeInDeclaration, node.ElementType, type);
+                        }
+
+                        var sizeExpr = BindExpression(size0, diagnostics);
+
+                        ulong arrSize;
+                        if (sizeExpr.ConstantValue?.IsIntegral != true)
+                        {
+                            Error(diagnostics, ErrorCode.ERR_ArraySizeInDeclaration, node.ElementType, type);
+                            arrSize = 1;
+                        }
+                        else
+                        {
+                            arrSize = sizeExpr.ConstantValue.UInt64Value;
+
+                            if (arrSize == 0 || arrSize > int.MaxValue)
+                            {
+                                Error(diagnostics, ErrorCode.ERR_ArraySizeInDeclaration, node.ElementType, type);
+                                arrSize = 1;
+                            }
+                        }
+
+                        var arrType = CreateValueArrayTypeSymbol(type, (int)arrSize, diagnostics, node);
+                        type = TypeWithAnnotations.Create(AreNullableAnnotationsEnabled(rankSpecifier.CloseBracketToken), arrType);
+                        continue;
+                    }
+                    else
+                    {
+                        // https://github.com/dotnet/roslyn/issues/32464
+                        // Should capture invalid dimensions for use in `SemanticModel` and `IOperation`.
+                        Error(diagnostics, ErrorCode.ERR_ArraySizeInDeclaration, rankSpecifier);
+                    }
                 }
 
                 var array = ArrayTypeSymbol.CreateCSharpArray(this.Compilation.Assembly, type, rankSpecifier.Rank);
@@ -670,6 +705,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return type;
+        }
+
+        internal TypeSymbol CreateValueArrayTypeSymbol(
+            TypeWithAnnotations elementTypeWithAnnotations,
+            int length,
+            BindingDiagnosticBag diagnostics,
+            SyntaxNode node)
+        {
+            var lengthMarker = Compilation.CreateArrayTypeSymbol(Compilation.GetSpecialType(SpecialType.System_Object), length);
+
+            return GetWellKnownType(WellKnownType.System_ValueArray_TR, diagnostics, node).Construct(ImmutableArray.Create(
+                elementTypeWithAnnotations,
+                TypeWithAnnotations.Create(lengthMarker, NullableAnnotation.Oblivious)));
         }
 
         private TypeSymbol BindTupleType(TupleTypeSyntax syntax, BindingDiagnosticBag diagnostics, ConsList<TypeSymbol> basesBeingResolved)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6786,6 +6786,21 @@ tryAgain:
                     case SyntaxKind.OpenBracketToken:
                         // Check for array types.
                         this.EatToken();
+
+                        if (this.CurrentToken.Kind == SyntaxKind.NumericLiteralToken ||
+                            this.CurrentToken.Kind == SyntaxKind.IdentifierToken)
+                        {
+                            if (this.PeekToken(1).Kind == SyntaxKind.CloseBracketToken)
+                            {
+                                // HACKATHON: we will allow trivial kinds of value array lengths.
+                                // [5]  or [ident]
+                                this.EatToken();
+                                this.EatToken();
+                                result = ScanTypeFlags.MustBeType;
+                                break;
+                            }
+                        }
+
                         while (this.CurrentToken.Kind == SyntaxKind.CommaToken)
                         {
                             this.EatToken();

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6796,7 +6796,7 @@ tryAgain:
                                 // [5]  or [ident]
                                 this.EatToken();
                                 this.EatToken();
-                                result = ScanTypeFlags.MustBeType;
+                                result = ScanTypeFlags.NonGenericTypeOrExpression;
                                 break;
                             }
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -146,9 +146,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ((NamedTypeSymbol)type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
         }
 
-        public static bool IsValueArrayType(this TypeSymbol type)
+        public static bool IsValueArrayType(this TypeSymbol type, CSharpCompilation compilation)
         {
-            if (type.OriginalDefinition.SpecialType != SpecialType.System_ValueArray_TR)
+            if ((object)type.OriginalDefinition != compilation?.GetWellKnownType(WellKnownType.System_ValueArray_TR))
             {
                 return false;
             }
@@ -157,24 +157,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return markerType.IsArray() && ((ArrayTypeSymbol)markerType).ElementType.IsObjectType();
         }
 
-        public static TypeSymbol GetValueArrayElementType(this TypeSymbol type)
+        public static TypeSymbol GetValueArrayElementType(this TypeSymbol type, CSharpCompilation compilation)
         {
-            return type.GetValueArrayElementTypeWithAnnotations().Type;
+            return type.GetValueArrayElementTypeWithAnnotations(compilation).Type;
         }
 
-        public static TypeWithAnnotations GetValueArrayElementTypeWithAnnotations(this TypeSymbol type)
+        public static TypeWithAnnotations GetValueArrayElementTypeWithAnnotations(this TypeSymbol type, CSharpCompilation compilation)
         {
             RoslynDebug.Assert((object)type != null);
-            RoslynDebug.Assert(IsValueArrayType(type));
+            RoslynDebug.Assert(type.IsValueArrayType(compilation));
             RoslynDebug.Assert(type is NamedTypeSymbol);  //not testing Kind because it may be an ErrorType
 
             return ((NamedTypeSymbol)type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[0];
         }
 
-        public static int GetValueArrayLength(this TypeSymbol type)
+        public static int GetValueArrayLength(this TypeSymbol type, CSharpCompilation compilation)
         {
             RoslynDebug.Assert((object)type != null);
-            RoslynDebug.Assert(IsValueArrayType(type));
+            RoslynDebug.Assert(type.IsValueArrayType(compilation));
             RoslynDebug.Assert(type is NamedTypeSymbol);  //not testing Kind because it may be an ErrorType
 
             return ((ArrayTypeSymbol)((NamedTypeSymbol)type).TypeArgumentsWithAnnotationsNoUseSiteDiagnostics[1].Type).Rank;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
@@ -1350,5 +1350,106 @@ class Program
       IL_0034:  ret
     }");
         }
+
+        [Fact]
+        public void ValueArrayArray()
+        {
+            var text =
+@"
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+    static T[] Create<T>(int size)
+    {
+        return new T[size];
+    }
+
+    static void Main()
+    {
+        int[][5] arrOfVarr = Create<int[5]>(10);
+        arrOfVarr[2][3] = 222;
+        Console.Write(arrOfVarr[2][3]);
+
+        int[5][] varrOfarr = default;
+        varrOfarr[2] = new int[5];
+        varrOfarr[2][3] = 333;
+        Console.Write(varrOfarr[2][3]);
+
+        int[5][5] varrOfVarr = default;
+        varrOfVarr[2][3] = 444;
+        Console.Write(varrOfVarr[2][3]);
+    }
+}
+";
+
+            var comp = CreateCompilation(new string[] { text, mockValueArray }, options: TestOptions.ReleaseExe);
+
+            var verifier = CompileAndVerify(comp, expectedOutput: "222333444");
+
+            verifier.VerifyIL("Program.Main",
+@"
+    {
+  // Code size      148 (0x94)
+  .maxstack  3
+  .locals init (System.ValueArray<int[], object[,,,,]> V_0, //varrOfarr
+                System.ValueArray<System.ValueArray<int, object[,,,,]>, object[,,,,]> V_1) //varrOfVarr
+  IL_0000:  ldc.i4.s   10
+  IL_0002:  call       ""System.ValueArray<int, object[,,,,]>[] Program.Create<System.ValueArray<int, object[,,,,]>>(int)""
+  IL_0007:  dup
+  IL_0008:  ldc.i4.2
+  IL_0009:  ldelema    ""System.ValueArray<int, object[,,,,]>""
+  IL_000e:  ldc.i4.3
+  IL_000f:  call       ""ref int System.ValueArray<int, object[,,,,]>.this[int].get""
+  IL_0014:  ldc.i4     0xde
+  IL_0019:  stind.i4
+  IL_001a:  ldc.i4.2
+  IL_001b:  ldelema    ""System.ValueArray<int, object[,,,,]>""
+  IL_0020:  ldc.i4.3
+  IL_0021:  call       ""ref int System.ValueArray<int, object[,,,,]>.this[int].get""
+  IL_0026:  ldind.i4
+  IL_0027:  call       ""void System.Console.Write(int)""
+  IL_002c:  ldloca.s   V_0
+  IL_002e:  initobj    ""System.ValueArray<int[], object[,,,,]>""
+  IL_0034:  ldloca.s   V_0
+  IL_0036:  ldc.i4.2
+  IL_0037:  call       ""ref int[] System.ValueArray<int[], object[,,,,]>.this[int].get""
+  IL_003c:  ldc.i4.5
+  IL_003d:  newarr     ""int""
+  IL_0042:  stind.ref
+  IL_0043:  ldloca.s   V_0
+  IL_0045:  ldc.i4.2
+  IL_0046:  call       ""ref int[] System.ValueArray<int[], object[,,,,]>.this[int].get""
+  IL_004b:  ldind.ref
+  IL_004c:  ldc.i4.3
+  IL_004d:  ldc.i4     0x14d
+  IL_0052:  stelem.i4
+  IL_0053:  ldloca.s   V_0
+  IL_0055:  ldc.i4.2
+  IL_0056:  call       ""ref int[] System.ValueArray<int[], object[,,,,]>.this[int].get""
+  IL_005b:  ldind.ref
+  IL_005c:  ldc.i4.3
+  IL_005d:  ldelem.i4
+  IL_005e:  call       ""void System.Console.Write(int)""
+  IL_0063:  ldloca.s   V_1
+  IL_0065:  initobj    ""System.ValueArray<System.ValueArray<int, object[,,,,]>, object[,,,,]>""
+  IL_006b:  ldloca.s   V_1
+  IL_006d:  ldc.i4.2
+  IL_006e:  call       ""ref System.ValueArray<int, object[,,,,]> System.ValueArray<System.ValueArray<int, object[,,,,]>, object[,,,,]>.this[int].get""
+  IL_0073:  ldc.i4.3
+  IL_0074:  call       ""ref int System.ValueArray<int, object[,,,,]>.this[int].get""
+  IL_0079:  ldc.i4     0x1bc
+  IL_007e:  stind.i4
+  IL_007f:  ldloca.s   V_1
+  IL_0081:  ldc.i4.2
+  IL_0082:  call       ""ref System.ValueArray<int, object[,,,,]> System.ValueArray<System.ValueArray<int, object[,,,,]>, object[,,,,]>.this[int].get""
+  IL_0087:  ldc.i4.3
+  IL_0088:  call       ""ref int System.ValueArray<int, object[,,,,]>.this[int].get""
+  IL_008d:  ldind.i4
+  IL_008e:  call       ""void System.Console.Write(int)""
+  IL_0093:  ret
+}");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -9273,11 +9273,14 @@ class C
 }
 ";
             CreateCompilation(source).VerifyDiagnostics(
-                // (6,12): error CS0270: Array size cannot be specified in a variable declaration (try initializing with a 'new' expression)
-                //         int[o];
-                Diagnostic(ErrorCode.ERR_ArraySizeInDeclaration, "[o]").WithLocation(6, 12),
+                // (6,9): error CS0270: Array size cannot be specified in a variable declaration (try initializing with a 'new' expression)
+                //         int[o] x;
+                Diagnostic(ErrorCode.ERR_ArraySizeInDeclaration, "int").WithArguments("int").WithLocation(6, 9),
+                // (6,9): error CS0518: Predefined type 'System.ValueArray`2' is not defined or imported
+                //         int[o] x;
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int[o]").WithArguments("System.ValueArray`2").WithLocation(6, 9),
                 // (6,13): error CS0266: Cannot implicitly convert type 'object' to 'int'. An explicit conversion exists (are you missing a cast?)
-                //         int[o];
+                //         int[o] x;
                 Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "o").WithArguments("object", "int").WithLocation(6, 13),
                 // (6,16): warning CS0168: The variable 'x' is declared but never used
                 //         int[o] x;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CompilationCreationTests.cs
@@ -77,12 +77,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             for (int i = 1; i <= (int)SpecialType.Count; i++)
             {
-                // HACKATHON: special type
-                if (i == (int)SpecialType.System_ValueArray_TR)
-                {
-                    continue;
-                }
-
                 NamedTypeSymbol type = c1.GetSpecialType((SpecialType)i);
                 if (i == (int)SpecialType.System_Runtime_CompilerServices_RuntimeFeature ||
                     i == (int)SpecialType.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -517,12 +517,6 @@ namespace System
                 var symbol = comp.GetSpecialType(special);
                 Assert.NotNull(symbol);
 
-                if (special == SpecialType.System_ValueArray_TR)
-                {
-                    // HACKATHON: experimental type
-                    continue;
-                }
-
                 if (special == SpecialType.System_Runtime_CompilerServices_RuntimeFeature ||
                     special == SpecialType.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute)
                 {
@@ -616,6 +610,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute:
                     case WellKnownType.System_Runtime_CompilerServices_IsExternalInit:
                     case WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler:
+                    case WellKnownType.System_ValueArray_TR:
                         // Not yet in the platform.
                         continue;
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
@@ -2917,7 +2917,6 @@ public class C
                     case SpecialType.System_Runtime_CompilerServices_IsVolatile: // static
                     case SpecialType.System_Runtime_CompilerServices_RuntimeFeature: // static and not available
                     case SpecialType.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute: // not available
-                    case SpecialType.System_ValueArray_TR: //  HACKATHON: special type
                         continue;
                 }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -707,21 +707,21 @@ public class MyClass
 }
 ";
             CreateCompilation(test).VerifyDiagnostics(
-                // (7,12): error CS0270: Array size cannot be specified in a variable declaration (try initializing with a 'new' expression)
+                // (7,9): error CS0518: Predefined type 'System.ValueArray`2' is not defined or imported
                 //         int[2] myarray;
-                Diagnostic(ErrorCode.ERR_ArraySizeInDeclaration, "[2]").WithLocation(7, 12),
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int[2]").WithArguments("System.ValueArray`2").WithLocation(7, 9),
                 // (7,16): warning CS0168: The variable 'myarray' is declared but never used
                 //         int[2] myarray;
                 Diagnostic(ErrorCode.WRN_UnreferencedVar, "myarray").WithArguments("myarray").WithLocation(7, 16),
-                // (8,9): error CS0119: 'MyClass' is a type, which is not valid in the given context
+                // (8,9): error CS0270: Array size cannot be specified in a variable declaration (try initializing with a 'new' expression)
                 //         MyClass[0] m;
-                Diagnostic(ErrorCode.ERR_BadSKunknown, "MyClass").WithArguments("MyClass", "type").WithLocation(8, 9),
-                // (8,20): error CS1002: ; expected
+                Diagnostic(ErrorCode.ERR_ArraySizeInDeclaration, "MyClass").WithArguments("MyClass").WithLocation(8, 9),
+                // (8,9): error CS0518: Predefined type 'System.ValueArray`2' is not defined or imported
                 //         MyClass[0] m;
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "m").WithLocation(8, 20),
-                // (8,20): error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "MyClass[0]").WithArguments("System.ValueArray`2").WithLocation(8, 9),
+                // (8,20): warning CS0168: The variable 'm' is declared but never used
                 //         MyClass[0] m;
-                Diagnostic(ErrorCode.ERR_IllegalStatement, "m").WithLocation(8, 20),
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "m").WithArguments("m").WithLocation(8, 20),
                 // (9,13): error CS0270: Array size cannot be specified in a variable declaration (try initializing with a 'new' expression)
                 //         byte[13,5] b;
                 Diagnostic(ErrorCode.ERR_ArraySizeInDeclaration, "[13,5]").WithLocation(9, 13),
@@ -746,18 +746,21 @@ public class MyClass
                 // (11,16): error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
                 //         E[,50] e;
                 Diagnostic(ErrorCode.ERR_IllegalStatement, "e").WithLocation(11, 16),
-                // (14,15): error CS0270: Array size cannot be specified in a variable declaration (try initializing with a 'new' expression)
+                // (14,12): error CS0518: Predefined type 'System.ValueArray`2' is not defined or imported
                 //     static int[2] myarray;
-                Diagnostic(ErrorCode.ERR_ArraySizeInDeclaration, "[2]").WithLocation(14, 15),
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int[2]").WithArguments("System.ValueArray`2").WithLocation(14, 12),
                 // (14,19): warning CS0169: The field 'MyClass.myarray' is never used
                 //     static int[2] myarray;
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "myarray").WithArguments("MyClass.myarray").WithLocation(14, 19),
-                // (15,19): error CS0270: Array size cannot be specified in a variable declaration (try initializing with a 'new' expression)
+                // (15,12): error CS0270: Array size cannot be specified in a variable declaration (try initializing with a 'new' expression)
                 //     static MyClass[0] m;
-                Diagnostic(ErrorCode.ERR_ArraySizeInDeclaration, "[0]").WithLocation(15, 19),
-                // (15,23): warning CS0649: Field 'MyClass.m' is never assigned to, and will always have its default value null
+                Diagnostic(ErrorCode.ERR_ArraySizeInDeclaration, "MyClass").WithArguments("MyClass").WithLocation(15, 12),
+                // (15,12): error CS0518: Predefined type 'System.ValueArray`2' is not defined or imported
                 //     static MyClass[0] m;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "m").WithArguments("MyClass.m", "null").WithLocation(15, 23),
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "MyClass[0]").WithArguments("System.ValueArray`2").WithLocation(15, 12),
+                // (15,23): warning CS0169: The field 'MyClass.m' is never used
+                //     static MyClass[0] m;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "m").WithArguments("MyClass.m").WithLocation(15, 23),
                 // (16,16): error CS0270: Array size cannot be specified in a variable declaration (try initializing with a 'new' expression)
                 //     static byte[13,5] b;
                 Diagnostic(ErrorCode.ERR_ArraySizeInDeclaration, "[13,5]").WithLocation(16, 16),
@@ -5433,72 +5436,60 @@ public class QueryExpressionTest
             // error CS1031: Type expected
             // error CS1525: Invalid expression term 'in' ... ...
             ParseAndValidate(text,
-              // (12,29): error CS1002: ; expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SemicolonExpected, "const"),
-              // (12,35): error CS1031: Type expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_TypeExpected, "in"),
-              // (12,35): error CS1001: Identifier expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_IdentifierExpected, "in"),
-              // (12,35): error CS0145: A const field requires a value to be provided
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_ConstValueRequired, "in"),
-              // (12,35): error CS1003: Syntax error, ',' expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SyntaxError, "in").WithArguments(",", "in"),
-              // (12,38): error CS1002: ; expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SemicolonExpected, "expr1"),
-              // (12,50): error CS1002: ; expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SemicolonExpected, "i"),
-              // (12,52): error CS1002: ; expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SemicolonExpected, "in"),
-              // (12,52): error CS1513: } expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_RbraceExpected, "in"),
-              // (12,64): error CS1002: ; expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SemicolonExpected, "const"),
-              // (12,77): error CS0145: A const field requires a value to be provided
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_ConstValueRequired, "i"),
-              // (12,79): error CS1002: ; expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SemicolonExpected, "select"),
-              // (12,86): error CS1002: ; expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SemicolonExpected, "new"),
-              // (12,92): error CS1513: } expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_RbraceExpected, "const"),
-              // (12,92): error CS1002: ; expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SemicolonExpected, "const"),
-              // (12,97): error CS1031: Type expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_TypeExpected, ","),
-              // (12,97): error CS1001: Identifier expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_IdentifierExpected, ","),
-              // (12,97): error CS0145: A const field requires a value to be provided
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_ConstValueRequired, ","),
-              // (12,99): error CS0145: A const field requires a value to be provided
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_ConstValueRequired, "i"),
-              // (12,101): error CS1002: ; expected
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_SemicolonExpected, "}"),
-              // (12,102): error CS1597: Semicolon after method or accessor block is not valid
-              //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
-              Diagnostic(ErrorCode.ERR_UnexpectedSemicolon, ";"),
-              // (14,1): error CS1022: Type or namespace definition, or end-of-file expected
-              // }
-              Diagnostic(ErrorCode.ERR_EOFExpected, "}")
+                // (12,29): error CS1002: ; expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "const").WithLocation(12, 29),
+                // (12,44): error CS0145: A const field requires a value to be provided
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_ConstValueRequired, "join").WithLocation(12, 44),
+                // (12,50): error CS1002: ; expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "i").WithLocation(12, 50),
+                // (12,52): error CS1002: ; expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "in").WithLocation(12, 52),
+                // (12,52): error CS1513: } expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "in").WithLocation(12, 52),
+                // (12,64): error CS1002: ; expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "const").WithLocation(12, 64),
+                // (12,77): error CS0145: A const field requires a value to be provided
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_ConstValueRequired, "i").WithLocation(12, 77),
+                // (12,79): error CS1002: ; expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "select").WithLocation(12, 79),
+                // (12,86): error CS1002: ; expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "new").WithLocation(12, 86),
+                // (12,92): error CS1513: } expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "const").WithLocation(12, 92),
+                // (12,92): error CS1002: ; expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "const").WithLocation(12, 92),
+                // (12,97): error CS1031: Type expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_TypeExpected, ",").WithLocation(12, 97),
+                // (12,97): error CS1001: Identifier expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ",").WithLocation(12, 97),
+                // (12,97): error CS0145: A const field requires a value to be provided
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_ConstValueRequired, ",").WithLocation(12, 97),
+                // (12,99): error CS0145: A const field requires a value to be provided
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_ConstValueRequired, "i").WithLocation(12, 99),
+                // (12,101): error CS1002: ; expected
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "}").WithLocation(12, 101),
+                // (12,102): error CS1597: Semicolon after method or accessor block is not valid
+                //         var query13 = from  const in expr1 join  i in expr2 on const equals i select new { const, i };
+                Diagnostic(ErrorCode.ERR_UnexpectedSemicolon, ";").WithLocation(12, 102),
+                // (14,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(14, 1)
                 );
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -18,24 +18,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             for (int i = 1; i <= (int)SpecialType.Count; i++)
             {
-                // HACKATHON: special type
-                if (i == (int)SpecialType.System_ValueArray_TR)
-                {
-                    continue;
-                }
-
                 string name = SpecialTypes.GetMetadataName((SpecialType)i);
                 Assert.Equal((SpecialType)i, SpecialTypes.GetTypeFromMetadataName(name));
             }
 
             for (int i = 0; i <= (int)SpecialType.Count; i++)
             {
-                // HACKATHON: special type
-                if (i == (int)SpecialType.System_ValueArray_TR)
-                {
-                    continue;
-                }
-
                 Cci.PrimitiveTypeCode code = SpecialTypes.GetTypeCode((SpecialType)i);
 
                 if (code != Cci.PrimitiveTypeCode.NotPrimitive)
@@ -46,12 +34,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             for (int i = 0; i <= (int)Cci.PrimitiveTypeCode.Invalid; i++)
             {
-                // HACKATHON: special type
-                if (i == (int)SpecialType.System_ValueArray_TR)
-                {
-                    continue;
-                }
-
                 SpecialType id = SpecialTypes.GetTypeFromMetadataName((Cci.PrimitiveTypeCode)i);
 
                 if (id != SpecialType.None)
@@ -92,12 +74,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             for (var specialType = SpecialType.None + 1; specialType <= SpecialType.Count; specialType++)
             {
-                // HACKATHON: special type
-                if (specialType == SpecialType.System_ValueArray_TR)
-                {
-                    continue;
-                }
-
                 var symbol = comp.GetSpecialType(specialType);
                 if (knownMissingTypes.Contains(specialType))
                 {

--- a/src/Compilers/Core/Portable/PublicAPI.Shipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Shipped.txt
@@ -2231,7 +2231,7 @@ Microsoft.CodeAnalysis.SourceFileResolver.SourceFileResolver(System.Collections.
 Microsoft.CodeAnalysis.SourceReferenceResolver
 Microsoft.CodeAnalysis.SourceReferenceResolver.SourceReferenceResolver() -> void
 Microsoft.CodeAnalysis.SpecialType
-Microsoft.CodeAnalysis.SpecialType.Count = 46 -> Microsoft.CodeAnalysis.SpecialType
+Microsoft.CodeAnalysis.SpecialType.Count = 45 -> Microsoft.CodeAnalysis.SpecialType
 Microsoft.CodeAnalysis.SpecialType.None = 0 -> Microsoft.CodeAnalysis.SpecialType
 Microsoft.CodeAnalysis.SpecialType.System_ArgIterator = 37 -> Microsoft.CodeAnalysis.SpecialType
 Microsoft.CodeAnalysis.SpecialType.System_Array = 23 -> Microsoft.CodeAnalysis.SpecialType

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -72,7 +72,6 @@ Microsoft.CodeAnalysis.LineMapping.LineMapping() -> void
 Microsoft.CodeAnalysis.LineMapping.LineMapping(Microsoft.CodeAnalysis.Text.LinePositionSpan span, int? characterOffset, Microsoft.CodeAnalysis.FileLinePositionSpan mappedSpan) -> void
 Microsoft.CodeAnalysis.LineMapping.MappedSpan.get -> Microsoft.CodeAnalysis.FileLinePositionSpan
 Microsoft.CodeAnalysis.LineMapping.Span.get -> Microsoft.CodeAnalysis.Text.LinePositionSpan
-Microsoft.CodeAnalysis.SpecialType.System_ValueArray_TR = 46 -> Microsoft.CodeAnalysis.SpecialType
 Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions.CollapseTupleTypes = 512 -> Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions
 override Microsoft.CodeAnalysis.LineMapping.Equals(object? obj) -> bool
 override Microsoft.CodeAnalysis.LineMapping.GetHashCode() -> int

--- a/src/Compilers/Core/Portable/SpecialType.cs
+++ b/src/Compilers/Core/Portable/SpecialType.cs
@@ -259,13 +259,8 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_PreserveBaseOverridesAttribute = 45,
 
         /// <summary>
-        /// Indicates that the type is ValueArray.
-        /// </summary>
-        System_ValueArray_TR = 46,
-
-        /// <summary>
         /// Count of special types. This is not a count of enum members.
         /// </summary>
-        Count = System_ValueArray_TR
+        Count = System_Runtime_CompilerServices_PreserveBaseOverridesAttribute
     }
 }

--- a/src/Compilers/Core/Portable/SpecialTypes.cs
+++ b/src/Compilers/Core/Portable/SpecialTypes.cs
@@ -69,7 +69,6 @@ namespace Microsoft.CodeAnalysis
             "System.AsyncCallback",
             "System.Runtime.CompilerServices.RuntimeFeature",
             "System.Runtime.CompilerServices.PreserveBaseOverridesAttribute",
-            "System.ValueArray`2",
         };
 
         private static readonly Dictionary<string, SpecialType> s_nameToTypeIdMap;

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2616,19 +2616,19 @@ namespace Microsoft.CodeAnalysis
 
                 // System_ValueTuple_T3__Item1
                 (byte)MemberFlags.Field,                                                                                    // Flags
-                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ValueTuple_T3 - WellKnownType.ExtSentinel),    // DeclaringTypeId
+                (byte)WellKnownType.System_ValueTuple_T3,                                                                   // DeclaringTypeId
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.GenericTypeParameter, 0,                                                        // Field Signature
 
                 // System_ValueTuple_T3__Item2
                 (byte)MemberFlags.Field,                                                                                    // Flags
-                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ValueTuple_T3 - WellKnownType.ExtSentinel),    // DeclaringTypeId
+                (byte)WellKnownType.System_ValueTuple_T3,                                                                   // DeclaringTypeId
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.GenericTypeParameter, 1,                                                        // Field Signature
 
                 // System_ValueTuple_T3__Item3
                 (byte)MemberFlags.Field,                                                                                    // Flags
-                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ValueTuple_T3 - WellKnownType.ExtSentinel),    // DeclaringTypeId
+                (byte)WellKnownType.System_ValueTuple_T3,                                                                   // DeclaringTypeId
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.GenericTypeParameter, 2,                                                        // Field Signature
 
@@ -2831,7 +2831,7 @@ namespace Microsoft.CodeAnalysis
 
                 // System_ValueTuple_T3__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
-                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ValueTuple_T3 - WellKnownType.ExtSentinel),    // DeclaringTypeId
+                (byte)WellKnownType.System_ValueTuple_T3,                                                                   // DeclaringTypeId
                 0,                                                                                                          // Arity
                     3,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -252,10 +252,10 @@ namespace Microsoft.CodeAnalysis
         System_ValueTuple,
         System_ValueTuple_T1,
         System_ValueTuple_T2,
+        System_ValueTuple_T3,
 
         ExtSentinel, // Not a real type, just a marker for types above 255 and strictly below 512
 
-        System_ValueTuple_T3,
         System_ValueTuple_T4,
         System_ValueTuple_T5,
         System_ValueTuple_T6,
@@ -314,6 +314,8 @@ namespace Microsoft.CodeAnalysis
         System_Text_StringBuilder,
 
         System_Runtime_CompilerServices_DefaultInterpolatedStringHandler,
+
+        System_ValueArray_TR,
 
         NextAvailable,
 
@@ -561,10 +563,10 @@ namespace Microsoft.CodeAnalysis
             "System.ValueTuple",
             "System.ValueTuple`1",
             "System.ValueTuple`2",
+            "System.ValueTuple`3",
 
             "", // extension marker
 
-            "System.ValueTuple`3",
             "System.ValueTuple`4",
             "System.ValueTuple`5",
             "System.ValueTuple`6",
@@ -623,6 +625,8 @@ namespace Microsoft.CodeAnalysis
 
             "System.Text.StringBuilder",
             "System.Runtime.CompilerServices.DefaultInterpolatedStringHandler",
+
+            "System.ValueArray`2"
         };
 
         private static readonly Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CompilationCreationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CompilationCreationTests.vb
@@ -92,12 +92,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Assert.Equal(SpecialType.None, c107.SpecialType)
 
             For i As Integer = 1 To SpecialType.Count Step 1
-
-                ' HACKATHON special Type
-                If i = SpecialType.System_ValueArray_TR Then
-                    Continue For
-                End If
-
                 Dim type As NamedTypeSymbol = c1.Assembly.GetSpecialType(CType(i, SpecialType))
 
                 If i = SpecialType.System_Runtime_CompilerServices_RuntimeFeature Or

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
@@ -2561,6 +2561,11 @@ End Class
             Dim integerType = helper.GetSpecialType(SpecialType.System_Int32)
 
             For Each st As SpecialType In [Enum].GetValues(GetType(SpecialType))
+                Select Case (st)
+                    Case SpecialType.None, SpecialType.System_Void, SpecialType.System_Runtime_CompilerServices_IsVolatile
+                        Continue For
+                End Select
+
                 Dim type = helper.GetSpecialType(st)
                 If type.Arity > 0 Then
                     type = type.Construct(ArrayBuilder(Of TypeSymbol).GetInstance(type.Arity, integerType).ToImmutableAndFree())

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
@@ -2561,11 +2561,6 @@ End Class
             Dim integerType = helper.GetSpecialType(SpecialType.System_Int32)
 
             For Each st As SpecialType In [Enum].GetValues(GetType(SpecialType))
-                Select Case (st)
-                    Case SpecialType.None, SpecialType.System_Void, SpecialType.System_Runtime_CompilerServices_IsVolatile, SpecialType.System_ValueArray_TR
-                        Continue For
-                End Select
-
                 Dim type = helper.GetSpecialType(st)
                 If type.Arity > 0 Then
                     type = type.Construct(ArrayBuilder(Of TypeSymbol).GetInstance(type.Arity, integerType).ToImmutableAndFree())

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -454,11 +454,6 @@ End Namespace
                 Dim symbol = comp.GetSpecialType(special)
                 Assert.NotNull(symbol)
 
-                If special = SpecialType.System_ValueArray_TR Then
-                    ' HACKATHON: experimental Type
-                    Continue For
-                End If
-
                 If special = SpecialType.System_Runtime_CompilerServices_RuntimeFeature OrElse
                    special = SpecialType.System_Runtime_CompilerServices_PreserveBaseOverridesAttribute Then
                     Assert.Equal(SymbolKind.ErrorType, symbol.Kind) ' Not available
@@ -549,7 +544,8 @@ End Namespace
                          WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException,
                          WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute,
                          WellKnownType.System_Runtime_CompilerServices_IsExternalInit,
-                         WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler
+                         WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler,
+                         WellKnownType.System_ValueArray_TR
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -615,7 +611,8 @@ End Namespace
                          WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException,
                          WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute,
                          WellKnownType.System_Runtime_CompilerServices_IsExternalInit,
-                         WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler
+                         WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler,
+                         WellKnownType.System_ValueArray_TR
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel


### PR DESCRIPTION
This change allows writing code with struct arrays in terms of` Type[length] ` :
```cs
class QuadTree
{
    public readonly int Depth;
    private QuadTree[4] _nodes;  //field

    public ref readonly QuadTree[4] Nodes => ref _nodes;  // ref return type

    public int[4] DepthMask()    // byval return type
    {
        int[4] mask = default;   // local variable
        for(int i = 0; i < mask.Length; i++)
        {
            mask[i] = _nodes[i].Depth;
        }

        return mask;
    }
}
```

@cston  - I have also changed `ValueArray<T, Size>` Roslyn classification from `SpecialType` to `WellKnownType`. 
I do not have a strong opinion on which it should be, but `WellKnown` is a lot easier to test in the absence of the actual type by providing a mock implementation.


