### PR TITLE
Remove legacy property from tagging

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -209,17 +209,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         }
 
         protected virtual Task ProduceTagsAsync(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag, int? caretPosition, CancellationToken cancellationToken)
-        {
-            // Keep legacy shape for TypeScript.  Once they adapt to the obsoletes and move to overriding this method
-            // we can remove once TypeScript finishes https://github.com/dotnet/roslyn/issues/57180.
-            context.CancellationToken = cancellationToken;
-            return ProduceTagsAsync(context, spanToTag, caretPosition);
-        }
-
-        /// <summary>
-        /// Remove once TypeScript finishes https://github.com/dotnet/roslyn/issues/57180.
-        /// </summary>
-        protected virtual Task ProduceTagsAsync(TaggerContext<TTag> context, DocumentSnapshotSpan snapshotSpan, int? caretPosition)
             => Task.CompletedTask;
 
         internal TestAccessor GetTestAccessor()

--- a/src/EditorFeatures/Core/Tagging/TaggerContext.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerContext.cs
@@ -45,11 +45,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         /// </summary>
         public object State { get; set; }
 
-        /// <summary>
-        /// Remove once TypeScript finishes https://github.com/dotnet/roslyn/issues/57180.
-        /// </summary>
-        public CancellationToken CancellationToken { get; internal set; }
-
         // For testing only.
         internal TaggerContext(
             Document document, ITextSnapshot snapshot,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/57180

Can be removed as F# does nto use, and TS stopped using in: https://devdiv.visualstudio.com/DevDiv/_git/TypeScript-VS/pullrequest/359652