### PR TITLE
Upgrade xunit to get newer asserts

### DIFF
--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenMethodGroupConversionCachingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenMethodGroupConversionCachingTests.cs
@@ -2069,7 +2069,7 @@ class E<V>
         {
             var testClass = module.GlobalNamespace.GetTypeMember("D");
             var container = testClass.GetTypeMember("<Test>O__1_0");
-            AssertEx.NotNull(container);
+            Assert.NotNull(container);
 
             var typeParameters = container.TypeParameters;
             Assert.Equal(1, container.TypeParameters.Length);
@@ -2130,7 +2130,7 @@ class E<V>
             var globalNs = module.GlobalNamespace;
             var mainClass = globalNs.GetTypeMember("C");
             var container = globalNs.GetMember<NamedTypeSymbol>("D.<Test>O__1_0");
-            AssertEx.NotNull(container);
+            Assert.NotNull(container);
 
             var typeParameters = container.TypeParameters;
             Assert.Equal(1, container.TypeParameters.Length);
@@ -2187,13 +2187,13 @@ class E
         static void containerValidator(ModuleSymbol module)
         {
             var container = module.GlobalNamespace.GetMember<NamedTypeSymbol>("D.<Test>O__0_0");
-            AssertEx.NotNull(container);
+            Assert.NotNull(container);
 
             var typeParameters = container.TypeParameters;
             Assert.Equal(1, container.TypeParameters.Length);
 
             var m = typeParameters[0];
-            AssertEx.NotNull(m);
+            Assert.NotNull(m);
             Assert.True(m.IsValueType);
         }
         CompileAndVerify(source, symbolValidator: containerValidator, expectedOutput: PASS).VerifyIL("D.Test<M>", @"
@@ -6304,7 +6304,7 @@ class Test
         {
             var container = module.GlobalNamespace.GetMember<NamedTypeSymbol>("Test.<M>O__1_0");
             var field = Assert.Single(container.GetMembers()) as FieldSymbol;
-            AssertEx.NotNull(field);
+            Assert.NotNull(field);
 
             var typeParameters = new List<TypeParameterSymbol>();
             field.Type.VisitType(static (typeSymbol, typeParameters, _) =>
@@ -6856,7 +6856,7 @@ class D
         return module =>
         {
             var container = module.GlobalNamespace.GetMember<NamedTypeSymbol>(typeName);
-            AssertEx.NotNull(container);
+            Assert.NotNull(container);
             Assert.Equal(arity, container.Arity);
 
             var fields = container.GetMembers().OfType<FieldSymbol>().Select(field => $"{field.Type.ToTestDisplayString()} {field.Name}").ToArray();
@@ -6869,7 +6869,7 @@ class D
         return module =>
         {
             var containingType = module.GlobalNamespace.GetMember<NamedTypeSymbol>(containingTypeName);
-            AssertEx.NotNull(containingType);
+            Assert.NotNull(containingType);
 
             var nestedTypes = containingType.GetTypeMembers();
             Assert.DoesNotContain(nestedTypes, t => t.Name.StartsWith("<") && t.Name.Contains(">O"));

--- a/src/Compilers/CSharp/Test/Emit3/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -731,14 +731,14 @@ public class B
 
                     // This assert will fire if you are adding a new compiler diagnostic (non-error severity),
                     // but did not add a title resource string for the diagnostic.
-                    Assert.True(false, message);
+                    Assert.Fail(message);
                 }
 
                 var category = descriptor.Category;
                 if (string.IsNullOrEmpty(title))
                 {
                     var message = string.Format("'{0}' must have a non-null non-empty 'Category'", descriptor.Id);
-                    Assert.True(false, message);
+                    Assert.Fail(message);
                 }
             }
         }

--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EndToEnd
 
             if (exception is object)
             {
-                Assert.False(true, exception.ToString());
+                Assert.Fail(exception.ToString());
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -1007,7 +1007,7 @@ class C { }
                 throw new InvalidOperationException("post init error");
             }
 
-            var generator = new CallbackGenerator((ic) => ic.RegisterForPostInitialization(postInit), (sgc) => Assert.True(false, "Should not execute"), source = "public class E : D {}");
+            var generator = new CallbackGenerator((ic) => ic.RegisterForPostInitialization(postInit), (sgc) => Assert.Fail("Should not execute"), source = "public class E : D {}");
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);
@@ -1039,10 +1039,10 @@ class C { }
             static void postInit(GeneratorPostInitializationContext context)
             {
                 context.AddSource("postInit", "public class D {} ");
-                Assert.True(false, "Should not execute");
+                Assert.Fail("Should not execute");
             }
 
-            var generator = new CallbackGenerator(init, (sgc) => Assert.True(false, "Should not execute"), source = "public class E : D {}");
+            var generator = new CallbackGenerator(init, (sgc) => Assert.Fail("Should not execute"), source = "public class E : D {}");
 
             GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
                     if (kind != result.Kind)
                     {
                         var result2 = c.ClassifyConversionFromType(types[j], types[i], ref useSiteDiagnostics); // set breakpoint here if this test is failing...
-                        Assert.True(false, string.Format("Expected {0} but got {1} when converting {2} -> {3}", kind, result, types[j], types[i]));
+                        Assert.Fail(string.Format("Expected {0} but got {1} when converting {2} -> {3}", kind, result, types[j], types[i]));
                     }
                 }
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
@@ -2653,7 +2653,7 @@ public class Wrapper
                 }
                 else
                 {
-                    Assert.True(false, "Unexpected type " + type.ToTestDisplayString());
+                    Assert.Fail("Unexpected type " + type.ToTestDisplayString());
                 }
             }
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingEvents.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingEvents.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
                     Assert.Same(@event.RemoveMethod, accessor);
                     break;
                 default:
-                    Assert.False(true, string.Format("Accessor {0} has unexpected MethodKind {1}", accessor, accessor.MethodKind));
+                    Assert.Fail(string.Format("Accessor {0} has unexpected MethodKind {1}", accessor, accessor.MethodKind));
                     break;
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
@@ -999,7 +999,7 @@ class Override : MetadataModifiers
                         Assert.False(method.IsSealed);
                         break;
                     default:
-                        Assert.False(true, "Unexpected enum value " + expectedVirtualness);
+                        Assert.Fail("Unexpected enum value " + expectedVirtualness);
                         break;
                 }
             });

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -7152,11 +7152,11 @@ public class Derived : Base
         CompileAndVerify(comp, symbolValidator: module =>
         {
             var c = module.ContainingAssembly.GetTypeByMetadataName("C");
-            AssertEx.NotNull(c);
+            Assert.NotNull(c);
             FieldSymbol field1 = c.GetMember<FieldSymbol>("Field1");
             PropertySymbol property1 = c.GetMember<PropertySymbol>("Property1");
             var d = module.ContainingAssembly.GetTypeByMetadataName("D");
-            AssertEx.NotNull(d);
+            Assert.NotNull(d);
             FieldSymbol field2 = d.GetMember<FieldSymbol>("Field2");
             PropertySymbol property2 = d.GetMember<PropertySymbol>("Property2");
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
@@ -1192,7 +1192,7 @@ public class C
                         CheckTypeParameters((TypeParameterSymbol)a, (TypeParameterSymbol)b);
                         break;
                     default:
-                        Assert.True(false, "Unexpected symbol kind: " + a.Kind);
+                        Assert.Fail("Unexpected symbol kind: " + a.Kind);
                         break;
                 }
             }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -489,7 +489,7 @@ class X
                         default:
                             // If a new warning is added, this test will fail
                             // and whoever is adding the new warning will have to update it with the expected error level.
-                            Assert.True(false, $"Please update this test case with a proper warning level ({ErrorFacts.GetWarningLevel(errorCode)}) for '{errorCodeName}'");
+                            Assert.Fail($"Please update this test case with a proper warning level ({ErrorFacts.GetWarningLevel(errorCode)}) for '{errorCodeName}'");
                             break;
                     }
                 }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/DocumentationCommentLexerTestBase.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/DocumentationCommentLexerTestBase.cs
@@ -48,12 +48,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     else if (!actualHadNext)
                     {
                         Assert.True(expectedHadNext);
-                        AssertEx.Fail("Unmatched expected: " + expectedEnumerator.Current);
+                        Assert.Fail("Unmatched expected: " + expectedEnumerator.Current);
                     }
                     else if (!expectedHadNext)
                     {
                         Assert.True(actualHadNext);
-                        AssertEx.Fail("Unmatched actual: " + expectedEnumerator.Current);
+                        Assert.Fail("Unmatched actual: " + expectedEnumerator.Current);
                     }
 
                     var actualToken = actualEnumerator.Current;

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -59,12 +59,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 else
                 {
-                    Assert.True(false, "More than one token was lexed: " + token);
+                    Assert.Fail("More than one token was lexed: " + token);
                 }
             }
             if (result.Kind() == SyntaxKind.None)
             {
-                Assert.True(false, "No tokens were lexed");
+                Assert.Fail("No tokens were lexed");
             }
             return result;
         }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     default:
                         if (null != exp.Text)
                         {
-                            Assert.True(false, String.Format("You are expecting some text in the directive, but this method doesn't know how to verify it for `{0}`.", exp.Kind));
+                            Assert.Fail(String.Format("You are expecting some text in the directive, but this method doesn't know how to verify it for `{0}`.", exp.Kind));
                         }
                         break;
                 } // switch
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         }
                         else
                         {
-                            Assert.True(false, "Warning ID must be an identifier or numeric literal");
+                            Assert.Fail("Warning ID must be an identifier or numeric literal");
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             {
                 var tk = _treeEnumerator.Current.Kind();
                 DumpAndCleanup();
-                Assert.False(true, "Found unexpected node or token of kind: " + tk);
+                Assert.Fail("Found unexpected node or token of kind: " + tk);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -2998,12 +2998,12 @@ case KeyValuePair<String, DateTime>[] pairs2:
                 catch (StackOverflowException)
                 {
                     Console.WriteLine("Failed on \"" + source + "\"");
-                    Assert.True(false, source);
+                    Assert.Fail(source);
                 }
                 catch (OutOfMemoryException)
                 {
                     Console.WriteLine("Failed on \"" + source + "\"");
-                    Assert.True(false, source);
+                    Assert.Fail(source);
                 }
             }
             return;

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             try
             {
                 SyntaxFactory.Token(SyntaxKind.IdentifierName);
-                AssertEx.Fail("Should have thrown - can't create an IdentifierName token");
+                Assert.Fail("Should have thrown - can't create an IdentifierName token");
                 return;
             }
             catch (Exception e)
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 try
                 {
                     SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.IdentifierToken, "text", "valueText", default(SyntaxTriviaList));
-                    AssertEx.Fail("Should have thrown");
+                    Assert.Fail("Should have thrown");
                     return;
                 }
                 catch (ArgumentException e)
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 try
                 {
                     SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.CharacterLiteralToken, "text", "valueText", default(SyntaxTriviaList));
-                    AssertEx.Fail("Should have thrown");
+                    Assert.Fail("Should have thrown");
                     return;
                 }
                 catch (ArgumentException e)
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 try
                 {
                     SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.NumericLiteralToken, "text", "valueText", default(SyntaxTriviaList));
-                    AssertEx.Fail("Should have thrown");
+                    Assert.Fail("Should have thrown");
                     return;
                 }
                 catch (ArgumentException e)

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdDumpTest.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdDumpTest.cs
@@ -458,7 +458,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata
                 string fileActual = Path.Combine(Path.GetTempPath(), "roslyn_winmd_dump.actual.txt");
                 File.WriteAllText(fileExpected, expected);
                 File.WriteAllText(fileActual, actual);
-                Assert.True(false, "Dump is different. To investigate compare files:\r\n\"" + fileExpected + "\" \"" + fileActual + "\"");
+                Assert.Fail("Dump is different. To investigate compare files:\r\n\"" + fileExpected + "\" \"" + fileActual + "\"");
             }
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerAssemblyLoaderTests.cs
@@ -242,9 +242,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 loader.AddDependencyLocation(analyzerDependencyFile);
 
                 var analyzerMainReference = new AnalyzerFileReference(analyzerMainFile, loader);
-                analyzerMainReference.AnalyzerLoadFailed += (_, e) => AssertEx.Fail(e.Exception!.Message);
+                analyzerMainReference.AnalyzerLoadFailed += (_, e) => Assert.Fail(e.Exception!.Message);
                 var analyzerDependencyReference = new AnalyzerFileReference(analyzerDependencyFile, loader);
-                analyzerDependencyReference.AnalyzerLoadFailed += (_, e) => AssertEx.Fail(e.Exception!.Message);
+                analyzerDependencyReference.AnalyzerLoadFailed += (_, e) => Assert.Fail(e.Exception!.Message);
 
                 var analyzers = analyzerMainReference.GetAnalyzersForAllLanguages();
                 Assert.Equal(1, analyzers.Length);
@@ -758,9 +758,9 @@ Delta: Gamma: Beta: Test B
                 var analyzerMainFile = testFixture.AnalyzerWithDependency;
 
                 var analyzerMainReference = new AnalyzerFileReference(analyzerMainFile, loader);
-                analyzerMainReference.AnalyzerLoadFailed += (_, e) => AssertEx.Fail(e.Exception!.Message);
+                analyzerMainReference.AnalyzerLoadFailed += (_, e) => Assert.Fail(e.Exception!.Message);
                 var analyzerDependencyReference = new AnalyzerFileReference(analyzerDependencyFile, loader);
-                analyzerDependencyReference.AnalyzerLoadFailed += (_, e) => AssertEx.Fail(e.Exception!.Message);
+                analyzerDependencyReference.AnalyzerLoadFailed += (_, e) => Assert.Fail(e.Exception!.Message);
 
                 Assert.NotNull(loader.GetResolvedAnalyzerPath(analyzerMainFile));
                 Assert.NotNull(loader.GetResolvedAnalyzerPath(analyzerDependencyFile));

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/SegmentedCollectionsMarshalTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/SegmentedCollectionsMarshalTests.cs
@@ -506,7 +506,7 @@ public class SegmentedCollectionsMarshalTests
             ImmutableSegmentedList<T> immutableList = ImmutableSegmentedList.Create(new T[17]);
             SegmentedList<T>? list = SegmentedCollectionsMarshal.AsSegmentedList(immutableList);
 
-            AssertEx.NotNull(list);
+            Assert.NotNull(list);
             Assert.Equal(17, list.Count);
 
             ref T expectedRef = ref Unsafe.AsRef(in immutableList.ItemRef(0));
@@ -637,7 +637,7 @@ public class SegmentedCollectionsMarshalTests
             ImmutableSegmentedHashSet<T> immutableHashSet = ImmutableSegmentedHashSet.CreateRange(values);
             SegmentedHashSet<T>? set = SegmentedCollectionsMarshal.AsSegmentedHashSet(immutableHashSet);
 
-            AssertEx.NotNull(set);
+            Assert.NotNull(set);
             Assert.Equal(17, set.Count);
 
             Assert.Same(set, SegmentedCollectionsMarshal.AsSegmentedHashSet(immutableHashSet));
@@ -768,7 +768,7 @@ public class SegmentedCollectionsMarshalTests
             ImmutableSegmentedDictionary<int, T> immutableDictionary = ImmutableSegmentedDictionary.CreateRange(Enumerable.Range(0, 17).Select(x => new KeyValuePair<int, T>(x, createValue())));
             SegmentedDictionary<int, T>? dictionary = SegmentedCollectionsMarshal.AsSegmentedDictionary(immutableDictionary);
 
-            AssertEx.NotNull(dictionary);
+            Assert.NotNull(dictionary);
             Assert.Equal(17, dictionary.Count);
 
             ref T expectedRef = ref Unsafe.AsRef(in SegmentedCollectionsMarshal.GetValueRefOrNullRef(immutableDictionary, 0));

--- a/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 }
             }
 
-            Assert.True(false, "Didn't return an error");
+            Assert.Fail("Didn't return an error");
         }
 
         [Fact]
@@ -987,7 +987,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 try
                 {
                     RuleSet.LoadEffectiveRuleSetFromFile(file.Path);
-                    Assert.True(false, "Didn't throw an exception");
+                    Assert.Fail("Didn't throw an exception");
                 }
                 catch (InvalidRuleSetException e)
                 {

--- a/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/SourceFileResolverTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     ImmutableArray.Create(""),
                     isABaseDirectory,
                     ImmutableArray.Create(KeyValuePair.Create<string, string>("key", null)));
-                AssertEx.Fail("Didn't throw");
+                Assert.Fail("Didn't throw");
             }
             catch (ArgumentException argException)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                     [""],
                     "not_a_root directory",
                     [KeyValuePair.Create("key", "value")]);
-                AssertEx.Fail("Didn't throw");
+                Assert.Fail("Didn't throw");
             }
             catch (ArgumentException argException)
             {

--- a/src/Compilers/Core/MSBuildTaskTests/MapSourceRootTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/MapSourceRootTests.cs
@@ -340,7 +340,7 @@ ERROR : {string.Format(ErrorString.MapSourceRoots_PathMustEndWithSlashOrBackslas
                     "MapSourceRoots.ContainsDuplicate", "SourceRoot", Utilities.GetFullPathNoThrow(path1), "SourceLinkUrl", "URL1", "URL2")) + Environment.NewLine,
                 engine.Log);
 
