### PR TITLE
Unskip BasicGenerateConstructorDialog.VerifyReordering

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateConstructorDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateConstructorDialog.cs
@@ -87,7 +87,7 @@ Class C
 End Class", actualText);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/57237"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
         public void VerifyReordering()
         {
             SetUpEditor(


### PR DESCRIPTION
Reverts test skipped for https://github.com/dotnet/roslyn/issues/57237