### PR TITLE
Fix the assembly name used in generator identity

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis
 
         public static string GetGeneratorAssemblyName(ISourceGenerator generator)
         {
-            return generator.GetType().Assembly.FullName!;
+            return generator.GetGeneratorType().Assembly.FullName!;
         }
 
         public static SourceGeneratedDocumentIdentity Generate(ProjectId projectId, string hintName, ISourceGenerator generator, string filePath)


### PR DESCRIPTION
There's various places we need to determine a generator identity, where we use the assembly name and generator type name. Incremental source generators are "wrapped" in the Roslyn API in a regular ISourceGenerator, and a special API gives you access to the underlying object. We updated one of the functions we use for identity (getting type name), but not the one for getting assembly name.

This could have been bad if you had two incremental generators with the same type name in different assemblies, since we might consider those the same.

I'm not sure there's an easily testable problem or observable problem here and short of writing a test that checks for this exact bug...I'm not sure there's much to test.