-            AssertEx.NotNull(task.MappedSourceRoots);
+            Assert.NotNull(task.MappedSourceRoots);
             AssertEx.Equal(string.Join("\n",
             [
                 $"'{Utilities.GetFullPathNoThrow(path1)}' SourceControl='git' RevisionId='RevId1' NestedRoot='NR1A' ContainingRoot='{(deterministic ? Utilities.GetFullPathNoThrow(path3) : path3)}' MappedPath='{(deterministic ? "/_/NR1A/" : Utilities.GetFullPathNoThrow(path1))}' SourceLinkUrl='URL1'",
@@ -445,7 +445,7 @@ ERROR : {string.Format(ErrorString.MapSourceRoots_PathMustEndWithSlashOrBackslas
             }
             else
             {
-                AssertEx.NotNull(task.MappedSourceRoots);
+                Assert.NotNull(task.MappedSourceRoots);
                 AssertEx.Equal(string.Join("\n",
                 [
                     $"'{Utilities.GetFullPathNoThrow(path1)}' SourceControl='' RevisionId='' NestedRoot='a/b' ContainingRoot='{(deterministic ? Utilities.GetFullPathNoThrow(path1) : path1)}' MappedPath='{Utilities.GetFullPathNoThrow(path1)}' SourceLinkUrl=''",
@@ -488,7 +488,7 @@ ERROR : {string.Format(ErrorString.MapSourceRoots_PathMustEndWithSlashOrBackslas
             var expectedContainingRoot = deterministic ? Utilities.GetFullPathNoThrow(normalizedPath1) : originalPath1;
             var expectedMappedPath2 = deterministic ? "/_/e/" : Utilities.GetFullPathNoThrow(normalizedPath2);
 
-            AssertEx.NotNull(task.MappedSourceRoots);
+            Assert.NotNull(task.MappedSourceRoots);
             AssertEx.Equal(
                 $"""
                 '{Utilities.GetFullPathNoThrow(normalizedPath1)}' SourceControl='' RevisionId='' NestedRoot='' ContainingRoot='' MappedPath='{expectedMappedPath1}' SourceLinkUrl=''
@@ -500,4 +500,3 @@ ERROR : {string.Format(ErrorString.MapSourceRoots_PathMustEndWithSlashOrBackslas
         }
     }
 }
-

--- a/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/TargetTests.cs
@@ -263,15 +263,15 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Equal("_GeneratedEditorConfigMetadata", item.ItemType);
 
             var itemType = item.Metadata.SingleOrDefault(m => m.Name == "ItemType");
-            AssertEx.NotNull(itemType);
+            Assert.NotNull(itemType);
             Assert.Equal("Compile", itemType.EvaluatedValue);
 
             var metaName = item.Metadata.SingleOrDefault(m => m.Name == "MetadataName");
-            AssertEx.NotNull(metaName);
+            Assert.NotNull(metaName);
             Assert.Equal("CustomMeta", metaName.EvaluatedValue);
 
             var customMeta = item.Metadata.SingleOrDefault(m => m.Name == metaName.EvaluatedValue);
-            AssertEx.NotNull(customMeta);
+            Assert.NotNull(customMeta);
             Assert.Equal("abc", customMeta.EvaluatedValue);
         }
 
@@ -305,15 +305,15 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Equal("_GeneratedEditorConfigMetadata", item.ItemType);
 
             var itemType = item.Metadata.SingleOrDefault(m => m.Name == "ItemType");
-            AssertEx.NotNull(itemType);
+            Assert.NotNull(itemType);
             Assert.Equal("Compile", itemType.EvaluatedValue);
 
             var metaName = item.Metadata.SingleOrDefault(m => m.Name == "MetadataName");
-            AssertEx.NotNull(metaName);
+            Assert.NotNull(metaName);
             Assert.Equal("CustomMeta", metaName.EvaluatedValue);
 
             var customMeta = item.Metadata.SingleOrDefault(m => m.Name == metaName.EvaluatedValue);
-            AssertEx.NotNull(customMeta);
+            Assert.NotNull(customMeta);
             Assert.Equal("abc", customMeta.EvaluatedValue);
         }
 
@@ -345,11 +345,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Equal("_GeneratedEditorConfigMetadata", item.ItemType);
 
             var itemType = item.Metadata.SingleOrDefault(m => m.Name == "ItemType");
-            AssertEx.NotNull(itemType);
+            Assert.NotNull(itemType);
             Assert.Equal("Compile", itemType.EvaluatedValue);
 
             var metaName = item.Metadata.SingleOrDefault(m => m.Name == "MetadataName");
-            AssertEx.NotNull(metaName);
+            Assert.NotNull(metaName);
             Assert.Equal("CustomMeta", metaName.EvaluatedValue);
         }
 
@@ -380,11 +380,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Equal("_GeneratedEditorConfigMetadata", item.ItemType);
 
             var itemType = item.Metadata.SingleOrDefault(m => m.Name == "ItemType");
-            AssertEx.NotNull(itemType);
+            Assert.NotNull(itemType);
             Assert.Equal("Compile", itemType.EvaluatedValue);
 
             var metaName = item.Metadata.SingleOrDefault(m => m.Name == "MetadataName");
-            AssertEx.NotNull(metaName);
+            Assert.NotNull(metaName);
             Assert.Equal("", metaName.EvaluatedValue);
         }
 

--- a/src/Compilers/Core/RebuildTest/CompilationOptionsReaderTests.cs
+++ b/src/Compilers/Core/RebuildTest/CompilationOptionsReaderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
             var peBytes = compilation.EmitToArray(new EmitOptions(debugInformationFormat: DebugInformationFormat.Embedded));
             var originalReader = new PEReader(peBytes);
             var originalPdbReader = originalReader.GetEmbeddedPdbMetadataReader();
-            AssertEx.NotNull(originalPdbReader);
+            Assert.NotNull(originalPdbReader);
             var factory = LoggerFactory.Create(configure => { });
             var logger = factory.CreateLogger("RoundTripVerification");
             return new CompilationOptionsReader(logger, originalPdbReader, originalReader);

--- a/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
+++ b/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
                 }
             }
 
-            Assert.True(false, $"Could not find reference with MVID {expectedMvid}");
+            Assert.Fail($"Could not find reference with MVID {expectedMvid}");
             throw null!;
         }
 

--- a/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
+++ b/src/Compilers/Core/RebuildTest/DeterministicKeyBuilderTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
                 errorLoggerOpt: null,
                 analyzerConfigOptions: default,
                 globalConfigOptions: default);
-            AssertEx.NotNull(compilation);
+            Assert.NotNull(compilation);
             Assert.Empty(writer.GetStringBuilder().ToString());
             var obj = GetSyntaxTreeValues(compilation, compiler.Arguments.PathMap);
             AssertJsonCore(expected, obj.ToString(Formatting.Indented));

--- a/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
+++ b/src/Compilers/Core/RebuildTest/RebuildCommandLineTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
                 errorLoggerOpt: null,
                 analyzerConfigOptions: default,
                 globalConfigOptions: default);
-            AssertEx.NotNull(compilation);
+            Assert.NotNull(compilation);
             RoundTripUtil.VerifyCompilationOptions(commonCompiler.Arguments.CompilationOptions, compilation.Options);
 
             RoundTripUtil.VerifyRoundTrip(

--- a/src/Compilers/Core/RebuildTest/RoundTripUtil.cs
+++ b/src/Compilers/Core/RebuildTest/RoundTripUtil.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Rebuild.UnitTests
 
                 // https://github.com/dotnet/roslyn/issues/52327
                 // this is not all that useful without manual copy/pasting. Can we diff this during the test and show the differences?
-                Assert.True(false, $@"
+                Assert.Fail($@"
 Expected:
 {originalMdv}
 
@@ -189,7 +189,7 @@ Actual:
                 var originalMdv = getMdv(originalEmit.PdbReader);
                 var rebuildMdv = getMdv(rebuildEmit.PdbReader);
 
-                Assert.True(false, $@"
+                Assert.Fail($@"
 Expected:
 {originalMdv}
 

--- a/src/Compilers/Server/VBCSCompilerTests/ClientConnectionHandlerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ClientConnectionHandlerTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         {
             var compilerServerHost = new TestableCompilerServerHost(delegate
             {
-                Assert.True(false, "Should not reach compilation");
+                Assert.Fail("Should not reach compilation");
                 throw new Exception("");
             });
             var clientConnectionHandler = new ClientConnectionHandler(compilerServerHost);
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             var compilerServerHost = new TestableCompilerServerHost(delegate
             {
                 hitCompilation = true;
-                Assert.True(false, "Should not reach compilation when compilations are disallowed");
+                Assert.Fail("Should not reach compilation when compilations are disallowed");
                 throw new Exception("");
             });
 

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -208,7 +208,7 @@ End Module")
                     Assert.Equal(CompletionData.RequestCompleted, listener.CompletionDataList.Single());
                 }
                 var bytes = File.ReadAllBytes(outFile);
-                AssertEx.NotNull(bytes);
+                Assert.NotNull(bytes);
 
                 return (bytes, finalFlags);
             }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -202,7 +202,7 @@ End Module")
                         currentDirectory: tempDir);
                     if (result.ExitCode != 0)
                     {
-                        AssertEx.Fail($"Deterministic compile failed \n stdout:  {result.Output}");
+                        Assert.Fail($"Deterministic compile failed \n stdout:  {result.Output}");
                     }
                     var listener = await serverData.Complete();
                     Assert.Equal(CompletionData.RequestCompleted, listener.CompletionDataList.Single());
@@ -1455,7 +1455,7 @@ static void Main(string[] args)
             {
                 if (first[i] != second[i])
                 {
-                    AssertEx.Fail($"Bytes were different at position {i} ({first[i]} vs {second[i]}).  Flags used were (\"{finalFlags1}\" vs \"{finalFlags2}\")");
+                    Assert.Fail($"Bytes were different at position {i} ({first[i]} vs {second[i]}).  Flags used were (\"{finalFlags1}\" vs \"{finalFlags2}\")");
                 }
             }
         }

--- a/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/NamedPipeClientConnectionHostTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             foreach (var streamTask in list)
             {
                 using var stream = await streamTask;
-                AssertEx.NotNull(stream);
+                Assert.NotNull(stream);
                 var readCount = await stream.ReadAsync(buffer, 0, buffer.Length);
                 Assert.Equal(0, readCount);
                 Assert.False(stream.IsConnected);

--- a/src/Compilers/Test/Core/Assert/AssertEx.cs
+++ b/src/Compilers/Test/Core/Assert/AssertEx.cs
@@ -134,11 +134,11 @@ namespace Roslyn.Test.Utilities
 
             if (expected == null)
             {
-                Fail("expected was null, but actual wasn't" + Environment.NewLine + message);
+                Assert.Fail("expected was null, but actual wasn't" + Environment.NewLine + message);
             }
             else if (actual == null)
             {
-                Fail("actual was null, but expected wasn't" + Environment.NewLine + message);
+                Assert.Fail("actual was null, but expected wasn't" + Environment.NewLine + message);
             }
             else if (!(comparer ?? AssertEqualityComparer<T>.Instance).Equals(expected, actual))
             {
@@ -157,7 +157,7 @@ namespace Roslyn.Test.Utilities
                         """;
                 }
 
-                Fail(message + Environment.NewLine + expectedAndActual);
+                Assert.Fail(message + Environment.NewLine + expectedAndActual);
             }
         }
 
@@ -313,7 +313,7 @@ namespace Roslyn.Test.Utilities
         {
             if (ReferenceEquals(expected, actual))
             {
-                Fail("expected and actual references are identical\r\n" + message);
+                Assert.Fail("expected and actual references are identical\r\n" + message);
             }
 
             if (expected == null || actual == null)
@@ -322,7 +322,7 @@ namespace Roslyn.Test.Utilities
             }
             else if (SequenceEqual(expected, actual, comparer))
             {
-                Fail("expected and actual sequences match\r\n" + message);
+                Assert.Fail("expected and actual sequences match\r\n" + message);
             }
         }
 
@@ -544,16 +544,6 @@ namespace Roslyn.Test.Utilities
             }
 
             return string.Join(separator, list.Select(itemInspector));
-        }
-
-        public static void Fail(string message)
-        {
-            throw new Xunit.Sdk.XunitException(message);
-        }
-
-        public static void Fail(string format, params object[] args)
-        {
-            throw new Xunit.Sdk.XunitException(string.Format(format, args));
         }
 
         public static void NotNull<T>([NotNull] T @object, string message)
@@ -873,7 +863,7 @@ namespace Roslyn.Test.Utilities
             var list = items.ToList();
             if (list.Count != 0)
             {
-                Fail($"Expected 0 items but found {list.Count}: {message}\r\nItems:\r\n    {string.Join("\r\n    ", list)}");
+                Assert.Fail($"Expected 0 items but found {list.Count}: {message}\r\nItems:\r\n    {string.Join("\r\n    ", list)}");
             }
         }
 
@@ -1003,7 +993,7 @@ namespace Roslyn.Test.Utilities
                     .AppendLine();
             }
 
-            Fail(stringBuilder.ToString());
+            Assert.Fail(stringBuilder.ToString());
         }
 
 #nullable enable
@@ -1017,7 +1007,7 @@ namespace Roslyn.Test.Utilities
                 }
             }
 
-            Fail("Filter does not match any item in the collection: " + Environment.NewLine +
+            Assert.Fail("Filter does not match any item in the collection: " + Environment.NewLine +
                 ToString(collection, itemSeparator ?? Environment.NewLine, itemInspector));
         }
 

--- a/src/Compilers/Test/Core/Assert/AssertEx.cs
+++ b/src/Compilers/Test/Core/Assert/AssertEx.cs
@@ -556,7 +556,7 @@ namespace Roslyn.Test.Utilities
             throw new Xunit.Sdk.XunitException(string.Format(format, args));
         }
 
-        public static void NotNull<T>([NotNull] T @object, string message = null)
+        public static void NotNull<T>([NotNull] T @object, string message)
         {
             Assert.False(AssertEqualityComparer<T>.IsNull(@object), message);
         }
@@ -1007,12 +1007,6 @@ namespace Roslyn.Test.Utilities
         }
 
 #nullable enable
-        public static void NotNull<T>([NotNull] T value)
-        {
-            Assert.NotNull(value);
-            Debug.Assert(value is object);
-        }
-
         public static void Contains<T>(IEnumerable<T> collection, Predicate<T> filter, Func<T, string>? itemInspector = null, string? itemSeparator = null)
         {
             foreach (var item in collection)

--- a/src/Compilers/Test/Core/Assert/AssertEx.cs
+++ b/src/Compilers/Test/Core/Assert/AssertEx.cs
@@ -216,7 +216,7 @@ namespace Roslyn.Test.Utilities
             message.AppendLine("Actual:");
             message.AppendLine(actual);
 
-            Assert.True(false, message.ToString());
+            Assert.Fail(message.ToString());
         }
 
         public static void Equal<T>(
@@ -243,7 +243,7 @@ namespace Roslyn.Test.Utilities
                 return;
             }
 
-            Assert.True(false, GetAssertMessage(expected, actual, comparer, message, itemInspector, itemSeparator, expectedValueSourcePath, expectedValueSourceLine));
+            Assert.Fail(GetAssertMessage(expected, actual, comparer, message, itemInspector, itemSeparator, expectedValueSourcePath, expectedValueSourceLine));
         }
 
         public static void Equal<T>(
@@ -259,7 +259,7 @@ namespace Roslyn.Test.Utilities
             if (SequenceEqual(expected, actual, comparer))
                 return;
 
-            Assert.True(false, GetAssertMessage(expected, actual, comparer, message, itemInspector, itemSeparator, expectedValueSourcePath, expectedValueSourceLine));
+            Assert.Fail(GetAssertMessage(expected, actual, comparer, message, itemInspector, itemSeparator, expectedValueSourcePath, expectedValueSourceLine));
         }
 
         /// <summary>
@@ -306,7 +306,7 @@ namespace Roslyn.Test.Utilities
                 messageBuilder.AppendLine(line.Text.Replace("\r", "<CR>").Replace("\n", "<LF>"));
             }
 
-            Assert.True(false, messageBuilder.ToString());
+            Assert.Fail(messageBuilder.ToString());
         }
 
         public static void NotEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T> comparer = null, string message = null)
@@ -496,7 +496,7 @@ namespace Roslyn.Test.Utilities
             if (!expectedSet.SetEquals(actual))
             {
                 var message = GetAssertMessage(ToString(expected, ",\r\n", itemInspector: withQuotes), ToString(actual, ",\r\n", itemInspector: withQuotes));
-                Assert.True(false, message);
+                Assert.Fail(message);
             }
 
             string withQuotes(T t) => $"\"{Convert.ToString(t)}\"";
@@ -565,7 +565,7 @@ namespace Roslyn.Test.Utilities
 
             if (normalizedExpected != normalizedActual)
             {
-                Assert.True(false, GetAssertMessage(expected, actual, message, escapeQuotes, expectedValueSourcePath, expectedValueSourceLine));
+                Assert.Fail(GetAssertMessage(expected, actual, message, escapeQuotes, expectedValueSourcePath, expectedValueSourceLine));
             }
         }
 
@@ -591,7 +591,7 @@ namespace Roslyn.Test.Utilities
                     message = GetAssertMessage(result1, result2);
                 }
 
-                Assert.True(false, message);
+                Assert.Fail(message);
             }
         }
 
@@ -942,7 +942,7 @@ namespace Roslyn.Test.Utilities
                     builder.AppendLine("},");
                 }
 
-                Assert.True(false, builder.ToString());
+                Assert.Fail(builder.ToString());
             }
         }
 

--- a/src/Compilers/Test/Core/Assert/AssertXml.cs
+++ b/src/Compilers/Test/Core/Assert/AssertXml.cs
@@ -49,7 +49,7 @@ namespace Roslyn.Test.Utilities
         {
             if (!CheckEqual(expectedRoot, actualRoot, ShallowElementComparer.Instance, out var firstMismatch))
             {
-                Assert.True(false, message +
+                Assert.Fail(message +
                     GetAssertText(
                         GetXmlString(expectedRoot, expectedIsXmlLiteral),
                         GetXmlString(actualRoot, expectedIsXmlLiteral),

--- a/src/Compilers/Test/Core/Compilation/CompilationExtensions.cs
+++ b/src/Compilers/Test/Core/Compilation/CompilationExtensions.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                         }
                         catch (ArgumentException)
                         {
-                            Assert.False(true, $"Duplicate explicit node for syntax ({operation.Syntax.RawKind}): {operation.Syntax.ToString()}");
+                            Assert.Fail($"Duplicate explicit node for syntax ({operation.Syntax.RawKind}): {operation.Syntax.ToString()}");
                         }
                     }
 

--- a/src/Compilers/Test/Core/Compilation/ControlFlowGraphVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/ControlFlowGraphVerifier.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                         break;
 
                     default:
-                        Assert.False(true, $"Unexpected block kind {block.Kind}");
+                        Assert.Fail($"Unexpected block kind {block.Kind}");
                         break;
                 }
 
@@ -1460,7 +1460,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                                 enterRegion($".catch {{{getRegionId(region)}}} ({region.ExceptionType?.ToTestDisplayString() ?? "null"})");
                                 break;
                             default:
-                                Assert.False(true, $"Unexpected region kind {region.EnclosingRegion.Kind}");
+                                Assert.Fail($"Unexpected region kind {region.EnclosingRegion.Kind}");
                                 break;
                         }
                         break;
@@ -1490,7 +1490,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                         break;
 
                     default:
-                        Assert.False(true, $"Unexpected region kind {region.Kind}");
+                        Assert.Fail($"Unexpected region kind {region.Kind}");
                         break;
                 }
 
@@ -1546,7 +1546,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                                 goto endRegion;
 
                             default:
-                                Assert.False(true, $"Unexpected region kind {region.EnclosingRegion.Kind}");
+                                Assert.Fail($"Unexpected region kind {region.EnclosingRegion.Kind}");
                                 break;
                         }
 
@@ -1559,7 +1559,7 @@ endRegion:
                     case ControlFlowRegionKind.TryAndFinally:
                         break;
                     default:
-                        Assert.False(true, $"Unexpected region kind {region.Kind}");
+                        Assert.Fail($"Unexpected region kind {region.Kind}");
                         break;
                 }
 
@@ -1683,12 +1683,12 @@ endRegion:
                 if (referencedLocalsAndMethods.Count != 0)
                 {
                     ISymbol symbol = referencedLocalsAndMethods.First();
-                    Assert.True(false, $"{(symbol.Kind == SymbolKind.Local ? "Local" : "Method")} without owning region {symbol.ToTestDisplayString()} in [{getBlockId(block)}]\n{finalGraph()}");
+                    Assert.Fail($"{(symbol.Kind == SymbolKind.Local ? "Local" : "Method")} without owning region {symbol.ToTestDisplayString()} in [{getBlockId(block)}]\n{finalGraph()}");
                 }
 
                 if (referencedCaptureIds.Count != 0)
                 {
-                    Assert.True(false, $"Capture [{referencedCaptureIds.First().Value}] without owning region in [{getBlockId(block)}]\n{finalGraph()}");
+                    Assert.Fail($"Capture [{referencedCaptureIds.First().Value}] without owning region in [{getBlockId(block)}]\n{finalGraph()}");
                 }
             }
 
@@ -1983,7 +1983,7 @@ endRegion:
                     return true;
             }
 
-            Assert.True(false, $"Unhandled node kind OperationKind.{n.Kind}");
+            Assert.Fail($"Unhandled node kind OperationKind.{n.Kind}");
             return false;
         }
 

--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 }
                 catch (ArgumentException)
                 {
-                    Assert.False(true, $"Duplicate explicit node for syntax ({operation.Syntax.RawKind}): {operation.Syntax.ToString()}");
+                    Assert.Fail($"Duplicate explicit node for syntax ({operation.Syntax.RawKind}): {operation.Syntax.ToString()}");
                 }
             }
 

--- a/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
+++ b/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         internal override void VisitNoneOperation(IOperation operation)
         {
 #if Test_IOperation_None_Kind
-            Assert.True(false, "Encountered an IOperation with `Kind == OperationKind.None` while walking the operation tree.");
+            Assert.Fail("Encountered an IOperation with `Kind == OperationKind.None` while walking the operation tree.");
 #endif
             Assert.Equal(OperationKind.None, operation.Kind);
         }
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                         }
                         catch (ArgumentException)
                         {
-                            Assert.False(true, $"Duplicate explicit node for syntax ({descendant.Syntax.RawKind}): {descendant.Syntax.ToString()}");
+                            Assert.Fail($"Duplicate explicit node for syntax ({descendant.Syntax.RawKind}): {descendant.Syntax.ToString()}");
                         }
                     }
 
@@ -1500,7 +1500,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     Assert.Equal("ITuple", type.Name);
                     break;
                 default:
-                    Assert.True(false, $"Unexpected symbol {operation.DeconstructSymbol}");
+                    Assert.Fail($"Unexpected symbol {operation.DeconstructSymbol}");
                     break;
             }
 
@@ -1544,7 +1544,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 case IPropertySymbol prop:
                     break;
                 case var symbol:
-                    Assert.True(false, $"Unexpected symbol {symbol}");
+                    Assert.Fail($"Unexpected symbol {symbol}");
                     break;
             }
         }
@@ -1722,7 +1722,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 case OperationKind.OmittedArgument:
                 case OperationKind.DeclarationExpression:
                 case OperationKind.Discard:
-                    Assert.False(true, $"A {operation.Value.Kind} node should not be spilled or captured.");
+                    Assert.Fail($"A {operation.Value.Kind} node should not be spilled or captured.");
                     break;
 
                 default:

--- a/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
+++ b/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
@@ -825,7 +825,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                                 semanticModel.Compilation.CreateBuiltinOperator(symbol.Name, method.ReturnType, method.Parameters[0].Type, method.Parameters[1].Type);
                                 break;
                             default:
-                                AssertEx.Fail($"Unexpected parameter count for built in method: {method.ToDisplayString()}");
+                                Assert.Fail($"Unexpected parameter count for built in method: {method.ToDisplayString()}");
                                 break;
                         }
                     }

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -707,7 +707,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 {
                     builder.AppendLine(AssertEx.GetAssertMessage(expected[i], actual[i], prefix: names[i], escapeQuotes: true));
                 }
