### PR TITLE
Switch to 1ES servicing pools on release/dev16.11-vs-deps

### DIFF
--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -20,7 +20,7 @@ jobs:
 - job: VS_Integration_LSP
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   timeoutInMinutes: 135
 
   steps:

--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -19,8 +19,8 @@ pr:
 jobs:
 - job: VS_Integration_LSP
   pool:
-    name: NetCorePublic-Pool
-    queue: $(queueName)
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 135
 
   steps:

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.VS2019.Pre.Open
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2019.Pre.Open
   strategy:
     maxParallel: 4
     matrix:

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -17,8 +17,8 @@ pr:
 jobs:
 - job: VS_Integration
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.VS2019.Pre.Scouting.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.VS2019.Pre.Scouting.Open
   strategy:
     maxParallel: 4
     matrix:

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.VS2019.Pre.Scouting.Open
+    demands: ImageOverride -equals Build.Windows.VS2019.Pre.Open
   strategy:
     maxParallel: 4
     matrix:

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
   strategy:
     maxParallel: 4
     matrix:

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2019.Pre.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
   strategy:
     maxParallel: 4
     matrix:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -71,8 +71,8 @@ stages:
     displayName: Official Build
     timeoutInMinutes: 360
     pool:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Server.Amd64.VS2017
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Server.Amd64.VS2017
 
     steps:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -65,14 +65,14 @@ variables:
 stages:
 - stage: build
   displayName: Build and Test
+  pool:
+    name: NetCore1ESPool-Svc-Internal
+    demands: ImageOverride -equals Build.Server.Amd64.VS2017
 
   jobs:
   - job: OfficialBuild
     displayName: Official Build
     timeoutInMinutes: 360
-    pool:
-      name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals Build.Server.Amd64.VS2017
 
     steps:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -5,8 +5,8 @@ pr: none
 jobs:
 - job: RichCodeNav_Indexing
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.10.Amd64.Open
   variables:
     EnableRichCodeNavigation: true
   timeoutInMinutes: 200

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,14 +21,14 @@ jobs:
     jobName: Build_Windows_Debug
     testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
-    queueName: BuildPool.Windows.10.Amd64.Open
+    queueName: Build.Windows.10.Amd64.Open
 
 - template: eng/pipelines/build-windows-job.yml
   parameters:
     jobName: Build_Windows_Release
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
-    queueName: BuildPool.Windows.10.Amd64.Open
+    queueName: Build.Windows.10.Amd64.Open
     buildArguments: "/p:Features=run-nullable-analysis=never"
 
 - template: eng/pipelines/test-windows-job.yml
@@ -137,7 +137,7 @@ jobs:
     testArtifactName: Transport_Artifacts_Unix_Debug
     configuration: Debug
     testArguments: --testCoreClr
-    queueName: 'BuildPool.Ubuntu.1804.amd64.Open'
+    queueName: 'Build.Ubuntu.1804.amd64.Open'
 
 - template: eng/pipelines/test-unix-job.yml
   parameters:
@@ -152,8 +152,8 @@ jobs:
 
 - job: Correctness_Determinism
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.VS2017.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml
@@ -168,8 +168,8 @@ jobs:
 
 - job: Correctness_Build
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.VS2017.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml
@@ -200,8 +200,8 @@ jobs:
 
 - job: Correctness_SourceBuild
   pool:
-   name: NetCorePublic-Pool
-   queue: BuildPool.Ubuntu.1804.amd64.Open
+   name: NetCore1ESPool-Svc-Public
+   demands: ImageOverride -equals Build.Ubuntu.1804.amd64.Open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-unix-task.yml
@@ -224,8 +224,8 @@ jobs:
 
 - job: Correctness_Rebuild
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.10.Amd64.Open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -20,8 +20,8 @@ jobs:
 - job: ${{ parameters.jobName }}
   pool:
     ${{ if ne(parameters.queueName, '') }}:
-      name: NetCorePublic-Pool
-      queue: ${{ parameters.queueName }}
+      name: NetCore1ESPool-Svc-Public
+      demands ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:
       vmImage: ${{ parameters.vmImageName }}

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -21,7 +21,7 @@ jobs:
   pool:
     ${{ if ne(parameters.queueName, '') }}:
       name: NetCore1ESPool-Svc-Public
-      demands ImageOverride -equals ${{ parameters.queueName }}
+      demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:
       vmImage: ${{ parameters.vmImageName }}

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -23,8 +23,8 @@ jobs:
 - job: ${{ parameters.jobName }}
   pool:
     ${{ if ne(parameters.queueName, '') }}:
-      name: NetCorePublic-Pool
-      queue: ${{ parameters.queueName }}
+      name: NetCore1ESPool-Svc-Public
+      demands ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:
       vmImage: ${{ parameters.vmImageName }}

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -24,7 +24,7 @@ jobs:
   pool:
     ${{ if ne(parameters.queueName, '') }}:
       name: NetCore1ESPool-Svc-Public
-      demands ImageOverride -equals ${{ parameters.queueName }}
+      demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:
       vmImage: ${{ parameters.vmImageName }}

--- a/eng/pipelines/test-unix-job-single-machine.yml
+++ b/eng/pipelines/test-unix-job-single-machine.yml
@@ -30,8 +30,8 @@ jobs:
   dependsOn: ${{ parameters.buildJobName }}
   pool:
     ${{ if ne(parameters.queueName, '') }}:
-      name: NetCorePublic-Pool
-      queue: ${{ parameters.queueName }}
+      name: NetCore1ESPool-Svc-Public
+      demands ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:
       vmImage: ${{ parameters.vmImageName }}

--- a/eng/pipelines/test-unix-job-single-machine.yml
+++ b/eng/pipelines/test-unix-job-single-machine.yml
@@ -31,7 +31,7 @@ jobs:
   pool:
     ${{ if ne(parameters.queueName, '') }}:
       name: NetCore1ESPool-Svc-Public
-      demands ImageOverride -equals ${{ parameters.queueName }}
+      demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:
       vmImage: ${{ parameters.vmImageName }}

--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -27,7 +27,7 @@ jobs:
   dependsOn: ${{ parameters.buildJobName }}
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands ImageOverride -equals ${{ parameters.queueName }}
+    demands: ImageOverride -equals ${{ parameters.queueName }}
   timeoutInMinutes: 120
   variables:
     DOTNET_ROLL_FORWARD: LatestMajor

--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -20,14 +20,14 @@ parameters:
   default: ''
 - name: queueName
   type: string
-  default: 'BuildPool.Windows.10.Amd64.Open'
+  default: 'Build.Windows.10.Amd64.Open'
 
 jobs:
 - job: ${{ parameters.jobName }}
   dependsOn: ${{ parameters.buildJobName }}
   pool:
-    name: NetCorePublic-Pool
-    queue: ${{ parameters.queueName }}
+    name: NetCore1ESPool-Svc-Public
+    demands ImageOverride -equals ${{ parameters.queueName }}
   timeoutInMinutes: 120
   variables:
     DOTNET_ROLL_FORWARD: LatestMajor


### PR DESCRIPTION
Per https://github.com/dotnet/core-eng/issues/14276.