### PR TITLE
AbstractFlowPass - VisitArrayCreation should use the regular way for visiting `initializer`.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1494,7 +1494,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        // Can be called as part of a bad expression.
         public override BoundNode VisitArrayInitialization(BoundArrayInitialization node)
         {
             foreach (var child in node.Initializers)
@@ -2601,27 +2600,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitRvalue(expr);
             }
 
-            if (node.InitializerOpt != null)
-            {
-                VisitArrayInitializationInternal(node, node.InitializerOpt);
-            }
-
+            VisitRvalue(node.InitializerOpt);
             return null;
-        }
-
-        private void VisitArrayInitializationInternal(BoundArrayCreation arrayCreation, BoundArrayInitialization node)
-        {
-            foreach (var child in node.Initializers)
-            {
-                if (child.Kind == BoundKind.ArrayInitialization)
-                {
-                    VisitArrayInitializationInternal(arrayCreation, (BoundArrayInitialization)child);
-                }
-                else
-                {
-                    VisitRvalue(child);
-                }
-            }
         }
 
         public override BoundNode VisitForStatement(BoundForStatement node)

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
@@ -8768,5 +8768,114 @@ public struct CustomHandler
         }
 
         #endregion
+
+        [Fact]
+        public void TestDataFlowsArrayInit_01()
+        {
+            var analysis = CompileAndAnalyzeDataFlowExpression(@"
+class C {
+    public void F(int x)
+    {
+        int a = 1, y = 2;
+        int[] b = /*<bind>*/{ a + x + 3 } /*</bind>*/;
+        int c = a + 4 + y;
+    }
+}");
+            Assert.Equal("x, a", GetSymbolNamesJoined(analysis.DataFlowsIn));
+        }
+
+        [Fact]
+        public void TestDataFlowsArrayInit_02()
+        {
+            var analysis = CompileAndAnalyzeDataFlowExpression(@"
+class C {
+    public void F(int x)
+    {
+        int a = 1, y = 2;
+        int[,] b = /*<bind>*/{ { a + x + 3 } }/*</bind>*/;
+        int c = a + 4 + y;
+    }
+}");
+            Assert.Equal("x, a", GetSymbolNamesJoined(analysis.DataFlowsIn));
+        }
+
+        [Fact]
+        public void TestDataFlowsArrayInit_03()
+        {
+            var analysis = CompileAndAnalyzeDataFlowExpression(@"
+class C {
+    public void F(int x)
+    {
+        int a = 1, y = 2;
+        int[,] b = {/*<bind>*/{ a + x + 3 } /*</bind>*/};
+        int c = a + 4 + y;
+    }
+}");
+            Assert.Equal("x, a", GetSymbolNamesJoined(analysis.DataFlowsIn));
+        }
+
+        [Fact]
+        [WorkItem(57572, "https://github.com/dotnet/roslyn/issues/57572")]
+        public void TestDataFlowsArrayInit_04()
+        {
+            var analysis = CompileAndAnalyzeDataFlowExpression(@"
+class C {
+    public void F(int x)
+    {
+        int a = 1, y = 2;
+        int[] b = new int[] /*<bind>*/{ a + x + 3 } /*</bind>*/;
+        int c = a + 4 + y;
+    }
+}");
+            Assert.Equal("x, a", GetSymbolNamesJoined(analysis.DataFlowsIn));
+        }
+
+        [Fact]
+        [WorkItem(57572, "https://github.com/dotnet/roslyn/issues/57572")]
+        public void TestDataFlowsArrayInit_05()
+        {
+            var analysis = CompileAndAnalyzeDataFlowExpression(@"
+class C {
+    public void F(int x)
+    {
+        int a = 1, y = 2;
+        int[,] b = new int[,] /*<bind>*/{ {a + x + 3} } /*</bind>*/;
+        int c = a + 4 + y;
+    }
+}");
+            Assert.Equal("x, a", GetSymbolNamesJoined(analysis.DataFlowsIn));
+        }
+
+        [Fact]
+        [WorkItem(57572, "https://github.com/dotnet/roslyn/issues/57572")]
+        public void TestDataFlowsArrayInit_06()
+        {
+            var analysis = CompileAndAnalyzeDataFlowExpression(@"
+class C {
+    public void F(int x)
+    {
+        int a = 1, y = 2;
+        int[,] b = new int[,] {/*<bind>*/{ a + x + 3 } /*</bind>*/};
+        int c = a + 4 + y;
+    }
+}");
+            Assert.Equal("x, a", GetSymbolNamesJoined(analysis.DataFlowsIn));
+        }
+
+        [Fact]
+        public void TestDataFlowsObjectInit()
+        {
+            var analysis = CompileAndAnalyzeDataFlowExpression(@"
+class C {
+    public int Data;
+    public void F(int x)
+    {
+        int a = 1, y = 2;
+        var b = new object() /*<bind>*/{ Data = a + x + 3 } /*</bind>*/;
+        int c = a + 4 + y;
+    }
+}");
+            Assert.Equal("x, a", GetSymbolNamesJoined(analysis.DataFlowsIn));
+        }
     }
 }


### PR DESCRIPTION
An array initializer node is a valid region designator for the Region Analysis.
Therefore, the analysis should be able to track when we enter/leave the region.
Fixes #57572.