-                Assert.True(false, builder.ToString());
+                Assert.Fail(builder.ToString());
             }
             actual.Free();
             expected.Free();

--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
@@ -558,7 +558,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 string message = d.ToString(CultureInfo.InvariantCulture);
                 if (Regex.Match(message, @"{\d+}").Success)
                 {
-                    Assert.True(false, "Diagnostic messages should never contain unsubstituted placeholders.\n    " + message);
+                    Assert.Fail("Diagnostic messages should never contain unsubstituted placeholders.\n    " + message);
                 }
 
                 if (i > 0)

--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis
             if (unmatchedActualDescription.Count > 0 || unmatchedExpected.Count > 0)
             {
                 var text = DiagnosticDescription.GetAssertText(expected, actual, unmatchedExpected.ToArray(), actual.Select((a, i) => (a, i)).Join(unmatchedActualIndex, ai => ai.i, i => i, (ai, _) => ai.a));
-                Assert.True(false, text);
+                Assert.Fail(text);
             }
 
             unmatchedExpected.Free();

--- a/src/Compilers/Test/Core/InstrumentationChecker.cs
+++ b/src/Compilers/Test/Core/InstrumentationChecker.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     }
                 }
             }
-            AssertEx.Fail(output.ToStringAndFree());
+            Assert.Fail(output.ToStringAndFree());
         }
 
         private static string GetTermination(int index, int length)
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.Runtime
                     }
                 }
             }
-            AssertEx.Fail(output.ToStringAndFree());
+            Assert.Fail(output.ToStringAndFree());
         }
 
         private static string GetTermination(int index, int length)

--- a/src/Compilers/Test/Core/Metadata/MetadataSignatureUnitTestHelper.cs
+++ b/src/Compilers/Test/Core/Metadata/MetadataSignatureUnitTestHelper.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             actualText = actualText.TrimEnd(',');
             var diffText = DiffUtil.DiffReport(expectedText, actualText);
 
-            Assert.True(false, "\n\nExpected:" + expectedText + "\n\nActual:" + actualText + "\n\nDifferences:\n" + diffText);
+            Assert.Fail("\n\nExpected:" + expectedText + "\n\nActual:" + actualText + "\n\nDifferences:\n" + diffText);
         }
     }
 }

--- a/src/Compilers/Test/Core/Metadata/MetadataValidation.cs
+++ b/src/Compilers/Test/Core/Metadata/MetadataValidation.cs
@@ -41,7 +41,7 @@ namespace Roslyn.Test.Utilities
             }
             else
             {
-                Assert.True(false, "not impl");
+                Assert.Fail("not impl");
                 return null;
             }
         }

--- a/src/Compilers/Test/Core/Syntax/TokenUtilities.cs
+++ b/src/Compilers/Test/Core/Syntax/TokenUtilities.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Xunit;
 using CS = Microsoft.CodeAnalysis.CSharp;
 using VB = Microsoft.CodeAnalysis.VisualBasic;
 
@@ -46,7 +47,7 @@ namespace Roslyn.Test.Utilities
                         }
                     }
 
-                    AssertEx.Fail($"Unexpected token.  Actual '{actualAll}' Expected '{expectedAll}'\r\nActual:\r\n{actual}");
+                    Assert.Fail($"Unexpected token.  Actual '{actualAll}' Expected '{expectedAll}'\r\nActual:\r\n{actual}");
                 }
             }
 
@@ -54,8 +55,7 @@ namespace Roslyn.Test.Utilities
             {
                 var expectedDisplay = string.Join(" ", expectedTokens.Select(t => t.ToString()));
                 var actualDisplay = string.Join(" ", actualTokens.Select(t => t.ToString()));
-                AssertEx.Fail(@"Wrong token count. Expected '{0}', Actual '{1}', Expected Text: '{2}', Actual Text: '{3}'",
-                    expectedTokens.Count, actualTokens.Count, expectedDisplay, actualDisplay);
+                Assert.Fail($@"Wrong token count. Expected '{expectedTokens.Count}', Actual '{actualTokens.Count}', Expected Text: '{expectedDisplay}', Actual Text: '{actualDisplay}'");
             }
         }
 

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -2119,7 +2119,7 @@ class ExpressionPrinter : System.Linq.Expressions.ExpressionVisitor
             try
             {
                 CompileAndVerify(comp, expectedOutput: "", verify: verify); //need expected output to force execution
-                Assert.False(true, string.Format("Expected exception {0}({1})", typeof(T).Name, expectedMessage));
+                Assert.Fail(string.Format("Expected exception {0}({1})", typeof(T).Name, expectedMessage));
             }
             catch (TargetInvocationException x)
             {

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var members = GetMembers(((CSharpCompilation)compilation).GlobalNamespace, qualifiedName, out lastContainer);
             if (members.IsEmpty)
             {
-                Assert.True(false, string.Format("Could not find member named '{0}'.  Available members:\r\n{1}",
+                Assert.Fail(string.Format("Could not find member named '{0}'.  Available members:\r\n{1}",
                     qualifiedName, string.Join("\r\n", lastContainer.GetMembers().Select(m => "\t\t" + m.Name))));
             }
             return members;
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             else if (members.Length > 1)
             {
-                Assert.True(false, "Found multiple members of specified name:\r\n" + string.Join("\r\n", members));
+                Assert.Fail("Found multiple members of specified name:\r\n" + string.Join("\r\n", members));
             }
 
             return members.Single();
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             else if (members.Length > 1)
             {
-                Assert.True(false, "Found multiple members of specified name:\r\n" + string.Join("\r\n", members));
+                Assert.Fail("Found multiple members of specified name:\r\n" + string.Join("\r\n", members));
             }
 
             return members.Single();
@@ -616,7 +616,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     }
                     break;
                 default:
-                    Assert.False(true, "Unexpected accessor kind " + accessor.MethodKind);
+                    Assert.Fail("Unexpected accessor kind " + accessor.MethodKind);
                     break;
             }
         }

--- a/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/FunctionPointerUtilities.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
                 case RefKind.Out:
                 default:
-                    Assert.True(false, $"Cannot have a return ref kind of {signature.RefKind}");
+                    Assert.Fail($"Cannot have a return ref kind of {signature.RefKind}");
                     break;
             }
             returnVerifier.TypeVerifier(signature.ReturnType);
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         break;
 
                     default:
-                        Assert.True(false, $"Cannot have a return ref kind of {parameter.RefKind}");
+                        Assert.Fail($"Cannot have a return ref kind of {parameter.RefKind}");
                         break;
                 }
             }

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -746,7 +746,7 @@ Friend Module CompilationUtils
             For Each d In diags
                 Console.WriteLine(ErrorText(d))
             Next
-            Assert.True(False, "Should not have any diagnostics")
+            Assert.Fail("Should not have any diagnostics")
         End If
     End Sub
 
@@ -766,7 +766,7 @@ Friend Module CompilationUtils
             For Each d In diags
                 Console.WriteLine(ErrorText(d))
             Next
-            Assert.True(False, "Should not have any errors")
+            Assert.Fail("Should not have any errors")
         End If
     End Sub
 
@@ -888,7 +888,7 @@ Friend Module CompilationUtils
                     .AppendLine("UNEXPECTED ERROR MESSAGES:")
                     .AppendLine(actualText.Substring(expectedText.Length))
 
-                    Assert.True(False, .ToString())
+                    Assert.Fail(.ToString())
                 Else
                     Dim expectedLines = expectedText.Split({vbCrLf, vbLf}, StringSplitOptions.RemoveEmptyEntries)
                     Dim actualLines = actualText.Split({vbCrLf, vbLf}, StringSplitOptions.RemoveEmptyEntries)
@@ -912,7 +912,7 @@ Friend Module CompilationUtils
                     Next
 
                     If appendedLines > 0 Then
-                        Assert.True(False, .ToString())
+                        Assert.Fail(.ToString())
                     Else
                         CompareLineByLine(expectedText, actualText)
                     End If

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -66,7 +66,7 @@ Friend Module Extensions
         If members.Length = 0 Then
             Return Nothing
         ElseIf members.Length > 1 Then
-            Assert.True(False, "Found multiple members of specified name:" & vbCrLf + String.Join(vbCrLf, members))
+            Assert.Fail("Found multiple members of specified name:" & vbCrLf + String.Join(vbCrLf, members))
         End If
 
         Return members.Single()

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -2597,7 +2597,7 @@ Imports System
                 End If
             Next
 
-            AssertEx.Fail("Unable to find type:" + typeName)
+            Assert.Fail("Unable to find type:" + typeName)
             Return Nothing
         End Function
 
@@ -2613,7 +2613,7 @@ Imports System
                 End If
             Next
 
-            AssertEx.Fail("Unable to find method:" + methodName)
+            Assert.Fail("Unable to find method:" + methodName)
             Return Nothing
         End Function
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -479,13 +479,13 @@ End Class
 
                     ' This assert will fire if you are adding a new compiler diagnostic (non-error severity),
                     ' but did not add a title resource string for the diagnostic.
-                    Assert.True(False, message)
+                    Assert.Fail(message)
                 End If
 
                 Dim category = descriptor.Category
                 If String.IsNullOrEmpty(title) Then
                     Dim message = String.Format("'{0}' must have a non-null non-empty 'Category'", descriptor.Id)
-                    Assert.True(False, message)
+                    Assert.Fail(message)
                 End If
             Next
         End Sub

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticTests.vb
@@ -94,26 +94,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
                         Assert.True(errString.StartsWith("ERR_"), GetErrorMessage(errString))
 
                     Case < WarningsStart
-                        Assert.True(False, GetErrorMessage(errString))
+                        Assert.Fail(GetErrorMessage(errString))
 
                     Case WarningsStart To ERRID.WRN_NextAvailable
                         Assert.True(errString.StartsWith("WRN_"), GetErrorMessage(errString))
 
                     Case < HiddenInfoStart
-                        Assert.True(False, GetErrorMessage(errString))
+                        Assert.Fail(GetErrorMessage(errString))
 
                     Case HiddenInfoStart To ERRID.HDN_NextAvailable
                         Assert.True(errString.StartsWith("HDN_") OrElse errString.StartsWith("INF_"),
                                     GetErrorMessage(errString))
 
                     Case < IdsStart
-                        Assert.True(False, GetErrorMessage(errString))
+                        Assert.Fail(GetErrorMessage(errString))
 
                     Case IdsStart To ERRID.IDS_NextAvailable
                         Assert.True(errString.StartsWith("IDS_"), GetErrorMessage(errString))
 
                     Case < FeatureStart
-                        Assert.True(False, GetErrorMessage(errString))
+                        Assert.Fail(GetErrorMessage(errString))
 
                     Case >= FeatureStart
                         Assert.True(errString.StartsWith("FEATURE_"), GetErrorMessage(errString))

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
@@ -1331,7 +1331,7 @@ End Interface
                                 AssertEx.Equal(_ONE4, reader.GetBlobBytes(constant.Value))
 
                             Case Else
-                                Assert.True(False, "Unknown field: " + name)
+                                Assert.Fail("Unknown field: " + name)
                         End Select
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
@@ -3487,10 +3487,10 @@ End Module
             Assert.Equal(Obj1, obj3)
             Assert.NotEqual(Obj1, Obj2)
             If Obj1 = Obj2 Then
-                Assert.True(False, "GlobalImports equal Failure")
+                Assert.Fail("GlobalImports equal Failure")
             End If
             If Obj1 <> obj3 Then
-                Assert.True(False, "GlobalImports Not equal Failure")
+                Assert.Fail("GlobalImports Not equal Failure")
             End If
         End Sub
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineMethod/CSharpInlineMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineMethod/CSharpInlineMethodTests.cs
@@ -96,7 +96,7 @@ public sealed class CSharpInlineMethodTests
             var secondMarkerIndex = expectedMarkUpForCallee.LastIndexOf(Marker);
             if (firstMarkerIndex == -1 || secondMarkerIndex == -1 || firstMarkerIndex == secondMarkerIndex)
             {
-                Assert.True(false, "Can't find proper marks that contains inlined method.");
+                Assert.Fail("Can't find proper marks that contains inlined method.");
             }
 
             var firstPartitionBeforeMarkUp = expectedMarkUpForCallee[..firstMarkerIndex];
@@ -130,7 +130,7 @@ public sealed class CSharpInlineMethodTests
             var secondMarkerIndex = expectedMarkUp.LastIndexOf(Marker);
             if (firstMarkerIndex == -1 || secondMarkerIndex == -1 || firstMarkerIndex == secondMarkerIndex)
             {
-                Assert.True(false, "Can't find proper marks that contains inlined method.");
+                Assert.Fail("Can't find proper marks that contains inlined method.");
             }
 
             var firstPartitionBeforeMarkUp = expectedMarkUp[..firstMarkerIndex];

--- a/src/EditorFeatures/CSharpTest/CodeActions/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -48,7 +48,7 @@ public sealed class CSharpPullMemberUpTests : AbstractCSharpCodeActionTest
         }
         else if (actions.Length > 1)
         {
-            Assert.True(false, "Pull Members Up is provided via quick action");
+            Assert.Fail("Pull Members Up is provided via quick action");
         }
         else
         {

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -61,7 +61,7 @@ public abstract class ExtractMethodBase
         }
 
         if (expected == "")
-            Assert.True(false, subjectBuffer.CurrentSnapshot.GetText());
+            Assert.Fail(subjectBuffer.CurrentSnapshot.GetText());
 
         Assert.Equal(expected, subjectBuffer.CurrentSnapshot.GetText());
     }

--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbSourceDocumentTests.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbSourceDocumentTests.cs
@@ -695,8 +695,8 @@ public sealed partial class PdbSourceDocumentTests : AbstractPdbSourceDocumentTe
 
             var (actualText, _) = await GetGeneratedSourceTextAsync(project, symbol, Location.Embedded, expectNullResult: false);
 
-            AssertEx.NotNull(actualText);
-            AssertEx.NotNull(actualText.Encoding);
+            Assert.NotNull(actualText);
+            Assert.NotNull(actualText.Encoding);
             AssertEx.Equal(encoding.WebName, actualText.Encoding.WebName);
             AssertEx.EqualOrDiff(source, actualText.ToString());
         });
@@ -724,8 +724,8 @@ public sealed partial class PdbSourceDocumentTests : AbstractPdbSourceDocumentTe
 
             var (actualText, _) = await GetGeneratedSourceTextAsync(project, symbol, Location.Embedded, expectNullResult: false);
 
-            AssertEx.NotNull(actualText);
-            AssertEx.NotNull(actualText.Encoding);
+            Assert.NotNull(actualText);
+            Assert.NotNull(actualText.Encoding);
             AssertEx.Equal(encoding.WebName, actualText.Encoding.WebName);
             AssertEx.EqualOrDiff(source, actualText.ToString());
         });
@@ -753,8 +753,8 @@ public sealed partial class PdbSourceDocumentTests : AbstractPdbSourceDocumentTe
 
             var (actualText, _) = await GetGeneratedSourceTextAsync(project, symbol, Location.Embedded, expectNullResult: false);
 
-            AssertEx.NotNull(actualText);
-            AssertEx.NotNull(actualText.Encoding);
+            Assert.NotNull(actualText);
+            Assert.NotNull(actualText.Encoding);
             AssertEx.Equal(encoding.WebName, actualText.Encoding.WebName);
             AssertEx.EqualOrDiff(source, actualText.ToString());
         });

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -80,7 +80,7 @@ public sealed class SemanticQuickInfoSourceTests : AbstractSemanticQuickInfoSour
         }
         else
         {
-            AssertEx.NotNull(info);
+            Assert.NotNull(info);
 
             foreach (var expected in expectedResults)
             {
@@ -142,7 +142,7 @@ public sealed class SemanticQuickInfoSourceTests : AbstractSemanticQuickInfoSour
         }
         else
         {
-            AssertEx.NotNull(info);
+            Assert.NotNull(info);
 
             foreach (var expected in expectedResults)
             {
@@ -311,7 +311,7 @@ public sealed class SemanticQuickInfoSourceTests : AbstractSemanticQuickInfoSour
         }
         else
         {
-            AssertEx.NotNull(info);
+            Assert.NotNull(info);
 
             foreach (var expected in expectedResults)
             {

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -129,7 +129,7 @@ public sealed class SplitStringLiteralCommandHandlerTests
             inputMarkup, expectedOutputMarkup,
             callback: () =>
             {
-                Assert.True(false, "Should not reach here.");
+                Assert.Fail("Should not reach here.");
             },
             verifyUndo, indentStyle, useTabs, endOfLine);
     }

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests.cs
@@ -369,7 +369,7 @@ public partial class CSharpJsonParserTests
             case JsonKind.EndOfLineTrivia:
                 break;
             default:
-                Assert.False(true, "Incorrect trivia kind");
+                Assert.Fail("Incorrect trivia kind");
                 return;
         }
 

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_NstTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/Json/CSharpJsonParserTests_NstTests.cs
@@ -52,7 +52,7 @@ public sealed partial class CSharpJsonParserNstTests : CSharpJsonParserTests
         }
         else
         {
-            Assert.False(true, "Unexpected test name.");
+            Assert.Fail("Unexpected test name.");
         }
     }
 

--- a/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
+++ b/src/EditorFeatures/CSharpTest2/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
@@ -168,7 +168,7 @@ public sealed partial class CSharpRegexParserTests
         if (!tree.Diagnostics.IsEmpty)
         {
             var expectedDiagnostics = CreateDiagnosticsElement(sourceText, tree);
-            Assert.False(true, "Expected diagnostics: \r\n" + expectedDiagnostics.ToString().Replace("""
+            Assert.Fail("Expected diagnostics: \r\n" + expectedDiagnostics.ToString().Replace("""
                 "
                 """, """
                 ""
@@ -313,7 +313,7 @@ public sealed partial class CSharpRegexParserTests
             case RegexKind.WhitespaceTrivia:
                 break;
             default:
-                Assert.False(true, "Incorrect trivia kind");
+                Assert.Fail("Incorrect trivia kind");
                 return;
         }
 

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
@@ -104,7 +104,7 @@ public abstract class RecommenderTests : TestBase
             else
             {
                 var result = (await RecommendKeywordsAsync(position, context)).SingleOrDefault();
-                AssertEx.NotNull(result);
+                Assert.NotNull(result);
                 Assert.Equal(KeywordText, result.Keyword);
                 if (matchPriority != null)
                 {

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
@@ -77,7 +77,7 @@ public abstract class RecommenderTests : TestBase
 
         if (tree.IsInNonUserCode(position, CancellationToken.None) && !absent)
         {
-            Assert.False(true, "Wanted keyword, but in non-user code position: " + KeywordText);
+            Assert.Fail("Wanted keyword, but in non-user code position: " + KeywordText);
         }
 
         var semanticModel = compilation.GetSemanticModel(tree);
@@ -99,7 +99,7 @@ public abstract class RecommenderTests : TestBase
         {
             if (RecommendKeywordsAsync == null)
             {
-                Assert.False(true, "No recommender for: " + KeywordText);
+                Assert.Fail("No recommender for: " + KeywordText);
             }
             else
             {

--- a/src/EditorFeatures/DiagnosticsTestUtilities/ChangeSignature/AbstractChangeSignatureTests.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/ChangeSignature/AbstractChangeSignatureTests.cs
@@ -133,7 +133,7 @@ public abstract class AbstractChangeSignatureTests : AbstractCodeActionTest
 
             if (diagnostics.Length > 0)
             {
-                Assert.True(false, CreateDiagnosticsString(diagnostics, updatedSignature, testState.InvocationDocument, totalParameters, (await testState.InvocationDocument.GetTextAsync()).ToString()));
+                Assert.Fail(CreateDiagnosticsString(diagnostics, updatedSignature, testState.InvocationDocument, totalParameters, (await testState.InvocationDocument.GetTextAsync()).ToString()));
             }
         }
 

--- a/src/EditorFeatures/DiagnosticsTestUtilities/SplitComments/AbstractSplitCommentCommandHandlerTests.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/SplitComments/AbstractSplitCommentCommandHandlerTests.cs
@@ -99,7 +99,7 @@ public abstract class AbstractSplitCommentCommandHandlerTests
             inputMarkup, expectedOutputMarkup,
             callback: () =>
             {
-                Assert.True(false, "Should not reach here.");
+                Assert.Fail("Should not reach here.");
             }, enabled, useTabs);
     }
 

--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
@@ -95,7 +95,7 @@ public sealed class IDEDiagnosticIDConfigurationTests
 
         if (helpLinkUri != $"https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/{diagnosticId.ToLowerInvariant()}")
         {
-            Assert.True(false, $"Invalid help link for {diagnosticId}");
+            Assert.Fail($"Invalid help link for {diagnosticId}");
         }
     }
 
@@ -138,7 +138,7 @@ public sealed class IDEDiagnosticIDConfigurationTests
 
             if (!expectedMap.TryGetValue(diagnosticIdString, out var expectedValue))
             {
-                Assert.False(true, $"""
+                Assert.Fail($"""
                     Missing entry:
 
                     {diagnosticIdString}
@@ -149,7 +149,7 @@ public sealed class IDEDiagnosticIDConfigurationTests
             // Verify entries match for diagnosticId
             if (expectedValue != editorConfigString)
             {
-                Assert.False(true, $"""
+                Assert.Fail($"""
                     Mismatch for '{diagnosticId}'
                     Expected: {expectedValue}
                     Actual: {editorConfigString}
@@ -161,7 +161,7 @@ public sealed class IDEDiagnosticIDConfigurationTests
 
         if (expectedLines.Length == 0)
         {
-            Assert.False(true, $"Test Baseline:{baseline}");
+            Assert.Fail($"Test Baseline:{baseline}");
         }
 
         if (expectedMap.Count > 0)
@@ -174,7 +174,7 @@ public sealed class IDEDiagnosticIDConfigurationTests
                 extraEntitiesBuilder.AppendLine(kvp.Value);
             }
 
-            Assert.False(true, $@"Unexpected entries:{extraEntitiesBuilder.ToString()}");
+            Assert.Fail($@"Unexpected entries:{extraEntitiesBuilder.ToString()}");
         }
     }
 
@@ -792,13 +792,13 @@ public sealed class IDEDiagnosticIDConfigurationTests
 
             if (!expectedMap.TryGetValue((diagnosticId, optionName), out var expectedValue))
             {
-                Assert.False(true, $@"Missing entry: {diagnosticId}, {optionName}, {optionValue}");
+                Assert.Fail($@"Missing entry: {diagnosticId}, {optionName}, {optionValue}");
             }
 
             // Verify entries match for diagnosticId
             if (expectedValue != optionValue)
             {
-                Assert.False(true, $@"Mismatch for: {diagnosticId}, {optionName}, {optionValue}");
+                Assert.Fail($@"Mismatch for: {diagnosticId}, {optionName}, {optionValue}");
             }
 
             expectedMap.Remove((diagnosticId, optionName));

--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.Utilities.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.Utilities.cs
@@ -36,7 +36,7 @@ public sealed partial class StackFrameParserTests
             return;
         }
 
-        AssertEx.NotNull(tree);
+        Assert.NotNull(tree);
         VerifyCharacterSpans(input, tree);
 
         if (methodDeclaration is null)

--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.Utilities.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.Utilities.cs
@@ -104,7 +104,7 @@ public sealed partial class StackFrameParserTests
 
                 if (textSeq[index++] != ch)
                 {
-                    Assert.True(false, PrintDifference());
+                    Assert.Fail(PrintDifference());
                 }
             }
         }

