### PR TITLE
Unskip BasicGenerateConstructorDialog.VerifyDeselect

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateConstructorDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateConstructorDialog.cs
@@ -124,7 +124,7 @@ Class C
 End Class", actualText);
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/57237"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
         public void VerifyDeselect()
         {
             SetUpEditor(


### PR DESCRIPTION
Reverts test skipped for https://github.com/dotnet/roslyn/issues/57237