### PR TITLE
Fix 'AssemblyVersion overridden by auto-generated version' warning in build

### DIFF
--- a/src/CodeStyle/Directory.Build.props
+++ b/src/CodeStyle/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <!-- https://github.com/dotnet/roslyn/issues/46984 -->
+    <AssemblyVersion></AssemblyVersion>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I think this will get rid of the warning in our build, based on the target file in arcade: https://github.com/dotnet/arcade/blob/0f4c86f28e74a9bc70bbaa6950ab51d44f1faa6a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets#L15
