### PR TITLE
Fix race condition in computing _hostAnalyzerStateMap

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private HostAnalyzerStateSets GetOrCreateHostStateSets(Project project, ProjectAnalyzerStateSets projectStateSets)
             {
-                var key = new HostAnalyzerStateSetKey { Language = project.Language, Analyzers = project.Solution.State.Analyzers };
+                var key = new HostAnalyzerStateSetKey(project.Language, project.Solution.State.Analyzers);
                 var hostStateSets = ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, key, CreateLanguageSpecificAnalyzerMap);
                 return hostStateSets.WithExcludedAnalyzers(projectStateSets.SkippedAnalyzersInfo.SkippedAnalyzers);
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -19,13 +19,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private HostAnalyzerStateSets GetOrCreateHostStateSets(Project project, ProjectAnalyzerStateSets projectStateSets)
             {
-                var hostStateSets = ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, (project.Language, project.Solution.State.Analyzers), CreateLanguageSpecificAnalyzerMap);
+                var key = new HostAnalyzerStateSetKey { Language = project.Language, Analyzers = project.Solution.State.Analyzers };
+                var hostStateSets = ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, key, CreateLanguageSpecificAnalyzerMap);
                 return hostStateSets.WithExcludedAnalyzers(projectStateSets.SkippedAnalyzersInfo.SkippedAnalyzers);
 
-                static HostAnalyzerStateSets CreateLanguageSpecificAnalyzerMap((string language, HostDiagnosticAnalyzers hostAnalyzers) arg)
+                static HostAnalyzerStateSets CreateLanguageSpecificAnalyzerMap(HostAnalyzerStateSetKey arg)
                 {
-                    var language = arg.language;
-                    var hostAnalyzers = arg.hostAnalyzers;
+                    var language = arg.Language;
+                    var hostAnalyzers = arg.Analyzers;
                     var analyzersPerReference = hostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(language);
 
                     var analyzerMap = CreateStateSetMap(language, analyzersPerReference.Values, includeFileContentLoadAnalyzer: true);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -19,14 +19,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private HostAnalyzerStateSets GetOrCreateHostStateSets(Project project, ProjectAnalyzerStateSets projectStateSets)
             {
-                var key = new HostAnalyzerStateSetKey(project.Language, project.Solution.State.Analyzers);
-                var hostStateSets = ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, key, CreateLanguageSpecificAnalyzerMap);
+                var key = new HostAnalyzerStateSetKey(project.Language, project.Solution.State.Analyzers.GetHostAnalyzerReferencesMap());
+                var hostStateSets = ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, key, CreateLanguageSpecificAnalyzerMap, project.Solution.State.Analyzers);
                 return hostStateSets.WithExcludedAnalyzers(projectStateSets.SkippedAnalyzersInfo.SkippedAnalyzers);
 
