### PR TITLE
Document that MyTaskMethodBuilder must be public

### DIFF
--- a/docs/features/task-types.md
+++ b/docs/features/task-types.md
@@ -25,12 +25,12 @@ class Awaiter<T> : INotifyCompletion
 }
 ```
 ## Builder Type
-The _builder type_ is a `class` or `struct` that corresponds to the specific _task type_.
+The _builder type_ is a public `class` or `struct` that corresponds to the specific _task type_.
 The _builder type_ can have at most 1 type parameter and must not be nested in a generic type.
 The _builder type_ has the following `public` methods.
 For non-generic _builder types_, `SetResult()` has no parameters.
 ```cs
-class MyTaskMethodBuilder<T>
+public class MyTaskMethodBuilder<T>
 {
     public static MyTaskMethodBuilder<T> Create();
 


### PR DESCRIPTION
As far as I can tell, the builder for a custom task-like type must be public. At least when compiling using `dotnet` on Linux.