### PR TITLE
Use VS2022 images when building Roslyn in CI

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -83,7 +83,7 @@ stages:
     timeoutInMinutes: 360
     pool:
       name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre
 
     steps:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -83,7 +83,7 @@ stages:
     timeoutInMinutes: 360
     pool:
       name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals Build.Server.Amd64.VS2019
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
 
     steps:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -49,7 +49,7 @@ stages:
     timeoutInMinutes: 360
     # Conditionally set build pool so we can share this YAML when building with different pipeline
     pool:
-      name: VSEngSS-MicroBuild2017
+      name: VSEngSS-MicroBuild2022-1ES
       demands:
       - msbuild
       - visualstudio
@@ -210,7 +210,7 @@ stages:
   displayName: Create Insertion
   dependsOn:
     - build
-  
+
   jobs:
   - job: insert
     displayName: Insert to VS
@@ -220,7 +220,7 @@ stages:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
       displayName: Setting SourceBranchName variable
       condition: succeeded()
-      
+
     - template: eng/pipelines/insert.yml
       parameters:
         createDraftPR: true
@@ -232,4 +232,4 @@ stages:
         titlePrefix: ${{ parameters.OptionalTitlePrefix }}
         sourceBranch: $(SourceBranchName)
         publishDataURI: "https://raw.githubusercontent.com/dotnet/roslyn/main/eng/config/PublishData.json"
-  
+

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -20,7 +20,7 @@ jobs:
 - job: RichCodeNav_Indexing
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.Open
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   variables:
     EnableRichCodeNavigation: true
   timeoutInMinutes: 200

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,14 +21,14 @@ jobs:
     jobName: Build_Windows_Debug
     testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
-    queueName: Build.Windows.10.Amd64.Open
+    queueName: Build.Windows.Amd64.VS2022.Pre.Open
 
 - template: eng/pipelines/build-windows-job.yml
   parameters:
     jobName: Build_Windows_Release
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
-    queueName: Build.Windows.10.Amd64.Open
+    queueName: Build.Windows.Amd64.VS2022.Pre.Open
 
 - template: eng/pipelines/test-windows-job.yml
   parameters:
@@ -202,7 +202,7 @@ jobs:
 - job: Correctness_Rebuild
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.Open
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml


### PR DESCRIPTION
Fixes these warnings in our CI

```
##[warning].dotnet\sdk\6.0.100-rc.2.21505.57\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(134,5): warning NETSDK1182: (NETCORE_ENGINEERING_TELEMETRY=Build) Targeting .NET 6.0 in Visual Studio 2019 is not supported.
```

Test Build - https://dev.azure.com/dnceng/internal/_build/results?buildId=1441426&view=results (microsoft only)

cc: @tmat 