### PR TITLE
Reference VS Debugger.Contracts in DebuggerContractVersionCheck

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/Remote/DebuggerContractVersionCheck.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/DebuggerContractVersionCheck.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
-using Microsoft.CodeAnalysis.EditAndContinue.Contracts;
+using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {


### PR DESCRIPTION
Fixes integration tests broken by https://github.com/dotnet/roslyn/pull/57386.
The change does not affect product behavior.