### PR TITLE
Skip failing tests on Core host

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesCommon.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesCommon.cs
@@ -4,13 +4,21 @@
 
 #nullable disable
 
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Roslyn.Test.Utilities;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     public abstract class CSharpSquigglesCommon : AbstractEditorTest
     {
+        protected sealed class DesktopServiceHubHostOnly : ExecutionCondition
+        {
+            public override bool ShouldSkip => string.Equals(Environment.GetEnvironmentVariable("ROSLYN_OOPCORECLR"), "true", StringComparison.OrdinalIgnoreCase);
+            public override string SkipReason => "https://github.com/dotnet/roslyn/issues/57395";
+        }
+
         protected CSharpSquigglesCommon(VisualStudioInstanceFactory instanceFactory, string projectTemplate)
             : base(instanceFactory, nameof(CSharpSquigglesCommon), projectTemplate)
         {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesDesktop.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesDesktop.cs
@@ -22,13 +22,15 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [ConditionalWpfFact(typeof(DesktopServiceHubHostOnly))]
+        [Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public override void VerifySyntaxErrorSquiggles()
         {
             base.VerifySyntaxErrorSquiggles();
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
+        [ConditionalWpfFact(typeof(DesktopServiceHubHostOnly))]
+        [Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         public override void VerifySemanticErrorSquiggles()
         {
             base.VerifySemanticErrorSquiggles();

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesNetCore.cs
@@ -32,7 +32,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.SolutionExplorer.OpenFile(new Project(ProjectName), WellKnownProjectTemplates.CSharpNetCoreClassLibraryClassFileName);
         }
 
-        [WpfFact]
+        [ConditionalWpfFact(typeof(DesktopServiceHubHostOnly))]
         [Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
         public override void VerifySyntaxErrorSquiggles()
@@ -40,7 +40,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             base.VerifySyntaxErrorSquiggles();
         }
 
-        [WpfFact]
+        [ConditionalWpfFact(typeof(DesktopServiceHubHostOnly))]
         [Trait(Traits.Feature, Traits.Features.ErrorSquiggles)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
         public override void VerifySemanticErrorSquiggles()


### PR DESCRIPTION
Tracking bug: https://github.com/dotnet/roslyn/issues/57395