### PR TITLE
Port BasicAddMissingReference.InvokeSomeFixesInVisualBasicThenVerifyReferences to the new test framework

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -500,6 +500,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSha
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Remote.ServiceHub.UnitTests", "src\Workspaces\Remote\ServiceHubTest\Microsoft.CodeAnalysis.Remote.ServiceHub.UnitTests.csproj", "{8D830CBB-CA6E-47D8-9FB8-9230AAD272F3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.LanguageServices.New.IntegrationTests", "src\VisualStudio\IntegrationTest\New.IntegrationTests\Microsoft.VisualStudio.LanguageServices.New.IntegrationTests.csproj", "{6272739B-31E4-483E-A3A5-2ABB5040ABF0}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Analyzers\VisualBasic\CodeFixes\VisualBasicCodeFixes.projitems*{0141285d-8f6c-42c7-baf3-3c0ccd61c716}*SharedItemsImports = 5
@@ -1303,6 +1305,10 @@ Global
 		{8D830CBB-CA6E-47D8-9FB8-9230AAD272F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D830CBB-CA6E-47D8-9FB8-9230AAD272F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8D830CBB-CA6E-47D8-9FB8-9230AAD272F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6272739B-31E4-483E-A3A5-2ABB5040ABF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6272739B-31E4-483E-A3A5-2ABB5040ABF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6272739B-31E4-483E-A3A5-2ABB5040ABF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6272739B-31E4-483E-A3A5-2ABB5040ABF0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1531,6 +1537,7 @@ Global
 		{8FCD1B85-BE63-4A2F-8E19-37244F19BE0F} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{2B7DC612-1B37-41F7-BE31-4D600930EAC9} = {32A48625-F0AD-419D-828B-A50BDABA38EA}
 		{8D830CBB-CA6E-47D8-9FB8-9230AAD272F3} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
+		{6272739B-31E4-483E-A3A5-2ABB5040ABF0} = {CC126D03-7EAC-493F-B187-DCDEE1EF6A70}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {604E6B91-7BC0-4126-AE07-D4D2FEFC3D29}

--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -18,6 +18,10 @@ pr:
 - features/*
 - demos/*
 
+variables:
+  - name: XUNIT_LOGS
+    value: $(Build.SourcesDirectory)\artifacts\log\$(_configuration)
+
 jobs:
 - job: VS_Integration_CoreHost
   pool:

--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -18,6 +18,10 @@ pr:
 - features/*
 - demos/*
 
+variables:
+  - name: XUNIT_LOGS
+    value: $(Build.SourcesDirectory)\artifacts\log\$(_configuration)
+
 jobs:
 - job: VS_Integration_LSP
   pool:

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -14,6 +14,10 @@ pr:
 - features/*
 - demos/*
 
+variables:
+  - name: XUNIT_LOGS
+    value: $(Build.SourcesDirectory)\artifacts\log\$(_configuration)
+
 jobs:
 - job: VS_Integration
   pool:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -140,6 +140,7 @@
     <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>
     <MicrosoftVisualStudioSDKEmbedInteropTypesVersion>15.0.36</MicrosoftVisualStudioSDKEmbedInteropTypesVersion>
     <MicrosoftVisualStudioEditorVersion>$(VisualStudioEditorNewPackagesVersion)</MicrosoftVisualStudioEditorVersion>
+    <MicrosoftVisualStudioExtensibilityTestingXunitVersion>0.1.90-beta</MicrosoftVisualStudioExtensibilityTestingXunitVersion>
     <MicrosoftVisualStudioGraphModelVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioGraphModelVersion>
     <MicrosoftVisualStudioImageCatalogVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioImageCatalogVersion>
     <MicrosoftVisualStudioImagingVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioImagingVersion>
@@ -237,13 +238,13 @@
     <VsWebsiteInteropVersion>8.0.50727</VsWebsiteInteropVersion>
     <vswhereVersion>2.4.1</vswhereVersion>
     <XamarinMacVersion>1.0.0</XamarinMacVersion>
-    <xunitVersion>2.4.1-pre.build.4059</xunitVersion>
+    <xunitVersion>2.4.1</xunitVersion>
     <xunitanalyzersVersion>0.10.0</xunitanalyzersVersion>
     <xunitassertVersion>$(xunitVersion)</xunitassertVersion>
     <XunitCombinatorialVersion>1.3.2</XunitCombinatorialVersion>
     <XUnitXmlTestLoggerVersion>2.1.26</XUnitXmlTestLoggerVersion>
     <xunitextensibilitycoreVersion>$(xunitVersion)</xunitextensibilitycoreVersion>
-    <xunitrunnerconsoleVersion>2.4.1-pre.build.4059</xunitrunnerconsoleVersion>
+    <xunitrunnerconsoleVersion>2.4.1</xunitrunnerconsoleVersion>
     <xunitrunnerwpfVersion>1.0.51</xunitrunnerwpfVersion>
     <xunitrunnervisualstudioVersion>$(xunitVersion)</xunitrunnervisualstudioVersion>
     <xunitextensibilityexecutionVersion>$(xunitVersion)</xunitextensibilityexecutionVersion>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -569,6 +569,34 @@ function Deploy-VsixViaTool() {
     Write-Host "`tInstalling $vsixFileName"
     Exec-Console $vsixExe $fullArg
   }
+
+  # Set up registry
+  $vsRegEdit = Join-Path (Join-Path (Join-Path $vsDir 'Common7') 'IDE') 'VsRegEdit.exe'
+
+  # Disable roaming settings to avoid interference from the online user profile
+  &$vsRegEdit set "$vsDir" $hive HKCU "ApplicationPrivateSettings\Microsoft\VisualStudio" RoamingEnabled string "1*System.Boolean*False"
+
+  # Disable IntelliCode line completions to avoid interference with argument completion testing
+  &$vsRegEdit set "$vsDir" $hive HKCU "ApplicationPrivateSettings\Microsoft\VisualStudio\IntelliCode" wholeLineCompletions string "0*System.Int32*2"
+
+  # Disable background download UI to avoid toasts
+  &$vsRegEdit set "$vsDir" $hive HKCU "FeatureFlags\Setup\BackgroundDownload" Value dword 0
+
+  # Configure LSP
+  $lspRegistryValue = [int]$lspEditor.ToBool()
+  &$vsRegEdit set "$vsDir" $hive HKCU "FeatureFlags\Roslyn\LSP\Editor" Value dword $lspRegistryValue
+
+  # Disable text editor error reporting because it pops up a dialog. We want to either fail fast in our
+  # custom handler or fail silently and continue testing.
+  &$vsRegEdit set "$vsDir" $hive HKCU "Text Editor" "Report Exceptions" dword 0
+
+  # Configure RemoteHostOptions.OOP64Bit for testing
+  $oop64bitValue = [int]$oop64bit.ToBool()
+  &$vsRegEdit set "$vsDir" $hive HKCU "Roslyn\Internal\OnOff\Features" OOP64Bit dword $oop64bitValue
+
+  # Configure RemoteHostOptions.OOPCoreClrFeatureFlag for testing
+  $oopCoreClrFeatureFlagValue = [int]$oopCoreClr.ToBool()
+  &$vsRegEdit set "$vsDir" $hive HKCU "FeatureFlags\Roslyn\ServiceHubCore" Value dword $oopCoreClrFeatureFlagValue
 }
 
 # Ensure that procdump is available on the machine.  Returns the path to the directory that contains

--- a/src/EditorFeatures/Core.Wpf/Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj
+++ b/src/EditorFeatures/Core.Wpf/Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj
@@ -48,6 +48,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.IntegrationTest.Utilities" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.New.IntegrationTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.DiagnosticsTests.Utilities" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities" />    
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities2" />

--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -93,6 +93,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.IntegrationTest.Utilities" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.IntegrationTests" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.New.IntegrationTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Test.Utilities2" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp.UnitTests" />

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -78,6 +78,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Workspaces.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.IntegrationTests" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.New.IntegrationTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.IntegrationTest.Utilities" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.Next.UnitTests" />

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
@@ -5,11 +5,9 @@
 #nullable disable
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Roslyn.Test.Utilities;
-using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests
@@ -61,11 +59,6 @@ namespace Roslyn.VisualStudio.IntegrationTests
                     VisualStudio.Editor.SetUseSuggestionMode(false);
                     ClearEditor();
                 }
-
-                // Work around potential hangs in 16.10p2 caused by the roslyn LSP server not completing initialization before solution closed.
-                // By waiting for the async operation tracking roslyn LSP server activation to complete we should never
-                // encounter the scenario where the solution closes while activation is incomplete.
-                VisualStudio.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.LanguageServer);
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractEditorTest.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Roslyn.VisualStudio.IntegrationTests.InProcess;
+
+namespace Roslyn.VisualStudio.IntegrationTests
+{
+    public abstract class AbstractEditorTest : AbstractIntegrationTest
+    {
+        private readonly string? _solutionName;
+        private readonly string? _projectTemplate;
+
+        protected AbstractEditorTest()
+        {
+        }
+
+        protected AbstractEditorTest(string solutionName)
+            : this(solutionName, WellKnownProjectTemplates.ClassLibrary)
+        {
+        }
+
+        protected AbstractEditorTest(string solutionName, string projectTemplate)
+        {
+            _solutionName = solutionName;
+            _projectTemplate = projectTemplate;
+        }
+
+        protected abstract string LanguageName { get; }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync().ConfigureAwait(true);
+
+            if (_solutionName != null)
+            {
+                RoslynDebug.AssertNotNull(_projectTemplate);
+
+                await TestServices.SolutionExplorer.CreateSolutionAsync(_solutionName, HangMitigatingCancellationToken);
+                await TestServices.SolutionExplorer.AddProjectAsync(ProjectName, _projectTemplate, LanguageName, HangMitigatingCancellationToken);
+                await TestServices.SolutionExplorer.RestoreNuGetPackagesAsync(ProjectName, HangMitigatingCancellationToken);
+
+                // Winforms and XAML do not open text files on creation
+                // so these editor tasks will not work if that is the project template being used.
+                if (_projectTemplate is not WellKnownProjectTemplates.WinFormsApplication and
+                    not WellKnownProjectTemplates.WpfApplication and
+                    not WellKnownProjectTemplates.CSharpNetCoreClassLibrary and
+                    not WellKnownProjectTemplates.VisualBasicNetCoreClassLibrary)
+                {
+                    await TestServices.Editor.SetUseSuggestionModeAsync(false, HangMitigatingCancellationToken);
+                    await ClearEditorAsync(HangMitigatingCancellationToken);
+                }
+
+                // Work around potential hangs in 16.10p2 caused by the roslyn LSP server not completing initialization before solution closed.
+                // By waiting for the async operation tracking roslyn LSP server activation to complete we should never
+                // encounter the scenario where the solution closes while activation is incomplete.
+                await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, waitForWorkspaceFirst: true, HangMitigatingCancellationToken);
+            }
+        }
+
+        protected async Task ClearEditorAsync(CancellationToken cancellationToken)
+            => await SetUpEditorAsync("$$", cancellationToken);
+
+        protected async Task SetUpEditorAsync(string markupCode, CancellationToken cancellationToken)
+        {
+            MarkupTestFile.GetPosition(markupCode, out var code, out int caretPosition);
+
+            await TestServices.Editor.DismissCompletionSessionsAsync(cancellationToken);
+            await TestServices.Editor.DismissLightBulbSessionAsync(cancellationToken);
+
+            var originalValue = await TestServices.Workspace.IsPrettyListingOnAsync(LanguageName, cancellationToken);
+
+            await TestServices.Workspace.SetPrettyListingAsync(LanguageName, false, cancellationToken);
+            try
+            {
+                await TestServices.Editor.SetTextAsync(code, cancellationToken);
+                await TestServices.Editor.MoveCaretAsync(caretPosition, cancellationToken);
+                await TestServices.Editor.ActivateAsync(cancellationToken);
+            }
+            finally
+            {
+                await TestServices.Workspace.SetPrettyListingAsync(LanguageName, originalValue, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractEditorTest.cs
@@ -4,7 +4,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -56,11 +55,6 @@ namespace Roslyn.VisualStudio.IntegrationTests
                     await TestServices.Editor.SetUseSuggestionModeAsync(false, HangMitigatingCancellationToken);
                     await ClearEditorAsync(HangMitigatingCancellationToken);
                 }
-
-                // Work around potential hangs in 16.10p2 caused by the roslyn LSP server not completing initialization before solution closed.
-                // By waiting for the async operation tracking roslyn LSP server activation to complete we should never
-                // encounter the scenario where the solution closes while activation is incomplete.
-                await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, waitForWorkspaceFirst: true, HangMitigatingCancellationToken);
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractIntegrationTest.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Roslyn.VisualStudio.IntegrationTests.InProcess;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests
+{
+    [IdeSettings(MinVersion = VisualStudioVersion.VS2022)]
+    public abstract class AbstractIntegrationTest : IAsyncLifetime, IDisposable
+    {
+        /// <summary>
+        /// A long timeout used to avoid hangs in tests, where a test failure manifests as an operation never occurring.
+        /// </summary>
+        public static readonly TimeSpan HangMitigatingTimeout = TimeSpan.FromMinutes(4);
+
+        private JoinableTaskContext? _joinableTaskContext;
+        private JoinableTaskCollection? _joinableTaskCollection;
+        private JoinableTaskFactory? _joinableTaskFactory;
+
+        private TestServices? _testServices;
+
+        private readonly CancellationTokenSource _hangMitigatingCancellationTokenSource;
+
+        protected AbstractIntegrationTest()
+        {
+            Assert.True(Application.Current.Dispatcher.CheckAccess());
+
+            JoinableTaskContext = ThreadHelper.JoinableTaskContext;
+
+            _hangMitigatingCancellationTokenSource = new CancellationTokenSource(HangMitigatingTimeout);
+        }
+
+        [NotNull]
+        protected JoinableTaskContext? JoinableTaskContext
+        {
+            get
+            {
+                return _joinableTaskContext ?? throw new InvalidOperationException();
+            }
+
+            private set
+            {
+                if (value == _joinableTaskContext)
+                {
+                    return;
+                }
+
+                if (value is null)
+                {
+                    _joinableTaskContext = null;
+                    _joinableTaskCollection = null;
+                    _joinableTaskFactory = null;
+                }
+                else
+                {
+                    _joinableTaskContext = value;
+                    _joinableTaskCollection = value.CreateCollection();
+                    _joinableTaskFactory = value.CreateFactory(_joinableTaskCollection).WithPriority(Application.Current.Dispatcher, DispatcherPriority.Background);
+                }
+            }
+        }
+
+        [NotNull]
+        private protected TestServices? TestServices
+        {
+            get
+            {
+                return _testServices ?? throw new InvalidOperationException();
+            }
+
+            private set
+            {
+                _testServices = value;
+            }
+        }
+
+        protected JoinableTaskFactory JoinableTaskFactory
+            => _joinableTaskFactory ?? throw new InvalidOperationException();
+
+        protected CancellationToken HangMitigatingCancellationToken
+            => _hangMitigatingCancellationTokenSource.Token;
+
+        public virtual async Task InitializeAsync()
+        {
+            TestServices = await CreateTestServicesAsync();
+        }
+
+        /// <summary>
+        /// This method implements <see cref="IAsyncLifetime.DisposeAsync"/>, and is used for releasing resources
+        /// created by <see cref="IAsyncLifetime.InitializeAsync"/>. This method is only called if
+        /// <see cref="InitializeAsync"/> completes successfully.
+        /// </summary>
+        public virtual async Task DisposeAsync()
+        {
+            if (_joinableTaskCollection is object)
+            {
+                await _joinableTaskCollection.JoinTillEmptyAsync();
+            }
+
+            JoinableTaskContext = null;
+        }
+
+        /// <summary>
+        /// This method provides the implementation for <see cref="IDisposable.Dispose"/>.
+        /// This method is called via the <see cref="IDisposable"/> interface if the constructor completes successfully.
+        /// The <see cref="InitializeAsync"/> may or may not have completed successfully.
+        /// </summary>
+        public virtual void Dispose()
+        {
+        }
+
+        private protected virtual async Task<TestServices> CreateTestServicesAsync()
+            => await TestServices.CreateAsync(JoinableTaskFactory);
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/AbstractIntegrationTest.cs
@@ -15,9 +15,12 @@ using Xunit;
 
 namespace Roslyn.VisualStudio.IntegrationTests
 {
-    [IdeSettings(MinVersion = VisualStudioVersion.VS2022)]
+    [IdeSettings(MinVersion = VisualStudioVersion.VS2022, RootSuffix = "RoslynDev")]
     public abstract class AbstractIntegrationTest : IAsyncLifetime, IDisposable
     {
+        protected const string ProjectName = "TestProj";
+        protected const string SolutionName = "TestSolution";
+
         /// <summary>
         /// A long timeout used to avoid hangs in tests, where a test failure manifests as an operation never occurring.
         /// </summary>
@@ -102,9 +105,11 @@ namespace Roslyn.VisualStudio.IntegrationTests
         /// </summary>
         public virtual async Task DisposeAsync()
         {
+            await TestServices.SolutionExplorer.CloseSolutionAsync(HangMitigatingCancellationToken);
+
             if (_joinableTaskCollection is object)
             {
-                await _joinableTaskCollection.JoinTillEmptyAsync();
+                await _joinableTaskCollection.JoinTillEmptyAsync(HangMitigatingCancellationToken);
             }
 
             JoinableTaskContext = null;

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorInProcess.cs
@@ -2,13 +2,531 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editor.Implementation.Suggestions;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Utilities;
+using IOleCommandTarget = Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget;
+using OLECMDEXECOPT = Microsoft.VisualStudio.OLE.Interop.OLECMDEXECOPT;
+
 namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 {
     internal class EditorInProcess : InProcComponent
     {
+        internal static readonly Guid IWpfTextViewId = new("8C40265E-9FDB-4F54-A0FD-EBB72B7D0476");
+
         public EditorInProcess(TestServices testServices)
             : base(testServices)
         {
+        }
+
+        public async Task<IWpfTextView> GetActiveTextViewAsync(CancellationToken cancellationToken)
+            => (await GetActiveTextViewHostAsync(cancellationToken)).TextView;
+
+        public async Task SetTextAsync(string text, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var view = await GetActiveTextViewAsync(cancellationToken);
+            var textSnapshot = view.TextSnapshot;
+            var replacementSpan = new SnapshotSpan(textSnapshot, 0, textSnapshot.Length);
+            view.TextBuffer.Replace(replacementSpan, text);
+        }
+
+        public async Task MoveCaretAsync(int position, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var view = await GetActiveTextViewAsync(cancellationToken);
+
+            var subjectBuffer = view.GetBufferContainingCaret();
+            Assumes.Present(subjectBuffer);
+
+            var point = new SnapshotPoint(subjectBuffer.CurrentSnapshot, position);
+
+            view.Caret.MoveTo(point);
+        }
+
+        public async Task ActivateAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
+            dte.ActiveDocument.Activate();
+        }
+
+        public async Task<bool> IsUseSuggestionModeOnAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var textView = await GetActiveTextViewAsync(cancellationToken);
+
+            var subjectBuffer = textView.GetBufferContainingCaret();
+            Assumes.Present(subjectBuffer);
+
+            var options = textView.Options.GlobalOptions;
+            EditorOptionKey<bool> optionKey;
+            bool defaultOption;
+            if (IsDebuggerTextView(textView))
+            {
+                optionKey = new EditorOptionKey<bool>(PredefinedCompletionNames.SuggestionModeInDebuggerCompletionOptionName);
+                defaultOption = true;
+            }
+            else
+            {
+                optionKey = new EditorOptionKey<bool>(PredefinedCompletionNames.SuggestionModeInCompletionOptionName);
+                defaultOption = false;
+            }
+
+            if (!options.IsOptionDefined(optionKey, localScopeOnly: false))
+            {
+                return defaultOption;
+            }
+
+            return options.GetOptionValue(optionKey);
+
+            static bool IsDebuggerTextView(IWpfTextView textView)
+                => textView.Roles.Contains("DEBUGVIEW");
+        }
+
+        public async Task SetUseSuggestionModeAsync(bool value, CancellationToken cancellationToken)
+        {
+            if (await IsUseSuggestionModeOnAsync(cancellationToken) != value)
+            {
+                var dispatcher = await GetRequiredGlobalServiceAsync<SUIHostCommandDispatcher, IOleCommandTarget>(cancellationToken);
+                ErrorHandler.ThrowOnFailure(dispatcher.Exec(typeof(VSConstants.VSStd2KCmdID).GUID, (uint)VSConstants.VSStd2KCmdID.ToggleConsumeFirstCompletionMode, (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, IntPtr.Zero, IntPtr.Zero));
+
+                if (await IsUseSuggestionModeOnAsync(cancellationToken) != value)
+                {
+                    throw new InvalidOperationException($"{WellKnownCommandNames.Edit_ToggleCompletionMode} did not leave the editor in the expected state.");
+                }
+            }
+
+            if (!value)
+            {
+                // For blocking completion mode, make sure we don't have responsive completion interfering when
+                // integration tests run slowly.
+                await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+                var view = await GetActiveTextViewAsync(cancellationToken);
+                var options = view.Options.GlobalOptions;
+                options.SetOptionValue(DefaultOptions.ResponsiveCompletionOptionId, false);
+
+                var latencyGuardOptionKey = new EditorOptionKey<bool>("EnableTypingLatencyGuard");
+                options.SetOptionValue(latencyGuardOptionKey, false);
+            }
+        }
+
+        public async Task DismissLightBulbSessionAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var view = await GetActiveTextViewAsync(cancellationToken);
+
+            var broker = await GetComponentModelServiceAsync<ILightBulbBroker>(cancellationToken);
+            broker.DismissSession(view);
+        }
+
+        public async Task DismissCompletionSessionsAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            await WaitForCompletionSetAsync(cancellationToken);
+
+            var view = await GetActiveTextViewAsync(cancellationToken);
+
+            var broker = await GetComponentModelServiceAsync<ICompletionBroker>(cancellationToken);
+            broker.DismissAllSessions(view);
+        }
+
+        public async Task ShowLightBulbAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var shell = await GetRequiredGlobalServiceAsync<SVsUIShell, IVsUIShell>(cancellationToken);
+            var cmdGroup = typeof(VSConstants.VSStd14CmdID).GUID;
+            var cmdExecOpt = OLECMDEXECOPT.OLECMDEXECOPT_DONTPROMPTUSER;
+
+            var cmdID = VSConstants.VSStd14CmdID.ShowQuickFixes;
+            object? obj = null;
+            shell.PostExecCommand(cmdGroup, (uint)cmdID, (uint)cmdExecOpt, ref obj);
+        }
+
+        public async Task WaitForLightBulbSessionAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var view = await GetActiveTextViewAsync(cancellationToken);
+            var broker = await GetComponentModelServiceAsync<ILightBulbBroker>(cancellationToken);
+            await LightBulbHelper.WaitForLightBulbSessionAsync(broker, view, cancellationToken);
+        }
+
+        public async Task InvokeCodeActionListAsync(CancellationToken cancellationToken)
+        {
+            await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.SolutionCrawler, cancellationToken);
+            await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.DiagnosticService, cancellationToken);
+
+            await ShowLightBulbAsync(cancellationToken);
+            await WaitForLightBulbSessionAsync(cancellationToken);
+            await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LightBulb, cancellationToken);
+        }
+
+        public async Task<bool> IsLightBulbSessionExpandedAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var view = await GetActiveTextViewAsync(cancellationToken);
+
+            var broker = await GetComponentModelServiceAsync<ILightBulbBroker>(cancellationToken);
+            if (!broker.IsLightBulbSessionActive(view))
+            {
+                return false;
+            }
+
+            var session = broker.GetSession(view);
+            if (session == null || !session.IsExpanded)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public async Task<string[]> GetLightBulbActionsAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var view = await GetActiveTextViewAsync(cancellationToken);
+
+            var broker = await GetComponentModelServiceAsync<ILightBulbBroker>(cancellationToken);
+            return (await GetLightBulbActionsAsync(broker, view, cancellationToken)).Select(a => a.DisplayText).ToArray();
+        }
+
+        public async Task<bool> ApplyLightBulbActionAsync(string actionName, FixAllScope? fixAllScope, bool blockUntilComplete, CancellationToken cancellationToken)
+        {
+            var lightBulbAction = GetLightBulbApplicationAction(actionName, fixAllScope, blockUntilComplete);
+
+            var listenerProvider = await GetComponentModelServiceAsync<IAsynchronousOperationListenerProvider>(cancellationToken);
+            var listener = listenerProvider.GetListener(FeatureAttribute.LightBulb);
+
+            var task = JoinableTaskFactory.RunAsync(async () =>
+            {
+                using var _ = listener.BeginAsyncOperation(nameof(ApplyLightBulbActionAsync));
+
+                await JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, cancellationToken);
+
+                var activeTextView = await GetActiveTextViewAsync(cancellationToken);
+                return await lightBulbAction(activeTextView, cancellationToken);
+            });
+
+            if (blockUntilComplete)
+            {
+                var result = await task.JoinAsync(cancellationToken);
+                await DismissLightBulbSessionAsync(cancellationToken);
+                return result;
+            }
+
+            return true;
+        }
+
+        private Func<IWpfTextView, CancellationToken, Task<bool>> GetLightBulbApplicationAction(string actionName, FixAllScope? fixAllScope, bool willBlockUntilComplete)
+        {
+            return async (view, cancellationToken) =>
+            {
+                await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+                var broker = await GetComponentModelServiceAsync<ILightBulbBroker>(cancellationToken);
+
+                var actions = (await GetLightBulbActionsAsync(broker, view, cancellationToken)).ToArray();
+                var action = actions.FirstOrDefault(a => a.DisplayText == actionName);
+
+                if (action == null)
+                {
+                    var sb = new StringBuilder();
+                    foreach (var item in actions)
+                    {
+                        sb.AppendLine("Actual ISuggestedAction: " + item.DisplayText);
+                    }
+
+                    var bufferType = view.TextBuffer.ContentType.DisplayName;
+                    throw new InvalidOperationException(
+                        string.Format("ISuggestedAction {0} not found.  Buffer content type={1}\r\nActions: {2}", actionName, bufferType, sb.ToString()));
+                }
+
+                if (fixAllScope != null)
+                {
+                    if (!action.HasActionSets)
+                    {
+                        throw new InvalidOperationException($"Suggested action '{action.DisplayText}' does not support FixAllOccurrences.");
+                    }
+
+                    var actionSetsForAction = await action.GetActionSetsAsync(cancellationToken);
+                    var fixAllAction = await GetFixAllSuggestedActionAsync(actionSetsForAction, fixAllScope.Value, cancellationToken);
+                    if (fixAllAction == null)
+                    {
+                        throw new InvalidOperationException($"Unable to find FixAll in {fixAllScope.ToString()} code fix for suggested action '{action.DisplayText}'.");
+                    }
+
+                    action = fixAllAction;
+
+                    if (willBlockUntilComplete
+                        && action is FixAllSuggestedAction fixAllSuggestedAction
+                        && fixAllSuggestedAction.CodeAction is FixSomeCodeAction fixSomeCodeAction)
+                    {
+                        // Ensure the preview changes dialog will not be shown. Since the operation 'willBlockUntilComplete',
+                        // the caller would not be able to interact with the preview changes dialog, and the tests would
+                        // either timeout or deadlock.
+                        fixSomeCodeAction.GetTestAccessor().ShowPreviewChangesDialog = false;
+                    }
+
+                    if (string.IsNullOrEmpty(actionName))
+                    {
+                        return false;
+                    }
+
+                    // Dismiss the lightbulb session as we not invoking the original code fix.
+                    broker.DismissSession(view);
+                }
+
+                if (action is not SuggestedAction suggestedAction)
+                    return true;
+
+                broker.DismissSession(view);
+                var threadOperationExecutor = await GetComponentModelServiceAsync<IUIThreadOperationExecutor>(cancellationToken);
+                var guardedOperations = await GetComponentModelServiceAsync<IGuardedOperations2>(cancellationToken);
+                threadOperationExecutor.Execute(
+                    title: "Execute Suggested Action",
+                    defaultDescription: Accelerator.StripAccelerators(action.DisplayText, '_'),
+                    allowCancellation: true,
+                    showProgress: true,
+                    action: context =>
+                    {
+                        guardedOperations.CallExtensionPoint(
+                            errorSource: suggestedAction,
+                            call: () => suggestedAction.Invoke(context),
+                            exceptionGuardFilter: e => e is not OperationCanceledException);
+                    });
+
+                return true;
+            };
+        }
+
+        private async Task<IEnumerable<ISuggestedAction>> GetLightBulbActionsAsync(ILightBulbBroker broker, IWpfTextView view, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            if (!broker.IsLightBulbSessionActive(view))
+            {
+                var bufferType = view.TextBuffer.ContentType.DisplayName;
+                throw new Exception(string.Format("No light bulb session in View!  Buffer content type={0}", bufferType));
+            }
+
+            var activeSession = broker.GetSession(view);
+            if (activeSession == null)
+            {
+                var bufferType = view.TextBuffer.ContentType.DisplayName;
+                throw new InvalidOperationException(string.Format("No expanded light bulb session found after View.ShowSmartTag.  Buffer content type={0}", bufferType));
+            }
+
+            var actionSets = await LightBulbHelper.WaitForItemsAsync(broker, view, cancellationToken);
+            return await SelectActionsAsync(actionSets, cancellationToken);
+        }
+
+        private async Task<IEnumerable<ISuggestedAction>> SelectActionsAsync(IEnumerable<SuggestedActionSet> actionSets, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var actions = new List<ISuggestedAction>();
+
+            if (actionSets != null)
+            {
+                foreach (var actionSet in actionSets)
+                {
+                    if (actionSet.Actions != null)
+                    {
+                        foreach (var action in actionSet.Actions)
+                        {
+                            actions.Add(action);
+                            var nestedActionSets = await action.GetActionSetsAsync(cancellationToken);
+                            var nestedActions = await SelectActionsAsync(nestedActionSets, cancellationToken);
+                            actions.AddRange(nestedActions);
+                        }
+                    }
+                }
+            }
+
+            return actions;
+        }
+
+        private async Task<FixAllSuggestedAction?> GetFixAllSuggestedActionAsync(IEnumerable<SuggestedActionSet> actionSets, FixAllScope fixAllScope, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            foreach (var actionSet in actionSets)
+            {
+                foreach (var action in actionSet.Actions)
+                {
+                    if (action is FixAllSuggestedAction fixAllSuggestedAction)
+                    {
+                        var fixAllCodeAction = fixAllSuggestedAction.CodeAction as FixSomeCodeAction;
+                        if (fixAllCodeAction?.FixAllState?.Scope == fixAllScope)
+                        {
+                            return fixAllSuggestedAction;
+                        }
+                    }
+
+                    if (action.HasActionSets)
+                    {
+                        var nestedActionSets = await action.GetActionSetsAsync(cancellationToken);
+                        var fixAllCodeAction = await GetFixAllSuggestedActionAsync(nestedActionSets, fixAllScope, cancellationToken);
+                        if (fixAllCodeAction != null)
+                        {
+                            return fixAllCodeAction;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public Task PlaceCaretAsync(string marker, int charsOffset, CancellationToken cancellationToken)
+            => PlaceCaretAsync(marker, charsOffset, occurrence: 0, extendSelection: false, selectBlock: false, cancellationToken);
+
+        public async Task PlaceCaretAsync(
+            string marker,
+            int charsOffset,
+            int occurrence,
+            bool extendSelection,
+            bool selectBlock,
+            CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var view = await GetActiveTextViewAsync(cancellationToken);
+
+            var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
+            dte.Find.FindWhat = marker;
+            dte.Find.MatchCase = true;
+            dte.Find.MatchInHiddenText = true;
+            dte.Find.Target = EnvDTE.vsFindTarget.vsFindTargetCurrentDocument;
+            dte.Find.Action = EnvDTE.vsFindAction.vsFindActionFind;
+
+            var originalPosition = await GetCaretPositionAsync(cancellationToken);
+            view.Caret.MoveTo(new SnapshotPoint(view.GetBufferContainingCaret()!.CurrentSnapshot, 0));
+
+            if (occurrence > 0)
+            {
+                var result = EnvDTE.vsFindResult.vsFindResultNotFound;
+                for (var i = 0; i < occurrence; i++)
+                {
+                    result = dte.Find.Execute();
+                }
+
+                if (result != EnvDTE.vsFindResult.vsFindResultFound)
+                {
+                    throw new Exception("Occurrence " + occurrence + " of marker '" + marker + "' not found in text: " + view.TextSnapshot.GetText());
+                }
+            }
+            else
+            {
+                var result = dte.Find.Execute();
+                if (result != EnvDTE.vsFindResult.vsFindResultFound)
+                {
+                    throw new Exception("Marker '" + marker + "' not found in text: " + view.TextSnapshot.GetText());
+                }
+            }
+
+            if (charsOffset > 0)
+            {
+                for (var i = 0; i < charsOffset - 1; i++)
+                {
+                    view.Caret.MoveToNextCaretPosition();
+                }
+
+                view.Selection.Clear();
+            }
+
+            if (charsOffset < 0)
+            {
+                // On the first negative charsOffset, move to anchor-point position, as if the user hit the LEFT key
+                view.Caret.MoveTo(new SnapshotPoint(view.TextSnapshot, view.Selection.AnchorPoint.Position.Position));
+
+                for (var i = 0; i < -charsOffset - 1; i++)
+                {
+                    view.Caret.MoveToPreviousCaretPosition();
+                }
+
+                view.Selection.Clear();
+            }
+
+            if (extendSelection)
+            {
+                var newPosition = view.Selection.ActivePoint.Position.Position;
+                view.Selection.Select(new VirtualSnapshotPoint(view.TextSnapshot, originalPosition), new VirtualSnapshotPoint(view.TextSnapshot, newPosition));
+                view.Selection.Mode = selectBlock ? TextSelectionMode.Box : TextSelectionMode.Stream;
+            }
+        }
+
+        public async Task<int> GetCaretPositionAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var view = await GetActiveTextViewAsync(cancellationToken);
+
+            var subjectBuffer = view.GetBufferContainingCaret();
+            Assumes.Present(subjectBuffer);
+
+            var bufferPosition = view.Caret.Position.BufferPosition;
+            return bufferPosition.Position;
+        }
+
+        private async Task WaitForCompletionSetAsync(CancellationToken cancellationToken)
+        {
+            await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.CompletionSet, cancellationToken);
+        }
+
+        private async Task<IWpfTextViewHost> GetActiveTextViewHostAsync(CancellationToken cancellationToken)
+        {
+            // The active text view might not have finished composing yet, waiting for the application to 'idle'
+            // means that it is done pumping messages (including WM_PAINT) and the window should return the correct text
+            // view.
+            await WaitForApplicationIdleAsync(cancellationToken);
+
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var activeVsTextView = (IVsUserData)await GetActiveVsTextViewAsync(cancellationToken);
+
+            ErrorHandler.ThrowOnFailure(activeVsTextView.GetData(IWpfTextViewId, out var wpfTextViewHost));
+
+            return (IWpfTextViewHost)wpfTextViewHost;
+        }
+
+        private async Task<IVsTextView> GetActiveVsTextViewAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var vsTextManager = await GetRequiredGlobalServiceAsync<SVsTextManager, IVsTextManager>(cancellationToken);
+
+            ErrorHandler.ThrowOnFailure(vsTextManager.GetActiveView(fMustHaveFocus: 1, pBuffer: null, ppView: out var vsTextView));
+
+            return vsTextView;
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorInProcess.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    internal class EditorInProcess : InProcComponent
+    {
+        public EditorInProcess(TestServices testServices)
+            : base(testServices)
+        {
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorVerifierInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorVerifierInProcess.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Roslyn.Utilities;
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    internal class EditorVerifierInProcess : InProcComponent
+    {
+        public EditorVerifierInProcess(TestServices testServices)
+            : base(testServices)
+        {
+        }
+
+        public async Task CodeActionAsync(
+            string expectedItem,
+            bool applyFix = false,
+            bool verifyNotShowing = false,
+            bool ensureExpectedItemsAreOrdered = false,
+            FixAllScope? fixAllScope = null,
+            bool blockUntilComplete = true,
+            CancellationToken cancellationToken = default)
+        {
+            var expectedItems = new[] { expectedItem };
+
+            bool? applied;
+            do
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                applied = await CodeActionsAsync(expectedItems, applyFix ? expectedItem : null, verifyNotShowing,
+                    ensureExpectedItemsAreOrdered, fixAllScope, blockUntilComplete, cancellationToken);
+            } while (applied is false);
+        }
+
+        /// <returns>
+        /// <list type="bullet">
+        /// <item><description><see langword="true"/> if <paramref name="applyFix"/> is specified and the fix is successfully applied</description></item>
+        /// <item><description><see langword="false"/> if <paramref name="applyFix"/> is specified but the fix is not successfully applied</description></item>
+        /// <item><description><see langword="null"/> if <paramref name="applyFix"/> is false, so there is no fix to apply</description></item>
+        /// </list>
+        /// </returns>
+        public async Task<bool?> CodeActionsAsync(
+            IEnumerable<string> expectedItems,
+            string? applyFix = null,
+            bool verifyNotShowing = false,
+            bool ensureExpectedItemsAreOrdered = false,
+            FixAllScope? fixAllScope = null,
+            bool blockUntilComplete = true,
+            CancellationToken cancellationToken = default)
+        {
+            await TestServices.Editor.ShowLightBulbAsync(cancellationToken);
+            await TestServices.Editor.WaitForLightBulbSessionAsync(cancellationToken);
+
+            if (verifyNotShowing)
+            {
+                await CodeActionsNotShowingAsync(cancellationToken);
+                return null;
+            }
+
+            var actions = await TestServices.Editor.GetLightBulbActionsAsync(cancellationToken);
+
+            if (expectedItems != null && expectedItems.Any())
+            {
+                if (ensureExpectedItemsAreOrdered)
+                {
+                    TestUtilities.ThrowIfExpectedItemNotFoundInOrder(
+                        actions,
+                        expectedItems);
+                }
+                else
+                {
+                    TestUtilities.ThrowIfExpectedItemNotFound(
+                        actions,
+                        expectedItems);
+                }
+            }
+
+            if (fixAllScope.HasValue)
+            {
+                Assumes.Present(applyFix);
+            }
+
+            if (!RoslynString.IsNullOrEmpty(applyFix))
+            {
+                var result = await TestServices.Editor.ApplyLightBulbActionAsync(applyFix, fixAllScope, blockUntilComplete, cancellationToken);
+
+                if (blockUntilComplete)
+                {
+                    // wait for action to complete
+                    await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LightBulb, cancellationToken);
+                }
+
+                return result;
+            }
+
+            return null;
+        }
+
+        public async Task CodeActionsNotShowingAsync(CancellationToken cancellationToken)
+        {
+            if (await TestServices.Editor.IsLightBulbSessionExpandedAsync(cancellationToken))
+            {
+                throw new InvalidOperationException("Expected no light bulb session, but one was found.");
+            }
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorVerifierInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorVerifierInProcess.cs
@@ -60,7 +60,6 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
             CancellationToken cancellationToken = default)
         {
             await TestServices.Editor.ShowLightBulbAsync(cancellationToken);
-            await TestServices.Editor.WaitForLightBulbSessionAsync(cancellationToken);
 
             if (verifyNotShowing)
             {

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ErrorListInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ErrorListInProcess.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    internal class ErrorListInProcess : InProcComponent
+    {
+        public ErrorListInProcess(TestServices testServices)
+            : base(testServices)
+        {
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/Helper.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/Helper.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    internal static class Helper
+    {
+        /// <summary>
+        /// This method will retry the asynchronous action represented by <paramref name="action"/>,
+        /// waiting for <paramref name="delay"/> time after each retry. If a given retry returns a value 
+        /// other than the default value of <typeparamref name="T"/>, this value is returned.
+        /// </summary>
+        /// <param name="action">the asynchronous action to retry</param>
+        /// <param name="delay">the amount of time to wait between retries</param>
+        /// <typeparam name="T">type of return value</typeparam>
+        /// <returns>the return value of <paramref name="action"/></returns>
+        public static Task<T?> RetryAsync<T>(Func<CancellationToken, Task<T>> action, TimeSpan delay, CancellationToken cancellationToken)
+        {
+            return RetryAsyncHelper(
+                async cancellationToken =>
+                {
+                    try
+                    {
+                        return await action(cancellationToken);
+                    }
+                    catch (COMException)
+                    {
+                        // Devenv can throw COMExceptions if it's busy when we make DTE calls.
+                        return default;
+                    }
+                },
+                delay,
+                cancellationToken);
+        }
+
+        private static async Task<T> RetryAsyncHelper<T>(Func<CancellationToken, Task<T>> action, TimeSpan delay, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                var retval = await action(cancellationToken).ConfigureAwait(true);
+                if (!Equals(default(T), retval))
+                {
+                    return retval;
+                }
+
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(true);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InProcComponent.cs
@@ -3,7 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using Microsoft;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
+using Xunit.Threading;
 
 namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 {
@@ -17,5 +26,42 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
         public TestServices TestServices { get; }
 
         protected JoinableTaskFactory JoinableTaskFactory => TestServices.JoinableTaskFactory;
+
+        protected async Task<TInterface> GetRequiredGlobalServiceAsync<TService, TInterface>(CancellationToken cancellationToken)
+            where TService : class
+            where TInterface : class
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var serviceProvider = (IAsyncServiceProvider2?)await AsyncServiceProvider.GlobalProvider.GetServiceAsync(typeof(SAsyncServiceProvider)).WithCancellation(cancellationToken);
+            Assumes.Present(serviceProvider);
+
+            var @interface = (TInterface?)await serviceProvider.GetServiceAsync(typeof(TService)).WithCancellation(cancellationToken);
+            Assumes.Present(@interface);
+            return @interface;
+        }
+
+        protected async Task<TService> GetComponentModelServiceAsync<TService>(CancellationToken cancellationToken)
+            where TService : class
+        {
+            var componentModel = await GetRequiredGlobalServiceAsync<SComponentModel, IComponentModel>(cancellationToken);
+            return componentModel.GetService<TService>();
+        }
+
+        /// <summary>
+        /// Waiting for the application to 'idle' means that it is done pumping messages (including WM_PAINT).
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token that the operation will observe.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        protected static async Task WaitForApplicationIdleAsync(CancellationToken cancellationToken)
+        {
+            var synchronizationContext = new DispatcherSynchronizationContext(Application.Current.Dispatcher, DispatcherPriority.ApplicationIdle);
+            var taskScheduler = new SynchronizationContextTaskScheduler(synchronizationContext);
+            await Task.Factory.StartNew(
+                () => { },
+                cancellationToken,
+                TaskCreationOptions.None,
+                taskScheduler);
+        }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InProcComponent.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.VisualStudio.Threading;
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    internal abstract class InProcComponent
+    {
+        protected InProcComponent(TestServices testServices)
+        {
+            TestServices = testServices ?? throw new ArgumentNullException(nameof(testServices));
+        }
+
+        public TestServices TestServices { get; }
+
+        protected JoinableTaskFactory JoinableTaskFactory => TestServices.JoinableTaskFactory;
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/LightBulbHelper.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/LightBulbHelper.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Threading;
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    public static class LightBulbHelper
+    {
+        public static async Task<bool> WaitForLightBulbSessionAsync(ILightBulbBroker broker, IWpfTextView view, CancellationToken cancellationToken)
+        {
+            var startTime = DateTimeOffset.Now;
+
+            var active = await Helper.RetryAsync(async cancellationToken =>
+            {
+                if (broker.IsLightBulbSessionActive(view))
+                {
+                    return true;
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    throw new InvalidOperationException("Expected a light bulb session to appear.");
+                }
+
+                // checking whether there is any suggested action is async up to editor layer and our waiter doesn't track up to that point.
+                // so here, we have no other way than sleep (with timeout) to see LB is available.
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+
+                return broker.IsLightBulbSessionActive(view);
+            }, TimeSpan.FromMilliseconds(1), cancellationToken);
+
+            if (!active)
+                return false;
+
+            await WaitForItemsAsync(broker, view, cancellationToken);
+            return true;
+        }
+
+        public static async Task<IEnumerable<SuggestedActionSet>> WaitForItemsAsync(ILightBulbBroker broker, IWpfTextView view, CancellationToken cancellationToken)
+        {
+            var activeSession = broker.GetSession(view);
+            if (activeSession == null)
+            {
+                var bufferType = view.TextBuffer.ContentType.DisplayName;
+                throw new InvalidOperationException($"No expanded light bulb session found after View.ShowSmartTag.  Buffer content type={bufferType}");
+            }
+
+            var asyncSession = (IAsyncLightBulbSession)activeSession;
+            var tcs = new TaskCompletionSource<List<SuggestedActionSet>>();
+
+            EventHandler<SuggestedActionsUpdatedArgs>? handler = null;
+            handler = (s, e) =>
+            {
+                // ignore these.  we care about when the lightbulb items are all completed.
+                if (e.Status == QuerySuggestedActionCompletionStatus.InProgress)
+                    return;
+
+                if (e.Status == QuerySuggestedActionCompletionStatus.Completed)
+                    tcs.SetResult(e.ActionSets.ToList());
+                else
+                    tcs.SetException(new InvalidOperationException($"Light bulb transitioned to non-complete state: {e.Status}"));
+
+                asyncSession.SuggestedActionsUpdated -= handler;
+            };
+
+            asyncSession.SuggestedActionsUpdated += handler;
+
+            asyncSession.Dismissed += (_, _) => tcs.TrySetCanceled(new CancellationToken(true));
+
+            if (asyncSession.IsDismissed)
+                tcs.TrySetCanceled(new CancellationToken(true));
+
+            // Calling PopulateWithData ensures the underlying session will call SuggestedActionsUpdated at least once
+            // with the latest data computed.  This is needed so that if the lightbulb computation is already complete
+            // that we hear about the results.
+            asyncSession.PopulateWithData(overrideRequestedActionCategories: null, operationContext: null);
+
+            return await tcs.Task.WithCancellation(cancellationToken);
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    internal class SolutionExplorerInProcess : InProcComponent
+    {
+        public SolutionExplorerInProcess(TestServices testServices)
+            : base(testServices)
+        {
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
@@ -2,6 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.OperationProgress;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Threading;
+using NuGet.SolutionRestoreManager;
+using IAsyncDisposable = System.IAsyncDisposable;
+using Reference = VSLangProj.Reference;
+using VSProject = VSLangProj.VSProject;
+
 namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 {
     internal class SolutionExplorerInProcess : InProcComponent
@@ -9,6 +33,528 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
         public SolutionExplorerInProcess(TestServices testServices)
             : base(testServices)
         {
+        }
+
+        public async Task CreateSolutionAsync(string solutionName, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var solutionPath = CreateTemporaryPath();
+            await CreateSolutionAsync(solutionPath, solutionName, cancellationToken);
+        }
+
+        public async Task CreateSolutionAsync(string solutionName, XElement solutionElement, CancellationToken cancellationToken)
+        {
+            if (solutionElement.Name != "Solution")
+            {
+                throw new ArgumentException(nameof(solutionElement));
+            }
+
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            await CreateSolutionAsync(solutionName, cancellationToken);
+
+            foreach (var projectElement in solutionElement.Elements("Project"))
+            {
+                await CreateProjectAsync(projectElement, cancellationToken);
+            }
+
+            foreach (var projectElement in solutionElement.Elements("Project"))
+            {
+                var projectReferences = projectElement.Attribute("ProjectReferences")?.Value;
+                if (projectReferences != null)
+                {
+                    var projectName = projectElement.Attribute("ProjectName").Value;
+                    foreach (var projectReference in projectReferences.Split(';'))
+                    {
+                        await AddProjectReferenceAsync(projectName, projectReference, cancellationToken);
+                    }
+                }
+            }
+        }
+
+        private async Task CreateProjectAsync(XElement projectElement, CancellationToken cancellationToken)
+        {
+            const string language = "Language";
+            const string name = "ProjectName";
+            const string template = "ProjectTemplate";
+            var languageName = projectElement.Attribute(language)?.Value
+                ?? throw new ArgumentException($"You must specify an attribute called '{language}' on a project element.");
+            var projectName = projectElement.Attribute(name)?.Value
+                ?? throw new ArgumentException($"You must specify an attribute called '{name}' on a project element.");
+            var projectTemplate = projectElement.Attribute(template)?.Value
+                ?? throw new ArgumentException($"You must specify an attribute called '{template}' on a project element.");
+
+            var projectPath = Path.Combine(await GetDirectoryNameAsync(cancellationToken), projectName);
+            var projectTemplatePath = await GetProjectTemplatePathAsync(projectTemplate, ConvertLanguageName(languageName), cancellationToken);
+
+            var solution = (await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken)).Solution;
+            Assumes.Present(solution);
+
+            solution.AddFromTemplate(projectTemplatePath, projectPath, projectName, Exclusive: false);
+            foreach (var documentElement in projectElement.Elements("Document"))
+            {
+                var fileName = documentElement.Attribute("FileName").Value;
+                await UpdateOrAddFileAsync(projectName, fileName, contents: documentElement.Value, cancellationToken: cancellationToken);
+            }
+        }
+
+        public async Task AddProjectReferenceAsync(string projectName, string projectToReferenceName, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var project = await GetProjectAsync(projectName, cancellationToken);
+            var projectToReference = await GetProjectAsync(projectToReferenceName, cancellationToken);
+            ((VSProject)project.Object).References.AddProject(projectToReference);
+        }
+
+        private async Task CreateSolutionAsync(string solutionPath, string solutionName, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            await CloseSolutionAsync(cancellationToken);
+
+            var solutionFileName = Path.ChangeExtension(solutionName, ".sln");
+            Directory.CreateDirectory(solutionPath);
+
+            var solution = await GetRequiredGlobalServiceAsync<SVsSolution, IVsSolution>(cancellationToken);
+            ErrorHandler.ThrowOnFailure(solution.CreateSolution(solutionPath, solutionFileName, (uint)__VSCREATESOLUTIONFLAGS.CSF_SILENT));
+            ErrorHandler.ThrowOnFailure(solution.SaveSolutionElement((uint)__VSSLNSAVEOPTIONS.SLNSAVEOPT_ForceSave, null, 0));
+        }
+
+        public async Task<string[]> GetAssemblyReferencesAsync(string projectName, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var project = await GetProjectAsync(projectName, cancellationToken);
+            var references = ((VSProject)project.Object).References.Cast<Reference>()
+                .Where(x => x.SourceProject == null)
+                .Select(x => x.Name + "," + x.Version + "," + x.PublicKeyToken).ToArray();
+            return references;
+        }
+
+        public async Task<string[]> GetProjectReferencesAsync(string projectName, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var project = await GetProjectAsync(projectName, cancellationToken);
+            var references = ((VSProject)project.Object).References.Cast<Reference>().Where(x => x.SourceProject != null).Select(x => x.Name).ToArray();
+            return references;
+        }
+
+        public async Task AddProjectAsync(string projectName, string projectTemplate, string languageName, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var projectPath = Path.Combine(await GetDirectoryNameAsync(cancellationToken), projectName);
+            var projectTemplatePath = await GetProjectTemplatePathAsync(projectTemplate, ConvertLanguageName(languageName), cancellationToken);
+            var solution = await GetRequiredGlobalServiceAsync<SVsSolution, IVsSolution6>(cancellationToken);
+            ErrorHandler.ThrowOnFailure(solution.AddNewProjectFromTemplate(projectTemplatePath, null, null, projectPath, projectName, null, out _));
+        }
+
+        public async Task RestoreNuGetPackagesAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
+            var solution = (EnvDTE80.Solution2)dte.Solution;
+            foreach (var project in solution.Projects.OfType<EnvDTE.Project>())
+            {
+                await RestoreNuGetPackagesAsync(project.FullName, cancellationToken);
+            }
+        }
+
+        public async Task RestoreNuGetPackagesAsync(string projectName, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var operationProgressStatus = await GetRequiredGlobalServiceAsync<SVsOperationProgress, IVsOperationProgressStatusService>(cancellationToken);
+            var stageStatus = operationProgressStatus.GetStageStatus(CommonOperationProgressStageIds.Intellisense);
+            await stageStatus.WaitForCompletionAsync().WithCancellation(cancellationToken);
+
+            var solutionRestoreService = await GetComponentModelServiceAsync<IVsSolutionRestoreService>(cancellationToken);
+            await solutionRestoreService.CurrentRestoreOperation;
+
+            var projectFullPath = (await GetProjectAsync(projectName, cancellationToken)).FullName;
+            var solutionRestoreStatusProvider = await GetComponentModelServiceAsync<IVsSolutionRestoreStatusProvider>(cancellationToken);
+            if (await solutionRestoreStatusProvider.IsRestoreCompleteAsync(cancellationToken))
+            {
+                return;
+            }
+
+            var solutionRestoreService2 = (IVsSolutionRestoreService2)solutionRestoreService;
+            await solutionRestoreService2.NominateProjectAsync(projectFullPath, cancellationToken);
+
+            while (true)
+            {
+                if (await solutionRestoreStatusProvider.IsRestoreCompleteAsync(cancellationToken))
+                {
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken);
+            }
+        }
+
+        public async Task OpenFileAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var filePath = await GetAbsolutePathForProjectRelativeFilePathAsync(projectName, relativeFilePath, cancellationToken);
+            VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, filePath, VSConstants.LOGVIEWID.Code_guid, out _, out _, out _, out var view);
+
+            // Reliably set focus using NavigateToLineAndColumn
+            var textManager = await GetRequiredGlobalServiceAsync<SVsTextManager, IVsTextManager>(cancellationToken);
+            ErrorHandler.ThrowOnFailure(view.GetBuffer(out var textLines));
+            ErrorHandler.ThrowOnFailure(view.GetCaretPos(out var line, out var column));
+            ErrorHandler.ThrowOnFailure(textManager.NavigateToLineAndColumn(textLines, VSConstants.LOGVIEWID.Code_guid, line, column, line, column));
+        }
+
+        public async Task CloseCodeFileAsync(string projectName, string relativeFilePath, bool saveFile, CancellationToken cancellationToken)
+        {
+            await CloseFileAsync(projectName, relativeFilePath, VSConstants.LOGVIEWID.Code_guid, saveFile, cancellationToken);
+        }
+
+        private async Task CloseFileAsync(string projectName, string relativeFilePath, Guid logicalView, bool saveFile, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var filePath = await GetAbsolutePathForProjectRelativeFilePathAsync(projectName, relativeFilePath, cancellationToken);
+            if (!VsShellUtilities.IsDocumentOpen(ServiceProvider.GlobalProvider, filePath, logicalView, out _, out _, out var windowFrame))
+            {
+                throw new InvalidOperationException($"File '{filePath}' is not open in logical view '{logicalView}'");
+            }
+
+            var frameClose = saveFile ? __FRAMECLOSE.FRAMECLOSE_SaveIfDirty : __FRAMECLOSE.FRAMECLOSE_NoSave;
+            ErrorHandler.ThrowOnFailure(windowFrame.CloseFrame((uint)frameClose));
+        }
+
+        /// <summary>
+        /// Update the given file if it already exists in the project, otherwise add a new file to the project.
+        /// </summary>
+        /// <param name="projectName">The project that contains the file.</param>
+        /// <param name="fileName">The name of the file to update or add.</param>
+        /// <param name="contents">The contents of the file to overwrite if the file already exists or set if the file it created. Empty string is used if null is passed.</param>
+        /// <param name="open">Whether to open the file after it has been updated/created.</param>
+        public async Task UpdateOrAddFileAsync(string projectName, string fileName, string? contents = null, bool open = false, CancellationToken cancellationToken = default)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var project = await GetProjectAsync(projectName, cancellationToken);
+            if (project.ProjectItems.Cast<EnvDTE.ProjectItem>().Any(x => x.Name == fileName))
+            {
+                await UpdateFileAsync(projectName, fileName, contents, open, cancellationToken);
+            }
+            else
+            {
+                await AddFileAsync(projectName, fileName, contents, open, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Update the given file to have the contents given.
+        /// </summary>
+        /// <param name="projectName">The project that contains the file.</param>
+        /// <param name="fileName">The name of the file to update or add.</param>
+        /// <param name="contents">The contents of the file to overwrite. Empty string is used if null is passed.</param>
+        /// <param name="open">Whether to open the file after it has been updated.</param>
+        public async Task UpdateFileAsync(string projectName, string fileName, string? contents = null, bool open = false, CancellationToken cancellationToken = default)
+        {
+            async Task SetTextAsync(string text, CancellationToken cancellationToken)
+            {
+                await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+                // The active text view might not have finished composing yet, waiting for the application to 'idle'
+                // means that it is done pumping messages (including WM_PAINT) and the window should return the correct text view
+                await WaitForApplicationIdleAsync(cancellationToken);
+
+                var vsTextManager = await GetRequiredGlobalServiceAsync<SVsTextManager, IVsTextManager>(cancellationToken);
+                var hresult = vsTextManager.GetActiveView(fMustHaveFocus: 1, pBuffer: null, ppView: out var vsTextView);
+                Marshal.ThrowExceptionForHR(hresult);
+                var activeVsTextView = (IVsUserData)vsTextView;
+
+                hresult = activeVsTextView.GetData(EditorInProcess.IWpfTextViewId, out var wpfTextViewHost);
+                Marshal.ThrowExceptionForHR(hresult);
+
+                var view = ((IWpfTextViewHost)wpfTextViewHost).TextView;
+                var textSnapshot = view.TextSnapshot;
+                var replacementSpan = new SnapshotSpan(textSnapshot, 0, textSnapshot.Length);
+                view.TextBuffer.Replace(replacementSpan, text);
+            }
+
+            await OpenFileAsync(projectName, fileName, cancellationToken);
+            await SetTextAsync(contents ?? string.Empty, cancellationToken);
+            await CloseCodeFileAsync(projectName, fileName, saveFile: true, cancellationToken);
+            if (open)
+            {
+                await OpenFileAsync(projectName, fileName, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Add new file to project.
+        /// </summary>
+        /// <param name="projectName">The project that contains the file.</param>
+        /// <param name="fileName">The name of the file to add.</param>
+        /// <param name="contents">The contents of the file to overwrite. An empty file is create if null is passed.</param>
+        /// <param name="open">Whether to open the file after it has been updated.</param>
+        public async Task AddFileAsync(string projectName, string fileName, string? contents = null, bool open = false, CancellationToken cancellationToken = default)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var project = await GetProjectAsync(projectName, cancellationToken);
+            var projectDirectory = Path.GetDirectoryName(project.FullName);
+            var filePath = Path.Combine(projectDirectory, fileName);
+            var directoryPath = Path.GetDirectoryName(filePath);
+            Directory.CreateDirectory(directoryPath);
+
+            if (contents != null)
+            {
+                File.WriteAllText(filePath, contents);
+            }
+            else if (!File.Exists(filePath))
+            {
+                File.Create(filePath).Dispose();
+            }
+
+            _ = project.ProjectItems.AddFromFile(filePath);
+
+            if (open)
+            {
+                await OpenFileAsync(projectName, fileName, cancellationToken);
+            }
+        }
+
+        private static string ConvertLanguageName(string languageName)
+        {
+            return languageName switch
+            {
+                LanguageNames.CSharp => "CSharp",
+                LanguageNames.VisualBasic => "VisualBasic",
+                _ => throw new ArgumentException($"'{languageName}' is not supported.", nameof(languageName)),
+            };
+        }
+
+        private async Task<string> GetAbsolutePathForProjectRelativeFilePathAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
+            var solution = dte.Solution;
+            Assumes.Present(solution);
+
+            var project = solution.Projects.Cast<EnvDTE.Project>().First(x => x.Name == projectName);
+            var projectPath = Path.GetDirectoryName(project.FullName);
+            return Path.Combine(projectPath, relativeFilePath);
+        }
+
+        private async Task<bool> IsSolutionOpenAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var solution = await GetRequiredGlobalServiceAsync<SVsSolution, IVsSolution>(cancellationToken);
+            ErrorHandler.ThrowOnFailure(solution.GetProperty((int)__VSPROPID.VSPROPID_IsSolutionOpen, out var isOpen));
+            return (bool)isOpen;
+        }
+
+        /// <summary>
+        /// Close the currently open solution without saving.
+        /// </summary>
+        public async Task CloseSolutionAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var solution = await GetRequiredGlobalServiceAsync<SVsSolution, IVsSolution>(cancellationToken);
+            if (!await IsSolutionOpenAsync(cancellationToken))
+            {
+                return;
+            }
+
+#pragma warning disable IDE0007 // Use implicit type (implicit type introduces a compiler warning)
+            using SemaphoreSlim semaphore = new SemaphoreSlim(1);
+#pragma warning restore IDE0007 // Use implicit type
+            await using var solutionEvents = new SolutionEvents(JoinableTaskFactory, solution);
+
+            await semaphore.WaitAsync(cancellationToken);
+
+            void HandleAfterCloseSolution(object sender, EventArgs e)
+                => semaphore.Release();
+
+            solutionEvents.AfterCloseSolution += HandleAfterCloseSolution;
+            try
+            {
+                ErrorHandler.ThrowOnFailure(solution.CloseSolutionElement((uint)__VSSLNCLOSEOPTIONS.SLNCLOSEOPT_DeleteProject | (uint)__VSSLNSAVEOPTIONS.SLNSAVEOPT_NoSave, null, 0));
+                await semaphore.WaitAsync(cancellationToken);
+            }
+            finally
+            {
+                solutionEvents.AfterCloseSolution -= HandleAfterCloseSolution;
+            }
+        }
+
+        private async Task<string> GetDirectoryNameAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var solution = await GetRequiredGlobalServiceAsync<SVsSolution, IVsSolution>(cancellationToken);
+            ErrorHandler.ThrowOnFailure(solution.GetSolutionInfo(out _, out var solutionFileFullPath, out _));
+            if (string.IsNullOrEmpty(solutionFileFullPath))
+            {
+                throw new InvalidOperationException();
+            }
+
+            return Path.GetDirectoryName(solutionFileFullPath);
+        }
+
+        private async Task<string> GetProjectTemplatePathAsync(string projectTemplate, string languageName, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
+            var solution = (EnvDTE80.Solution2)dte.Solution;
+
+            if (string.Equals(languageName, "csharp", StringComparison.OrdinalIgnoreCase)
+                && (await GetCSharpProjectTemplatesAsync(cancellationToken)).TryGetValue(projectTemplate, out var csharpProjectTemplate))
+            {
+                return solution.GetProjectTemplate(csharpProjectTemplate, languageName);
+            }
+
+            if (string.Equals(languageName, "visualbasic", StringComparison.OrdinalIgnoreCase)
+                && (await GetVisualBasicProjectTemplatesAsync(cancellationToken)).TryGetValue(projectTemplate, out var visualBasicProjectTemplate))
+            {
+                return solution.GetProjectTemplate(visualBasicProjectTemplate, languageName);
+            }
+
+            return solution.GetProjectTemplate(projectTemplate, languageName);
+        }
+
+        private async Task<ImmutableDictionary<string, string>> GetCSharpProjectTemplatesAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var hostLocale = await GetRequiredGlobalServiceAsync<SUIHostLocale, IUIHostLocale>(cancellationToken);
+            ErrorHandler.ThrowOnFailure(hostLocale.GetUILocale(out var localeID));
+
+            var builder = ImmutableDictionary.CreateBuilder<string, string>();
+            builder[WellKnownProjectTemplates.ClassLibrary] = $@"Windows\{localeID}\ClassLibrary.zip";
+            builder[WellKnownProjectTemplates.ConsoleApplication] = "Microsoft.CSharp.ConsoleApplication";
+            builder[WellKnownProjectTemplates.Website] = "EmptyWeb.zip";
+            builder[WellKnownProjectTemplates.WinFormsApplication] = "WindowsApplication.zip";
+            builder[WellKnownProjectTemplates.WpfApplication] = "WpfApplication.zip";
+            builder[WellKnownProjectTemplates.WebApplication] = "WebApplicationProject40";
+            return builder.ToImmutable();
+        }
+
+        private async Task<ImmutableDictionary<string, string>> GetVisualBasicProjectTemplatesAsync(CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var hostLocale = await GetRequiredGlobalServiceAsync<SUIHostLocale, IUIHostLocale>(cancellationToken);
+            ErrorHandler.ThrowOnFailure(hostLocale.GetUILocale(out var localeID));
+
+            var builder = ImmutableDictionary.CreateBuilder<string, string>();
+            builder[WellKnownProjectTemplates.ClassLibrary] = $@"Windows\{localeID}\ClassLibrary.zip";
+            builder[WellKnownProjectTemplates.ConsoleApplication] = "Microsoft.VisualBasic.Windows.ConsoleApplication";
+            builder[WellKnownProjectTemplates.Website] = "EmptyWeb.zip";
+            builder[WellKnownProjectTemplates.WinFormsApplication] = "WindowsApplication.zip";
+            builder[WellKnownProjectTemplates.WpfApplication] = "WpfApplication.zip";
+            builder[WellKnownProjectTemplates.WebApplication] = "WebApplicationProject40";
+            return builder.ToImmutable();
+        }
+
+        private static string CreateTemporaryPath()
+        {
+            return Path.Combine(Path.GetTempPath(), "roslyn-test", Path.GetRandomFileName());
+        }
+
+        private async Task<EnvDTE.Project> GetProjectAsync(string nameOrFileName, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
+            var solution = (EnvDTE80.Solution2)dte.Solution;
+            return solution.Projects.OfType<EnvDTE.Project>().First(
+                project =>
+                {
+                    ThreadHelper.ThrowIfNotOnUIThread();
+                    return string.Equals(project.FileName, nameOrFileName, StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(project.Name, nameOrFileName, StringComparison.OrdinalIgnoreCase);
+                });
+        }
+
+        private sealed class SolutionEvents : IVsSolutionEvents, IAsyncDisposable
+        {
+            private readonly JoinableTaskFactory _joinableTaskFactory;
+            private readonly IVsSolution _solution;
+            private readonly uint _cookie;
+
+            public SolutionEvents(JoinableTaskFactory joinableTaskFactory, IVsSolution solution)
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
+                _joinableTaskFactory = joinableTaskFactory;
+                _solution = solution;
+                ErrorHandler.ThrowOnFailure(solution.AdviseSolutionEvents(this, out _cookie));
+            }
+
+            public event EventHandler? AfterCloseSolution;
+
+            public async ValueTask DisposeAsync()
+            {
+                await _joinableTaskFactory.SwitchToMainThreadAsync(CancellationToken.None);
+                ErrorHandler.ThrowOnFailure(_solution.UnadviseSolutionEvents(_cookie));
+            }
+
+            public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
+            {
+                return VSConstants.S_OK;
+            }
+
+            public int OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
+            {
+                return VSConstants.S_OK;
+            }
+
+            public int OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
+            {
+                return VSConstants.S_OK;
+            }
+
+            public int OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
+            {
+                return VSConstants.S_OK;
+            }
+
+            public int OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)
+            {
+                return VSConstants.S_OK;
+            }
+
+            public int OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
+            {
+                return VSConstants.S_OK;
+            }
+
+            public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
+            {
+                return VSConstants.S_OK;
+            }
+
+            public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
+            {
+                return VSConstants.S_OK;
+            }
+
+            public int OnBeforeCloseSolution(object pUnkReserved)
+            {
+                return VSConstants.S_OK;
+            }
+
+            public int OnAfterCloseSolution(object pUnkReserved)
+            {
+                AfterCloseSolution?.Invoke(this, EventArgs.Empty);
+                return VSConstants.S_OK;
+            }
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionVerifierInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/SolutionVerifierInProcess.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    internal class SolutionVerifierInProcess : InProcComponent
+    {
+        public SolutionVerifierInProcess(TestServices testServices)
+            : base(testServices)
+        {
+        }
+
+        public async Task AssemblyReferencePresentAsync(string projectName, string assemblyName, string assemblyVersion, string assemblyPublicKeyToken, CancellationToken cancellationToken)
+        {
+            var assemblyReferences = await TestServices.SolutionExplorer.GetAssemblyReferencesAsync(projectName, cancellationToken);
+            var expectedAssemblyReference = assemblyName + "," + assemblyVersion + "," + assemblyPublicKeyToken.ToUpper();
+            Assert.Contains(expectedAssemblyReference, assemblyReferences);
+        }
+
+        public async Task ProjectReferencePresent(string projectName, string referencedProjectName, CancellationToken cancellationToken)
+        {
+            var projectReferences = await TestServices.SolutionExplorer.GetProjectReferencesAsync(projectName, cancellationToken);
+            Assert.Contains(referencedProjectName, projectReferences);
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/TestServices.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/TestServices.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    internal class TestServices
+    {
+        protected TestServices(JoinableTaskFactory joinableTaskFactory)
+        {
+            JoinableTaskFactory = joinableTaskFactory;
+
+            Editor = new EditorInProcess(this);
+            ErrorList = new ErrorListInProcess(this);
+            SolutionExplorer = new SolutionExplorerInProcess(this);
+        }
+
+        public JoinableTaskFactory JoinableTaskFactory { get; }
+
+        public EditorInProcess Editor { get; }
+
+        public ErrorListInProcess ErrorList { get; }
+
+        public SolutionExplorerInProcess SolutionExplorer { get; }
+
+        internal static async Task<TestServices> CreateAsync(JoinableTaskFactory joinableTaskFactory)
+        {
+            var services = new TestServices(joinableTaskFactory);
+            await services.InitializeAsync();
+            return services;
+        }
+
+        protected virtual Task InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/TestServices.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/TestServices.cs
@@ -14,17 +14,26 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
             JoinableTaskFactory = joinableTaskFactory;
 
             Editor = new EditorInProcess(this);
+            EditorVerifier = new EditorVerifierInProcess(this);
             ErrorList = new ErrorListInProcess(this);
             SolutionExplorer = new SolutionExplorerInProcess(this);
+            SolutionVerifier = new SolutionVerifierInProcess(this);
+            Workspace = new WorkspaceInProcess(this);
         }
 
         public JoinableTaskFactory JoinableTaskFactory { get; }
 
         public EditorInProcess Editor { get; }
 
+        public EditorVerifierInProcess EditorVerifier { get; }
+
         public ErrorListInProcess ErrorList { get; }
 
         public SolutionExplorerInProcess SolutionExplorer { get; }
+
+        public SolutionVerifierInProcess SolutionVerifier { get; }
+
+        public WorkspaceInProcess Workspace { get; }
 
         internal static async Task<TestServices> CreateAsync(JoinableTaskFactory joinableTaskFactory)
         {
@@ -35,6 +44,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 
         protected virtual Task InitializeAsync()
         {
+            WorkspaceInProcess.EnableAsynchronousOperationTracking();
             return Task.CompletedTask;
         }
     }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
@@ -60,7 +60,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
             await featureWaiter.ExpeditedWaitAsync().WithCancellation(cancellationToken);
         }
 
-        private async Task WaitForProjectSystemAsync(CancellationToken cancellationToken)
+        public async Task WaitForProjectSystemAsync(CancellationToken cancellationToken)
         {
             var operationProgressStatus = await GetRequiredGlobalServiceAsync<SVsOperationProgress, IVsOperationProgressStatusService>(cancellationToken);
             var stageStatus = operationProgressStatus.GetStageStatus(CommonOperationProgressStageIds.Intellisense);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.OperationProgress;
+using Microsoft.VisualStudio.Threading;
+
+namespace Roslyn.VisualStudio.IntegrationTests.InProcess
+{
+    internal class WorkspaceInProcess : InProcComponent
+    {
+        public WorkspaceInProcess(TestServices testServices)
+            : base(testServices)
+        {
+        }
+
+        internal static void EnableAsynchronousOperationTracking()
+        {
+            AsynchronousOperationListenerProvider.Enable(true);
+        }
+
+        public async Task<bool> IsPrettyListingOnAsync(string languageName, CancellationToken cancellationToken)
+        {
+            var globalOptions = await GetComponentModelServiceAsync<IGlobalOptionService>(cancellationToken);
+            return globalOptions.GetOption(FeatureOnOffOptions.PrettyListing, languageName);
+        }
+
+        public async Task SetPrettyListingAsync(string languageName, bool value, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var globalOptions = await GetComponentModelServiceAsync<IGlobalOptionService>(cancellationToken);
+            globalOptions.SetGlobalOption(new OptionKey(FeatureOnOffOptions.PrettyListing, languageName), value);
+        }
+
+        public Task WaitForAsyncOperationsAsync(string featuresToWaitFor, CancellationToken cancellationToken)
+            => WaitForAsyncOperationsAsync(featuresToWaitFor, waitForWorkspaceFirst: true, cancellationToken);
+
+        public async Task WaitForAsyncOperationsAsync(string featuresToWaitFor, bool waitForWorkspaceFirst, CancellationToken cancellationToken)
+        {
+            if (waitForWorkspaceFirst || featuresToWaitFor == FeatureAttribute.Workspace)
+            {
+                await WaitForProjectSystemAsync(cancellationToken);
+            }
+
+            var listenerProvider = await GetComponentModelServiceAsync<AsynchronousOperationListenerProvider>(cancellationToken);
+
+            if (waitForWorkspaceFirst)
+            {
+                var workspaceWaiter = listenerProvider.GetWaiter(FeatureAttribute.Workspace);
+                await workspaceWaiter.ExpeditedWaitAsync().WithCancellation(cancellationToken);
+            }
+
+            var featureWaiter = listenerProvider.GetWaiter(featuresToWaitFor);
+            await featureWaiter.ExpeditedWaitAsync().WithCancellation(cancellationToken);
+        }
+
+        private async Task WaitForProjectSystemAsync(CancellationToken cancellationToken)
+        {
+            var operationProgressStatus = await GetRequiredGlobalServiceAsync<SVsOperationProgress, IVsOperationProgressStatusService>(cancellationToken);
+            var stageStatus = operationProgressStatus.GetStageStatus(CommonOperationProgressStageIds.Intellisense);
+            await stageStatus.WaitForCompletionAsync().WithCancellation(cancellationToken);
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/Microsoft.VisualStudio.LanguageServices.New.IntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/Microsoft.VisualStudio.LanguageServices.New.IntegrationTests.csproj
@@ -7,6 +7,13 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\Compilers\Test\Core\MarkedSource\MarkupTestFile.cs" Link="MarkupTestFile.cs" />
+    <Compile Include="..\..\..\Compilers\Test\Core\Traits\Traits.cs" Link="Traits.cs" />
+    <Compile Include="..\TestUtilities\TestUtilities.cs" Link="TestUtilities.cs" />
+    <Compile Include="..\TestUtilities\WellKnownCommandNames.cs" Link="WellKnownCommandNames.cs" />
+    <Compile Include="..\TestUtilities\WellKnownProjectTemplates.cs" Link="WellKnownProjectTemplates.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
     <ProjectReference Include="..\..\..\Compilers\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
@@ -35,6 +42,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit" Version="$(MicrosoftVisualStudioExtensibilityTestingXunitVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
+    <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version="$(NuGetSolutionRestoreManagerInteropVersion)" />
     <PackageReference Include="xunit.assert" Version="$(xunitassertVersion)" />
     <PackageReference Include="xunit.extensibility.core" Version="$(xunitextensibilitycoreVersion)" />
     <PackageReference Include="xunit.extensibility.execution" Version="$(xunitextensibilityexecutionVersion)" />

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/Microsoft.VisualStudio.LanguageServices.New.IntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/Microsoft.VisualStudio.LanguageServices.New.IntegrationTests.csproj
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Roslyn.VisualStudio.IntegrationTests</RootNamespace>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
+    <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
+    <ProjectReference Include="..\..\..\Compilers\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
+    <ProjectReference Include="..\..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" />
+    <ProjectReference Include="..\..\..\EditorFeatures\Core.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj" />
+    <ProjectReference Include="..\..\..\EditorFeatures\CSharp\Microsoft.CodeAnalysis.CSharp.EditorFeatures.csproj" />
+    <ProjectReference Include="..\..\..\EditorFeatures\Text\Microsoft.CodeAnalysis.EditorFeatures.Text.csproj" />
+    <ProjectReference Include="..\..\..\EditorFeatures\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.vbproj" />
+    <ProjectReference Include="..\..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" />
+    <ProjectReference Include="..\..\..\Features\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
+    <ProjectReference Include="..\..\..\Features\LanguageServer\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
+    <ProjectReference Include="..\..\..\Features\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Features.vbproj" />
+    <ProjectReference Include="..\..\..\Interactive\Host\Microsoft.CodeAnalysis.InteractiveHost.csproj" />
+    <ProjectReference Include="..\..\..\Scripting\Core\Microsoft.CodeAnalysis.Scripting.csproj" />
+    <ProjectReference Include="..\..\..\Scripting\CSharp\Microsoft.CodeAnalysis.CSharp.Scripting.csproj" />
+    <ProjectReference Include="..\..\..\Scripting\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.Scripting.vbproj" />
+    <ProjectReference Include="..\..\..\Workspaces\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Workspaces.csproj" />
+    <ProjectReference Include="..\..\..\Workspaces\Remote\Core\Microsoft.CodeAnalysis.Remote.Workspaces.csproj" />
+    <ProjectReference Include="..\..\..\Workspaces\Remote\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.csproj" />
+    <ProjectReference Include="..\..\..\Workspaces\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj" />
+    <ProjectReference Include="..\..\Core\Def\Microsoft.VisualStudio.LanguageServices.csproj" />
+    <ProjectReference Include="..\..\Core\Impl\Microsoft.VisualStudio.LanguageServices.Implementation.csproj" />
+    <ProjectReference Include="..\..\CSharp\Impl\Microsoft.VisualStudio.LanguageServices.CSharp.csproj" />
+    <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit" Version="$(MicrosoftVisualStudioExtensibilityTestingXunitVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)" />
+    <PackageReference Include="xunit.assert" Version="$(xunitassertVersion)" />
+    <PackageReference Include="xunit.extensibility.core" Version="$(xunitextensibilitycoreVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(xunitextensibilityexecutionVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicAddMissingReference.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicAddMissingReference.cs
@@ -1,0 +1,168 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Roslyn.VisualStudio.IntegrationTests.InProcess;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
+{
+    public class BasicAddMissingReference : AbstractEditorTest
+    {
+        private const string FileInLibraryProject1 = @"Public Class Class1
+    Inherits System.Windows.Forms.Form
+    Public Sub goo()
+
+    End Sub
+End Class
+
+Public Class class2
+    Public Sub goo(ByVal x As System.Windows.Forms.Form)
+
+    End Sub
+
+    Public Event ee As System.Windows.Forms.ColumnClickEventHandler
+End Class
+
+Public Class class3
+    Implements System.Windows.Forms.IButtonControl
+
+    Public Property DialogResult() As System.Windows.Forms.DialogResult Implements System.Windows.Forms.IButtonControl.DialogResult
+        Get
+
+        End Get
+        Set(ByVal Value As System.Windows.Forms.DialogResult)
+
+        End Set
+    End Property
+
+    Public Sub NotifyDefault(ByVal value As Boolean) Implements System.Windows.Forms.IButtonControl.NotifyDefault
+
+    End Sub
+
+    Public Sub PerformClick() Implements System.Windows.Forms.IButtonControl.PerformClick
+
+    End Sub
+End Class
+";
+        private const string FileInLibraryProject2 = @"Public Class Class1
+    Inherits System.Xml.XmlAttribute
+    Sub New()
+        MyBase.New(Nothing, Nothing, Nothing, Nothing)
+    End Sub
+    Sub goo()
+
+    End Sub
+    Public bar As ClassLibrary3.Class1
+End Class
+";
+        private const string FileInLibraryProject3 = @"Public Class Class1
+    Public Enum E
+        E1
+        E2
+    End Enum
+
+    Public Function Goo() As ADODB.Recordset
+        Dim x As ADODB.Recordset = Nothing
+        Return x
+    End Function
+
+
+End Class
+";
+        private const string FileInConsoleProject1 = @"Imports System.Data.XLinq
+
+Module Module1
+
+    Sub Main()
+        'ERRID_UnreferencedAssembly3
+        Dim y As New ClassLibrary1.class2
+        y.goo(Nothing)
+
+        'ERRID_UnreferencedAssemblyEvent3
+        AddHandler y.ee, Nothing
+
+        'ERRID_UnreferencedAssemblyBase3
+        Dim x As New ClassLibrary1.Class1
+        x.goo()
+        'ERRID_UnreferencedAssemblyImplements3
+        Dim z As New ClassLibrary1.class3
+        Dim xxx = z.DialogResult
+        'ERRID_SymbolFromUnreferencedProject3
+        Dim a As New ClassLibrary2.Class1
+        Dim c As Boolean = a.HasChildNodes()
+
+        Dim d = a.bar
+    End Sub
+
+End Module
+";
+
+        private const string ClassLibrary1Name = "ClassLibrary1";
+        private const string ClassLibrary2Name = "ClassLibrary2";
+        private const string ClassLibrary3Name = "ClassLibrary3";
+        private const string ConsoleProjectName = "ConsoleApplication1";
+
+        protected override string LanguageName => LanguageNames.VisualBasic;
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync().ConfigureAwait(true);
+
+            await TestServices.SolutionExplorer.CreateSolutionAsync("ReferenceErrors", solutionElement: XElement.Parse(
+                "<Solution>" +
+               $"   <Project ProjectName=\"{ClassLibrary1Name}\" ProjectTemplate=\"{WellKnownProjectTemplates.WinFormsApplication}\" Language=\"{LanguageNames.VisualBasic}\">" +
+                "       <Document FileName=\"Class1.vb\"><![CDATA[" +
+                FileInLibraryProject1 +
+                "]]>" +
+                "       </Document>" +
+                "   </Project>" +
+               $"   <Project ProjectName=\"{ClassLibrary2Name}\" ProjectReferences=\"{ClassLibrary3Name}\" ProjectTemplate=\"{WellKnownProjectTemplates.ClassLibrary}\" Language=\"{LanguageNames.VisualBasic}\">" +
+                "       <Document FileName=\"Class1.vb\"><![CDATA[" +
+               FileInLibraryProject2 +
+                "]]>" +
+                "       </Document>" +
+                "   </Project>" +
+               $"   <Project ProjectName=\"{ClassLibrary3Name}\" ProjectTemplate=\"{WellKnownProjectTemplates.ClassLibrary}\" Language=\"{LanguageNames.VisualBasic}\">" +
+                "       <Document FileName=\"Class1.vb\"><![CDATA[" +
+               FileInLibraryProject3 +
+                "]]>" +
+                "       </Document>" +
+                "   </Project>" +
+               $"   <Project ProjectName=\"{ConsoleProjectName}\" ProjectReferences=\"{ClassLibrary1Name};{ClassLibrary2Name}\" ProjectTemplate=\"{WellKnownProjectTemplates.ConsoleApplication}\" Language=\"{LanguageNames.VisualBasic}\">" +
+                "       <Document FileName=\"Module1.vb\"><![CDATA[" +
+               FileInConsoleProject1 +
+                "]]>" +
+                "       </Document>" +
+               "   </Project>" +
+                "</Solution>"), HangMitigatingCancellationToken);
+        }
+
+        [IdeFact, Trait(Traits.Feature, Traits.Features.AddMissingReference)]
+        public async Task InvokeSomeFixesInVisualBasicThenVerifyReferences()
+        {
+            await TestServices.SolutionExplorer.OpenFileAsync(ConsoleProjectName, "Module1.vb", HangMitigatingCancellationToken);
+            await TestServices.Editor.PlaceCaretAsync("y.goo", charsOffset: 1, HangMitigatingCancellationToken);
+            await TestServices.Editor.InvokeCodeActionListAsync(HangMitigatingCancellationToken);
+            await TestServices.EditorVerifier.CodeActionAsync("Add reference to 'System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.", applyFix: true, cancellationToken: HangMitigatingCancellationToken);
+            await TestServices.SolutionVerifier.AssemblyReferencePresentAsync(
+               projectName: ConsoleProjectName,
+               assemblyName: "System.Windows.Forms",
+               assemblyVersion: "4.0.0.0",
+               assemblyPublicKeyToken: "b77a5c561934e089",
+               HangMitigatingCancellationToken);
+            await TestServices.Editor.PlaceCaretAsync("a.bar", charsOffset: 1, HangMitigatingCancellationToken);
+            await TestServices.Editor.InvokeCodeActionListAsync(HangMitigatingCancellationToken);
+            await TestServices.EditorVerifier.CodeActionAsync("Add project reference to 'ClassLibrary3'.", applyFix: true, cancellationToken: HangMitigatingCancellationToken);
+            await TestServices.SolutionVerifier.ProjectReferencePresent(
+               projectName: ConsoleProjectName,
+               referencedProjectName: ClassLibrary3Name,
+               HangMitigatingCancellationToken);
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -359,11 +359,19 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 {
                     Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"Roslyn\\Internal\\OnOff\\Features\" OOP64Bit dword 0")).WaitForExit();
                 }
+                else
+                {
+                    Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"Roslyn\\Internal\\OnOff\\Features\" OOP64Bit dword 1")).WaitForExit();
+                }
 
                 // Configure RemoteHostOptions.OOPCoreClrFeatureFlag for testing
                 if (string.Equals(Environment.GetEnvironmentVariable("ROSLYN_OOPCORECLR"), "true", StringComparison.OrdinalIgnoreCase))
                 {
                     Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"FeatureFlags\\Roslyn\\ServiceHubCore\" Value dword 1")).WaitForExit();
+                }
+                else
+                {
+                    Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"FeatureFlags\\Roslyn\\ServiceHubCore\" Value dword 0")).WaitForExit();
                 }
 
                 _firstLaunch = false;

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -115,6 +115,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.Closed.UnitTests" WorkItem="https://github.com/dotnet/roslyn/issues/35081" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.IntegrationTests" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.New.IntegrationTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.IntegrationTest.Setup" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.IntegrationTest.Utilities" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.Next.UnitTests" />


### PR DESCRIPTION
Roslyn's integration tests use a custom harness, where test code executes in a separate process (testhost.x86.exe or similar) and use .NET Remoting to invoke methods on objects within a Visual Studio instance. This pull request creates a second integration test project using the new test harness from microsoft/vs-extension-testing. In addition to moving maintenance of the test harness infrastructure to a common repository, this change significantly reduces integration test reliance on .NET Remoting in hopes of improving test performance and reliability by executing test code directly within the Visual Studio instance. It also standardizes diagnostics collection (screenshots, Windows event logs, the activity log, and IDE state at point of failure).

This change ports one notoriously flaky test from Roslyn's harness to the new harness, along with its required supporting methods. The new code differs primarily in the following ways:

* Where possible, non-DTE Visual Studio APIs are preferred to DTE APIs
* Where possible, operations are written as asynchronous (this especially includes the test itself, since the test entry point is now the main thread of a Visual Studio instance)
* Since tests run directly within Visual Studio, there is no need to separate in-proc and out-of-proc test objects

The goal of the new test project in the current limited form is twofold:

1. Evaluate the reliability of the test when run under the new harness
2. In the event of failure, compare our ability to diagnose the failure in the new harness with information provided by the old harness