-                static HostAnalyzerStateSets CreateLanguageSpecificAnalyzerMap(HostAnalyzerStateSetKey arg)
+                static HostAnalyzerStateSets CreateLanguageSpecificAnalyzerMap(HostAnalyzerStateSetKey arg, HostDiagnosticAnalyzers hostAnalyzers)
                 {
                     var language = arg.Language;
-                    var hostAnalyzers = arg.Analyzers;
                     var analyzersPerReference = hostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(language);
 
                     var analyzerMap = CreateStateSetMap(language, analyzersPerReference.Values, includeFileContentLoadAnalyzer: true);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -19,11 +19,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private HostAnalyzerStateSets GetOrCreateHostStateSets(Project project, ProjectAnalyzerStateSets projectStateSets)
             {
-                var hostStateSets = ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, project.Language, CreateLanguageSpecificAnalyzerMap, project.Solution.State.Analyzers);
+                var hostStateSets = ImmutableInterlocked.GetOrAdd(ref _hostAnalyzerStateMap, (project.Language, project.Solution.State.Analyzers), CreateLanguageSpecificAnalyzerMap);
                 return hostStateSets.WithExcludedAnalyzers(projectStateSets.SkippedAnalyzersInfo.SkippedAnalyzers);
 
-                static HostAnalyzerStateSets CreateLanguageSpecificAnalyzerMap(string language, HostDiagnosticAnalyzers hostAnalyzers)
+                static HostAnalyzerStateSets CreateLanguageSpecificAnalyzerMap((string language, HostDiagnosticAnalyzers hostAnalyzers) arg)
                 {
+                    var language = arg.language;
+                    var hostAnalyzers = arg.hostAnalyzers;
                     var analyzersPerReference = hostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(language);
 
                     var analyzerMap = CreateStateSetMap(language, analyzersPerReference.Values, includeFileContentLoadAnalyzer: true);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -17,11 +17,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             public IEnumerable<StateSet> GetAllHostStateSets()
             {
                 var analyzerReferencesMap = _workspace.CurrentSolution.State.Analyzers.GetHostAnalyzerReferencesMap();
-                foreach (var key in _hostAnalyzerStateMap.Keys)
+                foreach (var (key, value) in _hostAnalyzerStateMap)
                 {
                     if (key.AnalyzerReferences == analyzerReferencesMap)
                     {
-                        foreach (var stateSet in _hostAnalyzerStateMap[key].OrderedStateSets)
+                        foreach (var stateSet in value.OrderedStateSets)
                         {
                             yield return stateSet;
                         }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -15,7 +15,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private partial class StateManager
         {
             public IEnumerable<StateSet> GetAllHostStateSets()
-                => _hostAnalyzerStateMap.Values.SelectMany(v => v.OrderedStateSets);
+            {
+                var analyzerReferencesMap = _workspace.CurrentSolution.State.Analyzers.GetHostAnalyzerReferencesMap();
+                foreach (var key in _hostAnalyzerStateMap.Keys)
+                {
+                    if (key.AnalyzerReferences == analyzerReferencesMap)
+                    {
+                        foreach (var stateSet in _hostAnalyzerStateMap[key].OrderedStateSets)
+                        {
+                            yield return stateSet;
+                        }
+                    }
+                }
+            }
 
             private HostAnalyzerStateSets GetOrCreateHostStateSets(Project project, ProjectAnalyzerStateSets projectStateSets)
             {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         /// </summary>
         private partial class StateManager
         {
+            private readonly Workspace _workspace;
             private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;
 
             /// <summary>
@@ -40,8 +41,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// </summary>
             public event EventHandler<ProjectAnalyzerReferenceChangedEventArgs>? ProjectAnalyzerReferenceChanged;
 
-            public StateManager(DiagnosticAnalyzerInfoCache analyzerInfoCache)
+            public StateManager(Workspace workspace, DiagnosticAnalyzerInfoCache analyzerInfoCache)
             {
+                _workspace = workspace;
                 _analyzerInfoCache = analyzerInfoCache;
 
                 _hostAnalyzerStateMap = ImmutableDictionary<HostAnalyzerStateSetKey, HostAnalyzerStateSets>.Empty;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// Analyzers supplied by the host (IDE). These are built-in to the IDE, the compiler, or from an installed IDE extension (VSIX). 
             /// Maps language name to the analyzers and their state.
             /// </summary>
-            private ImmutableDictionary<(string, HostDiagnosticAnalyzers), HostAnalyzerStateSets> _hostAnalyzerStateMap;
+            private ImmutableDictionary<HostAnalyzerStateSetKey, HostAnalyzerStateSets> _hostAnalyzerStateMap;
 
             /// <summary>
             /// Analyzers referenced by the project via a PackageReference.
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             {
                 _analyzerInfoCache = analyzerInfoCache;
 
-                _hostAnalyzerStateMap = ImmutableDictionary<(string, HostDiagnosticAnalyzers), HostAnalyzerStateSets>.Empty;
+                _hostAnalyzerStateMap = ImmutableDictionary<HostAnalyzerStateSetKey, HostAnalyzerStateSets>.Empty;
                 _projectAnalyzerStateMap = new ConcurrentDictionary<ProjectId, ProjectAnalyzerStateSets>(concurrencyLevel: 2, capacity: 10);
             }
 
@@ -307,6 +307,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var hostStates = GetAllHostStateSets().Where(state => !projectAnalyzers.Contains(state.Analyzer));
 
                 VerifyUniqueStateNames(hostStates.Concat(stateSets));
+            }
+
+            private struct HostAnalyzerStateSetKey
+            {
+                public string Language { get; set; }
+                public HostDiagnosticAnalyzers Analyzers { get; set; }
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -309,7 +310,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 VerifyUniqueStateNames(hostStates.Concat(stateSets));
             }
 
-            private readonly struct HostAnalyzerStateSetKey
+            private readonly struct HostAnalyzerStateSetKey : IEquatable<HostAnalyzerStateSetKey>
             {
                 public HostAnalyzerStateSetKey(string language, HostDiagnosticAnalyzers analyzers)
                 {
@@ -319,6 +320,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 public string Language { get; }
                 public HostDiagnosticAnalyzers Analyzers { get; }
+
+                public bool Equals(HostAnalyzerStateSetKey other)
+                    => Language == other.Language && Analyzers == other.Analyzers;
+
+                public override bool Equals(object? obj)
+                    => obj is HostAnalyzerStateSetKey key && Equals(key);
+
+                public override int GetHashCode()
+                    => Hash.Combine(Language.GetHashCode(), Analyzers.GetHashCode());
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// Analyzers supplied by the host (IDE). These are built-in to the IDE, the compiler, or from an installed IDE extension (VSIX). 
             /// Maps language name to the analyzers and their state.
             /// </summary>
-            private ImmutableDictionary<string, HostAnalyzerStateSets> _hostAnalyzerStateMap;
+            private ImmutableDictionary<(string, HostDiagnosticAnalyzers), HostAnalyzerStateSets> _hostAnalyzerStateMap;
 
             /// <summary>
             /// Analyzers referenced by the project via a PackageReference.
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             {
                 _analyzerInfoCache = analyzerInfoCache;
 
-                _hostAnalyzerStateMap = ImmutableDictionary<string, HostAnalyzerStateSets>.Empty;
+                _hostAnalyzerStateMap = ImmutableDictionary<(string, HostDiagnosticAnalyzers), HostAnalyzerStateSets>.Empty;
                 _projectAnalyzerStateMap = new ConcurrentDictionary<ProjectId, ProjectAnalyzerStateSets>(concurrencyLevel: 2, capacity: 10);
             }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 VerifyUniqueStateNames(hostStates.Concat(stateSets));
             }
 
-            private struct HostAnalyzerStateSetKey
+            private readonly struct HostAnalyzerStateSetKey
             {
                 public string Language { get; set; }
                 public HostDiagnosticAnalyzers Analyzers { get; set; }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -311,8 +311,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private readonly struct HostAnalyzerStateSetKey
             {
-                public string Language { get; set; }
-                public HostDiagnosticAnalyzers Analyzers { get; set; }
+                public HostAnalyzerStateSetKey(string language, HostDiagnosticAnalyzers analyzers)
+                {
+                    Language = language;
+                    Analyzers = analyzers;
+                }
+
+                public string Language { get; }
+                public HostDiagnosticAnalyzers Analyzers { get; }
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -312,23 +312,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private readonly struct HostAnalyzerStateSetKey : IEquatable<HostAnalyzerStateSetKey>
             {
-                public HostAnalyzerStateSetKey(string language, HostDiagnosticAnalyzers analyzers)
+                public HostAnalyzerStateSetKey(string language, ImmutableDictionary<object, AnalyzerReference> analyzerReferences)
                 {
                     Language = language;
-                    Analyzers = analyzers;
+                    AnalyzerReferences = analyzerReferences;
                 }
 
                 public string Language { get; }
-                public HostDiagnosticAnalyzers Analyzers { get; }
+                public ImmutableDictionary<object, AnalyzerReference> AnalyzerReferences { get; }
 
                 public bool Equals(HostAnalyzerStateSetKey other)
-                    => Language == other.Language && Analyzers == other.Analyzers;
+                    => Language == other.Language && AnalyzerReferences == other.AnalyzerReferences;
 
                 public override bool Equals(object? obj)
                     => obj is HostAnalyzerStateSetKey key && Equals(key);
 
                 public override int GetHashCode()
-                    => Hash.Combine(Language.GetHashCode(), Analyzers.GetHashCode());
+                    => Hash.Combine(Language.GetHashCode(), AnalyzerReferences.GetHashCode());
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             _correlationId = correlationId;
 
-            _stateManager = new StateManager(analyzerInfoCache);
+            _stateManager = new StateManager(workspace, analyzerInfoCache);
             _stateManager.ProjectAnalyzerReferenceChanged += OnProjectAnalyzerReferenceChanged;
             _telemetry = new DiagnosticAnalyzerTelemetry();
 


### PR DESCRIPTION
We recently moved the [HostDiagnosticAnalyzers](https://sourceroslyn.io/#q=HostDiagnosticAnalyzers) from workspace into [solution state](https://sourceroslyn.io/#Microsoft.CodeAnalysis.Workspaces/Workspace/Solution/SolutionState.cs,152). However, the IDE diagnostic incremental analyzer still stores a `_hostAnalyzerStateMap` keyed only by the language name, which was based on the assumption that `HostDiagnosticAnalyzers` is a workspace level singleton. This leads to a race condition where in if the first instance of `HostDiagnosticAnalyzers` on the solution state doesn't include all built-in VS analyzer references, these analyzers will never be enabled in VS. With this change, we now include the `HostDiagnosticAnalyzers` from the solution state as part of the key for `_hostAnalyzerStateMap`, avoiding this race.

I noticed this while running some integration tests (compiler diagnostics go missing as compiler diagnostic analyzer is not identified). Additionally, we also seem to have few VS feedback tickets where compiler diagnostics are missing through the editing session, and this is a likely cause: [AB#1431611](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1431611/) and [AB#1430922](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1430922/).

We are considering taking this fix for servicing releases for Dev17.0 and Dev16.11 (needs approval).