### PR TITLE
use pair-wise testing on PR validation

### DIFF
--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -18,27 +18,34 @@ pr:
 - features/*
 - demos/*
 
-variables:
-  - name: XUNIT_LOGS
-    value: $(Build.SourcesDirectory)\artifacts\log\$(_configuration)
-
 jobs:
-- job: VS_Integration_CoreHost
+- job: VS_Integration_CoreHost_Debug
   pool:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals $(queueName)
-  strategy:
-    maxParallel: 2
-    matrix:
-      debug:
-        _configuration: Debug
-      release:
-        _configuration: Release
   timeoutInMinutes: 135
-
+  variables:
+    - name: XUNIT_LOGS
+      value: $(Build.SourcesDirectory)\artifacts\log\Debug
   steps:
     - template: eng/pipelines/test-integration-job.yml
       parameters:
-        configuration: $(_configuration)
+        configuration: Debug
         oop64bit: true
         oopCoreClr: true
+
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - job: VS_Integration_CoreHost_Release
+    pool:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals $(queueName)
+    timeoutInMinutes: 135
+    variables:
+      - name: XUNIT_LOGS
+        value: $(Build.SourcesDirectory)\artifacts\log\Debug
+    steps:
+      - template: eng/pipelines/test-integration-job.yml
+        parameters:
+          configuration: Release
+          oop64bit: true
+          oopCoreClr: true

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -14,35 +14,65 @@ pr:
 - features/*
 - demos/*
 
-variables:
-  - name: XUNIT_LOGS
-    value: $(Build.SourcesDirectory)\artifacts\log\$(_configuration)
-
 jobs:
-- job: VS_Integration
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - job: VS_Integration_Debug_32
+    pool:
+      name: $(poolName)
+      demands: ImageOverride -equals $(queueName)
+    timeoutInMinutes: 135
+    variables:
+      - name: XUNIT_LOGS
+        value: $(Build.SourcesDirectory)\artifacts\log\Debug
+    steps:
+      - template: eng/pipelines/test-integration-job.yml
+        parameters:
+          configuration: Debug
+          oop64bit: false
+          lspEditor: false
+
+- job: VS_Integration_Debug_64
   pool:
     name: $(poolName)
     demands: ImageOverride -equals $(queueName)
-  strategy:
-    maxParallel: 4
-    matrix:
-      debug_32:
-        _configuration: Debug
-        _oop64bit: false
-      debug_64:
-        _configuration: Debug
-        _oop64bit: true
-      release_32:
-        _configuration: Release
-        _oop64bit: false
-      release_64:
-        _configuration: Release
-        _oop64bit: true
   timeoutInMinutes: 135
-
+  variables:
+    - name: XUNIT_LOGS
+      value: $(Build.SourcesDirectory)\artifacts\log\Debug
   steps:
     - template: eng/pipelines/test-integration-job.yml
       parameters:
-        configuration: $(_configuration)
-        oop64bit: $(_oop64bit)
+        configuration: Debug
+        oop64bit: true
         lspEditor: false
+
+- job: VS_Integration_Release_32
+  pool:
+    name: $(poolName)
+    demands: ImageOverride -equals $(queueName)
+  timeoutInMinutes: 135
+  variables:
+    - name: XUNIT_LOGS
+      value: $(Build.SourcesDirectory)\artifacts\log\Release
+  steps:
+    - template: eng/pipelines/test-integration-job.yml
+      parameters:
+        configuration: Release
+        oop64bit: false
+        lspEditor: false
+
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - job: VS_Integration_Release_64
+    pool:
+      name: $(poolName)
+      demands: ImageOverride -equals $(queueName)
+    timeoutInMinutes: 135
+    variables:
+      - name: XUNIT_LOGS
+        value: $(Build.SourcesDirectory)\artifacts\log\Release
+    steps:
+      - template: eng/pipelines/test-integration-job.yml
+        parameters:
+          configuration: Release
+          oop64bit: true
+          lspEditor: false


### PR DESCRIPTION
Same approach as was done in this PR https://github.com/dotnet/roslyn/pull/57586 applied to integration tests.

| Configuration | Bitness | Runtime   | Editor | Run on PR |
|:--------------|---------|-----------|--------|-----------|
| Debug         | x86     | Framework | Legacy | No        |
| Debug         | amd64   | Framework | Legacy | Yes       |
| Release       | x86     | Framework | Legacy | Yes       |
| Release       | amd64   | Framework | Legacy | No        |
| Debug         | amd64   | Framework | LSP    | Yes       |
| Debug         | amd64   | Core      | Legacy | Yes       |
| Release       | amd64   | Core      | Legacy | No        |