### PR TITLE
Run net6.0-windows unit tests in CI

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -396,6 +396,7 @@ function TestUsingRunTests() {
     if ($testCompilerOnly) {
       $args += GetCompilerTestAssembliesIncludePaths
     } else {
+      $args += " --tfm net6.0-windows"
       $args += " --include '\.UnitTests'"
     }
   }


### PR DESCRIPTION
We can pass multiple TFMs into RunTests. Since this is the build.ps1 used on windows we can also add net6.0-windows.

CC: @genlu @RikkiGibson 