### PR TITLE
Don't throw when delay is expedited in tests

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -54,18 +54,16 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, expeditedDelayCancellationToken);
 
             var delayTask = Task.Delay(delay, cancellationTokenSource.Token);
-            await delayTask.NoThrowAwaitable(false);
+            await delayTask.NoThrowAwaitableInternal(false);
 
             if (delayTask.Status != TaskStatus.RanToCompletion)
             {
-                if (expeditedDelayCancellationToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                {
-                    // The cancellation only occurred due to a request to expedite the operation.
-                    // Don't use try-catch to reduce the number of first chance exceptions.
-                    return false;
-                }
-
                 cancellationToken.ThrowIfCancellationRequested();
+
+                // The cancellation only occurred due to a request to expedite the operation.
+                // Don't use try-catch to reduce the number of first chance exceptions.
+                if (expeditedDelayCancellationToken.IsCancellationRequested)
+                    return false;
             }
 
             return true;

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -53,16 +53,22 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
 
             using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, expeditedDelayCancellationToken);
 
-            try
+            var delayTask = Task.Delay(delay, cancellationTokenSource.Token);
+            await delayTask.NoThrowAwaitable(false);
+
+            if (delayTask.Status != TaskStatus.RanToCompletion)
             {
-                await Task.Delay(delay, cancellationTokenSource.Token).ConfigureAwait(false);
-                return true;
+                if (expeditedDelayCancellationToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    // The cancellation only occurred due to a request to expedite the operation.
+                    // Don't use try-catch to reduce the number of first chance exceptions.
+                    return false;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
             }
-            catch (OperationCanceledException) when (expeditedDelayCancellationToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-            {
-                // The cancellation only occurred due to a request to expedite the operation
-                return false;
-            }
+
+            return true;
         }
 
         public IAsyncToken BeginAsyncOperation(string name, object? tag = null, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0)

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/TaskExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/TaskExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             }
         }
 
-        // Following code is copied from Microsoft.VisualStudio.Threading.TplExtensions
+        // Following code is copied from Microsoft.VisualStudio.Threading.TplExtensions (renamed to avoid ambiguity)
         // https://github.com/microsoft/vs-threading/blob/main/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         /// <param name="task">The task whose completion should signal the completion of the returned awaitable.</param>
         /// <param name="captureContext">if set to <c>true</c> the continuation will be scheduled on the caller's context; <c>false</c> to always execute the continuation on the threadpool.</param>
         /// <returns>An awaitable.</returns>
-        public static NoThrowTaskAwaitable NoThrowAwaitable(this Task task, bool captureContext = true)
+        public static NoThrowTaskAwaitable NoThrowAwaitableInternal(this Task task, bool captureContext = true)
         {
             return new NoThrowTaskAwaitable(task, captureContext);
         }

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/TaskExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/TaskExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Roslyn.Utilities;
@@ -43,6 +44,123 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
                     CancellationToken.None,
                     TaskContinuationOptions.ExecuteSynchronously,
                     TaskScheduler.Default);
+            }
+        }
+
+        // Following code is copied from Microsoft.VisualStudio.Threading.TplExtensions
+        // https://github.com/microsoft/vs-threading/blob/main/src/Microsoft.VisualStudio.Threading/TplExtensions.cs
+
+        /// <summary>
+        /// Returns an awaitable for the specified task that will never throw, even if the source task
+        /// faults or is canceled.
+        /// </summary>
+        /// <param name="task">The task whose completion should signal the completion of the returned awaitable.</param>
+        /// <param name="captureContext">if set to <c>true</c> the continuation will be scheduled on the caller's context; <c>false</c> to always execute the continuation on the threadpool.</param>
+        /// <returns>An awaitable.</returns>
+        public static NoThrowTaskAwaitable NoThrowAwaitable(this Task task, bool captureContext = true)
+        {
+            return new NoThrowTaskAwaitable(task, captureContext);
+        }
+
+        /// <summary>
+        /// An awaitable that wraps a task and never throws an exception when waited on.
+        /// </summary>
+        public readonly struct NoThrowTaskAwaitable
+        {
+            /// <summary>
+            /// The task.
+            /// </summary>
+            private readonly Task _task;
+
+            /// <summary>
+            /// A value indicating whether the continuation should be scheduled on the current sync context.
+            /// </summary>
+            private readonly bool _captureContext;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NoThrowTaskAwaitable" /> struct.
+            /// </summary>
+            /// <param name="task">The task.</param>
+            /// <param name="captureContext">Whether the continuation should be scheduled on the current sync context.</param>
+            public NoThrowTaskAwaitable(Task task, bool captureContext)
+            {
+                Contract.ThrowIfNull(task, nameof(task));
+                _task = task;
+                _captureContext = captureContext;
+            }
+
+            /// <summary>
+            /// Gets the awaiter.
+            /// </summary>
+            /// <returns>The awaiter.</returns>
+            public NoThrowTaskAwaiter GetAwaiter()
+            {
+                return new NoThrowTaskAwaiter(_task, _captureContext);
+            }
+        }
+
+        /// <summary>
+        /// An awaiter that wraps a task and never throws an exception when waited on.
+        /// </summary>
+        public readonly struct NoThrowTaskAwaiter : ICriticalNotifyCompletion
+        {
+            /// <summary>
+            /// The task.
+            /// </summary>
+            private readonly Task _task;
+
+            /// <summary>
+            /// A value indicating whether the continuation should be scheduled on the current sync context.
+            /// </summary>
+            private readonly bool _captureContext;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NoThrowTaskAwaiter"/> struct.
+            /// </summary>
+            /// <param name="task">The task.</param>
+            /// <param name="captureContext">if set to <c>true</c> [capture context].</param>
+            public NoThrowTaskAwaiter(Task task, bool captureContext)
+            {
+                Contract.ThrowIfNull(task, nameof(task));
+                _task = task;
+                _captureContext = captureContext;
+            }
+
+            /// <summary>
+            /// Gets a value indicating whether the task has completed.
+            /// </summary>
+            public bool IsCompleted
+            {
+                get { return _task.IsCompleted; }
+            }
+
+            /// <summary>
+            /// Schedules a delegate for execution at the conclusion of a task's execution.
+            /// </summary>
+            /// <param name="continuation">The action.</param>
+            public void OnCompleted(Action continuation)
+            {
+                _task.ConfigureAwait(_captureContext).GetAwaiter().OnCompleted(continuation);
+            }
+
+            /// <summary>
+            /// Schedules a delegate for execution at the conclusion of a task's execution
+            /// without capturing the ExecutionContext.
+            /// </summary>
+            /// <param name="continuation">The action.</param>
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                _task.ConfigureAwait(_captureContext).GetAwaiter().UnsafeOnCompleted(continuation);
+            }
+
+            /// <summary>
+            /// Does nothing.
+            /// </summary>
+#pragma warning disable CA1822 // Mark members as static
+            public void GetResult()
+#pragma warning restore CA1822 // Mark members as static
+            {
+                // Never throw here.
             }
         }
     }


### PR DESCRIPTION
To reduce the number of first chance exceptions in tests, which make it easier for existing tools to detect regression in number of exceptions thrown during tests.

For example, this change eliminated 7,000+ TaskCancelledException in the typing RPS test.