### PR TITLE
Fix 'simplify conditional expression' with VB value equality

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/RemoveConfusingSuppression/CSharpRemoveConfusingSuppressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveConfusingSuppression/CSharpRemoveConfusingSuppressionCodeFixProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveConfusingSuppression
             Document document, ImmutableArray<Diagnostic> diagnostics,
             bool negate, CancellationToken cancellationToken)
         {
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var editor = new SyntaxEditor(root, document.Project.Solution.Workspace);
             var generator = editor.Generator;

--- a/src/Analyzers/Core/CodeFixes/SimplifyBooleanExpression/SimplifyConditionalCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/SimplifyBooleanExpression/SimplifyConditionalCodeFixProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.SimplifyBooleanExpression
             var generator = SyntaxGenerator.GetGenerator(document);
             var generatorInternal = document.GetRequiredLanguageService<SyntaxGeneratorInternal>();
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var diagnostic in diagnostics)
             {

--- a/src/Analyzers/Core/CodeFixes/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
         {
             var generator = SyntaxGenerator.GetGenerator(document);
             var generatorInternal = document.GetRequiredLanguageService<SyntaxGeneratorInternal>();
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var condition = ifOperation.Condition.Syntax;
             if (!isRef)

--- a/src/Analyzers/VisualBasic/Tests/SimplifyBooleanExpression/SimplifyConditionalTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/SimplifyBooleanExpression/SimplifyConditionalTests.vb
@@ -263,5 +263,101 @@ class C
     private function Y() as boolean
 end class")
         End Function
+
+        <WorkItem(57472, "https://github.com/dotnet/roslyn/issues/57472")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyConditional)>
+        Public Async Function TestValueEqualityOnReferenceType1() As Task
+            Await TestInRegularAndScript1Async(
+"
+Imports System
+
+class C
+    sub M()
+        Dim name As String = ""goober""
+        Dim hasName As Boolean = [|If(name = """", True, False)|]
+    end sub
+end class",
+"
+Imports System
+
+class C
+    sub M()
+        Dim name As String = ""goober""
+        Dim hasName As Boolean = name = """"
+    end sub
+end class")
+        End Function
+
+        <WorkItem(57472, "https://github.com/dotnet/roslyn/issues/57472")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyConditional)>
+        Public Async Function TestValueEqualityOnReferenceType2() As Task
+            Await TestInRegularAndScript1Async(
+"
+Imports System
+
+class C
+    sub M()
+        Dim name As String = ""goober""
+        Dim hasName As Boolean = [|If(name = """", False, True)|]
+    end sub
+end class",
+"
+Imports System
+
+class C
+    sub M()
+        Dim name As String = ""goober""
+        Dim hasName As Boolean = name <> """"
+    end sub
+end class")
+        End Function
+
+        <WorkItem(57472, "https://github.com/dotnet/roslyn/issues/57472")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyConditional)>
+        Public Async Function TestValueEqualityOnReferenceType3() As Task
+            Await TestInRegularAndScript1Async(
+"
+Imports System
+
+class C
+    sub M()
+        Dim name As String = ""goober""
+        Dim hasName As Boolean = [|If(name Is """", True, False)|]
+    end sub
+end class",
+"
+Imports System
+
+class C
+    sub M()
+        Dim name As String = ""goober""
+        Dim hasName As Boolean = name Is """"
+    end sub
+end class")
+        End Function
+
+        <WorkItem(57472, "https://github.com/dotnet/roslyn/issues/57472")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyConditional)>
+        Public Async Function TestValueEqualityOnReferenceType4() As Task
+            Await TestInRegularAndScript1Async(
+"
+Imports System
+
+class C
+    sub M()
+        Dim name As String = ""goober""
+        Dim hasName As Boolean = [|If(name IsNot """", False, True)|]
+    end sub
+end class",
+"
+Imports System
+
+class C
+    sub M()
+        Dim name As String = ""goober""
+        Dim hasName As Boolean = name Is """"
+    end sub
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/InvertIf/InvertMultiLineIfTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/InvertIf/InvertMultiLineIfTests.vb
@@ -671,7 +671,7 @@ Imports System
 end class",
 "class C
     sub M(x as String)
-        If x IsNot ""a"" Then
+        If x <> ""a"" Then
             DoSomething()
         End If
     end sub
@@ -698,7 +698,7 @@ end class")
 end class",
 "class C
     sub M(x as String)
-        If x IsNot ""a"" Then
+        If x <> ""a"" Then
             DoSomething()
         Else
             ' A comment in a blank if statement
@@ -724,7 +724,7 @@ end class")
 end class",
 "class C
     sub M(x as String)
-        If x IsNot ""a"" Then
+        If x <> ""a"" Then
             Return
         End If
         ' Comment

--- a/src/Features/Core/Portable/InvertConditional/AbstractInvertConditionalCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InvertConditional/AbstractInvertConditionalCodeRefactoringProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.InvertConditional
             var conditional = await FindConditionalAsync(document, span, cancellationToken).ConfigureAwait(false);
             Contract.ThrowIfNull(conditional);
 
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var editor = new SyntaxEditor(root, document.Project.Solution.Workspace);

--- a/src/Features/Core/Portable/InvertLogical/AbstractInvertLogicalCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InvertLogical/AbstractInvertLogicalCodeRefactoringProvider.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.InvertLogical
         private static async Task<Document> InvertInnerExpressionAsync(
             Document document, SyntaxNode binaryExpression, CancellationToken cancellationToken)
         {
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var generator = SyntaxGenerator.GetGenerator(document);
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.InvertLogical
             Document document, CancellationToken cancellationToken)
         {
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
             var expression = root.GetAnnotatedNodes(s_annotation).Single()!;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -81,8 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 var other => other,
             };
 
-        internal override SyntaxNode YieldReturnStatement(SyntaxNode expressionOpt = null)
-            => SyntaxFactory.YieldStatement(SyntaxKind.YieldReturnStatement, (ExpressionSyntax)expressionOpt);
+        internal override SyntaxNode YieldReturnStatement(SyntaxNode expression)
+            => SyntaxFactory.YieldStatement(SyntaxKind.YieldReturnStatement, (ExpressionSyntax)expression);
 
         /// <summary>
         /// C# always requires a type to be present with a local declaration.  (Even if that type is

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpSyntaxGeneratorInternal.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
@@ -134,6 +135,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         internal override SyntaxNode Type(ITypeSymbol typeSymbol, bool typeContext)
             => typeContext ? typeSymbol.GenerateTypeSyntax() : typeSymbol.GenerateExpressionSyntax();
+
+        public override SyntaxNode NegateEquality(SyntaxGenerator generator, SyntaxNode binaryExpression, SyntaxNode left, BinaryOperatorKind negatedKind, SyntaxNode right)
+            => negatedKind switch
+            {
+                BinaryOperatorKind.Equals => generator.ReferenceEqualsExpression(left, right),
+                BinaryOperatorKind.NotEquals => generator.ReferenceNotEqualsExpression(left, right),
+                _ => throw ExceptionUtilities.UnexpectedValue(negatedKind),
+            };
 
         #region Patterns
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -135,17 +135,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                                                 BinaryOperatorKind.ConditionalAnd or
                                                 BinaryOperatorKind.ConditionalOr;
 
-            //Workaround for https://github.com/dotnet/roslyn/issues/23956
-            //Issue to remove this when above is merged
-            if (binaryOperation.OperatorKind == BinaryOperatorKind.Or && syntaxFacts.IsLogicalOrExpression(expressionNode))
-            {
-                negatedKind = BinaryOperatorKind.ConditionalAnd;
-            }
-            else if (binaryOperation.OperatorKind == BinaryOperatorKind.And && syntaxFacts.IsLogicalAndExpression(expressionNode))
-            {
-                negatedKind = BinaryOperatorKind.ConditionalOr;
-            }
-
             if (negateOperands)
             {
                 leftOperand = generator.Negate(generatorInternal, leftOperand, semanticModel, cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -115,8 +115,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var syntaxFacts = generatorInternal.SyntaxFacts;
             syntaxFacts.GetPartsOfBinaryExpression(expressionNode, out var leftOperand, out var operatorToken, out var rightOperand);
 
-            var binaryOperation = semanticModel.GetOperation(expressionNode, cancellationToken) as IBinaryOperation;
-            if (binaryOperation == null)
+            var operation = semanticModel.GetOperation(expressionNode, cancellationToken);
+            if (operation is not IBinaryOperation binaryOperation)
             {
                 // x is y   ->    x is not y
                 if (syntaxFacts.IsIsExpression(expressionNode) && syntaxFacts.SupportsNotPattern(semanticModel.SyntaxTree.Options))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -17,17 +17,19 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
     internal static partial class SyntaxGeneratorExtensions
     {
         private static readonly ImmutableDictionary<BinaryOperatorKind, BinaryOperatorKind> s_negatedBinaryMap =
-            ImmutableDictionary<BinaryOperatorKind, BinaryOperatorKind>.Empty
-                .Add(BinaryOperatorKind.Equals, BinaryOperatorKind.NotEquals)
-                .Add(BinaryOperatorKind.NotEquals, BinaryOperatorKind.Equals)
-                .Add(BinaryOperatorKind.LessThan, BinaryOperatorKind.GreaterThanOrEqual)
-                .Add(BinaryOperatorKind.GreaterThan, BinaryOperatorKind.LessThanOrEqual)
-                .Add(BinaryOperatorKind.LessThanOrEqual, BinaryOperatorKind.GreaterThan)
-                .Add(BinaryOperatorKind.GreaterThanOrEqual, BinaryOperatorKind.LessThan)
-                .Add(BinaryOperatorKind.Or, BinaryOperatorKind.And)
-                .Add(BinaryOperatorKind.And, BinaryOperatorKind.Or)
-                .Add(BinaryOperatorKind.ConditionalOr, BinaryOperatorKind.ConditionalAnd)
-                .Add(BinaryOperatorKind.ConditionalAnd, BinaryOperatorKind.ConditionalOr);
+            new Dictionary<BinaryOperatorKind, BinaryOperatorKind>
+            {
+                { BinaryOperatorKind.Equals, BinaryOperatorKind.NotEquals },
+                { BinaryOperatorKind.NotEquals, BinaryOperatorKind.Equals },
+                { BinaryOperatorKind.LessThan, BinaryOperatorKind.GreaterThanOrEqual },
+                { BinaryOperatorKind.GreaterThan, BinaryOperatorKind.LessThanOrEqual },
+                { BinaryOperatorKind.LessThanOrEqual, BinaryOperatorKind.GreaterThan },
+                { BinaryOperatorKind.GreaterThanOrEqual, BinaryOperatorKind.LessThan },
+                { BinaryOperatorKind.Or, BinaryOperatorKind.And },
+                { BinaryOperatorKind.And, BinaryOperatorKind.Or },
+                { BinaryOperatorKind.ConditionalOr, BinaryOperatorKind.ConditionalAnd },
+                { BinaryOperatorKind.ConditionalAnd, BinaryOperatorKind.ConditionalOr },
+            }.ToImmutableDictionary();
 
         public static SyntaxNode Negate(
             this SyntaxGenerator generator,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -129,16 +129,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (!s_negatedBinaryMap.TryGetValue(binaryOperation.OperatorKind, out var negatedKind))
                 return generator.LogicalNotExpression(expressionNode);
 
-            var negateOperands = false;
-            switch (binaryOperation.OperatorKind)
-            {
-                case BinaryOperatorKind.Or:
-                case BinaryOperatorKind.And:
-                case BinaryOperatorKind.ConditionalAnd:
-                case BinaryOperatorKind.ConditionalOr:
-                    negateOperands = true;
-                    break;
-            }
+            var negateOperands =
+                binaryOperation.OperatorKind is BinaryOperatorKind.Or or
+                                                BinaryOperatorKind.And or
+                                                BinaryOperatorKind.ConditionalAnd or
+                                                BinaryOperatorKind.ConditionalOr;
 
             //Workaround for https://github.com/dotnet/roslyn/issues/23956
             //Issue to remove this when above is merged

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SyntaxGeneratorInternalExtensions/SyntaxGeneratorInternal.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/SyntaxGeneratorInternalExtensions/SyntaxGeneratorInternal.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.CodeAnalysis.Editing
 {
@@ -90,6 +91,8 @@ namespace Microsoft.CodeAnalysis.Editing
         /// what will happen if that tree is passed to any other components.
         /// </remarks>
         internal abstract SyntaxNode Type(ITypeSymbol typeSymbol, bool typeContext);
+
+        public abstract SyntaxNode NegateEquality(SyntaxGenerator generator, SyntaxNode binaryExpression, SyntaxNode left, BinaryOperatorKind negatedKind, SyntaxNode right);
 
         #region Patterns
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxGeneratorInternal.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxGeneratorInternal.vb
@@ -129,17 +129,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Public Overrides Function NegateEquality(generator As SyntaxGenerator, node As SyntaxNode, left As SyntaxNode, negatedKind As Operations.BinaryOperatorKind, right As SyntaxNode) As SyntaxNode
             If negatedKind = BinaryOperatorKind.Equals Then
-                If node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression) Then
-                    Return generator.ValueEqualsExpression(left, right)
-                Else
-                    Return generator.ReferenceEqualsExpression(left, right)
-                End If
+                Return If(node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression),
+                    generator.ValueEqualsExpression(left, right),
+                    generator.ReferenceEqualsExpression(left, right))
             ElseIf negatedKind = BinaryOperatorKind.NotEquals Then
-                If node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression) Then
-                    Return generator.ValueNotEqualsExpression(left, right)
-                Else
-                    Return generator.ReferenceNotEqualsExpression(left, right)
-                End If
+                Return If(node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression),
+                    generator.ValueNotEqualsExpression(left, right),
+                    generator.ReferenceNotEqualsExpression(left, right))
             Else
                 Throw ExceptionUtilities.UnexpectedValue(negatedKind)
             End If

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxGeneratorInternal.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxGeneratorInternal.vb
@@ -128,17 +128,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function NegateEquality(generator As SyntaxGenerator, node As SyntaxNode, left As SyntaxNode, negatedKind As Operations.BinaryOperatorKind, right As SyntaxNode) As SyntaxNode
-            If negatedKind = BinaryOperatorKind.Equals Then
-                Return If(node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression),
-                    generator.ValueEqualsExpression(left, right),
-                    generator.ReferenceEqualsExpression(left, right))
-            ElseIf negatedKind = BinaryOperatorKind.NotEquals Then
-                Return If(node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression),
-                    generator.ValueNotEqualsExpression(left, right),
-                    generator.ReferenceNotEqualsExpression(left, right))
-            Else
-                Throw ExceptionUtilities.UnexpectedValue(negatedKind)
-            End If
+            Select Case negatedKind
+                Case BinaryOperatorKind.Equals
+                    Return If(node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression),
+                        generator.ValueEqualsExpression(left, right),
+                        generator.ReferenceEqualsExpression(left, right))
+                Case BinaryOperatorKind.NotEquals
+                    Return If(node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression),
+                        generator.ValueNotEqualsExpression(left, right),
+                        generator.ReferenceNotEqualsExpression(left, right))
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(negatedKind)
+            End Select
         End Function
 
 #Region "Patterns"

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxGeneratorInternal.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxGeneratorInternal.vb
@@ -7,6 +7,7 @@ Imports System.Diagnostics.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.Operations
 Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -124,6 +125,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
         Friend Overrides Function Type(typeSymbol As ITypeSymbol, typeContext As Boolean) As SyntaxNode
             Return If(typeContext, typeSymbol.GenerateTypeSyntax(), typeSymbol.GenerateExpressionSyntax())
+        End Function
+
+        Public Overrides Function NegateEquality(generator As SyntaxGenerator, node As SyntaxNode, left As SyntaxNode, negatedKind As Operations.BinaryOperatorKind, right As SyntaxNode) As SyntaxNode
+            If negatedKind = BinaryOperatorKind.Equals Then
+                If node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression) Then
+                    Return generator.ValueEqualsExpression(left, right)
+                Else
+                    Return generator.ReferenceEqualsExpression(left, right)
+                End If
+            ElseIf negatedKind = BinaryOperatorKind.NotEquals Then
+                If node.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression) Then
+                    Return generator.ValueNotEqualsExpression(left, right)
+                Else
+                    Return generator.ReferenceNotEqualsExpression(left, right)
+                End If
+            Else
+                Throw ExceptionUtilities.UnexpectedValue(negatedKind)
+            End If
         End Function
 
 #Region "Patterns"


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/57472

Should be reviewed as two separate commits.