### PR TITLE
Don't compute the information for the code definition window if not open

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CodeDefinitionWindow/DefinitionContextTracker.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeDefinitionWindow/DefinitionContextTracker.cs
@@ -124,6 +124,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeDefinitionWindow
             {
                 await _asyncListener.Delay(TimeSpan.FromMilliseconds(250), cancellationToken).ConfigureAwait(false);
 
+                // If it's not open, don't do anything, since if we are going to show locations in metadata that might
+                // be expensive. This doesn't cause a functional issue, since opening the window clears whatever was previously there
+                // so the user won't notice we weren't doing anything when it was open.
+                if (!await _codeDefinitionWindowService.IsWindowOpenAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    return;
+                }
+
                 var document = pointInRoslynSnapshot.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
                 if (document == null)
                 {

--- a/src/EditorFeatures/Core/Implementation/CodeDefinitionWindow/ICodeDefinitionWindowService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeDefinitionWindow/ICodeDefinitionWindowService.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeDefinitionWindow
 {
     internal interface ICodeDefinitionWindowService
     {
+        Task<bool> IsWindowOpenAsync(CancellationToken cancellationToken);
         Task SetContextAsync(ImmutableArray<CodeDefinitionWindowLocation> locations, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Test2/CodeDefinitionWindow/AbstractCodeDefinitionWindowTests.vb
+++ b/src/EditorFeatures/Test2/CodeDefinitionWindow/AbstractCodeDefinitionWindowTests.vb
@@ -30,6 +30,10 @@ Namespace Microsoft.CodeAnalysis.Editor.CodeDefinitionWindow.UnitTests
             Public Sub New()
             End Sub
 
+            Public Function IsWindowOpenAsync(cancellationToken As CancellationToken) As Task(Of Boolean) Implements ICodeDefinitionWindowService.IsWindowOpenAsync
+                Throw New NotImplementedException()
+            End Function
+
             Public Function SetContextAsync(locations As ImmutableArray(Of CodeDefinitionWindowLocation), cancellationToken As CancellationToken) As Task Implements ICodeDefinitionWindowService.SetContextAsync
                 Throw New NotImplementedException()
             End Function


### PR DESCRIPTION
If the symbol your caret is over is from metadata, producing the output might be really expensive, so let's not do it in that case. The window clears anything when it's opened, so the user won't know it was never doing anything when closed.