### PR TITLE
Fix flaky issue in the SourceGeneratorItemTests

### DIFF
--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
@@ -248,7 +248,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                         cancellationToken.ThrowIfCancellationRequested();
 
                         return UpdateSourceGeneratedFileItemsAsync(_workspace.CurrentSolution, cancellationToken);
-                    }, cancellationToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default).CompletesAsyncOperation(asyncToken);
+                    }, cancellationToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default).Unwrap().CompletesAsyncOperation(asyncToken);
                 }
             }
         }


### PR DESCRIPTION
I did .ContinueWith().CompletesAsyncOperation(), not realizing that the task being returned from the ContinueWith was a `Task<Task>`; we'd end up waiting for the first half but not the second half. A call to Unwrap() fixes it.

Fixes https://github.com/dotnet/roslyn/issues/56826