### PR TITLE
Switch to 1ES servicing pools on release/dev16.7-vs-deps

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -17,8 +17,8 @@ pr:
 jobs:
 - job: VS_Integration
   pool:
-    name: NetCorePublic-Pool
-    queue: buildpool.windows.10.amd64.vs2019.open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -demands build.windows.10.amd64.vs2019.open
   strategy:
     maxParallel: 2
     matrix:

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -demands build.windows.10.amd64.vs2019.open
+    demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
   strategy:
     maxParallel: 2
     matrix:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -52,8 +52,8 @@ stages:
         - visualstudio
         - DotNetFramework
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -demands Build.Windows.10.Amd64.VS2019.Pre
 
     steps:        
     # Make sure our two pipelines generate builds with distinct build numbers to avoid confliction.

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -53,7 +53,7 @@ stages:
         - DotNetFramework
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -demands Build.Windows.10.Amd64.VS2019.Pre
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre
 
     steps:        
     # Make sure our two pipelines generate builds with distinct build numbers to avoid confliction.

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -11,8 +11,8 @@ schedules:
 jobs:
 - job: RichCodeNav_Indexing
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -demands Build.Windows.10.Amd64.Open
   variables:
     EnableRichCodeNavigation: true
   timeoutInMinutes: 200

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -12,7 +12,7 @@ jobs:
 - job: RichCodeNav_Indexing
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -demands Build.Windows.10.Amd64.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.Open
   variables:
     EnableRichCodeNavigation: true
   timeoutInMinutes: 200

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,8 @@ pr:
 jobs:
 - job: Windows_Desktop_Unit_Tests
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -demands Build.Windows.10.Amd64.Open
   strategy:
     maxParallel: 4
     matrix:
@@ -60,8 +60,8 @@ jobs:
 
 - job: Windows_Desktop_Spanish_Unit_Tests
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.ES.VS2017.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -demands Build.Windows.10.Amd64.ES.VS2017.Open
   timeoutInMinutes: 120
 
   steps:
@@ -87,8 +87,8 @@ jobs:
 
 - job: Windows_CoreClr_Unit_Tests
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.VS2017.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -demands Build.Windows.10.Amd64.VS2017.Open
   strategy:
     maxParallel: 2
     matrix:
@@ -122,8 +122,8 @@ jobs:
            
 - job: Windows_Determinism_Test
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.VS2017.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -demands Build.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - script: eng/test-determinism.cmd -configuration Debug
@@ -140,8 +140,8 @@ jobs:
 
 - job: Windows_Correctness_Test
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.VS2017.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -demands Build.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - script: eng/test-build-correctness.cmd -configuration Release
@@ -174,8 +174,8 @@ jobs:
 
 - job: Linux_Test
   pool:
-   name: NetCorePublic-Pool
-   queue: BuildPool.Ubuntu.1604.amd64.Open
+   name: NetCore1ESPool-Svc-Public
+   demands: ImageOverride -demands Build.Ubuntu.1604.amd64.Open
   strategy:
     maxParallel: 2
     matrix:
@@ -212,8 +212,8 @@ jobs:
 
 - job: SourceBuild_Test
   pool:
-   name: NetCorePublic-Pool
-   queue: BuildPool.Ubuntu.1604.amd64.Open
+   name: NetCore1ESPool-Svc-Public
+   demands: ImageOverride -demands Build.Ubuntu.1604.amd64.Open
   timeoutInMinutes: 90
   steps:
     - script: ./eng/cibuild.sh --configuration Debug --prepareMachine --docker --sourceBuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 - job: Windows_Desktop_Unit_Tests
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -demands Build.Windows.10.Amd64.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.Open
   strategy:
     maxParallel: 4
     matrix:
@@ -61,7 +61,7 @@ jobs:
 - job: Windows_Desktop_Spanish_Unit_Tests
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -demands Build.Windows.10.Amd64.ES.VS2017.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.ES.VS2017.Open
   timeoutInMinutes: 120
 
   steps:
@@ -88,7 +88,7 @@ jobs:
 - job: Windows_CoreClr_Unit_Tests
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -demands Build.Windows.10.Amd64.VS2017.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
   strategy:
     maxParallel: 2
     matrix:
@@ -123,7 +123,7 @@ jobs:
 - job: Windows_Determinism_Test
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -demands Build.Windows.10.Amd64.VS2017.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - script: eng/test-determinism.cmd -configuration Debug
@@ -141,7 +141,7 @@ jobs:
 - job: Windows_Correctness_Test
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -demands Build.Windows.10.Amd64.VS2017.Open
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
   timeoutInMinutes: 90
   steps:
     - script: eng/test-build-correctness.cmd -configuration Release
@@ -175,7 +175,7 @@ jobs:
 - job: Linux_Test
   pool:
    name: NetCore1ESPool-Svc-Public
-   demands: ImageOverride -demands Build.Ubuntu.1604.amd64.Open
+   demands: ImageOverride -equals Build.Ubuntu.1604.amd64.Open
   strategy:
     maxParallel: 2
     matrix:
@@ -213,7 +213,7 @@ jobs:
 - job: SourceBuild_Test
   pool:
    name: NetCore1ESPool-Svc-Public
-   demands: ImageOverride -demands Build.Ubuntu.1604.amd64.Open
+   demands: ImageOverride -equals Build.Ubuntu.1604.amd64.Open
   timeoutInMinutes: 90
   steps:
     - script: ./eng/cibuild.sh --configuration Debug --prepareMachine --docker --sourceBuild


### PR DESCRIPTION
Per https://github.com/dotnet/core-eng/issues/14276.