### PR TITLE
Add truly synchronous indentation service interface for F#

### DIFF
--- a/src/Tools/ExternalAccess/FSharp/Editor/IFSharpIndentationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Editor/IFSharpIndentationService.cs
@@ -61,6 +61,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
         /// no automatic indentation is desired.  May also return <see langword="null"/> if the line in
         /// question is not blank and thus indentation should be deferred to the formatting command handler to handle.
         /// </summary>
-        FSharpIndentationResult? GetDesiredIndentation(HostLanguageServices services, SourceText text, DocumentId documentId, string path, int lineNumber, int tabSize, FormattingOptions.IndentStyle indentStyle);
+        FSharpIndentationResult? GetDesiredIndentation(HostLanguageServices services, SourceText text, DocumentId documentId, string path, int lineNumber, FSharpIndentationOptions options);
     }
+
+    internal readonly record struct FSharpIndentationOptions(int TabSize, FormattingOptions.IndentStyle IndentStyle);
 }

--- a/src/Tools/ExternalAccess/FSharp/Editor/IFSharpIndentationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Editor/IFSharpIndentationService.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host;
+using System;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
 {
@@ -20,7 +22,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
     /// current line.  With this tuple, both forms can be expressed, and the implementor does not
     /// have to convert from one to the other.
     /// </summary>
-    internal struct FSharpIndentationResult
+    internal readonly struct FSharpIndentationResult
     {
         /// <summary>
         /// The base position in the document that the indent should be relative to.  This position
@@ -33,13 +35,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
         /// </summary>
         public int Offset { get; }
 
-        public FSharpIndentationResult(int basePosition, int offset) : this()
+        public FSharpIndentationResult(int basePosition, int offset)
         {
             BasePosition = basePosition;
             Offset = offset;
         }
     }
 
+    [Obsolete("Use IFSharpIndentationService instead")]
     internal interface IFSharpSynchronousIndentationService
     {
         /// <summary>
@@ -49,5 +52,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
         /// be deferred to the formatting command handler to handle.
         /// </summary>
         FSharpIndentationResult? GetDesiredIndentation(Document document, int lineNumber, CancellationToken cancellationToken);
+    }
+
+    internal interface IFSharpIndentationService
+    {
+        /// <summary>
+        /// Determines the desired indentation of a given line.  May return <see langword="null"/> if the
+        /// no automatic indentation is desired.  May also return <see langword="null"/> if the line in
+        /// question is not blank and thus indentation should be deferred to the formatting command handler to handle.
+        /// </summary>
+        FSharpIndentationResult? GetDesiredIndentation(HostLanguageServices services, SourceText text, DocumentId documentId, string path, int lineNumber, int tabSize, FormattingOptions.IndentStyle indentStyle);
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpSynchronousIndentationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpSynchronousIndentationService.cs
@@ -46,9 +46,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
             if (_service != null)
             {
                 var text = document.GetTextSynchronously(cancellationToken);
-                var options = document.GetOptionsAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-                var tabSize = options.GetOption(FormattingOptions.TabSize, LanguageNames.FSharp);
-                result = _service.GetDesiredIndentation(document.Project.LanguageServices, text, document.Id, document.FilePath, lineNumber, tabSize, indentStyle);
+                var documentOptions = document.GetOptionsAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+
+                var options = new FSharpIndentationOptions(
+                    TabSize: documentOptions.GetOption(FormattingOptions.TabSize, LanguageNames.FSharp),
+                    IndentStyle: indentStyle);
+
+                result = _service.GetDesiredIndentation(document.Project.LanguageServices, text, document.Id, document.FilePath, lineNumber, options);
             }
             else
             {

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpSynchronousIndentationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpSynchronousIndentationService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading;
@@ -11,6 +9,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Indentation;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 {
@@ -18,26 +17,46 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
     [ExportLanguageService(typeof(IIndentationService), LanguageNames.FSharp)]
     internal class FSharpSynchronousIndentationService : IIndentationService
     {
-        private readonly IFSharpSynchronousIndentationService _service;
+#pragma warning disable CS0618 // Type or member is obsolete
+        private readonly IFSharpSynchronousIndentationService? _legacyService;
+#pragma warning restore
+        private readonly IFSharpIndentationService? _service;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public FSharpSynchronousIndentationService(IFSharpSynchronousIndentationService service)
+        public FSharpSynchronousIndentationService(
+            [Import(AllowDefault = true)] IFSharpSynchronousIndentationService? legacyService,
+            [Import(AllowDefault = true)] IFSharpIndentationService? service)
         {
+            Contract.ThrowIfTrue(service == null && legacyService == null);
+
+            _legacyService = legacyService;
             _service = service;
         }
 
         public IndentationResult GetIndentation(Document document, int lineNumber, FormattingOptions.IndentStyle indentStyle, CancellationToken cancellationToken)
         {
-            var result = _service.GetDesiredIndentation(document, lineNumber, cancellationToken);
-            if (result.HasValue)
-            {
-                return new IndentationResult(result.Value.BasePosition, result.Value.Offset);
-            }
-            else
+            // all F# documents should have a file path
+            if (document.FilePath == null)
             {
                 return default;
             }
+
+            FSharpIndentationResult? result;
+            if (_service != null)
+            {
+                var text = document.GetTextSynchronously(cancellationToken);
+                var options = document.GetOptionsAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+                var tabSize = options.GetOption(FormattingOptions.TabSize, LanguageNames.FSharp);
+                result = _service.GetDesiredIndentation(document.Project.LanguageServices, text, document.Id, document.FilePath, lineNumber, tabSize, indentStyle);
+            }
+            else
+            {
+                Contract.ThrowIfNull(_legacyService);
+                result = _legacyService.GetDesiredIndentation(document, lineNumber, cancellationToken);
+            }
+
+            return result.HasValue ? new IndentationResult(result.Value.BasePosition, result.Value.Offset) : default;
         }
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Microsoft.CodeAnalysis.ExternalAccess.FSharp.csproj
+++ b/src/Tools/ExternalAccess/FSharp/Microsoft.CodeAnalysis.ExternalAccess.FSharp.csproj
@@ -14,6 +14,10 @@
       https://github.com/Microsoft/visualfsharp
     </PackageDescription>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="Internal\Utilities\IsExternalInit.cs" />
+  </ItemGroup>
   
   <ItemGroup>
     <!--
@@ -56,6 +60,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>ExternalAccessFSharpResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Internal\Utilities\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Allows F# to implement indentation synchronously.

Corresponding F# change: https://github.com/dotnet/fsharp/pull/12340