--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
@@ -126,7 +126,7 @@ internal static class StackFrameSyntaxFactory
             }
         }
 
-        AssertEx.NotNull(current);
+        Assert.NotNull(current);
         return (StackFrameQualifiedNameNode)current;
     }
 

--- a/src/EditorFeatures/Test/StackTraceExplorer/StackTraceExplorerTests.cs
+++ b/src/EditorFeatures/Test/StackTraceExplorer/StackTraceExplorerTests.cs
@@ -26,7 +26,7 @@ public sealed class StackTraceExplorerTests
         Assert.Single(result.ParsedFrames);
 
         var stackFrame = result.ParsedFrames[0] as ParsedStackFrame;
-        AssertEx.NotNull(stackFrame);
+        Assert.NotNull(stackFrame);
 
         // Test that ToString() and reparsing keeps the same outcome
         var reparsedResult = await StackTraceAnalyzer.AnalyzeAsync(stackFrame.ToString(), CancellationToken.None);
@@ -38,7 +38,7 @@ public sealed class StackTraceExplorerTests
         // Get the definition for the parsed frame
         var service = workspace.Services.GetRequiredService<IStackTraceExplorerService>();
         var definition = await service.TryFindDefinitionAsync(workspace.CurrentSolution, stackFrame, StackFrameSymbolPart.Method, CancellationToken.None);
-        AssertEx.NotNull(definition);
+        Assert.NotNull(definition);
 
         // Get the symbol that was indicated in the source code by cursor position
         var cursorDoc = workspace.Documents.Single();
@@ -49,7 +49,7 @@ public sealed class StackTraceExplorerTests
         var semanticModel = await doc.GetRequiredSemanticModelAsync(CancellationToken.None);
 
         var expectedSymbol = semanticModel.GetDeclaredSymbol(node);
-        AssertEx.NotNull(expectedSymbol);
+        Assert.NotNull(expectedSymbol);
 
         // Compare the definition found to the definition for the test symbol
         var expectedDefinition = await expectedSymbol.ToNonClassifiedDefinitionItemAsync(
@@ -848,7 +848,7 @@ public sealed class StackTraceExplorerTests
         var service = workspace.Services.GetRequiredService<IStackTraceExplorerService>();
         var definition = await service.TryFindDefinitionAsync(workspace.CurrentSolution, frame, StackFrameSymbolPart.Method, CancellationToken.None);
 
-        AssertEx.NotNull(definition);
+        Assert.NotNull(definition);
         Assert.Equal("String.ToLower", definition.NameDisplayParts.ToVisibleDisplayString(includeLeftToRightMarker: false));
     }
 
@@ -887,7 +887,7 @@ public sealed class StackTraceExplorerTests
         var (document, line) = service.GetDocumentAndLine(workspace.CurrentSolution, frame);
         Assert.Equal(5, line);
 
-        AssertEx.NotNull(document);
+        Assert.NotNull(document);
         Assert.Equal(@"C:/path/to/Component.razor", document.FilePath);
     }
 
@@ -926,7 +926,7 @@ public sealed class StackTraceExplorerTests
         var (document, line) = service.GetDocumentAndLine(workspace.CurrentSolution, frame);
         Assert.Equal(5, line);
 
-        AssertEx.NotNull(document);
+        Assert.NotNull(document);
         Assert.Equal(@"C:/path/to/Component.razor", document.FilePath);
     }
 }

--- a/src/EditorFeatures/Test/Utilities/StackFrameUtils.cs
+++ b/src/EditorFeatures/Test/Utilities/StackFrameUtils.cs
@@ -39,7 +39,7 @@ internal static class StackFrameUtils
             return;
         }
 
-        AssertEx.NotNull(actual);
+        Assert.NotNull(actual);
 
         Assert.Equal(expected.Kind, actual.Kind);
         Assert.True(expected.ChildCount == actual.ChildCount, PrintChildDifference(expected, actual));

--- a/src/EditorFeatures/Test2/Expansion/AbstractExpansionTest.vb
+++ b/src/EditorFeatures/Test2/Expansion/AbstractExpansionTest.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Expansion
                 Dim hostDocument = If(Not useLastProject, workspace.Documents.Single(), workspace.Documents.Last())
 
                 If hostDocument.AnnotatedSpans.Count <> 1 Then
-                    Assert.True(False, "Encountered unexpected span annotation -- only one of 'Expand' or 'ExpandAndSimplify' is legal")
+                    Assert.Fail("Encountered unexpected span annotation -- only one of 'Expand' or 'ExpandAndSimplify' is legal")
                 End If
 
                 Dim document = If(Not useLastProject, workspace.CurrentSolution.Projects.Single(), workspace.CurrentSolution.Projects.Last()).Documents.Single()

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -281,7 +281,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                         Dim actual = actualDefinitions(GetFilePathAndProjectLabel(doc)).Order()
 
                         If Not TextSpansMatch(expected, actual) Then
-                            Assert.True(False, PrintSpans(expected, actual, workspace.CurrentSolution.GetDocument(doc.Id), "{|Definition:", "|}"))
+                            Assert.Fail(PrintSpans(expected, actual, workspace.CurrentSolution.GetDocument(doc.Id), "{|Definition:", "|}"))
                         End If
                     Next
 
@@ -313,7 +313,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                             Dim actualSpans = actualReferences(GetFilePathAndProjectLabel(doc)).Order()
 
                             If Not TextSpansMatch(expectedSpans, actualSpans) Then
-                                Assert.True(False, PrintSpans(expectedSpans, actualSpans, workspace.CurrentSolution.GetDocument(doc.Id), $"{{|{key}:", "|}"))
+                                Assert.Fail(PrintSpans(expectedSpans, actualSpans, workspace.CurrentSolution.GetDocument(doc.Id), $"{{|{key}:", "|}"))
                             End If
                         Next
                     Next
@@ -332,7 +332,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                             Dim actualSpans = actualReferences(GetFilePathAndProjectLabel(doc)).Order()
 
                             If Not TextSpansMatch(expectedSpans, actualSpans) Then
-                                Assert.True(False, PrintSpans(expectedSpans, actualSpans, workspace.CurrentSolution.GetDocument(doc.Id), $"{{|{key}:", "|}"))
+                                Assert.Fail(PrintSpans(expectedSpans, actualSpans, workspace.CurrentSolution.GetDocument(doc.Id), $"{{|{key}:", "|}"))
                             End If
                         Next
                     Next
@@ -359,7 +359,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                 Dim actualSpans = actualReferences(GetFilePathAndProjectLabel(doc)).Order()
 
                                 If Not TextSpansMatch(expectedSpans, actualSpans) Then
-                                    Assert.True(False, PrintSpans(expectedSpans, actualSpans, workspace.CurrentSolution.GetDocument(doc.Id), $"{{|{annotationKey}:", "|}"))
+                                    Assert.Fail(PrintSpans(expectedSpans, actualSpans, workspace.CurrentSolution.GetDocument(doc.Id), $"{{|{annotationKey}:", "|}"))
                                 End If
                             Next
                         Next

--- a/src/EditorFeatures/Test2/Peek/PeekTests.vb
+++ b/src/EditorFeatures/Test2/Peek/PeekTests.vb
@@ -300,7 +300,7 @@ public partial class D
             Dim document = workspace.Documents.FirstOrDefault(Function(d) d.CursorPosition.HasValue)
 
             If document Is Nothing Then
-                AssertEx.Fail("The test is missing a $$ in the workspace.")
+                Assert.Fail("The test is missing a $$ in the workspace.")
             End If
 
             Dim textBuffer = document.GetTextBuffer()

--- a/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameCommandHandlerTests.vb
@@ -209,7 +209,7 @@ End Class
                 Dim session = StartSession(workspace)
 
                 commandHandler.ExecuteCommand(New TypeCharCommandArgs(view, view.TextBuffer, " "c),
-                                              Sub() AssertEx.Fail("Space should not have been passed to the editor."),
+                                              Sub() Assert.Fail("Space should not have been passed to the editor."),
                                               Utilities.TestCommandExecutionContext.Create())
 
                 session.Cancel()
@@ -288,7 +288,7 @@ class [|$$Goo|] // comment
 
                 ' with the caret at the start, this should delete the whole identifier
                 commandHandler.ExecuteCommand(New WordDeleteToEndCommandArgs(view, view.TextBuffer),
-                                              Sub() AssertEx.Fail("Command should not have been passed to the editor."),
+                                              Sub() Assert.Fail("Command should not have been passed to the editor."),
                                               Utilities.TestCommandExecutionContext.Create())
                 Await VerifyTagsAreCorrect(workspace)
 
@@ -301,7 +301,7 @@ class [|$$Goo|] // comment
                 ' that '@' character is in a read only region during rename.
                 view.Selection.Select(New SnapshotSpan(view.TextSnapshot, Span.FromBounds(startPosition + 2, startPosition + 4)), isReversed:=True)
                 commandHandler.ExecuteCommand(New WordDeleteToStartCommandArgs(view, view.TextBuffer),
-                                              Sub() AssertEx.Fail("Command should not have been passed to the editor."),
+                                              Sub() Assert.Fail("Command should not have been passed to the editor."),
                                               Utilities.TestCommandExecutionContext.Create())
                 Await VerifyTagsAreCorrect(workspace)
             End Using
