### PR TITLE
Enable dumps for hung tests

### DIFF
--- a/eng/pipelines/publish-logs.yml
+++ b/eng/pipelines/publish-logs.yml
@@ -1,4 +1,3 @@
-# Build on windows desktop
 parameters:
 - name: jobName
   type: string
@@ -8,6 +7,22 @@ parameters:
   default: 'Debug'
 
 steps:
+  - task: CopyFiles@2
+    displayName: Copy Test Artifacts to Logs
+    inputs:
+      contents: '$(Build.SourcesDirectory)/TestArtifacts/**'
+      targetPath: '$(Build.SourcesDirectory)/artifacts/log/${{ parameters.configuration }}'
+    continueOnError: true
+    condition: not(succeeded())
+
+  - task: CopyFiles@2
+    displayName: Copy Dumps to Logs
+    inputs:
+      contents: '$(Build.SourcesDirectory)/bin/**/*.dmp'
+      targetPath: '$(Build.SourcesDirectory)/artifacts/log/${{ parameters.configuration }}'
+    continueOnError: true
+    condition: not(succeeded())
+
   - task: PublishPipelineArtifact@1
     displayName: Publish Logs
     inputs:

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -75,7 +75,7 @@ namespace RunTests
                 builder.AppendFormat($@" --logger {sep}html;LogFileName={GetResultsFilePath(assemblyInfo, "html")}{sep}");
             }
 
-            builder.Append(" --blame-crash --blame-hang-dump-type full --blame-hang-timeout 10minutes");
+            builder.Append(" --blame-crash --blame-hang-dump-type full --blame-hang-timeout 15minutes");
 
             return builder.ToString();
         }

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -75,7 +75,7 @@ namespace RunTests
                 builder.AppendFormat($@" --logger {sep}html;LogFileName={GetResultsFilePath(assemblyInfo, "html")}{sep}");
             }
 
-            builder.Append(" --blame-hang-dump-type full --blame-hang-timeout 10minutes");
+            builder.Append(" --blame-crash --blame-hang-dump-type full --blame-hang-timeout 10minutes");
 
             return builder.ToString();
         }

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -75,6 +75,8 @@ namespace RunTests
                 builder.AppendFormat($@" --logger {sep}html;LogFileName={GetResultsFilePath(assemblyInfo, "html")}{sep}");
             }
 
+            builder.Append(" --blame-hang-dump-type full --blame-hang-timeout 10minutes");
+
             return builder.ToString();
         }
 

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -201,7 +201,7 @@ namespace RunTests
             <PostCommands>
                 {postCommands}
             </PostCommands>
-            <Timeout>00:20:00</Timeout>
+            <Timeout>00:30:00</Timeout>
         </HelixWorkItem>
 ";
                 return workItem;

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -122,6 +122,7 @@ namespace RunTests
 ";
 
             File.WriteAllText("helix-tmp.csproj", project);
+
             var process = ProcessRunner.CreateProcess(
                 executable: _options.DotnetFilePath,
                 arguments: "build helix-tmp.csproj",
@@ -171,13 +172,36 @@ namespace RunTests
 
                 command.AppendLine($"dotnet {commandLineArguments}");
 
+                // We want to collect any dumps during the post command step here; these commands are ran after the
+                // return value of the main command is captured; a Helix Job is considered to fail if the main command returns a
+                // non-zero error code, and we don't want the cleanup steps to interefere with that. PostCommands exist
+                // precisely to address this problem.
+                var postCommands = new StringBuilder();
+
+                var payloadDirectory = Path.Combine(msbuildTestPayloadRoot, Path.GetDirectoryName(assemblyInfo.AssemblyPath)!);
+
+                if (isUnix)
+                {
+                    // Write out this command into a separate file; unfortunately the use of single quotes and ; that is required
+                    // for the command to work causes too much escaping issues in MSBuild.
+                    File.WriteAllText(Path.Combine(payloadDirectory, "copy-dumps.sh"), "find . -name '*.dmp' -exec cp {} $HELIX_DUMP_FOLDER \\;");
+                    postCommands.AppendLine("./copy-dumps.sh");
+                }
+                else
+                {
+                    postCommands.AppendLine("for /r %%f in (*.dmp) do copy %%f %HELIX_DUMP_FOLDER%");
+                }
+
                 var workItem = $@"
         <HelixWorkItem Include=""{assemblyInfo.DisplayName}"">
-            <PayloadDirectory>{Path.Combine(msbuildTestPayloadRoot, Path.GetDirectoryName(assemblyInfo.AssemblyPath)!)}</PayloadDirectory>
+            <PayloadDirectory>{payloadDirectory}</PayloadDirectory>
             <Command>
                 {command}
             </Command>
-            <Timeout>00:15:00</Timeout>
+            <PostCommands>
+                {postCommands}
+            </PostCommands>
+            <Timeout>00:20:00</Timeout>
         </HelixWorkItem>
 ";
                 return workItem;

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -159,9 +159,9 @@ namespace RunTests
                 var setEnvironmentVariable = isUnix ? "export" : "set";
 
                 var command = new StringBuilder();
-                command.AppendLine(isUnix ? "ls" : "dir");
+                command.AppendLine(isUnix ? "ls -l" : "dir");
                 command.AppendLine(isUnix ? $"./rehydrate.sh" : $@"call .\rehydrate.cmd");
-                command.AppendLine(isUnix ? "ls" : "dir");
+                command.AppendLine(isUnix ? "ls -l" : "dir");
                 command.AppendLine($"{setEnvironmentVariable} DOTNET_ROLL_FORWARD=LatestMajor");
                 command.AppendLine($"{setEnvironmentVariable} DOTNET_ROLL_FORWARD_TO_PRERELEASE=1");
                 command.AppendLine("dotnet --info");


### PR DESCRIPTION
This enables Helix jobs to collect dumps if a single test takes more than 15 minutes.