### PR TITLE
Move hte dependent checksum computation directly into the CompilationTracker component

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         ///   <item>The <see cref="Project.GetDependentVersionAsync(CancellationToken)"/> of the project snapshot that was used to calculate diagnostics.
         ///       <para>Note that this version can change even when nothing has actually changed (for example, forking the LSP text, reloading the same project).
         ///       So we additionally store:</para></item>
-        ///   <item>A checksum representing the project and its dependencies from <see cref="CalculateDependentProjectChecksumAsync(Project, CancellationToken)"/>.</item>
+        ///   <item>A checksum representing the project and its dependencies from <see cref="Project.GetDependentChecksumAsync(CancellationToken)"/>.</item>
         /// </list>
         /// This is used to determine if we need to re-calculate diagnostics.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -490,18 +490,20 @@ namespace Microsoft.CodeAnalysis
             => _projectState.GetSemanticVersionAsync(cancellationToken);
 
         /// <summary>
-        /// Calculates a checksum that contains a project's checksum along with a checksum for each of the project's transitive dependencies.
+        /// Calculates a checksum that contains a project's checksum along with a checksum for each of the project's 
+        /// transitive dependencies.
         /// </summary>
         /// <remarks>
-        /// This checksum calculation is used to determine if a diagnostics need to be recalculated based on the last reported checksum.
-        /// The goal is to ensure that changes to
+        /// This checksum calculation can be used for cases where a feature needs to know if the semantics in this project
+        /// changed.  For example, for diagnostics or caching computed semantic data. The goal is to ensure that changes to
         /// <list type="bullet">
         ///    <item>Files inside the current project</item>
         ///    <item>Project properties of the current project</item>
         ///    <item>Visible files in referenced projects</item>
         ///    <item>Project properties in referenced projects</item>
         /// </list>
-        /// are reflected in the metadata we keep so that comparing solutions accurately tells us when we need to recompute diagnostics.   
+        /// are reflected in the metadata we keep so that comparing solutions accurately tells us when we need to recompute
+        /// semantic work.   
         /// 
         /// <para>This method of checking for changes has a few important properties that differentiate it from other methods of determining project version.
         /// <list type="bullet">
@@ -510,7 +512,6 @@ namespace Microsoft.CodeAnalysis
         ///    <item>Reloading a project without making any changes will re-use cached diagnostics.
         ///        <see cref="Project.GetDependentSemanticVersionAsync(CancellationToken)"/> changes as the project is removed, then added resulting in a version change.</item>
         /// </list>   
