### PR TITLE
Forbid interpolated string handler conversions that reference an instance as indexer arguments in nested member initializers

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -12,3 +12,25 @@
 
     class var { }
     ```
+
+2. In Visual Studio 17.1, indexers that take an interpolated string handler and require the receiver as an input for the constructor cannot be used in an object initializer.
+
+    ```cs
+    using System.Runtime.CompilerServices;
+    _ = new C { [$""] = 1 }; // error: Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.
+
+    class C
+    {
+        public int this[[InterpolatedStringHandlerArgument("")] CustomHandler c]
+        {
+            get => throw null;
+            set => throw null;
+        }
+    }
+
+    [InterpolatedStringHandler]
+    class CustomHandler
+    {
+        public CustomHandler(int literalLength, int formattedCount, C c) {}
+    }
+    ```

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -4799,27 +4799,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                         defaultArguments = indexer.DefaultArguments;
                         expanded = indexer.Expanded;
 
-                        // If this is not for a new instance and any of the arguments is an interpolated string handler that takes the receiver
-                        // as an argument for creation, we disallow this. During lowering, indexer arguments are evaluated before the receiver
-                        // for this scenario, and we therefore can't get the receiver at the point it will be needed for the constructor.
-                        if (!implicitReceiver.IsNewInstance)
+                        // If any of the arguments is an interpolated string handler that takes the receiver as an argument for creation,
+                        // we disallow this. During lowering, indexer arguments are evaluated before the receiver for this scenario, and
+                        // we therefore can't get the receiver at the point it will be needed for the constructor. We could technically
+                        // support it for top-level member indexer initializers (ie, initializers directly on the `new Type` instance),
+                        // but for user and language simplicity we blanket forbid this.
+                        foreach (var argument in arguments)
                         {
-                            foreach (var argument in arguments)
+                            if (argument is BoundConversion { Conversion.IsInterpolatedStringHandler: true, Operand: var operand })
                             {
-                                if (argument is BoundConversion { Conversion.IsInterpolatedStringHandler: true, Operand: var operand })
+                                var handlerPlaceholders = operand switch
                                 {
-                                    var handlerPlaceholders = operand switch
-                                    {
-                                        BoundBinaryOperator { InterpolatedStringHandlerData: { } data } => data.ArgumentPlaceholders,
-                                        BoundInterpolatedString { InterpolationData: { } data } => data.ArgumentPlaceholders,
-                                        _ => throw ExceptionUtilities.UnexpectedValue(operand.Kind)
-                                    };
+                                    BoundBinaryOperator { InterpolatedStringHandlerData: { } data } => data.ArgumentPlaceholders,
+                                    BoundInterpolatedString { InterpolationData: { } data } => data.ArgumentPlaceholders,
+                                    _ => throw ExceptionUtilities.UnexpectedValue(operand.Kind)
+                                };
 
-                                    if (handlerPlaceholders.Any(placeholder => placeholder.ArgumentIndex == BoundInterpolatedStringArgumentPlaceholder.InstanceParameter))
-                                    {
-                                        diagnostics.Add(ErrorCode.ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers, argument.Syntax.Location);
-                                        hasErrors = true;
-                                    }
+                                if (handlerPlaceholders.Any(placeholder => placeholder.ArgumentIndex == BoundInterpolatedStringArgumentPlaceholder.InstanceParameter))
+                                {
+                                    diagnostics.Add(ErrorCode.ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers, argument.Syntax.Location);
+                                    hasErrors = true;
                                 }
                             }
                         }

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6878,4 +6878,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureNewLinesInInterpolations" xml:space="preserve">
     <value>newlines in interpolations</value>
   </data>
+  <data name="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers" xml:space="preserve">
+    <value>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6878,7 +6878,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureNewLinesInInterpolations" xml:space="preserve">
     <value>newlines in interpolations</value>
   </data>
-  <data name="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers" xml:space="preserve">
-    <value>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</value>
+  <data name="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers" xml:space="preserve">
+    <value>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2001,6 +2001,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_CompileTimeCheckedOverflow = 8973,
         WRN_MethGrpToNonDel = 8974,
         ERR_LambdaExplicitReturnTypeVar = 8975,
+        ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers = 8976
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2001,7 +2001,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_CompileTimeCheckedOverflow = 8973,
         WRN_MethGrpToNonDel = 8974,
         ERR_LambdaExplicitReturnTypeVar = 8975,
-        ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers = 8976
+        ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers = 8976,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Metoda obslužné rutiny interpolovaného řetězce {0} je poškozená. Nevrací hodnoty void ani bool.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -677,6 +677,11 @@
         <target state="translated">Metoda obslužné rutiny interpolovaného řetězce {0} je poškozená. Nevrací hodnoty void ani bool.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">{0} není platný modifikátor návratového typu ukazatele na funkci. Platné modifikátory jsou ref a ref readonly.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -677,6 +677,11 @@
         <target state="translated">Die Handlermethode „{0}“ einer interpolierten Zeichenfolgen ist falsch formatiert. „Void“ oder „bool“ wird nicht zurückgegeben.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">"{0}" ist kein gültiger Rückgabetyp-Modifizierer für Funktionszeiger. Gültige Modifizierer sind "ref" und "ref readonly".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Die Handlermethode „{0}“ einer interpolierten Zeichenfolgen ist falsch formatiert. „Void“ oder „bool“ wird nicht zurückgegeben.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -677,6 +677,11 @@
         <target state="translated">El método de controlador de cadena interpolada "{0}" tiene un formato incorrecto. No devuelve "void" ni "bool".</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">"{0}" no es un modificador de tipo de valor devuelto de puntero de función válido. Los modificadores válidos son "ref" y "ref readonly".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -677,9 +677,9 @@
         <target state="translated">El método de controlador de cadena interpolada "{0}" tiene un formato incorrecto. No devuelve "void" ni "bool".</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -677,9 +677,9 @@
         <target state="translated">La méthode du gestionnaire de chaînes interpolées « {0} » est incorrecte. Il ne retourne pas « void » ou « bool ».</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -677,6 +677,11 @@
         <target state="translated">La méthode du gestionnaire de chaînes interpolées « {0} » est incorrecte. Il ne retourne pas « void » ou « bool ».</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">'{0}' n'est pas un modificateur de type de retour de pointeur de fonction valide. Les modificateurs valides sont 'ref' et 'ref readonly'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Il formato del metodo di gestione delle stringhe interpolate '{0}' non è valido. Non restituisce 'void' o 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -677,6 +677,11 @@
         <target state="translated">Il formato del metodo di gestione delle stringhe interpolate '{0}' non è valido. Non restituisce 'void' o 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">'{0}' non è un modificatore di tipo restituito di puntatore a funzione valido. I modificatori validi sono 'ref' e 'ref readonly'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -677,9 +677,9 @@
         <target state="translated">補間された文字列ハンドラー メソッド '{0}' の形式が正しくありません。'void' または 'bool' を返すことはありません。</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -677,6 +677,11 @@
         <target state="translated">補間された文字列ハンドラー メソッド '{0}' の形式が正しくありません。'void' または 'bool' を返すことはありません。</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">'{0}' は有効な関数ポインターの戻り値の型修飾子ではありません。有効な修飾子は 'ref ' および 'ref readonly' です。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -677,9 +677,9 @@
         <target state="translated">보간된 문자열 처리기 메서드 '{0}'의 형식이 잘못되었습니다. 'void' 또는 'bool'을 반환하지 않습니다.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -677,6 +677,11 @@
         <target state="translated">보간된 문자열 처리기 메서드 '{0}'의 형식이 잘못되었습니다. 'void' 또는 'bool'을 반환하지 않습니다.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">'{0}'은(는) 유효한 함수 포인터 반환 형식 한정자가 아닙니다. 유효한 한정자는 'ref' 및 'ref readonly'입니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Metoda procedury obsługi ciągu interpolowanego "{0}" ma nieprawidłową postać. Nie zwraca ona wartości "void" lub "bool".</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -677,6 +677,11 @@
         <target state="translated">Metoda procedury obsługi ciągu interpolowanego "{0}" ma nieprawidłową postać. Nie zwraca ona wartości "void" lub "bool".</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">Element „{0}” nie jest prawidłowym modyfikatorem zwracanego typu wskaźnikowego funkcji. Prawidłowe modyfikatory to „ref” i „ref readonly”.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -677,6 +677,11 @@
         <target state="translated">O método do manipulador de cadeia de caracteres interpolada '{0}' está malformado. Ele não retorna 'void' ou 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">'{0}' não é um modificador de tipo de retorno de ponteiro de função válido. Os modificadores válidos são 'ref' e 'ref readonly'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -677,9 +677,9 @@
         <target state="translated">O método do manipulador de cadeia de caracteres interpolada '{0}' está malformado. Ele não retorna 'void' ou 'bool'.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -677,9 +677,9 @@
         <target state="translated">Неверный формат метода обработчика интерполированных строк "{0}". Он не возвращает значения "void" или "bool".</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -677,6 +677,11 @@
         <target state="translated">Неверный формат метода обработчика интерполированных строк "{0}". Он не возвращает значения "void" или "bool".</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">"{0}" не является допустимым модификатором типа для возвращаемого значения указателя на функцию. Допустимые модификаторы: ref и ref readonly.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -677,6 +677,11 @@
         <target state="translated">'{0}' düz metin arasına kod eklenmiş dize işleyicisi yöntemi hatalı biçimlendirilmiş. 'void ' veya 'bool' döndürmez.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">'{0}', geçerli bir işlev işaretçisi dönüş türü değiştiricisi değil. Geçerli değiştiriciler: 'ref' ve 'ref readonly'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -677,9 +677,9 @@
         <target state="translated">'{0}' düz metin arasına kod eklenmiş dize işleyicisi yöntemi hatalı biçimlendirilmiş. 'void ' veya 'bool' döndürmez.</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -677,9 +677,9 @@
         <target state="translated">内插字符串处理程序方法“{0}”格式错误。它不返回“void”或“bool”。</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -677,6 +677,11 @@
         <target state="translated">内插字符串处理程序方法“{0}”格式错误。它不返回“void”或“bool”。</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">“{0}”不是有效的函数指针返回类型修饰符。有效的修饰符为 "ref" 和 "ref readonly"。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -677,9 +677,9 @@
         <target state="translated">差補字串處理常式方法 '{0}' 格式不正確。它不會傳回 'void' 或 'bool'。</target>
         <note>void and bool are keywords</note>
       </trans-unit>
-      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
-        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
-        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -677,6 +677,11 @@
         <target state="translated">差補字串處理常式方法 '{0}' 格式不正確。它不會傳回 'void' 或 'bool'。</target>
         <note>void and bool are keywords</note>
       </trans-unit>
+      <trans-unit id="ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers">
+        <source>Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</source>
+        <target state="new">Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InvalidFuncPointerReturnTypeModifier">
         <source>'{0}' is not a valid function pointer return type modifier. Valid modifiers are 'ref' and 'ref readonly'.</source>
         <target state="translated">'{0}'不是有效的函式指標傳回型別修飾元。有效的修飾元為 'ref' 與 'ref readonly'。</target>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -14201,5 +14201,162 @@ struct CustomHandler
                 Diagnostic(ErrorCode.ERR_BadArgExtraRef, @"$""""").WithArguments("3", "out").WithLocation(4, 19)
             );
         }
+
+        [Theory]
+        [InlineData(@"$""literal{1}""")]
+        [InlineData(@"$""literal"" + $""{1}""")]
+        public void ReferencingThis_TopLevelObjectInitializer(string expression)
+        {
+            var code = @"
+using System;
+using System.Runtime.CompilerServices;
+
+_ = new C2 { [" + expression + @"] = { A = 1, B = 2 } };
+
+public class C2
+{
+    public C3 this[[InterpolatedStringHandlerArgument("""")] CustomHandler c]
+    {
+        get => new C3();
+        set { }
+    }
+}
+
+public class C3
+{
+    public int A
+    {
+        get => 0;
+        set { }
+    }
+    public int B
+    {
+        get => 0;
+        set { }
+    }
+}
+
+public partial struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount, C2 c) : this(literalLength, formattedCount)
+    {
+        Console.WriteLine(""CustomHandler ctor"");
+    }
+}
+";
+            CompileAndVerify(new[] { code, InterpolatedStringHandlerArgumentAttribute, GetInterpolatedStringCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) },
+                             expectedOutput: @"CustomHandler ctor");
+        }
+
+        [Theory]
+        [InlineData(@"$""literal{1}""")]
+        [InlineData(@"$""literal"" + $""{1}""")]
+        public void ReferencingThis_NestedObjectInitializer(string expression)
+        {
+            var code = @"
+using System;
+using System.Runtime.CompilerServices;
+
+_ = new C1 { C2 = { [" + expression + @"] = { A = 1, B = 2 } } };
+
+class C1
+{
+    public C2 C2 { get => null; set { } }
+}
+
+public class C2
+{
+    public C3 this[[InterpolatedStringHandlerArgument("""")] CustomHandler c]
+    {
+        get => new C3();
+        set { }
+    }
+}
+
+public class C3
+{
+    public int A
+    {
+        get => 0;
+        set { }
+    }
+    public int B
+    {
+        get => 0;
+        set { }
+    }
+}
+
+public partial struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount, C2 c) : this(literalLength, formattedCount)
+    {
+        Console.WriteLine(""CustomHandler ctor"");
+    }
+}
+";
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, GetInterpolatedStringCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) });
+            comp.VerifyDiagnostics(
+                // (5,22): error CS8976: Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.
+                // _ = new C1 { C2 = { [$"literal{1}"] = { A = 1, B = 2 } } };
+                Diagnostic(ErrorCode.ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers, @"$""literal{1}""").WithLocation(5, 22)
+            );
+        }
+
+        [Theory]
+        [InlineData(@"$""literal{1}""")]
+        [InlineData(@"$""literal"" + $""{1}""")]
+        public void NotReferencingThis_NestedObjectInitializer(string expression)
+        {
+            var code = @"
+using System;
+using System.Runtime.CompilerServices;
+
+_ = new C1 { C2 = { [3, " + expression + @"] = { A = 1, B = 2 } } };
+
+class C1
+{
+    public C2 C2 { get { Console.WriteLine(""get_C2""); return new C2(); } set { } }
+}
+
+public class C2
+{
+    public C3 this[int arg1, [InterpolatedStringHandlerArgument(""arg1"")] CustomHandler c]
+    {
+        get { Console.WriteLine(""Indexer""); return new C3(); }
+        set { }
+    }
+}
+
+public class C3
+{
+    public int A
+    {
+        get => 0;
+        set { }
+    }
+    public int B
+    {
+        get => 0;
+        set { }
+    }
+}
+
+public partial struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount, int arg1) : this(literalLength, formattedCount)
+    {
+        Console.WriteLine(""CustomHandler ctor"");
+    }
+}
+";
+            CompileAndVerify(new[] { code, InterpolatedStringHandlerArgumentAttribute, GetInterpolatedStringCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) },
+                             expectedOutput: @"
+CustomHandler ctor
+get_C2
+Indexer
+get_C2
+Indexer");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -10566,39 +10566,11 @@ public partial struct CustomHandler
             var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false);
 
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, handler });
-            var verifier = CompileAndVerify(comp, expectedOutput: @"
-c.Field:1
-literal:literal
-");
-            verifier.VerifyDiagnostics();
-
-            verifier.VerifyIL("<top-level-statements-entry-point>", @"
-{
-  // Code size       40 (0x28)
-  .maxstack  4
-  .locals init (C V_0,
-                CustomHandler V_1,
-                CustomHandler V_2)
-  IL_0000:  ldc.i4.1
-  IL_0001:  newobj     ""C..ctor(int)""
-  IL_0006:  stloc.0
-  IL_0007:  ldloca.s   V_2
-  IL_0009:  ldc.i4.7
-  IL_000a:  ldc.i4.0
-  IL_000b:  ldloc.0
-  IL_000c:  call       ""CustomHandler..ctor(int, int, C)""
-  IL_0011:  ldloca.s   V_2
-  IL_0013:  ldstr      ""literal""
-  IL_0018:  call       ""void CustomHandler.AppendLiteral(string)""
-  IL_001d:  ldloc.2
-  IL_001e:  stloc.1
-  IL_001f:  ldloc.0
-  IL_0020:  ldloc.1
-  IL_0021:  ldc.i4.1
-  IL_0022:  callvirt   ""void C.this[CustomHandler].set""
-  IL_0027:  ret
-}
-");
+            comp.VerifyDiagnostics(
+                // (5,17): error CS8976: Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.
+                // _ = new C(1) { [$"literal"] = 1 };
+                Diagnostic(ErrorCode.ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers, expression).WithLocation(5, 17)
+            );
         }
 
         [Theory]
@@ -14208,7 +14180,6 @@ struct CustomHandler
         public void ReferencingThis_TopLevelObjectInitializer(string expression)
         {
             var code = @"
-using System;
 using System.Runtime.CompilerServices;
 
 _ = new C2 { [" + expression + @"] = { A = 1, B = 2 } };
@@ -14240,12 +14211,16 @@ public partial struct CustomHandler
 {
     public CustomHandler(int literalLength, int formattedCount, C2 c) : this(literalLength, formattedCount)
     {
-        Console.WriteLine(""CustomHandler ctor"");
     }
 }
 ";
-            CompileAndVerify(new[] { code, InterpolatedStringHandlerArgumentAttribute, GetInterpolatedStringCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) },
-                             expectedOutput: @"CustomHandler ctor");
+
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, GetInterpolatedStringCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) });
+            comp.VerifyDiagnostics(
+                // (4,15): error CS8976: Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.
+                // _ = new C2 { [$"literal" + $"{1}"] = { A = 1, B = 2 } };
+                Diagnostic(ErrorCode.ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers, expression).WithLocation(4, 15)
+            );
         }
 
         [Theory]
@@ -14297,9 +14272,9 @@ public partial struct CustomHandler
 ";
             var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, GetInterpolatedStringCustomHandlerType("CustomHandler", "partial struct", useBoolReturns: false) });
             comp.VerifyDiagnostics(
-                // (5,22): error CS8976: Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.
+                // (5,22): error CS8976: Interpolated string handler conversions that reference the instance being indexed cannot be used in indexer member initializers.
                 // _ = new C1 { C2 = { [$"literal{1}"] = { A = 1, B = 2 } } };
-                Diagnostic(ErrorCode.ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers, expression).WithLocation(5, 22)
+                Diagnostic(ErrorCode.ERR_InterpolatedStringsReferencingInstanceCannotBeInObjectInitializers, expression).WithLocation(5, 22)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -14299,7 +14299,7 @@ public partial struct CustomHandler
             comp.VerifyDiagnostics(
                 // (5,22): error CS8976: Interpolated string handler conversions that reference the instance being indexed cannot be used in nested member initializers.
                 // _ = new C1 { C2 = { [$"literal{1}"] = { A = 1, B = 2 } } };
-                Diagnostic(ErrorCode.ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers, @"$""literal{1}""").WithLocation(5, 22)
+                Diagnostic(ErrorCode.ERR_InterpolatedStringsReferencingInstanceCannotBeInNestedObjectInitializers, expression).WithLocation(5, 22)
             );
         }
 


### PR DESCRIPTION
Followup to LDM discussion. This scenario is pathological, and we don't want to support it.
