### PR TITLE
Add MS.CA.CSharp.Workspaces and MS.CA.VB.Workspaces as VSIX analyzer …

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -84,27 +84,6 @@ class Program
             VisualStudio.Editor.Verify.CodeAction("using System;");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
-        [WorkItem(57293, "https://github.com/dotnet/roslyn/issues/57293")]
-        public void RemoveRedundantAssignmentCodeFix()
-        {
-            SetUpEditor(@"
-using System;
-
-public class Program
-{
-    public static void Main(string[] args)
-    {
-        int x = 2;
-        x = 5;$$
-    }
-}
-");
-
-            VisualStudio.Editor.InvokeCodeActionList();
-            VisualStudio.Editor.Verify.CodeAction("Remove redundant assignment");
-        }
-
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
         public void FastDoubleInvoke()
         {


### PR DESCRIPTION
…assets

Fixes #57293
With recent changes to move OOP to .NET Core, we seem to require specifying analyzer dependencies as analyzer assets. https://github.com/dotnet/roslyn/commit/6c7f97b20dae05588b601467faa24fee0000638e added MS.CA.Workspaces as an asset, this change extends it to add the C# and VB Workspaces assemblies as analyzer assets. These assemblies define CSharpCodeStyleOptions and VisualBasicCodeStyleOptions types, which are used in ctors of many of our analyzers.

- [ ] TODO: Add an integration test