-        /// Since diagnostic calculations happen OOP, these checksums already have been (or will be) created to do the diagnostics calculation anyway.
         /// </para>
         /// </remarks>
         internal Task<Checksum> GetDependentChecksumAsync(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -490,6 +490,33 @@ namespace Microsoft.CodeAnalysis
             => _projectState.GetSemanticVersionAsync(cancellationToken);
 
         /// <summary>
+        /// Calculates a checksum that contains a project's checksum along with a checksum for each of the project's transitive dependencies.
+        /// </summary>
+        /// <remarks>
+        /// This checksum calculation is used to determine if a diagnostics need to be recalculated based on the last reported checksum.
+        /// The goal is to ensure that changes to
+        /// <list type="bullet">
+        ///    <item>Files inside the current project</item>
+        ///    <item>Project properties of the current project</item>
+        ///    <item>Visible files in referenced projects</item>
+        ///    <item>Project properties in referenced projects</item>
+        /// </list>
+        /// are reflected in the metadata we keep so that comparing solutions accurately tells us when we need to recompute diagnostics.   
+        /// 
+        /// <para>This method of checking for changes has a few important properties that differentiate it from other methods of determining project version.
+        /// <list type="bullet">
+        ///    <item>Changes to methods inside the current project will be reflected to compute updated diagnostics.
+        ///        <see cref="Project.GetDependentSemanticVersionAsync(CancellationToken)"/> does not change as it only returns top level changes.</item>
+        ///    <item>Reloading a project without making any changes will re-use cached diagnostics.
+        ///        <see cref="Project.GetDependentSemanticVersionAsync(CancellationToken)"/> changes as the project is removed, then added resulting in a version change.</item>
+        /// </list>   
+        /// Since diagnostic calculations happen OOP, these checksums already have been (or will be) created to do the diagnostics calculation anyway.
+        /// </para>
+        /// </remarks>
+        internal Task<Checksum> GetDependentChecksumAsync(CancellationToken cancellationToken)
+            => _solution.State.GetDependentChecksumAsync(this.Id, cancellationToken);
+
+        /// <summary>
         /// Creates a new instance of this project updated to have the new assembly name.
         /// </summary>
         public Project WithAssemblyName(string assemblyName)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -952,18 +952,11 @@ namespace Microsoft.CodeAnalysis
             {
                 try
                 {
-                    // if we already have the compilation and its right kind then use it.
-                    if (this.ProjectState.LanguageServices == fromProject.LanguageServices
-                        && this.TryGetCompilation(out var compilation))
-                    {
-                        return compilation.ToMetadataReference(projectReference.Aliases, projectReference.EmbedInteropTypes);
-                    }
-
                     // If same language then we can wrap the other project's compilation into a compilation reference
                     if (this.ProjectState.LanguageServices == fromProject.LanguageServices)
                     {
                         // otherwise, base it off the compilation by building it first.
-                        compilation = await this.GetCompilationAsync(solution, cancellationToken).ConfigureAwait(false);
+                        var compilation = await this.GetCompilationAsync(solution, cancellationToken).ConfigureAwait(false);
                         return compilation.ToMetadataReference(projectReference.Aliases, projectReference.EmbedInteropTypes);
                     }
                     else

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -1170,7 +1170,7 @@ namespace Microsoft.CodeAnalysis
                 var projectChecksum = await this.ProjectState.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
                 tempChecksumArray.Add(projectChecksum);
 
-                // Calculate a checksum this project and for each dependent project that could affect diagnostics for
+                // Calculate a checksum this project and for each dependent project that could affect semantics for
                 // this project. Ensure that the checksum calculation orders the projects consistently so that we get
                 // the same checksum across sessions of VS.  Note: we use the project filepath+name as a unique way
                 // to reference a project.  This matches the logic in our persistence-service implemention as to how

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -1078,12 +1078,13 @@ namespace Microsoft.CodeAnalysis
                 return state is FinalState finalState ? finalState.GeneratorInfo.Documents.GetState(documentId) : null;
             }
 
-            #region Versions
+            #region Versions and Checksums
 
             // Dependent Versions are stored on compilation tracker so they are more likely to survive when unrelated solution branching occurs.
 
             private AsyncLazy<VersionStamp>? _lazyDependentVersion;
             private AsyncLazy<VersionStamp>? _lazyDependentSemanticVersion;
+            private AsyncLazy<Checksum>? _lazyDependentChecksum;
 
             public Task<VersionStamp> GetDependentVersionAsync(SolutionState solution, CancellationToken cancellationToken)
             {
@@ -1148,6 +1149,52 @@ namespace Microsoft.CodeAnalysis
 
                 return version;
             }
+
+            public Task<Checksum> GetDependentChecksumAsync(SolutionState solution, CancellationToken cancellationToken)
+            {
+                if (_lazyDependentChecksum == null)
+                {
+                    var tmp = solution; // temp. local to avoid a closure allocation for the fast path
+                    // note: solution is captured here, but it will go away once GetValueAsync executes.
+                    Interlocked.CompareExchange(ref _lazyDependentChecksum, new AsyncLazy<Checksum>(c => ComputeDependentChecksumAsync(tmp, c), cacheResult: true), null);
+                }
+
+                return _lazyDependentChecksum.GetValueAsync(cancellationToken);
+            }
+
+            private async Task<Checksum> ComputeDependentChecksumAsync(SolutionState solution, CancellationToken cancellationToken)
+            {
+                using var tempChecksumArray = TemporaryArray<Checksum>.Empty;
+
+                // Get the checksum for the project itself.
+                var projectChecksum = await this.ProjectState.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
+                tempChecksumArray.Add(projectChecksum);
+
+                // Calculate a checksum this project and for each dependent project that could affect diagnostics for
+                // this project. Ensure that the checksum calculation orders the projects consistently so that we get
+                // the same checksum across sessions of VS.  Note: we use the project filepath+name as a unique way
+                // to reference a project.  This matches the logic in our persistence-service implemention as to how
+                // information is associated with a project.
+                var transitiveDependencies = solution.GetProjectDependencyGraph().GetProjectsThatThisProjectTransitivelyDependsOn(this.ProjectState.Id);
+                var orderedProjectIds = transitiveDependencies.Add(this.ProjectState.Id).OrderBy(id =>
+                {
+                    var depProject = solution.GetRequiredProjectState(id);
+                    return (depProject.FilePath, depProject.Name);
+                });
+
+                foreach (var projectId in orderedProjectIds)
+                {
+                    var referencedProject = solution.GetRequiredProjectState(projectId);
+
+                    // Note that these checksums should only actually be calculated once, if the project is unchanged
+                    // the same checksum will be returned.
+                    var referencedProjectChecksum = await referencedProject.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
+                    tempChecksumArray.Add(referencedProjectChecksum);
+                }
+
+                return Checksum.Create(tempChecksumArray.ToImmutableAndClear());
+            }
+
             #endregion
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
@@ -106,15 +106,14 @@ namespace Microsoft.CodeAnalysis
                 return _compilationWithReplacement;
             }
 
-            public Task<VersionStamp> GetDependentSemanticVersionAsync(SolutionState solution, CancellationToken cancellationToken)
-            {
-                return _underlyingTracker.GetDependentSemanticVersionAsync(solution, cancellationToken);
-            }
-
             public Task<VersionStamp> GetDependentVersionAsync(SolutionState solution, CancellationToken cancellationToken)
-            {
-                return _underlyingTracker.GetDependentVersionAsync(solution, cancellationToken);
-            }
+                => _underlyingTracker.GetDependentVersionAsync(solution, cancellationToken);
+
+            public Task<VersionStamp> GetDependentSemanticVersionAsync(SolutionState solution, CancellationToken cancellationToken)
+                => _underlyingTracker.GetDependentSemanticVersionAsync(solution, cancellationToken);
+
+            public Task<Checksum> GetDependentChecksumAsync(SolutionState solution, CancellationToken cancellationToken)
+                => _underlyingTracker.GetDependentChecksumAsync(solution, cancellationToken);
 
             public async Task<MetadataReference> GetMetadataReferenceAsync(SolutionState solution, ProjectState fromProject, ProjectReference projectReference, CancellationToken cancellationToken)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
@@ -54,22 +54,6 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            public bool? ContainsSymbolsWithNameFromDeclarationOnlyCompilation(Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken)
-            {
-                // TODO: This only needs to be implemented if a feature that operates from a source generated file needs to search for declarations
-                // with other names; those APIs are only used by certain code fixes which isn't a need for now. This will need to be fixed up when
-                // we complete https://github.com/dotnet/roslyn/issues/49533.
-                throw new NotImplementedException();
-            }
-
-            public bool? ContainsSymbolsWithNameFromDeclarationOnlyCompilation(string name, SymbolFilter filter, CancellationToken cancellationToken)
-            {
-                // TODO: This only needs to be implemented if a feature that operates from a source generated file needs to search for declarations
-                // with other names; those APIs are only used by certain code fixes which isn't a need for now. This will need to be fixed up when
-                // we complete https://github.com/dotnet/roslyn/issues/49533.
-                throw new NotImplementedException();
-            }
-
             public ICompilationTracker Fork(SolutionServices solutionServices, ProjectState newProject, CompilationAndGeneratorDriverTranslationAction? translate = null, CancellationToken cancellationToken = default)
             {
                 // TODO: This only needs to be implemented if a feature that operates from a source generated file then makes

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.ICompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.ICompilationTracker.cs
@@ -34,8 +34,10 @@ namespace Microsoft.CodeAnalysis
             ICompilationTracker Fork(SolutionServices solutionServices, ProjectState newProject, CompilationAndGeneratorDriverTranslationAction? translate = null, CancellationToken cancellationToken = default);
             ICompilationTracker FreezePartialStateWithTree(SolutionState solution, DocumentState docState, SyntaxTree tree, CancellationToken cancellationToken);
             Task<Compilation> GetCompilationAsync(SolutionState solution, CancellationToken cancellationToken);
-            Task<VersionStamp> GetDependentSemanticVersionAsync(SolutionState solution, CancellationToken cancellationToken);
+
             Task<VersionStamp> GetDependentVersionAsync(SolutionState solution, CancellationToken cancellationToken);
+            Task<VersionStamp> GetDependentSemanticVersionAsync(SolutionState solution, CancellationToken cancellationToken);
+            Task<Checksum> GetDependentChecksumAsync(SolutionState solution, CancellationToken cancellationToken);
 
             /// <summary>
             /// Get a metadata reference to this compilation info's compilation with respect to

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -399,6 +399,9 @@ namespace Microsoft.CodeAnalysis
         public Task<VersionStamp> GetDependentSemanticVersionAsync(ProjectId projectId, CancellationToken cancellationToken)
             => this.GetCompilationTracker(projectId).GetDependentSemanticVersionAsync(this, cancellationToken);
 
+        public Task<Checksum> GetDependentChecksumAsync(ProjectId projectId, CancellationToken cancellationToken)
+            => this.GetCompilationTracker(projectId).GetDependentChecksumAsync(this, cancellationToken);
+
         public ProjectState? GetProjectState(ProjectId projectId)
         {
             _projectIdToProjectStateMap.TryGetValue(projectId, out var state);


### PR DESCRIPTION
Move hte dependent checksum computation directly into the CompilationTracker component