### PR TITLE
Re-enable BuildWithCommandLine test

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
@@ -50,7 +50,7 @@ class Program
             // TODO: Validate build works as expected
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/18204"), Trait(Traits.Feature, Traits.Features.Build)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Build)]
         public void BuildWithCommandLine()
         {
             VisualStudio.SolutionExplorer.SaveAll();


### PR DESCRIPTION
This test was previously disabled for being flaky. This flakiness has been resolved with [this PR](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/341836), which allows us to re-enable the test.

Fixes #18204