@@ -344,7 +344,7 @@ Goo f;
 
                 ' LineStart should move to the beginning of identifierSpan
                 commandHandler.ExecuteCommand(New LineStartCommandArgs(view, view.TextBuffer),
-                                              Sub() AssertEx.Fail("Home should not have been passed to the editor."),
+                                              Sub() Assert.Fail("Home should not have been passed to the editor."),
                                               Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(0, view.Selection.SelectedSpans.Single().Span.Length)
                 Assert.Equal(startPosition, view.Caret.Position.BufferPosition.Position)
@@ -361,7 +361,7 @@ Goo f;
 
                 ' LineStartExtend should move to the beginning of identifierSpan and extend the selection
                 commandHandler.ExecuteCommand(New LineStartExtendCommandArgs(view, view.TextBuffer),
-                                              Sub() AssertEx.Fail("Shift+Home should not have been passed to the editor."),
+                                              Sub() Assert.Fail("Shift+Home should not have been passed to the editor."),
                                               Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(New Span(startPosition, 1), view.Selection.SelectedSpans.Single().Span)
 
@@ -377,7 +377,7 @@ Goo f;
 
                 ' LineEnd should move to the end of identifierSpan
                 commandHandler.ExecuteCommand(New LineEndCommandArgs(view, view.TextBuffer),
-                                              Sub() AssertEx.Fail("End should not have been passed to the editor."),
+                                              Sub() Assert.Fail("End should not have been passed to the editor."),
                                               Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(0, view.Selection.SelectedSpans.Single().Span.Length)
                 Assert.Equal(identifierSpan.End, view.Caret.Position.BufferPosition.Position)
@@ -394,7 +394,7 @@ Goo f;
 
                 ' LineEndExtend should move to the end of identifierSpan and extend the selection
                 commandHandler.ExecuteCommand(New LineEndExtendCommandArgs(view, view.TextBuffer),
-                                              Sub() AssertEx.Fail("Shift+End should not have been passed to the editor."),
+                                              Sub() Assert.Fail("Shift+End should not have been passed to the editor."),
                                               Utilities.TestCommandExecutionContext.Create())
                 Assert.Equal(Span.FromBounds(startPosition + 1, identifierSpan.End), view.Selection.SelectedSpans.Single().Span)
 

--- a/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             Dim engineResult As RenameEngineResult = Nothing
             Try
                 If workspace.Documents.Where(Function(d) d.CursorPosition.HasValue).Count <> 1 Then
-                    AssertEx.Fail("The test must have a single $$ marking the symbol being renamed.")
+                    Assert.Fail("The test must have a single $$ marking the symbol being renamed.")
                 End If
 
                 Dim cursorDocument = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
 
                 Dim symbol = RenameUtilities.TryGetRenamableSymbolAsync(document, cursorPosition, CancellationToken.None).Result
                 If symbol Is Nothing Then
-                    AssertEx.Fail("The symbol touching the $$ could not be found.")
+                    Assert.Fail("The symbol touching the $$ could not be found.")
                 End If
 
                 Dim result = GetConflictResolution(renameTo, workspace.CurrentSolution, symbol, renameOptions, host)
@@ -213,7 +213,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
 
             If locations.Count = 0 Then
                 _failedAssert = True
-                AssertEx.Fail(String.Format("The label '{0}' was not mentioned in the test.", label))
+                Assert.Fail(String.Format("The label '{0}' was not mentioned in the test.", label))
             End If
 
             Return locations
@@ -266,7 +266,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             ' over. So let's just suppress these so we don't lose the root cause
             If Not _failedAssert Then
                 If _unassertedRelatedLocations.Count > 0 Then
-                    AssertEx.Fail(
+                    Assert.Fail(
                         "There were additional related locations that were unasserted:" + Environment.NewLine _
                         + String.Join(Environment.NewLine,
                             From location In _unassertedRelatedLocations

--- a/src/EditorFeatures/Test2/Simplification/AbstractSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/AbstractSimplificationTests.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
             If explicitSpanToSimplifyAnnotatedSpans.Count <> 1 OrElse explicitSpanToSimplifyAnnotatedSpans.Single().Key <> "SpanToSimplify" Then
                 For Each span In explicitSpanToSimplifyAnnotatedSpans
                     If span.Key <> "SpanToSimplify" Then
-                        Assert.True(False, "Encountered unexpected span annotation: " + span.Key)
+                        Assert.Fail("Encountered unexpected span annotation: " + span.Key)
                     End If
                 Next
             End If

--- a/src/EditorFeatures/TestUtilities/BracePairs/AbstractBracePairsTests.cs
+++ b/src/EditorFeatures/TestUtilities/BracePairs/AbstractBracePairsTests.cs
@@ -42,7 +42,7 @@ public abstract class AbstractBracePairsTests
         foreach (var bracePair in bracePairs)
         {
             if (!FindMatch(expected, bracePair))
-                AssertEx.Fail($"Unexpected brace pair: {bracePair}");
+                Assert.Fail($"Unexpected brace pair: {bracePair}");
         }
     }
 

--- a/src/EditorFeatures/TestUtilities/Classification/ClassificationTestHelper.cs
+++ b/src/EditorFeatures/TestUtilities/Classification/ClassificationTestHelper.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Classification;
-using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification;
@@ -41,11 +40,11 @@ public static class ClassificationTestHelper
             {
                 if (i >= expectedClassificationList.Count)
                 {
-                    AssertEx.Fail("Unexpected actual classification: {0}", GetText(actualClassificationList[i]));
+                    Assert.Fail($"Unexpected actual classification: {GetText(actualClassificationList[i])}");
                 }
                 else if (i >= actualClassificationList.Count)
                 {
-                    AssertEx.Fail("Missing classification for: {0}", GetText(expectedClassificationList[i]));
+                    Assert.Fail($"Missing classification for: {GetText(expectedClassificationList[i])}");
                 }
 
                 var actual = actualClassificationList[i];

--- a/src/EditorFeatures/TestUtilities/KeywordHighlighting/AbstractKeywordHighlighterTests.cs
+++ b/src/EditorFeatures/TestUtilities/KeywordHighlighting/AbstractKeywordHighlighterTests.cs
@@ -73,13 +73,13 @@ public abstract class AbstractKeywordHighlighterTests
             {
                 var actualLineSpan = tree.GetLineSpan(highlightSpans[j]).Span;
                 var actualText = tree.GetText().ToString(highlightSpans[j]);
-                Assert.False(true, $"Unexpected highlight at {actualLineSpan}: '{actualText}'");
+                Assert.Fail($"Unexpected highlight at {actualLineSpan}: '{actualText}'");
             }
             else if (j >= highlightSpans.Count)
             {
                 var expectedLineSpan = tree.GetLineSpan(expectedHighlightSpans[j]).Span;
                 var expectedText = tree.GetText().ToString(expectedHighlightSpans[j]);
-                Assert.False(true, $"Missing highlight at {expectedLineSpan}: '{expectedText}'");
+                Assert.Fail($"Missing highlight at {expectedLineSpan}: '{expectedText}'");
             }
 
             var expected = expectedHighlightSpans[j];

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -259,7 +259,7 @@ public abstract class AbstractSignatureHelpProviderTests<TWorkspaceFixture> : Te
     {
         if (expectedOrderedItemsMetadataReference == null || expectedOrderedItemsSameSolution == null)
         {
-            AssertEx.Fail("Expected signature help items must be provided for EditorBrowsable tests. If there are no expected items, provide an empty IEnumerable rather than null.");
+            Assert.Fail("Expected signature help items must be provided for EditorBrowsable tests. If there are no expected items, provide an empty IEnumerable rather than null.");
         }
 
         await TestSignatureHelpWithMetadataReferenceHelperAsync(markup, referencedCode, expectedOrderedItemsMetadataReference, sourceLanguage, referencedLanguage, hideAdvancedMembers);

--- a/src/EditorFeatures/TestUtilities2/Utilities/AssertEx.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/AssertEx.vb
@@ -15,8 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             If expectedNewTokens.Count <> actualNewTokens.Count Then
                 Dim expectedDisplay = String.Join(" ", expectedNewTokens.Select(Function(t) t.ToString()))
                 Dim actualDisplay = String.Join(" ", actualNewTokens.Select(Function(t) t.ToString()))
-                Roslyn.Test.Utilities.AssertEx.Fail("Wrong token count. Expected '{0}', Actual '{1}', Expected Text: '{2}', Actual Text: '{3}'",
-                    expectedNewTokens.Count, actualNewTokens.Count, expectedDisplay, actualDisplay)
+                Assert.Fail($"Wrong token count. Expected '{expectedNewTokens.Count}', Actual '{actualNewTokens.Count}', Expected Text: '{expectedDisplay}', Actual Text: '{actualDisplay}'")
             End If
 
             For i = 0 To actualNewTokens.Count - 1

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/InlineMethod/VisualBasicInlineMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/InlineMethod/VisualBasicInlineMethodTests.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.InlineMethod
                 Dim firstMarkerIndex = expectedMarkUp.IndexOf(Marker)
                 Dim secondMarkerIndex = expectedMarkUp.LastIndexOf(Marker)
                 If firstMarkerIndex = -1 OrElse secondMarkerIndex = 1 OrElse firstMarkerIndex = secondMarkerIndex Then
-                    Assert.True(False, "Can't find proper marks that contains inlined method.")
+                    Assert.Fail("Can't find proper marks that contains inlined method.")
                 End If
 
                 Dim firstPartitionBeforeMarkUp = expectedMarkUp.Substring(0, firstMarkerIndex)
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.InlineMethod
                 Dim firstMarkerIndex = expectedMarkUpForCallee.IndexOf(Marker)
                 Dim secondMarkerIndex = expectedMarkUpForCallee.LastIndexOf(Marker)
                 If firstMarkerIndex = -1 OrElse secondMarkerIndex = -1 OrElse firstMarkerIndex = secondMarkerIndex Then
-                    Assert.True(False, "Can't find proper marks that contains inlined method.")
+                    Assert.Fail("Can't find proper marks that contains inlined method.")
                 End If
 
                 Dim firstPartitionBeforeMarkUp = expectedMarkUpForCallee.Substring(0, firstMarkerIndex)

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -66,7 +66,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
                     Assert.NotEqual(expected, subjectBuffer.CurrentSnapshot.GetText())
                 Else
                     If expected = "" Then
-                        Assert.True(False, subjectBuffer.CurrentSnapshot.GetText())
+                        Assert.Fail(subjectBuffer.CurrentSnapshot.GetText())
                     End If
 
                     AssertEx.EqualOrDiff(expected, subjectBuffer.CurrentSnapshot.GetText())

--- a/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
@@ -488,7 +488,7 @@ public abstract partial class AbstractCodeActionOrUserDiagnosticTest_NoEditor<
 
         if (expectedSpans.Length != unnecessaryLocations.Length)
         {
-            AssertEx.Fail(BuildFailureMessage(expectedSpans, WellKnownDiagnosticTags.Unnecessary, markupKey, initialMarkupWithoutSpans, diagnostics));
+            Assert.Fail(BuildFailureMessage(expectedSpans, WellKnownDiagnosticTags.Unnecessary, markupKey, initialMarkupWithoutSpans, diagnostics));
         }
 
         for (var i = 0; i < expectedSpans.Length; i++)
@@ -685,7 +685,7 @@ public abstract partial class AbstractCodeActionOrUserDiagnosticTest_NoEditor<
                 }
                 else
                 {
-                    AssertEx.Fail($"Could not find document with name '{doc.Name}'");
+                    Assert.Fail($"Could not find document with name '{doc.Name}'");
                 }
 
                 var expectedDocument = expectedDocuments.Single();

--- a/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
+++ b/src/Features/DiagnosticsTestUtilities/CodeActionsLegacy/AbstractCodeActionOrUserDiagnosticTest_NoEditor.cs
@@ -837,7 +837,7 @@ public abstract partial class AbstractCodeActionOrUserDiagnosticTest_NoEditor<
                         Consider using the title as the equivalence key instead of 'null'
                         """;
 
-                    Assert.False(true, $"""
+                    Assert.Fail($"""
                         Expected different 'CodeAction.EquivalenceKey' for code actions registered for same diagnostic:
                         - Name: '{provider.GetType().Name}'
                         - Title 1: '{codeAction.Title}'

--- a/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
+++ b/src/Features/TestUtilities/EditAndContinue/EditAndContinueWorkspaceTestBase.cs
@@ -529,7 +529,7 @@ public abstract class EditAndContinueWorkspaceTestBase : TestBase, IDisposable
     {
         public override Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
         {
-            Assert.True(false, $"Content of document should never be loaded");
+            Assert.Fail($"Content of document should never be loaded");
             throw ExceptionUtilities.Unreachable();
         }
     }

--- a/src/Features/TestUtilities/EditAndContinue/RudeEditDiagnosticDescription.cs
+++ b/src/Features/TestUtilities/EditAndContinue/RudeEditDiagnosticDescription.cs
@@ -79,7 +79,7 @@ internal readonly struct RudeEditDiagnosticDescription : IEquatable<RudeEditDiag
         }
         catch (FormatException)
         {
-            Assert.True(false, $"Message format string was not supplied enough arguments.\nRudeEditKind: {RudeEditKind}\nArguments supplied: {_arguments.Length}\nFormat string: {format}");
+            Assert.Fail($"Message format string was not supplied enough arguments.\nRudeEditKind: {RudeEditKind}\nArguments supplied: {_arguments.Length}\nFormat string: {format}");
         }
     }
 }

--- a/src/Features/TestUtilities/Snippets/AbstractSnippetProviderTests.cs
+++ b/src/Features/TestUtilities/Snippets/AbstractSnippetProviderTests.cs
@@ -89,7 +89,7 @@ public abstract class AbstractSnippetProviderTests
         {
             if (!int.TryParse(placeholderLocationPair.Key, out var locationIndex))
             {
-                Assert.True(false, "Expected placeholder locations contains span with invalid annotation");
+                Assert.Fail("Expected placeholder locations contains span with invalid annotation");
                 return;
             }
 
@@ -100,7 +100,7 @@ public abstract class AbstractSnippetProviderTests
         {
             if (placeholderLocationsArray[i].IsDefault)
             {
-                Assert.True(false, $"Placeholder location for index {i} was not specified");
+                Assert.Fail($"Placeholder location for index {i} was not specified");
             }
         }
 

--- a/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
+++ b/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
 
             if (remoteService == null)
             {
-                Assert.True(false, @$"
+                Assert.Fail(@$"
 Remote service unavailable
 STDERR: {_synchronizedErrorOutput}
 STDOUT: {_synchronizedOutput}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
@@ -62,8 +62,8 @@ public sealed class ServerInitializationTests : AbstractLanguageServerHostTests
         await using var server = await CreateLanguageServerAsync();
 
         var capabilities = server.ServerCapabilities as VSInternalServerCapabilities;
-        AssertEx.NotNull(capabilities);
-        AssertEx.NotNull(capabilities.OnAutoInsertProvider);
+        Assert.NotNull(capabilities);
+        Assert.NotNull(capabilities.OnAutoInsertProvider);
         Assert.NotEmpty(capabilities.OnAutoInsertProvider.TriggerCharacters);
     }
 }

--- a/src/LanguageServer/Protocol.TestUtilities/AbstractLspMiscellaneousFilesWorkspaceTests.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/AbstractLspMiscellaneousFilesWorkspaceTests.cs
@@ -259,7 +259,7 @@ public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLang
         // Verify file is added to the misc file workspace.
         await AssertFileInMiscWorkspaceAsync(testLspServer, looseFileUri).ConfigureAwait(false);
         var miscDoc = await GetMiscellaneousDocumentAsync(testLspServer);
-        AssertEx.NotNull(miscDoc);
+        Assert.NotNull(miscDoc);
         Assert.Equal(LanguageNames.CSharp, miscDoc.Project.Language);
     }
 
@@ -298,11 +298,11 @@ public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLang
         // Verify file was added to the misc file workspace.
         await AssertFileInMiscWorkspaceAsync(testLspServer, looseFileUri).ConfigureAwait(false);
         var miscDoc = await GetMiscellaneousDocumentAsync(testLspServer);
-        AssertEx.NotNull(miscDoc);
+        Assert.NotNull(miscDoc);
         Assert.Equal(LanguageNames.CSharp, miscDoc.Project.Language);
 
         // Verify GTD request succeeded.
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal(0, result.Single().Range.Start.Line);
         Assert.Equal(6, result.Single().Range.Start.Character);
         Assert.Equal(0, result.Single().Range.End.Line);
@@ -345,7 +345,7 @@ public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLang
         // Make a change and verify the misc document is updated.
         await testLspServer.InsertTextAsync(newDocumentUri, (0, 0, "More LSP text"));
         (_, miscDocument) = await GetLspWorkspaceAndDocumentAsync(newDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(miscDocument);
+        Assert.NotNull(miscDocument);
         var miscText = await miscDocument.GetTextAsync(CancellationToken.None);
         Assert.Equal("More LSP textLSP text", miscText.ToString());
         Assert.True(await testLspServer.GetManagerAccessor().IsMiscellaneousFilesDocumentAsync(miscDocument));
@@ -355,7 +355,7 @@ public abstract class AbstractLspMiscellaneousFilesWorkspaceTests : AbstractLang
 
         // Verify that the newly added document in the registered workspace is returned.
         var (documentWorkspace, document) = await GetLspWorkspaceAndDocumentAsync(newDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(document);
+        Assert.NotNull(document);
         Assert.Equal(GetHostWorkspace(testLspServer), documentWorkspace);
         Assert.False(await testLspServer.GetManagerAccessor().IsMiscellaneousFilesDocumentAsync(document));
         Assert.Equal(newDocumentId, document.Id);

--- a/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLspBuildOnlyDiagnosticsTests.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLspBuildOnlyDiagnosticsTests.cs
@@ -48,6 +48,6 @@ public abstract class AbstractLspBuildOnlyDiagnosticsTests
         }
 
         if (errorMessage.Length > 0)
-            AssertEx.Fail(errorMessage.ToString());
+            Assert.Fail(errorMessage.ToString());
     }
 }

--- a/src/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionResolveTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionResolveTests.cs
@@ -239,7 +239,7 @@ public sealed class CodeActionResolveTests : AbstractLanguageServerProtocolTests
 
         var actualResolvedAction = await RunGetCodeActionResolveAsync(testLspServer, unresolvedCodeAction);
 
-        AssertEx.NotNull(actualResolvedAction.Edit);
+        Assert.NotNull(actualResolvedAction.Edit);
         var textDocumentEdit = (LSP.TextDocumentEdit[])actualResolvedAction.Edit.DocumentChanges!.Value;
         Assert.Single(textDocumentEdit);
         var originalText = await testLspServer.GetDocumentTextAsync(textDocumentEdit[0].TextDocument.DocumentUri);

--- a/src/LanguageServer/ProtocolUnitTests/CodeLens/AbstractCodeLensTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/CodeLens/AbstractCodeLensTests.cs
@@ -36,7 +36,7 @@ public abstract class AbstractCodeLensTests : AbstractLanguageServerProtocolTest
         var expectedCodeLens = testLspServer.GetLocations("codeLens").Single();
 
         var actualCodeLenses = await GetCodeLensAsync(testLspServer);
-        AssertEx.NotNull(actualCodeLenses);
+        Assert.NotNull(actualCodeLenses);
         Assert.NotEmpty(actualCodeLenses);
 
         var matchingCodeLenses = actualCodeLenses.Where(actualCodeLens => actualCodeLens.Range == expectedCodeLens.Range);
@@ -46,7 +46,7 @@ public abstract class AbstractCodeLensTests : AbstractLanguageServerProtocolTest
         Assert.Null(matchingCodeLens.Command);
 
         var resolvedCodeLens = await testLspServer.ExecuteRequestAsync<LSP.CodeLens, LSP.CodeLens>(LSP.Methods.CodeLensResolveName, matchingCodeLens, CancellationToken.None);
-        AssertEx.NotNull(resolvedCodeLens?.Command);
+        Assert.NotNull(resolvedCodeLens?.Command);
 
         var expectedReferenceCountString = isCapped ? "99+" : expectedNumberOfReferences.ToString();
         Assert.True(resolvedCodeLens.Command.Title.StartsWith(expectedReferenceCountString));
@@ -63,7 +63,7 @@ public abstract class AbstractCodeLensTests : AbstractLanguageServerProtocolTest
         };
 
         var actualCodeLenses = await testLspServer.ExecuteRequestAsync<LSP.CodeLensParams, LSP.CodeLens[]?>(LSP.Methods.TextDocumentCodeLensName, codeLensParams, CancellationToken.None);
-        AssertEx.NotNull(actualCodeLenses);
+        Assert.NotNull(actualCodeLenses);
         Assert.NotEmpty(actualCodeLenses);
 
         var matchingCodeLenses = actualCodeLenses
@@ -86,7 +86,7 @@ public abstract class AbstractCodeLensTests : AbstractLanguageServerProtocolTest
         };
 
         var actualCodeLenses = await testLspServer.ExecuteRequestAsync<LSP.CodeLensParams, LSP.CodeLens[]?>(LSP.Methods.TextDocumentCodeLensName, codeLensParams, CancellationToken.None);
-        AssertEx.NotNull(actualCodeLenses);
+        Assert.NotNull(actualCodeLenses);
         Assert.NotEmpty(actualCodeLenses);
         Assert.All(actualCodeLenses, actualCodeLens => Assert.NotEqual(CodeLensHandler.RunTestsCommandIdentifier, actualCodeLens.Command?.CommandIdentifier));
     }

--- a/src/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
@@ -436,7 +436,7 @@ public sealed class CSharpCodeLensTests : AbstractCodeLensTests
         var actualCodeLenses = await testLspServer.ExecuteRequestAsync<LSP.CodeLensParams, LSP.CodeLens[]?>(LSP.Methods.TextDocumentCodeLensName, codeLensParamsDoc1, CancellationToken.None);
         var firstCodeLens = actualCodeLenses!.First();
         var data = JsonSerializer.Deserialize<CodeLensResolveData>(firstCodeLens.Data!.ToString()!, ProtocolConversions.LspJsonSerializerOptions);
-        AssertEx.NotNull(data);
+        Assert.NotNull(data);
 
         // Update the document so the syntax version changes
         await testLspServer.OpenDocumentAsync(documentUri);

--- a/src/LanguageServer/ProtocolUnitTests/Commands/ExecuteWorkspaceCommandTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Commands/ExecuteWorkspaceCommandTests.cs
@@ -39,7 +39,7 @@ public sealed class ExecuteWorkspaceCommandTests : AbstractLanguageServerProtoco
             Command = TestWorkspaceCommandHandler.CommandName
         };
         var response = await server.ExecuteRequestAsync<ExecuteCommandParams, object>(Methods.WorkspaceExecuteCommandName, request, CancellationToken.None);
-        AssertEx.NotNull(response);
+        Assert.NotNull(response);
         Assert.True((bool)response);
 
     }

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -92,7 +92,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
         var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
         var results = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName, completionParams, CancellationToken.None);
-        AssertEx.NotNull(results);
+        Assert.NotNull(results);
         Assert.NotEmpty(results.Items);
     }
 
@@ -664,7 +664,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
         var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
         var results = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName, completionParams, CancellationToken.None);
-        AssertEx.NotNull(results);
+        Assert.NotNull(results);
         Assert.NotEmpty(results.Items);
         Assert.Equal(new() { Start = new(2, 0), End = caret.Range.Start }, results.ItemDefaults.EditRange.Value.First);
     }
@@ -771,7 +771,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
         var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
         var results = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName, completionParams, CancellationToken.None);
-        AssertEx.NotNull(results);
+        Assert.NotNull(results);
         Assert.NotEmpty(results.Items);
         Assert.Empty(results.ItemDefaults.CommitCharacters);
         Assert.True(results.Items.All(item => item.CommitCharacters is null));
@@ -1103,7 +1103,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         // Because of the limit in list size, we should not have item "if" returned here
         var results = await testLspServer.ExecuteRequestAsync<LSP.CompletionParams, LSP.CompletionList>(LSP.Methods.TextDocumentCompletionName, completionParams, CancellationToken.None);
-        AssertEx.NotNull(results);
+        Assert.NotNull(results);
         Assert.True(results.IsIncomplete);
         Assert.Equal(listMaxSize, results.Items.Length);
         Assert.False(results.Items.Any(i => i.Label == "if"));

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -1534,7 +1534,7 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
             triggerKind: LSP.CompletionTriggerKind.Invoked);
 
         var results = await RunGetCompletionsAsync(testLspServer, completionParams);
-        AssertEx.NotNull(results);
+        Assert.NotNull(results);
         Assert.NotEmpty(results.Items);
         Assert.Equal(new() { Start = new(2, 0), End = new(2, 8) }, results.ItemDefaults.EditRange.Value.First);
     }
@@ -1621,7 +1621,6 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
             triggerKind: LSP.CompletionTriggerKind.TriggerForIncompleteCompletions);
 
         var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
-        AssertEx.NotNull(results);
 
         var nullItem = results.Items.SingleOrDefault(i => i.Label == "null");
         var nuintItem = results.Items.SingleOrDefault(i => i.Label == "nuint");
@@ -1659,7 +1658,6 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
             triggerKind: LSP.CompletionTriggerKind.TriggerForIncompleteCompletions);
 
         var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
-        AssertEx.NotNull(results);
 
         // Find a standard keyword like "int" — it should have default (0) MatchPriority
         var intItem = results.Items.SingleOrDefault(i => i.Label == "int");

--- a/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -199,7 +199,7 @@ public sealed class DidChangeConfigurationNotificationHandlerTest : AbstractLang
         {
             if (WorkspaceDidChangeConfigurationRegistered)
             {
-                AssertEx.Fail($"{Methods.WorkspaceDidChangeConfigurationName} is registered twice.");
+                Assert.Fail($"{Methods.WorkspaceDidChangeConfigurationName} is registered twice.");
                 return;
             }
 

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
@@ -107,7 +107,7 @@ public abstract class AbstractPullDiagnosticTestsBase(ITestOutputHelper testOutp
             diagnostics = progress!.Value.GetFlattenedValues();
         }
 
-        AssertEx.NotNull(diagnostics);
+        Assert.NotNull(diagnostics);
         return [.. diagnostics.Select(d => new TestDiagnosticResult(d.TextDocument!, d.ResultId!, d.Diagnostics))];
     }
 
@@ -144,7 +144,7 @@ public abstract class AbstractPullDiagnosticTestsBase(ITestOutputHelper testOutp
 
         }
 
-        AssertEx.NotNull(returnedResult);
+        Assert.NotNull(returnedResult);
         return [.. returnedResult.Items.Select(diagnostics => ConvertWorkspaceDiagnosticResult(diagnostics))];
     }
 
@@ -265,7 +265,7 @@ public abstract class AbstractPullDiagnosticTestsBase(ITestOutputHelper testOutp
                 diagnostics = progress!.Value.GetFlattenedValues();
             }
 
-            AssertEx.NotNull(diagnostics);
+            Assert.NotNull(diagnostics);
             return [.. diagnostics.Select(d => new TestDiagnosticResult(vsTextDocumentIdentifier, d.ResultId!, d.Diagnostics))];
         }
         else
@@ -279,7 +279,7 @@ public abstract class AbstractPullDiagnosticTestsBase(ITestOutputHelper testOutp
             {
                 Assert.IsType<FullDocumentDiagnosticReport>(diagnostics.Value);
                 Assert.Empty(diagnostics.First.Items);
-                AssertEx.NotNull(progress);
+                Assert.NotNull(progress);
                 diagnostics = progress.Value.GetValues()!.Single().First;
             }
 

--- a/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -735,7 +735,7 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
 
             results = await RunGetDocumentPullDiagnosticsAsync(testLspServer, document.GetURI(), useVSDiagnostics, previousResultId: secondResultId);
             var thirdResultId = results.Single().ResultId;
-            AssertEx.NotNull(results.Single().Diagnostics);
+            Assert.NotNull(results.Single().Diagnostics);
             Assert.Empty(results.Single().Diagnostics!);
             Assert.NotEqual(firstResultId, thirdResultId);
         }
@@ -790,7 +790,7 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         var sourceGeneratorDocumentUri = SourceGeneratedDocumentUri.Create(sourceGeneratedDocumentIdentity);
 
         var originalSgText = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(originalSgText);
+        Assert.NotNull(originalSgText);
         Assert.Equal("Iteration0", originalSgText.Text);
 
         // Open the document - this will cause the queue to generate frozen sg documents based on the LSP open text
@@ -1806,7 +1806,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Verify we a diagnostic in A.cs since B does not exist
         // and a diagnostic in B.cs since it is missing the class name.
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
-        AssertEx.NotNull(results);
         Assert.Equal(4, results.Length);
         Assert.Equal("CS0246", results[0].Diagnostics!.Single().Code);
         Assert.Equal("CS1001", results[2].Diagnostics!.Single().Code);
@@ -1820,7 +1819,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Get updated workspace diagnostics for the change.
         var previousResultIds = CreateDiagnosticParamsFromPreviousReports(results);
         results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, previousResults: previousResultIds);
-        AssertEx.NotNull(results);
 
         // We should get updated diagnostics for both A and B now that B exists.
         Assert.Equal(2, results.Length);
@@ -1887,7 +1885,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
 
         // Verify we have diagnostics in A.cs, B.cs, and C.cs initially.
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
-        AssertEx.NotNull(results);
         Assert.Equal(6, results.Length);
         // Type C does not exist.
         Assert.Equal("CS0246", results[0].Diagnostics!.Single().Code);
@@ -1908,7 +1905,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Get updated workspace diagnostics for the change.
         var previousResultIds = CreateDiagnosticParamsFromPreviousReports(results);
         results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, previousResults: previousResultIds).ConfigureAwait(false);
-        AssertEx.NotNull(results);
 
         // Verify that we get 3 new reports as the diagnostics in A.cs, B.cs, and C.cs have all changed due to the transitive change in C.cs.
         Assert.Equal(3, results.Length);
@@ -1962,7 +1958,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Verify we a diagnostic in A.cs since B does not exist
         // and a diagnostic in B.cs since it is missing the class name.
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
-        AssertEx.NotNull(results);
         Assert.Equal(4, results.Length);
         Assert.Equal("CS0246", results[0].Diagnostics!.Single().Code);
         AssertEx.Empty(results[1].Diagnostics);
@@ -1978,7 +1973,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Get updated workspace diagnostics for the change.
         var previousResultIds = CreateDiagnosticParamsFromPreviousReports(results);
         results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, previousResultIds);
-        AssertEx.NotNull(results);
 
         // We should get 1 report from B.cs reflecting the change we made to it.
         // A.cs is unchanged and we will not get a report for it.
@@ -2030,7 +2024,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Verify we a diagnostic in A.cs since B does not exist
         // and a diagnostic in B.cs since it is missing the class name.
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
-        AssertEx.NotNull(results);
         Assert.Equal(4, results.Length);
         AssertEx.Empty(results[0].Diagnostics);
         Assert.Equal("CS0168", results[2].Diagnostics!.Single().Code);
@@ -2046,8 +2039,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Get updated workspace diagnostics for the change.
         var previousResultIds = CreateDiagnosticParamsFromPreviousReports(results);
         results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, previousResults: previousResultIds);
-
-        AssertEx.NotNull(results);
 
         // We should get a single report back for B.cs now that the diagnostic has been promoted to an error.
         // The diagnostics in A.cs did not change and so are not reported again.
@@ -2093,7 +2084,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Verify we a diagnostic in A.cs since B does not exist
         // and a diagnostic in B.cs since it is missing the class name.
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
-        AssertEx.NotNull(results);
         Assert.Equal(4, results.Length);
         Assert.Equal("CS0246", results[0].Diagnostics!.Single().Code);
         Assert.Equal("CS1001", results[2].Diagnostics!.Single().Code);
@@ -2111,7 +2101,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Verify that since no actual changes have been made we report unchanged diagnostics.
         // We get an empty array here as this is workspace diagnostics, and we do not report unchanged
         // docs there for efficiency.
-        AssertEx.NotNull(results);
         Assert.Empty(results);
     }
 
@@ -2149,7 +2138,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Verify we a diagnostic in A.cs since B does not exist
         // and a diagnostic in B.cs since it is missing the class name.
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
-        AssertEx.NotNull(results);
         Assert.Equal(6, results.Length);
         Assert.Equal("CS0246", results[0].Diagnostics!.Single().Code);
 
@@ -2167,7 +2155,6 @@ public sealed class PullDiagnosticTests(ITestOutputHelper testOutputHelper) : Ab
         // Verify that since no actual changes have been made we report unchanged diagnostics.
         // We get an empty array here as this is workspace diagnostics, and we do not report unchanged
         // docs there for efficiency.
-        AssertEx.NotNull(results);
         Assert.Empty(results);
     }
 

--- a/src/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.cs
@@ -86,7 +86,7 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
 
             var document = testLspServer.GetTrackedTexts().FirstOrDefault();
 
-            AssertEx.NotNull(document);
+            Assert.NotNull(document);
             Assert.Equal(documentText, document.ToString());
         }
     }
@@ -209,7 +209,7 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
 
             var document = testLspServer.GetTrackedTexts().FirstOrDefault();
 
-            AssertEx.NotNull(document);
+            Assert.NotNull(document);
             Assert.Equal("""
                 class A
                 {
@@ -280,7 +280,7 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
 
             var document = testLspServer.GetTrackedTexts().FirstOrDefault();
 
-            AssertEx.NotNull(document);
+            Assert.NotNull(document);
             Assert.Equal("""
             class A
             {
@@ -315,7 +315,7 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
 
             var document = testLspServer.GetTrackedTexts().FirstOrDefault();
 
-            AssertEx.NotNull(document);
+            Assert.NotNull(document);
             Assert.Equal("""
             class A
             {
@@ -349,7 +349,7 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
 
             var document = testLspServer.GetTrackedTexts().FirstOrDefault();
 
-            AssertEx.NotNull(document);
+            Assert.NotNull(document);
             Assert.Equal("""
             class A
             {
@@ -428,7 +428,7 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
 
             var document = testLspServer.GetTrackedTexts().FirstOrDefault();
 
-            AssertEx.NotNull(document);
+            Assert.NotNull(document);
             Assert.Equal("""
             class A
             {

--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -547,7 +547,7 @@ class C
         var project = testLspServer.GetCurrentSolution().Projects.Single(p => p.AssemblyName == "Net472");
         var result = await RunGetHoverAsync(testLspServer, location, project.Id);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal($"""
             ```csharp
             ({FeaturesResources.constant}) string WithConstant.Target = "Target in net472"

--- a/src/LanguageServer/ProtocolUnitTests/InlayHint/AbstractInlayHintTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/InlayHint/AbstractInlayHintTests.cs
@@ -34,7 +34,7 @@ public abstract class AbstractInlayHintTests : AbstractLanguageServerProtocolTes
         };
 
         var actualInlayHints = await testLspServer.ExecuteRequestAsync<LSP.InlayHintParams, LSP.InlayHint[]?>(LSP.Methods.TextDocumentInlayHintName, inlayHintParams, CancellationToken.None);
-        AssertEx.NotNull(actualInlayHints);
+        Assert.NotNull(actualInlayHints);
 
         foreach (var kvp in expectedInlayHints)
         {
@@ -49,16 +49,16 @@ public abstract class AbstractInlayHintTests : AbstractLanguageServerProtocolTes
                 var matchingInlayHint = matchingInlayHints.Single();
                 AssertEx.Equal(name, matchingInlayHint.Label.First.TrimEnd(':'));
 
-                AssertEx.NotNull(matchingInlayHint.Kind);
+                Assert.NotNull(matchingInlayHint.Kind);
                 Assert.True(matchingInlayHint.PaddingRight);
                 Assert.False(matchingInlayHint.PaddingLeft);
                 if (hasTextEdits)
                 {
-                    AssertEx.NotNull(matchingInlayHint.TextEdits);
+                    Assert.NotNull(matchingInlayHint.TextEdits);
                 }
 
                 var resolvedInlayHint = await testLspServer.ExecuteRequestAsync<LSP.InlayHint, LSP.InlayHint>(LSP.Methods.InlayHintResolveName, matchingInlayHint, CancellationToken.None);
-                AssertEx.NotNull(resolvedInlayHint?.ToolTip);
+                Assert.NotNull(resolvedInlayHint?.ToolTip);
             }
         }
     }

--- a/src/LanguageServer/ProtocolUnitTests/InlayHint/CSharpInlayHintTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/InlayHint/CSharpInlayHintTests.cs
@@ -121,10 +121,10 @@ public sealed class CSharpInlayHintTests : AbstractInlayHintTests
         };
 
         var actualInlayHints = await testLspServer.ExecuteRequestAsync<LSP.InlayHintParams, LSP.InlayHint[]?>(LSP.Methods.TextDocumentInlayHintName, inlayHintParams, CancellationToken.None);
-        AssertEx.NotNull(actualInlayHints);
+        Assert.NotNull(actualInlayHints);
         var firstInlayHint = actualInlayHints.First();
         var data = JsonSerializer.Deserialize<InlayHintResolveData>(firstInlayHint.Data!.ToString()!, ProtocolConversions.LspJsonSerializerOptions);
-        AssertEx.NotNull(data);
+        Assert.NotNull(data);
         var firstResultId = data.ResultId;
 
         // Verify the inlay hint item is in the cache.
@@ -135,7 +135,7 @@ public sealed class CSharpInlayHintTests : AbstractInlayHintTests
         await testLspServer.ExecuteRequestAsync<LSP.InlayHintParams, LSP.InlayHint[]?>(LSP.Methods.TextDocumentInlayHintName, inlayHintParams, CancellationToken.None);
         await testLspServer.ExecuteRequestAsync<LSP.InlayHintParams, LSP.InlayHint[]?>(LSP.Methods.TextDocumentInlayHintName, inlayHintParams, CancellationToken.None);
         var lastInlayHints = await testLspServer.ExecuteRequestAsync<LSP.InlayHintParams, LSP.InlayHint[]?>(LSP.Methods.TextDocumentInlayHintName, inlayHintParams, CancellationToken.None);
-        AssertEx.NotNull(lastInlayHints);
+        Assert.NotNull(lastInlayHints);
         Assert.True(lastInlayHints.Any());
 
         // Assert that the first result id is no longer in the cache.

--- a/src/LanguageServer/ProtocolUnitTests/InlineCompletions/InlineCompletionsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/InlineCompletions/InlineCompletionsTests.cs
@@ -244,11 +244,11 @@ public sealed class InlineCompletionsTests : AbstractLanguageServerProtocolTests
 
         var result = await GetInlineCompletionsAsync(testLspServer, locationTyped, options ?? new LSP.FormattingOptions { InsertSpaces = true, TabSize = 4 });
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Single(result.Items);
 
         var item = result.Items.Single();
-        AssertEx.NotNull(item.Range);
+        Assert.NotNull(item.Range);
         Assert.Equal(LSP.InsertTextFormat.Snippet, item.TextFormat);
         Assert.Equal(expected.ReplaceLineEndings("\r\n"), item.Text.ReplaceLineEndings("\r\n"));
     }

--- a/src/LanguageServer/ProtocolUnitTests/MapCode/MapCodeTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/MapCode/MapCodeTests.cs
@@ -96,7 +96,7 @@ public sealed class MapCodeTests : AbstractLanguageServerProtocolTests
         var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
         var results = await testLspServer.ExecuteRequestAsync<LSP.VSInternalMapCodeParams, LSP.WorkspaceEdit>(VSInternalMethods.WorkspaceMapCodeName, mapCodeParams, CancellationToken.None);
-        AssertEx.NotNull(results);
+        Assert.NotNull(results);
 
         TextEdit[]? edits;
         if (supportDocumentChanges)
@@ -117,7 +117,7 @@ public sealed class MapCodeTests : AbstractLanguageServerProtocolTests
             Assert.True(results.Changes!.TryGetValue(ProtocolConversions.GetDocumentFilePathFromUri(documentUri.GetRequiredParsedUri()), out edits));
         }
 
-        AssertEx.NotNull(edits);
+        Assert.NotNull(edits);
 
         var documentText = await document.GetTextAsync();
         var actualText = ApplyTextEdits(edits, documentText);

--- a/src/LanguageServer/ProtocolUnitTests/Metadata/LspMetadataAsSourceWorkspaceTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Metadata/LspMetadataAsSourceWorkspaceTests.cs
@@ -41,7 +41,7 @@ public sealed class LspMetadataAsSourceWorkspaceTests : AbstractLanguageServerPr
         var location = testLspServer.GetLocations("definition").Single();
         var definition = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Location[]>(LSP.Methods.TextDocumentDefinitionName,
                            CreateTextDocumentPositionParams(location), CancellationToken.None);
-        AssertEx.NotNull(definition);
+        Assert.NotNull(definition);
 
         // Open the metadata file and verify it gets added to the metadata workspace.
         await testLspServer.OpenDocumentAsync(definition.Single().DocumentUri, text: string.Empty).ConfigureAwait(false);
@@ -78,7 +78,7 @@ public sealed class LspMetadataAsSourceWorkspaceTests : AbstractLanguageServerPr
         var location = testLspServer.GetLocations("definition").Single();
         var definition = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Location[]>(LSP.Methods.TextDocumentDefinitionName,
                            CreateTextDocumentPositionParams(location), CancellationToken.None);
-        AssertEx.NotNull(definition);
+        Assert.NotNull(definition);
 
         // Open the metadata file and verify it gets added to the metadata workspace.
         // We don't have the real metadata source, so just populate it with our fake metadata source.

--- a/src/LanguageServer/ProtocolUnitTests/OnAutoInsert/AbstractOnAutoInsertTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/OnAutoInsert/AbstractOnAutoInsertTests.cs
@@ -52,7 +52,7 @@ public abstract class AbstractOnAutoInsertTests(ITestOutputHelper testOutputHelp
 
         var result = await RunOnAutoInsertAsync(testLspServer, characterTyped, locationTyped, insertSpaces, tabSize);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal(InsertTextFormat.Snippet, result.TextEditFormat);
         var actualText = ApplyTextEdits([result.TextEdit], documentText);
         Assert.Equal(expected, actualText);

--- a/src/LanguageServer/ProtocolUnitTests/OnAutoInsert/RawStringOnAutoInsertTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/OnAutoInsert/RawStringOnAutoInsertTests.cs
@@ -221,7 +221,7 @@ public sealed class RawStringOnAutoInsertTests(ITestOutputHelper testOutputHelpe
 
         var result = await RunOnAutoInsertAsync(testLspServer, characterTyped, locationTyped, insertSpaces: true, tabSize: 4);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         var actualText = ApplyTextEdits([result.TextEdit], documentText);
 
         var expectedCaret = expected.IndexOf("$0");

--- a/src/LanguageServer/ProtocolUnitTests/SpellCheck/SpellCheckTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/SpellCheck/SpellCheckTests.cs
@@ -630,7 +630,7 @@ class {|Identifier:A{{v}}|}
                 spans = progress!.Value.GetFlattenedValues();
             }
 
-            AssertEx.NotNull(spans);
+            Assert.NotNull(spans);
             return spans;
         }
 
@@ -651,7 +651,7 @@ class {|Identifier:A{{v}}|}
                 spans = progress!.Value.GetFlattenedValues();
             }
 
-            AssertEx.NotNull(spans);
+            Assert.NotNull(spans);
             return spans;
         }
 

--- a/src/LanguageServer/ProtocolUnitTests/UriTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/UriTests.cs
@@ -149,14 +149,14 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
 
         // Verify file is added to the workspace and the text matches the file document
         var (workspace, _, fileDocument) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { DocumentUri = fileDocumentUri }, CancellationToken.None);
-        AssertEx.NotNull(fileDocument);
+        Assert.NotNull(fileDocument);
         var fileTextResult = await fileDocument.GetTextAsync();
         Assert.Equal(fileDocumentUri, fileDocument.GetURI());
         Assert.Equal(fileDocumentText, fileTextResult.ToString());
 
         // Verify file is added to the workspace and the text matches the git document
         var (gitWorkspace, _, gitDocument) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { DocumentUri = gitDocumentUri }, CancellationToken.None);
-        AssertEx.NotNull(gitDocument);
+        Assert.NotNull(gitDocument);
         var gitText = await gitDocument.GetTextAsync();
         Assert.Equal(gitDocumentUri, gitDocument.GetURI());
         Assert.Equal(gitDocumentText, gitText.ToString());
@@ -185,7 +185,7 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
 
         // Access the document using the unencoded URI to make sure we find it in the C# misc files.
         var (workspace, _, lspDocument) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { DocumentUri = unencodedUri }, CancellationToken.None).ConfigureAwait(false);
-        AssertEx.NotNull(lspDocument);
+        Assert.NotNull(lspDocument);
         Assert.Equal(WorkspaceKind.MiscellaneousFiles, workspace?.Kind);
         Assert.Equal(LanguageNames.CSharp, lspDocument.Project.Language);
         var originalText = await lspDocument.GetTextAsync(CancellationToken.None);
@@ -201,7 +201,7 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
 
         var (encodedWorkspace, _, encodedDocument) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { DocumentUri = encodedUri }, CancellationToken.None).ConfigureAwait(false);
         Assert.Same(workspace, encodedWorkspace);
-        AssertEx.NotNull(encodedDocument);
+        Assert.NotNull(encodedDocument);
         Assert.Equal(LanguageNames.CSharp, encodedDocument.Project.Language);
         var encodedText = await encodedDocument.GetTextAsync(CancellationToken.None);
         Assert.Equal("LSP text", encodedText.ToString());
@@ -233,7 +233,7 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
 
         // Access the document using the upper case to make sure we find it in the C# misc files.
         var (workspace, _, lspDocument) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { DocumentUri = upperCaseUri }, CancellationToken.None).ConfigureAwait(false);
-        AssertEx.NotNull(lspDocument);
+        Assert.NotNull(lspDocument);
         Assert.Equal(WorkspaceKind.MiscellaneousFiles, workspace?.Kind);
         Assert.Equal(LanguageNames.CSharp, lspDocument.Project.Language);
         var originalText = await lspDocument.GetTextAsync(CancellationToken.None);
@@ -247,7 +247,7 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
 
         var (lowerCaseWorkspace, _, lowerCaseDocument) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { DocumentUri = lowerCaseUri }, CancellationToken.None).ConfigureAwait(false);
         Assert.Same(workspace, lowerCaseWorkspace);
-        AssertEx.NotNull(lowerCaseDocument);
+        Assert.NotNull(lowerCaseDocument);
         Assert.Equal(LanguageNames.CSharp, lowerCaseDocument.Project.Language);
         var lowerCaseText = await lowerCaseDocument.GetTextAsync(CancellationToken.None);
         Assert.Equal("LSP text", lowerCaseText.ToString());
@@ -279,7 +279,7 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
 
         // Access the document using the upper case to make sure we find it in the C# misc files.
         var (workspace, _, lspDocument) = await testLspServer.GetManager().GetLspDocumentInfoAsync(new LSP.TextDocumentIdentifier { DocumentUri = upperCaseUri }, CancellationToken.None).ConfigureAwait(false);
-        AssertEx.NotNull(lspDocument);
+        Assert.NotNull(lspDocument);
         Assert.Equal(WorkspaceKind.MiscellaneousFiles, workspace?.Kind);
         Assert.Equal(LanguageNames.CSharp, lspDocument.Project.Language);
         var originalText = await lspDocument.GetTextAsync(CancellationToken.None);

--- a/src/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
@@ -33,13 +33,13 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         await testLspServer.OpenDocumentAsync(documentUri, "LSP text");
 
         var (_, lspDocument) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(lspDocument);
+        Assert.NotNull(lspDocument);
         Assert.Equal("LSP text", (await lspDocument.GetTextAsync(CancellationToken.None)).ToString());
 
         // Verify LSP text changes are reflected in the opened document.
         await testLspServer.InsertTextAsync(documentUri, (0, 0, "More text"));
         (_, lspDocument) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(lspDocument);
+        Assert.NotNull(lspDocument);
         Assert.Equal("More textLSP text", (await lspDocument.GetTextAsync(CancellationToken.None)).ToString());
 
         // Close the document in LSP and verify all LSP tracked changes are now gone.
@@ -81,13 +81,13 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // Make a text change in one of the opened documents in both LSP and the workspace.
         await testLspServer.InsertTextAsync(firstDocumentUri, (0, 0, "Some more text"));
-        AssertEx.NotNull(firstDocument);
+        Assert.NotNull(firstDocument);
         await testLspServer.TestWorkspace.ChangeDocumentAsync(firstDocument.Id, SourceText.From($"Some more text{markupOne}", System.Text.Encoding.UTF8, SourceHashAlgorithms.Default));
 
         var (_, firstDocumentWithChange) = await GetLspWorkspaceAndDocumentAsync(firstDocumentUri, testLspServer).ConfigureAwait(false);
         var (_, secondDocumentUnchanged) = await GetLspWorkspaceAndDocumentAsync(secondDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(firstDocumentWithChange);
-        AssertEx.NotNull(secondDocumentUnchanged);
+        Assert.NotNull(firstDocumentWithChange);
+        Assert.NotNull(secondDocumentUnchanged);
 
         // Verify that the document that we inserted text into had a version change.
         Assert.NotEqual(firstDocumentInitialVersion, await firstDocumentWithChange.GetSyntaxVersionAsync(CancellationToken.None));
@@ -120,12 +120,12 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // Verify that the LSP solution has the LSP text from the open document.
         var (_, openedDocument) = await GetLspWorkspaceAndDocumentAsync(firstDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(openedDocument);
+        Assert.NotNull(openedDocument);
         Assert.Equal("LSP text", (await openedDocument.GetTextAsync(CancellationToken.None)).ToString());
 
         // Verify that the LSP solution has the workspace text in the closed document.
         (_, secondDocument) = await GetLspWorkspaceAndDocumentAsync(secondDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(secondDocument);
+        Assert.NotNull(secondDocument);
         Assert.Equal("Two is now three!", (await secondDocument.GetTextAsync()).ToString());
 
         if (mutatingLspWorkspace)
@@ -158,7 +158,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // Verify that the new LSP solution has the updated project info.
         (_, openedDocument) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(openedDocument);
+        Assert.NotNull(openedDocument);
         Assert.Equal(markup, (await openedDocument.GetTextAsync(CancellationToken.None)).ToString());
         Assert.Equal("NewCSProj1", openedDocument.Project.AssemblyName);
         Assert.Equal(testLspServer.TestWorkspace.CurrentSolution, openedDocument.Project.Solution);
@@ -191,7 +191,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // Verify that the new LSP solution has the updated project info.
         (_, openedDocument) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(openedDocument);
+        Assert.NotNull(openedDocument);
         Assert.Equal("LSP text", (await openedDocument.GetTextAsync(CancellationToken.None)).ToString());
         Assert.Equal("NewCSProj1", openedDocument.Project.AssemblyName);
 
@@ -225,7 +225,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         // Verify that the lsp server sees the workspace change and picks up the document in the correct workspace.
         await testLspServer.OpenDocumentAsync(newDocumentUri);
         var (_, lspDocument) = await GetLspWorkspaceAndDocumentAsync(newDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(lspDocument);
+        Assert.NotNull(lspDocument);
         Assert.Equal(testLspServer.TestWorkspace.CurrentSolution, lspDocument.Project.Solution);
     }
 
@@ -272,7 +272,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // Verify the host workspace returned is the workspace with kind host.
         var (_, hostSolution) = await GetLspHostWorkspaceAndSolutionAsync(testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(hostSolution);
+        Assert.NotNull(hostSolution);
         Assert.Equal("FirstWorkspaceProject", hostSolution.Projects.First().Name);
     }
 
@@ -336,12 +336,12 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // Verify we can get both documents from their respective workspaces.
         var (firstWorkspace, firstDocument) = await GetLspWorkspaceAndDocumentAsync(firstWorkspaceDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(firstDocument);
+        Assert.NotNull(firstDocument);
         Assert.Equal(firstWorkspaceDocumentUri, firstDocument.GetURI());
         Assert.Equal(testLspServer.TestWorkspace, firstWorkspace);
 
         var (secondWorkspace, secondDocument) = await GetLspWorkspaceAndDocumentAsync(secondWorkspaceDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(secondDocument);
+        Assert.NotNull(secondDocument);
         Assert.Equal(secondWorkspaceDocumentUri, secondDocument.GetURI());
         Assert.Equal(testWorkspaceTwo, secondWorkspace);
 
@@ -350,7 +350,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // The first document should now different text.
         var (_, changedFirstDocument) = await GetLspWorkspaceAndDocumentAsync(firstWorkspaceDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(changedFirstDocument);
+        Assert.NotNull(changedFirstDocument);
         var changedFirstDocumentText = await changedFirstDocument.GetTextAsync(CancellationToken.None);
         var firstDocumentText = await firstDocument.GetTextAsync(CancellationToken.None);
         Assert.NotEqual(firstDocumentText, changedFirstDocumentText);
@@ -391,12 +391,12 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // Verify we can get both documents from their respective workspaces.
         var (firstWorkspace, firstDocument) = await GetLspWorkspaceAndDocumentAsync(firstWorkspaceDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(firstDocument);
+        Assert.NotNull(firstDocument);
         Assert.Equal(firstWorkspaceDocumentUri, firstDocument.GetURI());
         Assert.Equal(testLspServer.TestWorkspace, firstWorkspace);
 
         var (secondWorkspace, secondDocument) = await GetLspWorkspaceAndDocumentAsync(secondWorkspaceDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(secondDocument);
+        Assert.NotNull(secondDocument);
         Assert.Equal(secondWorkspaceDocumentUri, secondDocument.GetURI());
         Assert.Equal(testWorkspaceTwo, secondWorkspace);
 
@@ -406,7 +406,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // The second document should have an updated project assembly name.
         var (_, secondDocumentChangedProject) = await GetLspWorkspaceAndDocumentAsync(secondWorkspaceDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(secondDocumentChangedProject);
+        Assert.NotNull(secondDocumentChangedProject);
         Assert.Equal("NewCSProj1", secondDocumentChangedProject.Project.AssemblyName);
         Assert.NotEqual(secondDocument, secondDocumentChangedProject);
 
@@ -441,7 +441,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         var documentServerOne = await OpenDocumentAndVerifyLspTextAsync(documentUri, testLspServerOne, "Server one text");
 
         var (_, documentServerTwo) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServerTwo).ConfigureAwait(false);
-        AssertEx.NotNull(documentServerTwo);
+        Assert.NotNull(documentServerTwo);
 
         if (mutatingLspWorkspace)
         {
@@ -461,10 +461,10 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // Verify LSP solution has the project changes.
         (_, documentServerOne) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServerOne).ConfigureAwait(false);
-        AssertEx.NotNull(documentServerOne);
+        Assert.NotNull(documentServerOne);
         Assert.Equal(newAssemblyName, documentServerOne.Project.AssemblyName);
         (_, documentServerTwo) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServerTwo).ConfigureAwait(false);
-        AssertEx.NotNull(documentServerTwo);
+        Assert.NotNull(documentServerTwo);
         Assert.Equal(newAssemblyName, documentServerTwo.Project.AssemblyName);
     }
 
@@ -482,7 +482,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         await testLspServer.OpenDocumentAsync(documentUri, "Text");
 
         var (_, lspDocument) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(lspDocument);
+        Assert.NotNull(lspDocument);
         Assert.Equal("Text", (await lspDocument.GetTextAsync(CancellationToken.None)).ToString());
 
         Assert.Same(testLspServer.TestWorkspace.CurrentSolution, lspDocument.Project.Solution);
@@ -507,7 +507,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         var (workspace1, document1) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
         Assert.Equal(WorkspaceKind.MiscellaneousFiles, workspace1?.Kind);
 
-        AssertEx.NotNull(document1);
+        Assert.NotNull(document1);
         Assert.Equal("Text", (await document1.GetTextAsync(CancellationToken.None)).ToString());
 
         // Now, add a project to the actual workspace containing Test1.cs with different content.
@@ -526,7 +526,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         (workspace1, document1) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
         Assert.Equal(WorkspaceKind.Host, workspace1?.Kind);
 
-        AssertEx.NotNull(document1);
+        Assert.NotNull(document1);
         Assert.Equal("Text", (await document1.GetTextAsync(CancellationToken.None)).ToString());
 
         // Retrieving the document from lsp should push its content into the workspace.
@@ -544,7 +544,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         (workspace1, document1) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
         Assert.Equal(WorkspaceKind.MiscellaneousFiles, workspace1?.Kind);
 
-        AssertEx.NotNull(document1);
+        Assert.NotNull(document1);
         Assert.Equal("Text", (await document1.GetTextAsync(CancellationToken.None)).ToString());
     }
 
@@ -565,7 +565,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(WorkspaceKind.Host, workspace?.Kind);
 
         // We should see the contents lsp told us about.
-        AssertEx.NotNull(document);
+        Assert.NotNull(document);
         Assert.Equal("Text", (await document.GetTextAsync(CancellationToken.None)).ToString());
 
         // Now, explicitly update the workspace, simulating the project system externally changing it.
@@ -579,7 +579,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         // However, once we retrieve from LSP, the lsp contents should be pushed back into the workspace.
         (workspace, document) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
 
-        AssertEx.NotNull(document);
+        Assert.NotNull(document);
         Assert.Equal("Text", (await document.GetTextAsync(CancellationToken.None)).ToString());
 
         document = testLspServer.TestWorkspace.CurrentSolution.Projects.Single().Documents.Single();
@@ -604,7 +604,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(WorkspaceKind.Host, workspace?.Kind);
 
         // We should see the contents lsp told us about.
-        AssertEx.NotNull(originalDocument);
+        Assert.NotNull(originalDocument);
         var originalSourceText = await originalDocument.GetTextAsync(CancellationToken.None);
         var originalRoot = await originalDocument.GetRequiredSyntaxRootAsync(CancellationToken.None);
         Assert.Equal(initialContents, originalSourceText.ToString());
@@ -615,7 +615,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         var (_, newDocument) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
 
-        AssertEx.NotNull(newDocument);
+        Assert.NotNull(newDocument);
         var newSourceText = await newDocument.GetTextAsync(CancellationToken.None);
         var newRoot = await newDocument.GetRequiredSyntaxRootAsync(CancellationToken.None);
         Assert.Equal("namespace N { class C1 { void X() { } } class C2 { void Y() { } } class D3 { void Z() { } } }", newSourceText.ToString());
@@ -663,7 +663,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         await Task.Delay(TimeSpan.FromSeconds(1));
 
         var sourceGeneratedDocument = await OpenDocumentAndVerifyLspTextAsync(sourceGeneratorDocumentUri, testLspServer, generatorText) as SourceGeneratedDocument;
-        AssertEx.NotNull(sourceGeneratedDocument);
+        Assert.NotNull(sourceGeneratedDocument);
         Assert.Same(testLspServer.TestWorkspace.CurrentSolution, sourceGeneratedDocument.Project.Solution);
     }
 
@@ -679,7 +679,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         var sourceGeneratorDocumentUri = SourceGeneratedDocumentUri.Create(sourceGeneratedDocumentIdentity);
 
         var sourceGeneratedDocument = await OpenDocumentAndVerifyLspTextAsync(sourceGeneratorDocumentUri, testLspServer, lspGeneratedText) as SourceGeneratedDocument;
-        AssertEx.NotNull(sourceGeneratedDocument);
+        Assert.NotNull(sourceGeneratedDocument);
         Assert.NotSame(testLspServer.TestWorkspace.CurrentSolution, sourceGeneratedDocument.Project.Solution);
     }
 
@@ -695,14 +695,14 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         var sourceGeneratorDocumentUri = SourceGeneratedDocumentUri.Create(sourceGeneratedDocumentIdentity);
 
         var sourceGeneratedDocument = await OpenDocumentAndVerifyLspTextAsync(sourceGeneratorDocumentUri, testLspServer, generatorText) as SourceGeneratedDocument;
-        AssertEx.NotNull(sourceGeneratedDocument);
+        Assert.NotNull(sourceGeneratedDocument);
         Assert.Same(testLspServer.TestWorkspace.CurrentSolution, sourceGeneratedDocument.Project.Solution);
 
         // Remove the generator and verify the document is forked.
         await RemoveGeneratorAsync(generatorReference, testLspServer.TestWorkspace);
 
         var (_, removedSourceGeneratorDocument) = await GetLspWorkspaceAndDocumentAsync(sourceGeneratorDocumentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(sourceGeneratedDocument as SourceGeneratedDocument);
+        Assert.NotNull(sourceGeneratedDocument as SourceGeneratedDocument);
         Assert.Equal(generatorText, (await sourceGeneratedDocument.GetTextAsync(CancellationToken.None)).ToString());
         Assert.NotSame(testLspServer.TestWorkspace.CurrentSolution, sourceGeneratedDocument.Project.Solution);
     }
@@ -713,7 +713,7 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
 
         // Verify we can find the document with correct text in the new LSP solution.
         var (_, lspDocument) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
-        AssertEx.NotNull(lspDocument);
+        Assert.NotNull(lspDocument);
         Assert.Equal(openText, (await lspDocument.GetTextAsync(CancellationToken.None)).ToString());
         return lspDocument;
     }

--- a/src/LanguageServer/ProtocolUnitTests/Workspaces/SourceGeneratedDocumentTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Workspaces/SourceGeneratedDocumentTests.cs
@@ -42,7 +42,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal("// Hello, World", result.Text);
     }
 
@@ -57,7 +57,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal("// Hello, World", result.Text);
 
         // Verifying opening and closing the document doesn't cause any issues.
@@ -80,7 +80,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         foreach (var sourceGeneratorDocumentUri in sourceGeneratorDocumentUris)
         {
             var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-            AssertEx.NotNull(result?.Text);
+            Assert.NotNull(result?.Text);
             await testLspServer.OpenDocumentAsync(sourceGeneratorDocumentUri, result.Text);
         }
 
@@ -104,7 +104,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, clientCapabilities);
 
         var textDocumentContentCapabilities = testLspServer.GetServerCapabilities().Workspace?.TextDocumentContent;
-        AssertEx.NotNull(textDocumentContentCapabilities);
+        Assert.NotNull(textDocumentContentCapabilities);
         Assert.Contains(SourceGeneratedDocumentUri.Scheme, textDocumentContentCapabilities.Schemes);
     }
 
@@ -122,7 +122,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         var hover = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Hover>(LSP.Methods.TextDocumentHoverName,
                 CreateTextDocumentPositionParams(location), CancellationToken.None);
 
-        AssertEx.NotNull(hover);
+        Assert.NotNull(hover);
         Assert.Contains("class A", hover.Contents.Fourth.Value);
     }
 
@@ -142,7 +142,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal(sourceGeneratorSource, result.Text);
     }
 
@@ -157,12 +157,12 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal("// Hello, World", result.Text);
 
         // Make a second request - since nothing has changed we should get back the same text.
         var secondResult = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(secondResult);
+        Assert.NotNull(secondResult);
         Assert.Equal("// Hello, World", secondResult.Text);
     }
 
@@ -183,7 +183,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal("// callCount: 0", result.Text);
 
         // Modify a normal document in the workspace.
@@ -198,13 +198,13 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         if (sourceGeneratorExecution == SourceGeneratorExecutionPreference.Automatic)
         {
             // We should get newly generated text
-            AssertEx.NotNull(secondResult);
+            Assert.NotNull(secondResult);
             Assert.Equal("// callCount: 1", secondResult.Text);
         }
         else
         {
             // We should get the same text as before
-            AssertEx.NotNull(secondResult);
+            Assert.NotNull(secondResult);
             Assert.Equal("// callCount: 0", secondResult.Text);
         }
     }
@@ -226,14 +226,14 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal("// callCount: 0", result.Text);
 
         // Updating the execution version should trigger source generators to run in both automatic and balanced mode.
         await testLspServer.RefreshSourceGeneratorsAsync(forceRegeneration: true);
 
         var secondResult = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(secondResult);
+        Assert.NotNull(secondResult);
         Assert.Equal("// callCount: 1", secondResult.Text);
     }
 
@@ -265,7 +265,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         Assert.Equal([sourceGeneratorDocumentUri], clientCallbackTarget.GetRefreshedUris());
 
         var refreshedResult = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(refreshedResult);
+        Assert.NotNull(refreshedResult);
         Assert.Equal("// callCount: 1", refreshedResult.Text);
     }
 
@@ -304,7 +304,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         }
 
         var refreshedResult = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(refreshedResult);
+        Assert.NotNull(refreshedResult);
         Assert.Equal(
             sourceGeneratorExecution == SourceGeneratorExecutionPreference.Automatic ? "// callCount: 1" : "// callCount: 0",
             refreshedResult.Text);
@@ -363,7 +363,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal("// callCount: 0", result.Text);
 
         var initialSolution = testLspServer.GetCurrentSolution();
@@ -376,7 +376,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         var solutionWithChangedExecutionVersion = testLspServer.GetCurrentSolution();
 
         var secondResult = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(secondResult);
+        Assert.NotNull(secondResult);
 
         if (forceRegeneration)
         {
@@ -444,7 +444,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         var sourceGeneratorDocumentUri = SourceGeneratedDocumentUri.Create(sourceGeneratedDocumentIdentity);
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal("// Hello, World", result.Text);
 
         // Remove the generator - the document is not opened so it will no longer exist in the workspace.
@@ -468,7 +468,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         var sourceGeneratorDocumentUri = SourceGeneratedDocumentUri.Create(sourceGeneratedDocumentIdentity);
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal("// Hello, World", result.Text);
 
         // Open the document - this will cause the queue to generate frozen sg documents based on the LSP open text
@@ -503,7 +503,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
 
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
         Assert.Equal("// callCount: 0", result.Text);
 
         await testLspServer.OpenDocumentAsync(documentUri, string.Empty);
@@ -515,7 +515,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         await testLspServer.WaitForSourceGeneratorsAsync();
 
         var secondResult = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(secondResult);
+        Assert.NotNull(secondResult);
         if (sourceGeneratorExecution == SourceGeneratorExecutionPreference.Automatic)
         {
             Assert.Equal("// callCount: 1", secondResult.Text);
@@ -535,7 +535,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         await testLspServer.WaitForSourceGeneratorsAsync();
 
         var thirdResult = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratorDocumentUri);
-        AssertEx.NotNull(thirdResult);
+        Assert.NotNull(thirdResult);
         Assert.Equal("// callCount: 1", thirdResult.Text);
     }
 
@@ -554,7 +554,7 @@ public sealed class SourceGeneratedDocumentTests(ITestOutputHelper? testOutputHe
         var sourceGeneratedDocumentUri = SourceGeneratedDocumentUri.Create(sourceGeneratedDocuments.Single().Identity);
 
         var result = await testLspServer.GetSourceGeneratedDocumentTextAsync(sourceGeneratedDocumentUri);
-        AssertEx.NotNull(result);
+        Assert.NotNull(result);
 
         await testLspServer.OpenDocumentAsync(sourceGeneratedDocumentUri, result.Text);
         await testLspServer.WaitForSourceGeneratorsAsync();

--- a/src/LanguageServer/ProtocolUnitTests/Workspaces/SourceGeneratedDocumentUriTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Workspaces/SourceGeneratedDocumentUriTests.cs
@@ -35,7 +35,7 @@ public sealed class SourceGeneratedDocumentUrisTests : AbstractLanguageServerPro
         Assert.Equal(SourceGeneratedDocumentUri.Scheme, uri.GetRequiredParsedUri().Scheme);
         var deserialized = SourceGeneratedDocumentUri.DeserializeIdentity(testLspServer.TestWorkspace.CurrentSolution, uri.GetRequiredParsedUri());
 
-        AssertEx.NotNull(deserialized);
+        Assert.NotNull(deserialized);
         Assert.Equal(identity, deserialized.Value);
 
         // Debug name is not considered as a the usual part of equality, but we want to ensure we pass this through too

--- a/src/RoslynAnalyzers/Test.Utilities/CodeMetricsTestsBase.cs
+++ b/src/RoslynAnalyzers/Test.Utilities/CodeMetricsTestsBase.cs
@@ -110,7 +110,7 @@ namespace Test.Utilities.CodeMetrics
             if (!success)
             {
                 // Dump the entire expected and actual lines for easy update to baseline.
-                Assert.True(false, $"Expected:\r\n{expectedMetricsText}\r\n\r\nActual:\r\n{actualMetricsText}");
+                Assert.Fail($"Expected:\r\n{expectedMetricsText}\r\n\r\nActual:\r\n{actualMetricsText}");
             }
         }
 

--- a/src/RoslynAnalyzers/Test.Utilities/CompilationUtils.cs
+++ b/src/RoslynAnalyzers/Test.Utilities/CompilationUtils.cs
@@ -23,7 +23,7 @@ namespace Test.Utilities
                 builder.Append(string.Concat(compileErrors.Select(x => "\n" + x.ToString())));
 
                 string message = builder.ToString();
-                Assert.True(false, message);
+                Assert.Fail(message);
             }
         }
     }

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1435,7 +1435,7 @@ d
             try
             {
                 CSharpScript.RunAsync<C<int>>("null", ScriptOptions);
-                Assert.True(false, "Expected an exception");
+                Assert.Fail("Expected an exception");
             }
             catch (CompilationErrorException e)
             {
@@ -1454,7 +1454,7 @@ d
             try
             {
                 CSharpScript.RunAsync<int>("null", ScriptOptions);
-                Assert.True(false, "Expected an exception");
+                Assert.Fail("Expected an exception");
             }
             catch (CompilationErrorException e)
             {
@@ -1467,7 +1467,7 @@ d
             try
             {
                 CSharpScript.RunAsync<string>("1+1", ScriptOptions);
-                Assert.True(false, "Expected an exception");
+                Assert.Fail("Expected an exception");
             }
             catch (CompilationErrorException e)
             {

--- a/src/Scripting/CoreTestUtilities/ScriptingTestHelpers.cs
+++ b/src/Scripting/CoreTestUtilities/ScriptingTestHelpers.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
             }
             catch (Exception e)
             {
-                Assert.False(true, "Unexpected exception: " + e);
+                Assert.Fail("Unexpected exception: " + e);
             }
 
             Assert.False(noException);

--- a/src/Test/PdbUtilities/Reader/PdbValidation.cs
+++ b/src/Test/PdbUtilities/Reader/PdbValidation.cs
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             bool originalIsPortable)
         {
             var pdbStreamConverted = new MemoryStream();
-            var converter = new PdbConverter(diagnostic => Assert.True(false, diagnostic.ToString()));
+            var converter = new PdbConverter(diagnostic => Assert.Fail(diagnostic.ToString()));
 
             peStreamOriginal.Position = 0;
             pdbStreamOriginal.Position = 0;

--- a/src/Tools/IdeBenchmarks/Lsp/LspSourceGeneratorBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/Lsp/LspSourceGeneratorBenchmarks.cs
@@ -130,7 +130,7 @@ namespace IdeBenchmarks.Lsp
                 new LSP.TextDocumentContentParams { Uri = sgUri },
                 CancellationToken.None);
 
-            AssertEx.NotNull(sgResult);
+            Assert.NotNull(sgResult);
             Assert.Contains("public partial class C", sgResult.Text);
         }
 

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionAssetCacheTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionAssetCacheTests.cs
@@ -64,7 +64,7 @@ public sealed class SolutionAssetCacheTests
         }
 
         // it should not reach here
-        AssertEx.Fail("asset not cleaned up");
+        Assert.Fail("asset not cleaned up");
     }
 
     [Fact]
@@ -119,6 +119,6 @@ public sealed class SolutionAssetCacheTests
         }
 
         // it should not reach here
-        AssertEx.Fail("asset not cleaned up");
+        Assert.Fail("asset not cleaned up");
     }
 }

--- a/src/VisualStudio/Core/Test/ChangeSignature/AddParameterViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/ChangeSignature/AddParameterViewModelTests.vb
@@ -300,7 +300,7 @@ class MyClass
                 Dim doc = workspace.Documents.Single()
                 Dim workspaceDoc = workspace.CurrentSolution.GetDocument(doc.Id)
                 If Not doc.CursorPosition.HasValue Then
-                    Assert.True(False, "Missing caret location in document.")
+                    Assert.Fail("Missing caret location in document.")
                 End If
 
                 Dim document = Await SemanticDocument.CreateAsync(workspaceDoc, CancellationToken.None)

--- a/src/VisualStudio/Core/Test/ChangeSignature/ChangeSignatureViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/ChangeSignature/ChangeSignatureViewModelTests.vb
@@ -459,7 +459,7 @@ class Goo
                 Dim doc = workspace.Documents.Single()
                 Dim workspaceDoc = workspace.CurrentSolution.GetDocument(doc.Id)
                 If (Not doc.CursorPosition.HasValue) Then
-                    Assert.True(False, "Missing caret location in document.")
+                    Assert.Fail("Missing caret location in document.")
                 End If
 
                 Dim tree = Await workspaceDoc.GetSyntaxTreeAsync()

--- a/src/VisualStudio/Core/Test/CommonControls/MemberSelectionViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/CommonControls/MemberSelectionViewModelTests.vb
@@ -156,7 +156,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CommonControls
         Private Shared Function FindMemberByName(name As String, memberArray As ImmutableArray(Of MemberSymbolViewModel)) As MemberSymbolViewModel
             Dim member = memberArray.FirstOrDefault(Function(memberViewModel) memberViewModel.SymbolName.Equals(name))
             If (member Is Nothing) Then
-                Assert.True(False, $"No member called {name} found")
+                Assert.Fail($"No member called {name} found")
             End If
 
             Return member

--- a/src/VisualStudio/Core/Test/CommonControls/NewTypeDestinationSelectionViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/CommonControls/NewTypeDestinationSelectionViewModelTests.vb
@@ -228,7 +228,7 @@ class $$MyClass
                 Dim doc = workspace.Documents.Single()
                 Dim workspaceDoc = workspace.CurrentSolution.GetDocument(doc.Id)
                 If (Not doc.CursorPosition.HasValue) Then
-                    Assert.True(False, "Missing caret location in document.")
+                    Assert.Fail("Missing caret location in document.")
                 End If
 
                 Dim tree = Await workspaceDoc.GetSyntaxTreeAsync()

--- a/src/VisualStudio/Core/Test/ExtractInterface/ExtractInterfaceViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/ExtractInterface/ExtractInterfaceViewModelTests.vb
@@ -289,7 +289,7 @@ public class $$MyClass
                 Dim doc = workspace.Documents.Single()
                 Dim workspaceDoc = workspace.CurrentSolution.GetDocument(doc.Id)
                 If Not doc.CursorPosition.HasValue Then
-                    Assert.True(False, "Missing caret location in document.")
+                    Assert.Fail("Missing caret location in document.")
                 End If
 
                 Dim tree = Await workspaceDoc.GetSyntaxTreeAsync()

--- a/src/VisualStudio/Core/Test/Preview/PreviewChangesTests.vb
+++ b/src/VisualStudio/Core/Test/Preview/PreviewChangesTests.vb
@@ -375,7 +375,7 @@ End Class
                 End If
             Next
 
-            Assert.True(False, "Didn't find child with name '" + text + "'")
+            Assert.Fail("Didn't find child with name '" + text + "'")
         End Sub
 
     End Class

--- a/src/VisualStudio/Core/Test/PullMemberUp/PullMemberUpViewModelTest.vb
+++ b/src/VisualStudio/Core/Test/PullMemberUp/PullMemberUpViewModelTest.vb
@@ -229,7 +229,7 @@ class MyClass : Level1BaseClass, Level1Interface
         Private Shared Function FindMemberByName(name As String, memberArray As ImmutableArray(Of MemberSymbolViewModel)) As MemberSymbolViewModel
             Dim member = memberArray.FirstOrDefault(Function(memberViewModel) memberViewModel.SymbolName.Equals(name))
             If (member Is Nothing) Then
-                Assert.True(False, $"No member called {name} found")
+                Assert.Fail($"No member called {name} found")
             End If
 
             Return member

--- a/src/VisualStudio/Core/Test/RQName/RQNameTests.vb
+++ b/src/VisualStudio/Core/Test/RQName/RQNameTests.vb
@@ -251,7 +251,7 @@ class G<T>
                 End If
 
                 If symbol Is Nothing Then
-                    AssertEx.Fail("Could not find symbol")
+                    Assert.Fail("Could not find symbol")
                 End If
 
                 If expectedRQName IsNot Nothing Then

--- a/src/VisualStudio/Core/Test/Venus/CSharpContainedLanguageSupportTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/CSharpContainedLanguageSupportTests.vb
@@ -648,7 +648,7 @@ public class _Default
                     targetDocument:=targetDocument,
                     cancellationToken:=Nothing) Then
 
-                    Assert.True(False, "Should have succeeded")
+                    Assert.Fail("Should have succeeded")
                 End If
 
                 Assert.Equal(expectedSpan, actualSpan)

--- a/src/VisualStudio/Core/Test/Venus/VisualBasicContainedLanguageSupportTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/VisualBasicContainedLanguageSupportTests.vb
@@ -695,7 +695,7 @@ End Class</text>.Value
                     targetDocument:=targetDocument,
                     cancellationToken:=Nothing) Then
 
-                    Assert.True(False, "should have succeeded")
+                    Assert.Fail("should have succeeded")
                 End If
 
                 Assert.Equal(expectedSpan, actualSpan)

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -768,7 +768,7 @@ public sealed class CSharpCodeActions() : AbstractEditorTest(nameof(CSharpCodeAc
                 builder.AppendLine($"Error list result {i}: {actualContents}");
             }
 
-            AssertEx.Fail(builder.ToString());
+            Assert.Fail(builder.ToString());
         }
     }
 
@@ -850,7 +850,7 @@ public sealed class CSharpCodeActions() : AbstractEditorTest(nameof(CSharpCodeAc
                 builder.AppendLine($"Error list result {i}: {actualContents}");
             }
 
-            AssertEx.Fail(builder.ToString());
+            Assert.Fail(builder.ToString());
         }
     }
 
@@ -978,7 +978,7 @@ public sealed class CSharpCodeActions() : AbstractEditorTest(nameof(CSharpCodeAc
                     return;
             }
 
-            AssertEx.Fail(builder.ToString());
+            Assert.Fail(builder.ToString());
         }
     }
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/AddParameterDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/AddParameterDialogInProcess.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Extensibility.Testing;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature;
 using Roslyn.Test.Utilities;
+using Xunit;
 
 namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess;
 
@@ -30,7 +31,7 @@ internal sealed partial class AddParameterDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await buttonAccessor(dialog).SimulateClickAsync(JoinableTaskFactory));
     }
@@ -85,7 +86,7 @@ internal sealed partial class AddParameterDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         dialog.CallsiteValueTextBox.Focus();
         dialog.CallsiteValueTextBox.Text = callsiteValue;
@@ -96,7 +97,7 @@ internal sealed partial class AddParameterDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         dialog.NameContentControl.Focus();
         dialog.NameContentControl.Text = parameterName;
@@ -107,7 +108,7 @@ internal sealed partial class AddParameterDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         dialog.TypeContentControl.Focus();
         dialog.TypeContentControl.Text = typeName;

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ChangeSignatureDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ChangeSignatureDialogInProcess.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature;
 using Roslyn.Test.Utilities;
 using WindowsInput.Native;
+using Xunit;
 
 namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess;
 
@@ -32,7 +33,7 @@ internal sealed partial class ChangeSignatureDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await buttonAccessor(dialog).SimulateClickAsync(JoinableTaskFactory));
     }
@@ -111,7 +112,7 @@ internal sealed partial class ChangeSignatureDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         var members = dialog.GetTestAccessor().Members;
         members.SelectedItem = dialog.GetTestAccessor().ViewModel.AllParameters.Single(p => p.ShortAutomationText == parameterName);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorVerifierInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorVerifierInProcess.cs
@@ -167,7 +167,7 @@ internal sealed partial class EditorVerifierInProcess : ITextViewWindowVerifierI
                 if (expectedTag.taggedText != actualTaggedText)
                     return false;
 
-                AssertEx.NotNull(actualTaggedSpan.Tag.ToolTipContent);
+                Assert.NotNull(actualTaggedSpan.Tag.ToolTipContent);
                 var containerElement = (ContainerElement)actualTaggedSpan.Tag.ToolTipContent;
                 var actualTooltipText = CollectTextInRun(containerElement);
                 if (expectedTag.tooltipText != actualTooltipText)

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ExtractInterfaceDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ExtractInterfaceDialogInProcess.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.LanguageServices.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
+using Xunit;
 
 namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess;
 
@@ -35,7 +36,7 @@ internal sealed partial class ExtractInterfaceDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await buttonAccessor(dialog).SimulateClickAsync(JoinableTaskFactory));
     }
@@ -96,7 +97,7 @@ internal sealed partial class ExtractInterfaceDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         return dialog.DestinationControl.fileNameTextBox.Text;
     }
@@ -106,7 +107,7 @@ internal sealed partial class ExtractInterfaceDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         var memberSelectionList = dialog.GetTestAccessor().Members;
         var comListItems = memberSelectionList.Items;
@@ -130,7 +131,7 @@ internal sealed partial class ExtractInterfaceDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         var memberSelectionList = dialog.GetTestAccessor().Members;
         var items = memberSelectionList.Items.Cast<MemberSymbolViewModel>().ToArray();

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/GenerateTypeDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/GenerateTypeDialogInProcess.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
+using Xunit;
 
 namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess;
 
@@ -33,7 +34,7 @@ internal sealed partial class GenerateTypeDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await buttonAccessor(dialog).SimulateClickAsync(JoinableTaskFactory));
     }
@@ -82,7 +83,7 @@ internal sealed partial class GenerateTypeDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await dialog.GetTestAccessor().AccessListComboBox.SimulateSelectItemAsync(JoinableTaskFactory, accessibility, cancellationToken));
     }
@@ -92,7 +93,7 @@ internal sealed partial class GenerateTypeDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await dialog.GetTestAccessor().KindListComboBox.SimulateSelectItemAsync(JoinableTaskFactory, kind, cancellationToken));
     }
@@ -102,7 +103,7 @@ internal sealed partial class GenerateTypeDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await dialog.GetTestAccessor().ProjectListComboBox.SimulateSelectItemAsync(JoinableTaskFactory, projectName, cancellationToken));
     }
@@ -112,7 +113,7 @@ internal sealed partial class GenerateTypeDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await dialog.GetTestAccessor().CreateNewFileRadioButton.SimulateClickAsync(JoinableTaskFactory));
         Contract.ThrowIfFalse(await dialog.GetTestAccessor().CreateNewFileComboBox.SimulateSelectItemAsync(JoinableTaskFactory, newFileName, mustExist: false, cancellationToken));
@@ -141,7 +142,7 @@ internal sealed partial class GenerateTypeDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         return dialog.GetTestAccessor().CreateNewFileComboBox.Items.Cast<string>().ToImmutableArray();
     }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
@@ -134,7 +134,7 @@ internal sealed partial class InheritanceMarginInProcess
 
         if (glyphsOnLine.Count != 1)
         {
-            Assert.False(true, $"{glyphsOnLine.Count} glyphs are found at line: {lineNumber}.");
+            Assert.Fail($"{glyphsOnLine.Count} glyphs are found at line: {lineNumber}.");
         }
 
         return glyphsOnLine[0];

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MessageBoxInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MessageBoxInProcess.cs
@@ -197,7 +197,7 @@ internal sealed partial class MessageBoxInProcess
                         //    return VSConstants.S_OK;
                         //}
 
-                        //Assert.True(false, "RevertEditsOnHotReload() failed");
+                        //Assert.Fail("RevertEditsOnHotReload() failed");
                         //throw ExceptionUtilities.Unreachable();
                         throw new NotImplementedException();
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MoveToNamespaceDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/MoveToNamespaceDialogInProcess.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.Extensibility.Testing;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace;
 using Roslyn.Test.Utilities;
+using Xunit;
 
 namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess;
 
@@ -31,7 +32,7 @@ internal sealed partial class MoveToNamespaceDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await buttonAccessor(dialog).SimulateClickAsync(JoinableTaskFactory));
     }
@@ -92,7 +93,7 @@ internal sealed partial class MoveToNamespaceDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         var success = await dialog.GetTestAccessor().NamespaceBox.SimulateSelectItemAsync(JoinableTaskFactory, @namespace, mustExist: false, cancellationToken);
         Contract.ThrowIfFalse(success);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/PickMembersDialogInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/PickMembersDialogInProcess.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.LanguageServices.Implementation.PickMembers;
 using Microsoft.VisualStudio.Threading;
 using Roslyn.Test.Utilities;
+using Xunit;
 
 namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess;
 
@@ -32,7 +33,7 @@ internal sealed partial class PickMembersDialogInProcess
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var dialog = await TryGetDialogAsync(cancellationToken);
-        AssertEx.NotNull(dialog);
+        Assert.NotNull(dialog);
 
         Contract.ThrowIfFalse(await buttonAccessor(dialog).SimulateClickAsync(JoinableTaskFactory));
     }

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
@@ -168,7 +168,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
             Next
 
             If result Is Nothing Then
-                Assert.True(False, "Could not locate code element")
+                Assert.Fail("Could not locate code element")
             End If
 
             Return CType(result, T)

--- a/src/VisualStudio/TestUtilities2/PropertyChangedTestMonitor.vb
+++ b/src/VisualStudio/TestUtilities2/PropertyChangedTestMonitor.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
             Next
 
             If _failures.Any() Then
-                Assert.False(True, String.Format("The following INotifyPropertyChanged expectations were not met: {0}", Environment.NewLine + String.Join(Environment.NewLine, _failures)))
+                Assert.Fail(String.Format("The following INotifyPropertyChanged expectations were not met: {0}", Environment.NewLine + String.Join(Environment.NewLine, _failures)))
             End If
         End Sub
 

--- a/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/RemoveUnnecessaryLineContinuationTests.cs
@@ -1338,7 +1338,7 @@ public sealed class RemoveUnnecessaryLineContinuationTests
             .AddProject(projectId, "Project", "Project.dll", language)
             .GetRequiredProject(projectId);
 
-        AssertEx.NotNull(project.ParseOptions);
+        Assert.NotNull(project.ParseOptions);
         var parseOptions = (VisualBasicParseOptions)project.ParseOptions;
         parseOptions = parseOptions.WithLanguageVersion(langVersion);
         project = project.WithParseOptions(parseOptions);

--- a/src/Workspaces/CoreTest/FunctionIdTests.cs
+++ b/src/Workspaces/CoreTest/FunctionIdTests.cs
@@ -20,7 +20,7 @@ public sealed class FunctionIdTests
             var value = (FunctionId)Enum.Parse(typeof(FunctionId), name);
             if (map.TryGetValue(value, out var existingName))
             {
-                Assert.True(false, $"'{nameof(FunctionId)}.{name}' cannot have the same value as '{nameof(FunctionId)}.{existingName}'");
+                Assert.Fail($"'{nameof(FunctionId)}.{name}' cannot have the same value as '{nameof(FunctionId)}.{existingName}'");
             }
 
             map.Add(value, name);

--- a/src/Workspaces/CoreTest/UtilityTest/AsyncLazyTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/AsyncLazyTests.cs
@@ -183,7 +183,7 @@ public sealed partial class AsyncLazyTests
         try
         {
             doGetValue(lazy, cancellationTokenSource.Token);
-            AssertEx.Fail(nameof(AsyncLazy<>.GetValue) + " did not throw an exception.");
+            Assert.Fail(nameof(AsyncLazy<>.GetValue) + " did not throw an exception.");
         }
         catch (OperationCanceledException oce)
         {
@@ -211,7 +211,7 @@ public sealed partial class AsyncLazyTests
         try
         {
             task.Wait();
-            AssertEx.Fail(nameof(AsyncLazy<>.GetValueAsync) + " did not throw an exception.");
+            Assert.Fail(nameof(AsyncLazy<>.GetValueAsync) + " did not throw an exception.");
         }
         catch (AggregateException ex)
         {

--- a/src/Workspaces/CoreTest/UtilityTest/ExceptionHelpersTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/ExceptionHelpersTests.cs
@@ -43,7 +43,7 @@ public sealed class ExceptionHelpersTests : TestBase
                 throw ExceptionUtilities.Unreachable();
             }
 
-            Assert.True(false, "Should not get here because an exception should be thrown before this point.");
+            Assert.Fail("Should not get here because an exception should be thrown before this point.");
         }
         catch (OperationCanceledException)
         {
@@ -51,7 +51,7 @@ public sealed class ExceptionHelpersTests : TestBase
             return;
         }
 
-        Assert.True(false, "Should have returned in the catch block before this point.");
+        Assert.Fail("Should have returned in the catch block before this point.");
     }
 
     [Fact]

--- a/src/Workspaces/CoreTest/UtilityTest/XmlDocumentationProviderTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/XmlDocumentationProviderTests.cs
@@ -39,7 +39,7 @@ public sealed class XmlDocumentationProviderTests
 
         // Verify we can parse it and it contains a single node
         var xml = compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.AdditionalTextFile")!.GetDocumentationCommentXml();
-        AssertEx.NotNull(xml);
+        Assert.NotNull(xml);
         var xmlDocument = XDocument.Parse(xml);
         Assert.Equal("member", xmlDocument.Root!.Name.LocalName);
         Assert.Equal("T:Microsoft.CodeAnalysis.AdditionalTextFile", xmlDocument.Root!.Attribute("name")!.Value);

--- a/src/Workspaces/CoreTestUtilities/TestErrorReportingService.cs
+++ b/src/Workspaces/CoreTestUtilities/TestErrorReportingService.cs
@@ -20,7 +20,7 @@ internal sealed class TestErrorReportingService : IErrorReportingService
     {
     }
 
-    public Action<string> OnError { get; set; } = message => Assert.False(true, message);
+    public Action<string> OnError { get; set; } = message => Assert.Fail(message);
 
     public string HostDisplayName
         => "Test Host";

--- a/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/Workspaces/CoreTestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -669,7 +669,7 @@ public partial class TestWorkspace<TDocument, TProject, TSolution>
         }
         else if (testDocumentServiceProvider != null)
         {
-            AssertEx.Fail($"The document attributes on file {fileName} conflicted");
+            Assert.Fail($"The document attributes on file {fileName} conflicted");
         }
 
         var resolveFilePath = (bool?)documentElement.Attribute("ResolveFilePath");

--- a/src/Workspaces/MSBuild/Test/NetCoreTests.cs
+++ b/src/Workspaces/MSBuild/Test/NetCoreTests.cs
@@ -305,7 +305,7 @@ public sealed class NetCoreTests : MSBuildWorkspaceTestBase
                     break;
 
                 default:
-                    Assert.True(false, $"Unexpected project: {project.Name}");
+                    Assert.Fail($"Unexpected project: {project.Name}");
                     break;
             }
         }
@@ -382,7 +382,7 @@ public sealed class NetCoreTests : MSBuildWorkspaceTestBase
                     break;
 
                 default:
-                    Assert.True(false, $"Encountered unexpected project: {project.FilePath}");
+                    Assert.Fail($"Encountered unexpected project: {project.FilePath}");
                     return;
             }
 
@@ -412,7 +412,7 @@ public sealed class NetCoreTests : MSBuildWorkspaceTestBase
             }
             else
             {
-                Assert.True(false, "OutputFilePath with expected TFM not found.");
+                Assert.Fail("OutputFilePath with expected TFM not found.");
             }
         }
     }


### PR DESCRIPTION
Years ago we added some helpers to AssertEx to work around limitations of the default xunit asserts. Those shortcomings have been fixed by newer xunit.assert which we upgraded to awhile back, but never did the cleanup.