### PR TITLE
Reference VS Debugger.Contracts in DebuggerContractVersionCheck

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "6.0.100-rc.2.21505.57",
     "allowPrerelease": true,
-    "rollForward": "major"
+    "rollForward": "disable"
   },
   "tools": {
     "dotnet": "6.0.100-rc.2.21505.57",

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/DebuggerContractVersionCheck.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/DebuggerContractVersionCheck.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
-using Microsoft.CodeAnalysis.EditAndContinue.Contracts;
+using Microsoft.VisualStudio.Debugger.Contracts;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/DebuggerContractVersionCheck.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/DebuggerContractVersionCheck.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
-using Microsoft.VisualStudio.Debugger.Contracts;
+using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {


### PR DESCRIPTION
Fixes integration tests broken by #57386.
The change does not affect product behavior.