### PR TITLE
Include a type for NoneOperations in VB, print the type in tests

### DIFF
--- a/src/Compilers/CSharp/Test/IOperation/IOperation/FunctionPointerOperations.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/FunctionPointerOperations.cs
@@ -235,7 +235,7 @@ static unsafe class C
             var expectedOperationTree = @"
 IFunctionPointerInvocationOperation (OperationKind.FunctionPointerInvocation, Type: System.Int32) (Syntax: 'p[i](i)')
   Target:
-    IOperation:  (OperationKind.None, Type: null) (Syntax: 'p[i]')
+    IOperation:  (OperationKind.None, Type: delegate*<System.Int32, System.Int32>) (Syntax: 'p[i]')
       Children(2):
           IParameterReferenceOperation: p (OperationKind.ParameterReference, Type: delegate*<System.Int32, System.Int32>*) (Syntax: 'p')
           ILocalReferenceOperation: i (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i')

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IAddressOfOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IAddressOfOperation.cs
@@ -125,7 +125,7 @@ Block[B0] - Entry
                       Reference: 
                         IFieldReferenceOperation: System.Int32 S2.i (OperationKind.FieldReference, Type: System.Int32) (Syntax: '(x ? p1 : p2)->i')
                           Instance Receiver: 
-                            IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '(x ? p1 : p2)')
+                            IOperation:  (OperationKind.None, Type: S2, IsImplicit) (Syntax: '(x ? p1 : p2)')
                               Children(1):
                                   IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: S2*, IsImplicit) (Syntax: 'x ? p1 : p2')
 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IArgument.cs
@@ -3544,7 +3544,7 @@ IPropertyReferenceOperation: System.Int32 P.this[params System.Int32[] array] { 
 [assembly: /*<bind>*/System.CLSCompliant(isCompliant: true)/*</bind>*/]
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null) (Syntax: 'System.CLSC ... iant: true)')
+IOperation:  (OperationKind.None, Type: System.CLSCompliantAttribute) (Syntax: 'System.CLSC ... iant: true)')
   Children(1):
       ILiteralOperation (OperationKind.Literal, Type: System.Boolean, Constant: True) (Syntax: 'true')
 ";

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IDynamicIndexerAccessExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IDynamicIndexerAccessExpression.cs
@@ -460,7 +460,7 @@ Block[B1] - Block
                   Expression: 
                     IInvalidOperation (OperationKind.Invalid, Type: C, IsInvalid, IsImplicit) (Syntax: 'C')
                       Children(1):
-                          IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'C')
+                          IOperation:  (OperationKind.None, Type: C, IsInvalid) (Syntax: 'C')
                   Arguments(1):
                       IParameterReferenceOperation: d (OperationKind.ParameterReference, Type: dynamic) (Syntax: 'd')
                   ArgumentNames(0)

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFieldReferenceExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFieldReferenceExpression.cs
@@ -34,7 +34,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null) (Syntax: 'Conditional(field)')
+IOperation:  (OperationKind.None, Type: System.Diagnostics.ConditionalAttribute) (Syntax: 'Conditional(field)')
   Children(1):
       IFieldReferenceOperation: System.String C.field (Static) (OperationKind.FieldReference, Type: System.String, Constant: ""field"") (Syntax: 'field')
         Instance Receiver: 
@@ -275,7 +275,7 @@ unsafe class C
             string expectedOperationTree = @"
 ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: 's.field[3] = 1')
   Left: 
-    IOperation:  (OperationKind.None, Type: null) (Syntax: 's.field[3]')
+    IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: 's.field[3]')
       Children(2):
           IFieldReferenceOperation: System.Int32* S1.field (OperationKind.FieldReference, Type: System.Int32*) (Syntax: 's.field')
             Instance Receiver: 
@@ -313,7 +313,7 @@ unsafe class C
             string expectedOperationTree = @"
 ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: 's.field[3] = 1')
   Left: 
-    IOperation:  (OperationKind.None, Type: null) (Syntax: 's.field[3]')
+    IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: 's.field[3]')
       Children(2):
           IFieldReferenceOperation: System.Int32* S1.field (OperationKind.FieldReference, Type: System.Int32*) (Syntax: 's.field')
             Instance Receiver: 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFixedStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFixedStatement.cs
@@ -46,7 +46,7 @@ IFixedOperation (OperationKind.None, Type: null) (Syntax: 'fixed(int * ... }')
             IVariableDeclaratorOperation (Symbol: System.Int32* p) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p = &i')
               Initializer: 
                 IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &i')
-                  IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i')
+                  IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i')
                     Children(1):
                         IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i')
                           Reference: 
@@ -71,7 +71,7 @@ IFixedOperation (OperationKind.None, Type: null) (Syntax: 'fixed(int * ... }')
                             ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""P is "", IsImplicit) (Syntax: 'P is ')
                         IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{*p}')
                           Expression: 
-                            IOperation:  (OperationKind.None, Type: null) (Syntax: '*p')
+                            IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*p')
                               Children(1):
                                   ILocalReferenceOperation: p (OperationKind.LocalReference, Type: System.Int32*) (Syntax: 'p')
                           Alignment: 
@@ -123,7 +123,7 @@ IFixedOperation (OperationKind.None, Type: null) (Syntax: 'fixed (int* ... }')
             IVariableDeclaratorOperation (Symbol: System.Int32* p1) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p1 = &i1')
               Initializer: 
                 IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &i1')
-                  IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i1')
+                  IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i1')
                     Children(1):
                         IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i1')
                           Reference: 
@@ -133,7 +133,7 @@ IFixedOperation (OperationKind.None, Type: null) (Syntax: 'fixed (int* ... }')
             IVariableDeclaratorOperation (Symbol: System.Int32* p2) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p2 = &i2')
               Initializer: 
                 IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &i2')
-                  IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i2')
+                  IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i2')
                     Children(1):
                         IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i2')
                           Reference: 
@@ -152,11 +152,11 @@ IFixedOperation (OperationKind.None, Type: null) (Syntax: 'fixed (int* ... }')
             Right: 
               IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.Int32) (Syntax: '*p1 + *p2')
                 Left: 
-                  IOperation:  (OperationKind.None, Type: null) (Syntax: '*p1')
+                  IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*p1')
                     Children(1):
                         ILocalReferenceOperation: p1 (OperationKind.LocalReference, Type: System.Int32*) (Syntax: 'p1')
                 Right: 
-                  IOperation:  (OperationKind.None, Type: null) (Syntax: '*p2')
+                  IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*p2')
                     Children(1):
                         ILocalReferenceOperation: p2 (OperationKind.LocalReference, Type: System.Int32*) (Syntax: 'p2')
 ";
@@ -204,7 +204,7 @@ IFixedOperation (OperationKind.None, Type: null) (Syntax: 'fixed (int* ... }')
             IVariableDeclaratorOperation (Symbol: System.Int32* p1) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p1 = &i1')
               Initializer: 
                 IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &i1')
-                  IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i1')
+                  IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i1')
                     Children(1):
                         IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i1')
                           Reference: 
@@ -223,7 +223,7 @@ IFixedOperation (OperationKind.None, Type: null) (Syntax: 'fixed (int* ... }')
                 IVariableDeclaratorOperation (Symbol: System.Int32* p2) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p2 = &i2')
                   Initializer: 
                     IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &i2')
-                      IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i2')
+                      IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i2')
                         Children(1):
                             IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i2')
                               Reference: 
@@ -242,11 +242,11 @@ IFixedOperation (OperationKind.None, Type: null) (Syntax: 'fixed (int* ... }')
                 Right: 
                   IBinaryOperation (BinaryOperatorKind.Add) (OperationKind.Binary, Type: System.Int32) (Syntax: '*p1 + *p2')
                     Left: 
-                      IOperation:  (OperationKind.None, Type: null) (Syntax: '*p1')
+                      IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*p1')
                         Children(1):
                             ILocalReferenceOperation: p1 (OperationKind.LocalReference, Type: System.Int32*) (Syntax: 'p1')
                     Right: 
-                      IOperation:  (OperationKind.None, Type: null) (Syntax: '*p2')
+                      IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*p2')
                         Children(1):
                             ILocalReferenceOperation: p2 (OperationKind.LocalReference, Type: System.Int32*) (Syntax: 'p2')
 ";
@@ -301,7 +301,7 @@ IFixedOperation (OperationKind.None, Type: null, IsInvalid) (Syntax: 'fixed (int
             Left: 
               ILocalReferenceOperation: i3 (OperationKind.LocalReference, Type: System.Int32) (Syntax: 'i3')
             Right: 
-              IOperation:  (OperationKind.None, Type: null) (Syntax: '*p1')
+              IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*p1')
                 Children(1):
                     ILocalReferenceOperation: p1 (OperationKind.LocalReference, Type: System.Int32*) (Syntax: 'p1')
 ";
@@ -349,7 +349,7 @@ IFixedOperation (OperationKind.None, Type: null, IsInvalid) (Syntax: 'fixed (int
             IVariableDeclaratorOperation (Symbol: System.Int32* p1) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p1 = &i1')
               Initializer: 
                 IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &i1')
-                  IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i1')
+                  IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i1')
                     Children(1):
                         IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i1')
                           Reference: 
@@ -426,7 +426,7 @@ Block[B0] - Entry
               Left: 
                 ILocalReferenceOperation: p (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32*, IsImplicit) (Syntax: 'p = &i')
               Right: 
-                IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i')
+                IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i')
                   Children(1):
                       IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i')
                         Reference: 
@@ -513,7 +513,7 @@ Block[B0] - Entry
               Left: 
                 ILocalReferenceOperation: p (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32*, IsImplicit) (Syntax: 'p = &i')
               Right: 
-                IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i')
+                IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i')
                   Children(1):
                       IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i')
                         Reference: 
@@ -676,7 +676,7 @@ Block[B0] - Entry
                                   ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""P is "", IsImplicit) (Syntax: 'P is ')
                               IInterpolationOperation (OperationKind.Interpolation, Type: null) (Syntax: '{*p}')
                                 Expression: 
-                                  IOperation:  (OperationKind.None, Type: null) (Syntax: '*p')
+                                  IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*p')
                                     Children(1):
                                         ILocalReferenceOperation: p (OperationKind.LocalReference, Type: System.Int32*) (Syntax: 'p')
                                 Alignment: 
@@ -734,7 +734,7 @@ Block[B0] - Entry
               Left: 
                 ILocalReferenceOperation: p (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32*, IsImplicit) (Syntax: 'p = &i')
               Right: 
-                IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i')
+                IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i')
                   Children(1):
                       IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i')
                         Reference: 
@@ -824,7 +824,7 @@ Block[B0] - Entry
               Left: 
                 ILocalReferenceOperation: p1 (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32*, IsImplicit) (Syntax: 'p1 = &i')
               Right: 
-                IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&i')
+                IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&i')
                   Children(1):
                       IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&i')
                         Reference: 
@@ -881,7 +881,7 @@ Block[B0] - Entry
                   Left: 
                     ILocalReferenceOperation: p2 (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32*, IsImplicit) (Syntax: 'p2 = &(input ?? this).j')
                   Right: 
-                    IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&(input ?? this).j')
+                    IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&(input ?? this).j')
                       Children(1):
                           IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&(input ?? this).j')
                             Reference: 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IForEachLoopStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IForEachLoopStatement.cs
@@ -1608,7 +1608,7 @@ IForEachLoopOperation (LoopKind.ForEach, Continue Label Id: 0, Exit Label Id: 1)
         Expression: 
           IInvalidOperation (OperationKind.Invalid, Type: System.Void) (Syntax: 'System.Cons ... Line(value)')
             Children(2):
-                IOperation:  (OperationKind.None, Type: null) (Syntax: 'System.Console')
+                IOperation:  (OperationKind.None, Type: System.Console) (Syntax: 'System.Console')
                 ILocalReferenceOperation: value (OperationKind.LocalReference, Type: var) (Syntax: 'value')
   NextVariables(0)";
             VerifyOperationTreeForTest<ForEachStatementSyntax>(source, expectedOperationTree, parseOptions: TestOptions.Regular9);
@@ -1822,7 +1822,7 @@ IForEachLoopOperation (LoopKind.ForEach, IsAsynchronous, Continue Label Id: 0, E
         Expression: 
           IInvalidOperation (OperationKind.Invalid, Type: System.Void) (Syntax: 'System.Cons ... Line(value)')
             Children(2):
-                IOperation:  (OperationKind.None, Type: null) (Syntax: 'System.Console')
+                IOperation:  (OperationKind.None, Type: System.Console) (Syntax: 'System.Console')
                 ILocalReferenceOperation: value (OperationKind.LocalReference, Type: var) (Syntax: 'value')
   NextVariables(0)";
             var comp = CreateCompilationWithTasksExtensions(new[] { source, s_IAsyncEnumerable }, parseOptions: TestOptions.Regular9);
@@ -4563,7 +4563,7 @@ Block[B2] - Block
               Expression: 
                 IInvalidOperation (OperationKind.Invalid, Type: System.Void) (Syntax: 'System.Cons ... Line(value)')
                   Children(2):
-                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'System.Console')
+                      IOperation:  (OperationKind.None, Type: System.Console) (Syntax: 'System.Console')
                       ILocalReferenceOperation: value (OperationKind.LocalReference, Type: var) (Syntax: 'value')
         Next (Regular) Block[B2]
             Leaving: {R1}
@@ -5089,7 +5089,7 @@ Block[B2] - Block
               Expression: 
                 IInvalidOperation (OperationKind.Invalid, Type: System.Void) (Syntax: 'System.Cons ... Line(value)')
                   Children(2):
-                      IOperation:  (OperationKind.None, Type: null) (Syntax: 'System.Console')
+                      IOperation:  (OperationKind.None, Type: System.Console) (Syntax: 'System.Console')
                       ILocalReferenceOperation: value (OperationKind.LocalReference, Type: var) (Syntax: 'value')
         Next (Regular) Block[B2]
             Leaving: {R1}

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFromEndIndexOperation_IRangeOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IFromEndIndexOperation_IRangeOperation.cs
@@ -39,7 +39,7 @@ IBlockOperation (2 statements) (OperationKind.Block, Type: null) (Syntax: '{ ...
         Left: 
           IDiscardOperation (Symbol: System.Int32 _) (OperationKind.Discard, Type: System.Int32) (Syntax: '_')
         Right: 
-          IOperation:  (OperationKind.None, Type: null) (Syntax: 'this[^0]')
+          IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: 'this[^0]')
             Children(2):
                 IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
                 IUnaryOperation (UnaryOperatorKind.Hat) (OperationKind.Unary, Type: System.Index) (Syntax: '^0')
@@ -51,7 +51,7 @@ IBlockOperation (2 statements) (OperationKind.Block, Type: null) (Syntax: '{ ...
         Left: 
           IDiscardOperation (Symbol: System.Int32 _) (OperationKind.Discard, Type: System.Int32) (Syntax: '_')
         Right: 
-          IOperation:  (OperationKind.None, Type: null) (Syntax: 'this[0..]')
+          IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: 'this[0..]')
             Children(2):
                 IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
                 IRangeOperation (OperationKind.Range, Type: System.Range) (Syntax: '0..')
@@ -79,7 +79,7 @@ Block[B1] - Block
               Left: 
                 IDiscardOperation (Symbol: System.Int32 _) (OperationKind.Discard, Type: System.Int32) (Syntax: '_')
               Right: 
-                IOperation:  (OperationKind.None, Type: null) (Syntax: 'this[^0]')
+                IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: 'this[^0]')
                   Children(2):
                       IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
                       IUnaryOperation (UnaryOperatorKind.Hat) (OperationKind.Unary, Type: System.Index) (Syntax: '^0')
@@ -91,7 +91,7 @@ Block[B1] - Block
               Left: 
                 IDiscardOperation (Symbol: System.Int32 _) (OperationKind.Discard, Type: System.Int32) (Syntax: '_')
               Right: 
-                IOperation:  (OperationKind.None, Type: null) (Syntax: 'this[0..]')
+                IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: 'this[0..]')
                   Children(2):
                       IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C) (Syntax: 'this')
                       IRangeOperation (OperationKind.Range, Type: System.Range) (Syntax: '0..')

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringOperation.cs
@@ -447,7 +447,7 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
         Expression: 
           IInvalidOperation (OperationKind.Invalid, Type: Class, IsInvalid, IsImplicit) (Syntax: 'Class')
             Children(1):
-                IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Class')
+                IOperation:  (OperationKind.None, Type: Class, IsInvalid) (Syntax: 'Class')
         Alignment: 
           null
         FormatString: 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInvocationOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IInvocationOperation.cs
@@ -86,7 +86,7 @@ class C
             string expectedOperationTree = @"
 IInvalidOperation (OperationKind.Invalid, Type: System.Void, IsInvalid) (Syntax: 'C.M1()')
   Children(1):
-      IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'C')
+      IOperation:  (OperationKind.None, Type: C, IsInvalid) (Syntax: 'C')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
                 // file.cs(8,19): error CS0120: An object reference is required for the non-static field, method, or property 'C.M1()'

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_INoneOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_INoneOperation.cs
@@ -318,7 +318,7 @@ Block[B0] - Entry
                   Left: 
                     IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.Int32, IsImplicit) (Syntax: 'j')
                   Right: 
-                    IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'i[1, (a ? b : c)]')
+                    IOperation:  (OperationKind.None, Type: System.Int32, IsInvalid) (Syntax: 'i[1, (a ? b : c)]')
                       Children(2):
                           IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.Int32*, IsInvalid, IsImplicit) (Syntax: 'i')
                           IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid, IsImplicit) (Syntax: 'i[1, (a ? b : c)]')

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IParameterReferenceExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IParameterReferenceExpression.cs
@@ -480,7 +480,7 @@ class Class1
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null) (Syntax: '*x')
+IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*x')
   Children(1):
       IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.Int32*) (Syntax: 'x')
 ";
@@ -515,7 +515,7 @@ internal class Class
 IVariableDeclaratorOperation (Symbol: System.Int32* p) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p = array')
   Initializer: 
     IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= array')
-      IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'array')
+      IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: 'array')
         Children(1):
             IParameterReferenceOperation: array (OperationKind.ParameterReference, Type: System.Int32[]) (Syntax: 'array')
 ";
@@ -542,7 +542,7 @@ class Class1
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null) (Syntax: '__reftype(x)')
+IOperation:  (OperationKind.None, Type: System.Type) (Syntax: '__reftype(x)')
   Children(1):
       IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.TypedReference) (Syntax: 'x')
 ";
@@ -565,7 +565,7 @@ class Class1
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null) (Syntax: '__makeref(x)')
+IOperation:  (OperationKind.None, Type: System.TypedReference) (Syntax: '__makeref(x)')
   Children(1):
       IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.Type) (Syntax: 'x')
 ";
@@ -588,7 +588,7 @@ class Class1
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null) (Syntax: '__refvalue(x, int)')
+IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '__refvalue(x, int)')
   Children(1):
       IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.TypedReference) (Syntax: 'x')
 ";
@@ -730,7 +730,7 @@ internal class Class
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null) (Syntax: 'stackalloc int[x]')
+IOperation:  (OperationKind.None, Type: System.Int32*) (Syntax: 'stackalloc int[x]')
   Children(1):
       IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'x')
 ";

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IPointerIndirectionReferenceOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IPointerIndirectionReferenceOperation.cs
@@ -46,7 +46,7 @@ Block[B1] - Block
               Left: 
                 IParameterReferenceOperation: s (OperationKind.ParameterReference, Type: C.S) (Syntax: 's')
               Right: 
-                IOperation:  (OperationKind.None, Type: null) (Syntax: '*sp')
+                IOperation:  (OperationKind.None, Type: C.S) (Syntax: '*sp')
                   Children(1):
                       IParameterReferenceOperation: sp (OperationKind.ParameterReference, Type: C.S*) (Syntax: 'sp')
 
@@ -90,7 +90,7 @@ Block[B1] - Block
               Left: 
                 IFieldReferenceOperation: System.Int32 C.S.x (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'sp->x')
                   Instance Receiver: 
-                    IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'sp')
+                    IOperation:  (OperationKind.None, Type: C.S, IsImplicit) (Syntax: 'sp')
                       Children(1):
                           IParameterReferenceOperation: sp (OperationKind.ParameterReference, Type: C.S*) (Syntax: 'sp')
               Right: 
@@ -104,7 +104,7 @@ Block[B1] - Block
               Right: 
                 IFieldReferenceOperation: System.Int32 C.S.x (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'sp->x')
                   Instance Receiver: 
-                    IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'sp')
+                    IOperation:  (OperationKind.None, Type: C.S, IsImplicit) (Syntax: 'sp')
                       Children(1):
                           IParameterReferenceOperation: sp (OperationKind.ParameterReference, Type: C.S*) (Syntax: 'sp')
 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IPropertyReferenceExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IPropertyReferenceExpression.cs
@@ -269,7 +269,7 @@ IPropertyReferenceOperation: C C.this[System.Int32 i] { get; set; } (OperationKi
   Instance Receiver: 
     IInvalidOperation (OperationKind.Invalid, Type: C, IsInvalid, IsImplicit) (Syntax: 'C')
       Children(1):
-          IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'C')
+          IOperation:  (OperationKind.None, Type: C, IsInvalid) (Syntax: 'C')
   Arguments(1):
       IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: i) (OperationKind.Argument, Type: null) (Syntax: '1')
         ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
@@ -309,7 +309,7 @@ IPropertyReferenceOperation: C C.this[System.Int32 i] { get; set; } (OperationKi
   Instance Receiver: 
     IInvalidOperation (OperationKind.Invalid, Type: C, IsInvalid, IsImplicit) (Syntax: 'C')
       Children(1):
-          IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'C')
+          IOperation:  (OperationKind.None, Type: C, IsInvalid) (Syntax: 'C')
   Arguments(1):
       IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: i) (OperationKind.Argument, Type: null) (Syntax: '1')
         ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUnaryOperatorExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUnaryOperatorExpression.cs
@@ -3326,7 +3326,7 @@ class A
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null) (Syntax: '*p2')
+IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*p2')
   Children(1):
       ILocalReferenceOperation: p2 (OperationKind.LocalReference, Type: System.Int32*) (Syntax: 'p2')
 ";

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IVariableDeclaration.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IVariableDeclaration.cs
@@ -1422,7 +1422,7 @@ IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration
       IVariableDeclaratorOperation (Symbol: System.Int32* p) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p = &reference.i1')
         Initializer: 
           IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &reference.i1')
-            IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&reference.i1')
+            IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&reference.i1')
               Children(1):
                   IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&reference.i1')
                     Reference: 
@@ -1468,7 +1468,7 @@ IVariableDeclarationOperation (2 declarators) (OperationKind.VariableDeclaration
       IVariableDeclaratorOperation (Symbol: System.Int32* p1) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p1 = &reference.i1')
         Initializer: 
           IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &reference.i1')
-            IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&reference.i1')
+            IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&reference.i1')
               Children(1):
                   IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&reference.i1')
                     Reference: 
@@ -1478,7 +1478,7 @@ IVariableDeclarationOperation (2 declarators) (OperationKind.VariableDeclaration
       IVariableDeclaratorOperation (Symbol: System.Int32* p2) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p2 = &reference.i2')
         Initializer: 
           IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &reference.i2')
-            IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&reference.i2')
+            IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&reference.i2')
               Children(1):
                   IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&reference.i2')
                     Reference: 
@@ -1728,7 +1728,7 @@ IVariableDeclarationOperation (2 declarators) (OperationKind.VariableDeclaration
       IVariableDeclaratorOperation (Symbol: System.Int32* p1) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'p1 = &reference.i1')
         Initializer: 
           IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= &reference.i1')
-            IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '&reference.i1')
+            IOperation:  (OperationKind.None, Type: System.Int32*, IsImplicit) (Syntax: '&reference.i1')
               Children(1):
                   IAddressOfOperation (OperationKind.AddressOf, Type: System.Int32*) (Syntax: '&reference.i1')
                     Reference: 

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_InvalidExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_InvalidExpression.cs
@@ -35,7 +35,7 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'Console.
   Children(1):
       IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'Console.WriteLine2')
         Children(1):
-            IOperation:  (OperationKind.None, Type: null) (Syntax: 'Console')
+            IOperation:  (OperationKind.None, Type: System.Console) (Syntax: 'Console')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
                 // CS0117: 'Console' does not contain a definition for 'WriteLine2'
@@ -428,7 +428,7 @@ IFieldInitializerOperation (Field: System.Int32 Program.x) (OperationKind.FieldI
     Operand: 
       IInvalidOperation (OperationKind.Invalid, Type: Program, IsInvalid, IsImplicit) (Syntax: 'Program')
         Children(1):
-            IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Program')
+            IOperation:  (OperationKind.None, Type: Program, IsInvalid) (Syntax: 'Program')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
                 // CS0119: 'Program' is a type, which is not valid in the given context
@@ -510,7 +510,7 @@ IArrayCreationOperation (OperationKind.ArrayCreation, Type: X[], IsInvalid) (Syn
   Dimension Sizes(1):
       IInvalidOperation (OperationKind.Invalid, Type: Program, IsInvalid, IsImplicit) (Syntax: 'Program')
         Children(1):
-            IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Program')
+            IOperation:  (OperationKind.None, Type: Program, IsInvalid) (Syntax: 'Program')
   Initializer: 
     IArrayInitializerOperation (1 elements) (OperationKind.ArrayInitializer, Type: null, IsInvalid) (Syntax: '{ { 1 } }')
       Element Values(1):
@@ -591,7 +591,7 @@ public class C
             string expectedOperationTree = @"
 IInvalidOperation (OperationKind.Invalid, Type: System.String, IsInvalid) (Syntax: 'string.Form ... format: """")')
   Children(3):
-      IOperation:  (OperationKind.None, Type: null) (Syntax: 'string')
+      IOperation:  (OperationKind.None, Type: System.String) (Syntax: 'string')
       ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: """") (Syntax: '""""')
       ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: """") (Syntax: '""""')
 ";

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_InvalidStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_InvalidStatement.cs
@@ -90,7 +90,7 @@ ISwitchOperation (1 cases, Exit Label Id: 0) (OperationKind.Switch, Type: null, 
   Switch expression: 
     IInvalidOperation (OperationKind.Invalid, Type: Program, IsInvalid, IsImplicit) (Syntax: 'Program')
       Children(1):
-          IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Program')
+          IOperation:  (OperationKind.None, Type: Program, IsInvalid) (Syntax: 'Program')
   Sections:
       ISwitchCaseOperation (1 case clauses, 1 statements) (OperationKind.SwitchCase, Type: null, IsInvalid) (Syntax: 'case 1: ... break;')
           Clauses:

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_StackAllocArrayCreationAndInitializer.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_StackAllocArrayCreationAndInitializer.cs
@@ -26,7 +26,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[1]')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[1]')
   Children(1):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid) (Syntax: '1')
 ";
@@ -54,7 +54,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc M[1]')
+IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc M[1]')
   Children(1):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid) (Syntax: '1')
 ";
@@ -83,7 +83,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc M[dimension]')
+IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc M[dimension]')
   Children(1):
       ILocalReferenceOperation: dimension (OperationKind.LocalReference, Type: System.Int32, Constant: 1, IsInvalid) (Syntax: 'dimension')
 ";
@@ -111,7 +111,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc M[dimension]')
+IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc M[dimension]')
   Children(1):
       IParameterReferenceOperation: dimension (OperationKind.ParameterReference, Type: System.Int32, IsInvalid) (Syntax: 'dimension')
 ";
@@ -139,7 +139,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc M[dimension]')
+IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc M[dimension]')
   Children(1):
       IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: 'dimension')
         Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: True, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
@@ -170,7 +170,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc  ... )dimension]')
+IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc  ... )dimension]')
   Children(1):
       IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid) (Syntax: '(int)dimension')
         Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
@@ -199,7 +199,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[] { 42 }')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[] { 42 }')
   Children(2):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid, IsImplicit) (Syntax: 'stackalloc int[] { 42 }')
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 42, IsInvalid) (Syntax: '42')
@@ -226,7 +226,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[1] { 42 }')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[1] { 42 }')
   Children(2):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid) (Syntax: '1')
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 42, IsInvalid) (Syntax: '42')
@@ -253,7 +253,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[2] { 42 }')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[2] { 42 }')
   Children(2):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2, IsInvalid) (Syntax: '2')
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 42, IsInvalid) (Syntax: '42')
@@ -280,7 +280,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc  ... ion] { 42 }')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc  ... ion] { 42 }')
   Children(2):
       IParameterReferenceOperation: dimension (OperationKind.ParameterReference, Type: System.Int32, IsInvalid) (Syntax: 'dimension')
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 42) (Syntax: '42')
@@ -309,7 +309,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc  ... { new M() }')
+IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc  ... { new M() }')
   Children(2):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid, IsImplicit) (Syntax: 'stackalloc  ... { new M() }')
       IObjectCreationOperation (Constructor: M..ctor()) (OperationKind.ObjectCreation, Type: M, IsInvalid) (Syntax: 'new M()')
@@ -341,7 +341,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc[] { new M() }')
+IOperation:  (OperationKind.None, Type: M*, IsInvalid) (Syntax: 'stackalloc[] { new M() }')
   Children(2):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid, IsImplicit) (Syntax: 'stackalloc[] { new M() }')
       IObjectCreationOperation (Constructor: M..ctor()) (OperationKind.ObjectCreation, Type: M, IsInvalid) (Syntax: 'new M()')
@@ -371,7 +371,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc[]/*</bind>*/')
+IOperation:  (OperationKind.None, Type: ?*, IsInvalid) (Syntax: 'stackalloc[]/*</bind>*/')
   Children(1):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0, IsInvalid, IsImplicit) (Syntax: 'stackalloc[]/*</bind>*/')
 ";
@@ -403,7 +403,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc[2]/*</bind>*/')
+IOperation:  (OperationKind.None, Type: ?*, IsInvalid) (Syntax: 'stackalloc[2]/*</bind>*/')
   Children(1):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0, IsInvalid, IsImplicit) (Syntax: 'stackalloc[2]/*</bind>*/')
 ";
@@ -439,7 +439,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc[ ... , default }')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc[ ... , default }')
   Children(4):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 3, IsInvalid, IsImplicit) (Syntax: 'stackalloc[ ... , default }')
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2, IsInvalid) (Syntax: '2')
@@ -471,7 +471,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[]')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[]')
   Children(1):
       IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: '')
         Children(0)
@@ -498,7 +498,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[] { 1 }')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[] { 1 }')
   Children(2):
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid, IsImplicit) (Syntax: 'stackalloc int[] { 1 }')
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1, IsInvalid) (Syntax: '1')
@@ -525,7 +525,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[b]')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[b]')
   Children(1):
       IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: 'b')
         Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
@@ -559,7 +559,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[M()]')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[M()]')
   Children(1):
       IInvocationOperation ( System.Int32 C.M()) (OperationKind.Invocation, Type: System.Int32, IsInvalid) (Syntax: 'M()')
         Instance Receiver: 
@@ -590,7 +590,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[(int)M()]')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[(int)M()]')
   Children(1):
       IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid) (Syntax: '(int)M()')
         Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
@@ -624,7 +624,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-    IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[M()]')
+    IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[M()]')
       Children(1):
           IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: 'M()')
             Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
@@ -656,7 +656,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[(int)M()]')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[(int)M()]')
   Children(1):
       IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid) (Syntax: '(int)M()')
         Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
@@ -688,7 +688,7 @@ class C
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'stackalloc int[0.0]')
+IOperation:  (OperationKind.None, Type: System.Int32*, IsInvalid) (Syntax: 'stackalloc int[0.0]')
   Children(1):
       IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, Constant: 0, IsInvalid, IsImplicit) (Syntax: '0.0')
         Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: True, IsReference: False, IsUserDefined: False) (MethodSymbol: null)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -908,8 +908,8 @@ IInvocationOperation (virtual System.String (System.Int32, System.String).ToStri
     ITupleOperation (OperationKind.Tuple, Type: (System.Int32, System.String), IsInvalid) (Syntax: '(int, string)')
       NaturalType: (System.Int32, System.String)
       Elements(2):
-          IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'int')
-          IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'string')
+          IOperation:  (OperationKind.None, Type: System.Int32, IsInvalid) (Syntax: 'int')
+          IOperation:  (OperationKind.None, Type: System.String, IsInvalid) (Syntax: 'string')
   Arguments(0)
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -3520,7 +3520,7 @@ class C
             VerifyOperationTree(compilation, initializerOperation.Parent.Parent, @"
 IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: ':base(TakeO ... && x1 >= 5)')
   Expression: 
-    IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: '(TakeOutPar ... && x1 >= 5)')
+    IOperation:  (OperationKind.None, Type: System.Void, IsImplicit) (Syntax: '(TakeOutPar ... && x1 >= 5)')
       Children(1):
           IInvocationOperation ( C..ctor(System.Boolean b)) (OperationKind.Invocation, Type: System.Void) (Syntax: ':base(TakeO ... && x1 >= 5)')
             Instance Receiver: 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7355,7 +7355,7 @@ unsafe public class MyClass
 
             compilation.VerifyOperationTree(node, expectedOperationTree:
 @"
-IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'i[1,2]')
+IOperation:  (OperationKind.None, Type: System.Int32, IsInvalid) (Syntax: 'i[1,2]')
   Children(2):
       ILocalReferenceOperation: i (OperationKind.LocalReference, Type: System.Int32*, IsInvalid) (Syntax: 'i')
       IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid, IsImplicit) (Syntax: 'i[1,2]')

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
@@ -1277,7 +1277,7 @@ IBlockOperation (2 statements, 2 locals) (OperationKind.Block, Type: null, IsInv
                                       Right: 
                                         IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'ClassA.BB')
                                           Children(1):
-                                              IOperation:  (OperationKind.None, Type: null) (Syntax: 'ClassA')
+                                              IOperation:  (OperationKind.None, Type: ClassA) (Syntax: 'ClassA')
                                     ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: ?, IsInvalid, IsImplicit) (Syntax: 'ClassA.CCC')
                                       Left: 
                                         IPropertyReferenceOperation: ? <anonymous type: ? aa, ? BB, ? CCC>.CCC { get; } (OperationKind.PropertyReference, Type: ?, IsInvalid, IsImplicit) (Syntax: 'ClassA.CCC')
@@ -1286,7 +1286,7 @@ IBlockOperation (2 statements, 2 locals) (OperationKind.Block, Type: null, IsInv
                                       Right: 
                                         IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'ClassA.CCC')
                                           Children(1):
-                                              IOperation:  (OperationKind.None, Type: null) (Syntax: 'ClassA')
+                                              IOperation:  (OperationKind.None, Type: ClassA) (Syntax: 'ClassA')
       Initializer: 
         null
 ";

--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -97,17 +97,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             // Type
             LogString(", ");
-            if (operation.Language == LanguageNames.CSharp && operation is NoneOperation)
-            {
-                //TODO: this should be removed!
-                //We need to update the tests to allow Types on NoneOperations
-                //(see: https://github.com/dotnet/roslyn/issues/57531)
-                LogType(null);
-            }
-            else
-            {
-                LogType(operation.Type);
-            }
+            LogType(operation.Type);
 
             // ConstantValue
             if (operation.ConstantValue.HasValue)

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -309,10 +309,16 @@ Namespace Microsoft.CodeAnalysis.Operations
                      BoundKind.UnboundLambda,
                      BoundKind.UnstructuredExceptionHandlingStatement
 
-                    Dim constantValue = TryCast(boundNode, BoundExpression)?.ConstantValueOpt
+                    Dim constantValue As ConstantValue = Nothing
+                    Dim type As TypeSymbol = Nothing
+                    Dim expression = TryCast(boundNode, BoundExpression)
+                    If expression IsNot Nothing Then
+                        constantValue = expression.ConstantValueOpt
+                        type = expression.Type
+                    End If
                     Dim isImplicit As Boolean = boundNode.WasCompilerGenerated
                     Dim children As ImmutableArray(Of IOperation) = GetIOperationChildren(boundNode)
-                    Return New NoneOperation(children, _semanticModel, boundNode.Syntax, type:=Nothing, constantValue, isImplicit)
+                    Return New NoneOperation(children, _semanticModel, boundNode.Syntax, type, constantValue, isImplicit)
 
                 Case Else
                     ' If you're hitting this because the IOperation test hook has failed, see

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests.vb
@@ -459,7 +459,7 @@ IAnonymousObjectCreationOperation (OperationKind.AnonymousObjectCreation, Type: 
                   Children(1):
                       IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'c1.S')
                         Children(1):
-                            IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'c1')
+                            IOperation:  (OperationKind.None, Type: Program.C1, IsInvalid) (Syntax: 'c1')
 ]]>.Value
 
             Dim expectedDiagnostics = <![CDATA[

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IConditionalAccessExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IConditionalAccessExpression.vb
@@ -683,7 +683,7 @@ Block[B0] - Entry
             Statements (1)
                 IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: '.@a1')
                   Value: 
-                    IOperation:  (OperationKind.None, Type: null) (Syntax: '.@a1')
+                    IOperation:  (OperationKind.None, Type: System.String) (Syntax: '.@a1')
             Next (Regular) Block[B7]
                 Leaving: {R2}
     }
@@ -783,7 +783,7 @@ Block[B0] - Entry
             Statements (1)
                 IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: '.X.@a1')
                   Value: 
-                    IOperation:  (OperationKind.None, Type: null) (Syntax: '.X.@a1')
+                    IOperation:  (OperationKind.None, Type: System.String) (Syntax: '.X.@a1')
 
             Next (Regular) Block[B5]
                 Leaving: {R2}
@@ -890,7 +890,7 @@ Block[B0] - Entry
             Statements (1)
                 IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: '.@a1')
                   Value: 
-                    IOperation:  (OperationKind.None, Type: null) (Syntax: '.@a1')
+                    IOperation:  (OperationKind.None, Type: System.String) (Syntax: '.@a1')
 
             Next (Regular) Block[B5]
                 Leaving: {R2}
@@ -1030,12 +1030,12 @@ Block[B0] - Entry
                 Statements (1)
                     IFlowCaptureOperation: 4 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: '.@a1')
                       Value: 
-                        IOperation:  (OperationKind.None, Type: null) (Syntax: '.@a1')
+                        IOperation:  (OperationKind.None, Type: System.String) (Syntax: '.@a1')
 
                 Jump if True (Regular) to Block[B7]
                     IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: '.@a1')
                       Operand: 
-                        IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: null, IsImplicit) (Syntax: '.@a1')
+                        IFlowCaptureReferenceOperation: 4 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: '.@a1')
                     Leaving: {R4}
 
                 Next (Regular) Block[B6]
@@ -1044,7 +1044,7 @@ Block[B0] - Entry
                 Statements (1)
                     IFlowCaptureOperation: 3 (OperationKind.FlowCapture, Type: null, IsInvalid, IsImplicit) (Syntax: '.<e1>')
                       Value: 
-                        IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: '.<e1>')
+                        IOperation:  (OperationKind.None, Type: ?, IsInvalid) (Syntax: '.<e1>')
 
                 Next (Regular) Block[B9]
                     Leaving: {R4} {R2}

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IConversionExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IConversionExpression.vb
@@ -1318,7 +1318,7 @@ IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDecla
               Children(1):
                   IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'c1.M2')
                     Children(1):
-                        IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'c1')
+                        IOperation:  (OperationKind.None, Type: Program.C1, IsInvalid) (Syntax: 'c1')
 ]]>.Value
 
             Dim expectedDiagnostics = <![CDATA[

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IDelegateCreationExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IDelegateCreationExpression.vb
@@ -4109,7 +4109,7 @@ IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'AddressOf C1.
   Children(1):
       IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'C1.S1')
         Children(1):
-            IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'C1')
+            IOperation:  (OperationKind.None, Type: M1.C1, IsInvalid) (Syntax: 'C1')
 ]]>.Value
 
             Dim expectedDiagnostics = <![CDATA[

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IFieldReferenceExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IFieldReferenceExpression.vb
@@ -27,7 +27,7 @@ Class C
 End Class]]>.Value
 
             Dim expectedOperationTree = <![CDATA[
-IOperation:  (OperationKind.None, Type: null) (Syntax: 'Conditional(field)')
+IOperation:  (OperationKind.None, Type: System.Diagnostics.ConditionalAttribute) (Syntax: 'Conditional(field)')
   Children(1):
       IFieldReferenceOperation: C.field As System.String (Static) (OperationKind.FieldReference, Type: System.String, Constant: "field") (Syntax: 'field')
         Instance Receiver: 

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IInterpolatedStringExpression.vb
@@ -407,7 +407,7 @@ IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.Str
           ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: " and constant ", IsImplicit) (Syntax: ' and constant ')
       IInterpolationOperation (OperationKind.Interpolation, Type: null, IsInvalid) (Syntax: '{[Class]}')
         Expression: 
-          IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: '[Class]')
+          IOperation:  (OperationKind.None, Type: [Class], IsInvalid) (Syntax: '[Class]')
         Alignment: 
           null
         FormatString: 

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_INoneOperation.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_INoneOperation.vb
@@ -33,11 +33,11 @@ Block[B1] - Block
             IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'Mid(str, 1, 1) = ""')
               Children(2):
                   IParameterReferenceOperation: str (OperationKind.ParameterReference, Type: System.String) (Syntax: 'str')
-                  IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'Mid(str, 1, 1) = ""')
+                  IOperation:  (OperationKind.None, Type: System.String, IsImplicit) (Syntax: 'Mid(str, 1, 1) = ""')
                     Children(4):
                         IParenthesizedOperation (OperationKind.Parenthesized, Type: System.String) (Syntax: 'Mid(str, 1, 1)')
                           Operand: 
-                            IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'str')
+                            IOperation:  (OperationKind.None, Type: System.String, IsImplicit) (Syntax: 'str')
                         ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
                         ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
                         ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: "") (Syntax: '""')
@@ -83,7 +83,7 @@ Block[B0] - Entry
               Value: 
                 IParenthesizedOperation (OperationKind.Parenthesized, Type: System.String) (Syntax: 'Mid(str, 1, 1)')
                   Operand: 
-                    IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'str')
+                    IOperation:  (OperationKind.None, Type: System.String, IsImplicit) (Syntax: 'str')
 
             IFlowCaptureOperation: 2 (OperationKind.FlowCapture, Type: null, IsImplicit) (Syntax: '1')
               Value: 
@@ -121,7 +121,7 @@ Block[B0] - Entry
                 IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'Mid(str, 1, ... str1, str2)')
                   Children(2):
                       IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 'str')
-                      IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'Mid(str, 1, ... str1, str2)')
+                      IOperation:  (OperationKind.None, Type: System.String, IsImplicit) (Syntax: 'Mid(str, 1, ... str1, str2)')
                         Children(4):
                             IFlowCaptureReferenceOperation: 1 (OperationKind.FlowCaptureReference, Type: System.String, IsImplicit) (Syntax: 'Mid(str, 1, 1)')
                             IFlowCaptureReferenceOperation: 2 (OperationKind.FlowCaptureReference, Type: System.Int32, Constant: 1, IsImplicit) (Syntax: '1')
@@ -198,7 +198,7 @@ Block[B0] - Entry
                       IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid, IsImplicit) (Syntax: 'If(b, str1, str2)')
                         Children(1):
                             IFlowCaptureReferenceOperation: 0 (OperationKind.FlowCaptureReference, Type: System.String, IsInvalid, IsImplicit) (Syntax: 'If(b, str1, str2)')
-                      IOperation:  (OperationKind.None, Type: null, IsInvalid, IsImplicit) (Syntax: 'Mid(If(b, s ... 1, 1) = str')
+                      IOperation:  (OperationKind.None, Type: System.String, IsInvalid, IsImplicit) (Syntax: 'Mid(If(b, s ... 1, 1) = str')
                         Children(4):
                             IParenthesizedOperation (OperationKind.Parenthesized, Type: System.String, IsInvalid) (Syntax: 'Mid(If(b, s ... tr2), 1, 1)')
                               Operand: 

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IParameterReferenceExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IParameterReferenceExpression.vb
@@ -716,11 +716,11 @@ IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (S
     IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'Mid(str, st ... ngth) = str')
       Children(2):
           IParameterReferenceOperation: str (OperationKind.ParameterReference, Type: System.String) (Syntax: 'str')
-          IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'Mid(str, st ... ngth) = str')
+          IOperation:  (OperationKind.None, Type: System.String, IsImplicit) (Syntax: 'Mid(str, st ... ngth) = str')
             Children(4):
                 IParenthesizedOperation (OperationKind.Parenthesized, Type: System.String) (Syntax: 'Mid(str, start, length)')
                   Operand: 
-                    IOperation:  (OperationKind.None, Type: null, IsImplicit) (Syntax: 'str')
+                    IOperation:  (OperationKind.None, Type: System.String, IsImplicit) (Syntax: 'str')
                 IParameterReferenceOperation: start (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'start')
                 IParameterReferenceOperation: length (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'length')
                 IParameterReferenceOperation: str (OperationKind.ParameterReference, Type: System.String) (Syntax: 'str')
@@ -871,7 +871,7 @@ Class Class1
 End Class]]>.Value
 
             Dim expectedOperationTree = <![CDATA[
-IOperation:  (OperationKind.None, Type: null) (Syntax: 'AddressOf x.Method')
+IOperation:  (OperationKind.None, Type: System.Object) (Syntax: 'AddressOf x.Method')
   Children(1):
       IDynamicMemberReferenceOperation (Member Name: "Method", Containing Type: null) (OperationKind.DynamicMemberReference, Type: System.Object) (Syntax: 'x.Method')
         Type Arguments(0)

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IWhileUntilLoopStatement.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IWhileUntilLoopStatement.vb
@@ -1222,12 +1222,12 @@ IWhileLoopOperation (ConditionIsTop: True, ConditionIsUntil: False) (LoopKind.Wh
               Children(3):
                   IOperation:  (OperationKind.None, Type: null) (Syntax: 'System.Math.Max')
                     Children(1):
-                        IOperation:  (OperationKind.None, Type: null) (Syntax: 'System.Math')
+                        IOperation:  (OperationKind.None, Type: System.Math) (Syntax: 'System.Math')
                   IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'System.Thre ... ecrement(x)')
                     Children(2):
                         IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'System.Thre ... d.Decrement')
                           Children(1):
-                              IOperation:  (OperationKind.None, Type: null) (Syntax: 'System.Thre ... Interlocked')
+                              IOperation:  (OperationKind.None, Type: System.Threading.Interlocked) (Syntax: 'System.Thre ... Interlocked')
                         ILocalReferenceOperation: x (OperationKind.LocalReference, Type: System.SByte) (Syntax: 'x')
                   IBinaryOperation (BinaryOperatorKind.Add, Checked) (OperationKind.Binary, Type: System.Int32) (Syntax: 'x + 1')
                     Left: 

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_InvalidExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_InvalidExpression.vb
@@ -30,7 +30,7 @@ IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'Console.
   Children(1):
       IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'Console.WriteLine2')
         Children(1):
-            IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Console')
+            IOperation:  (OperationKind.None, Type: System.Console, IsInvalid) (Syntax: 'Console')
 ]]>.Value
 
             Dim expectedDiagnostics = <![CDATA[
@@ -344,7 +344,7 @@ IFieldInitializerOperation (Field: Program.x As System.Int32) (OperationKind.Fie
   IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: 'Program')
     Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
     Operand: 
-      IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Program')
+      IOperation:  (OperationKind.None, Type: Program, IsInvalid) (Syntax: 'Program')
 ]]>.Value
 
             Dim expectedDiagnostics = <![CDATA[
@@ -406,7 +406,7 @@ IArrayCreationOperation (OperationKind.ArrayCreation, Type: X(), IsInvalid) (Syn
             Operand: 
               IBinaryOperation (BinaryOperatorKind.Subtract, Checked) (OperationKind.Binary, Type: ?, IsInvalid) (Syntax: 'Program - 1')
                 Left: 
-                  IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Program')
+                  IOperation:  (OperationKind.None, Type: Program, IsInvalid) (Syntax: 'Program')
                 Right: 
                   ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
         Right: 
@@ -492,7 +492,7 @@ End Module]]>.Value
             Dim expectedOperationTree = <![CDATA[
 IInvalidOperation (OperationKind.Invalid, Type: ?, IsInvalid) (Syntax: 'C1(1)')
   Children(2):
-      IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'C1')
+      IOperation:  (OperationKind.None, Type: M1.C1, IsInvalid) (Syntax: 'C1')
       ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
 ]]>.Value
 

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_InvalidStatement.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_InvalidStatement.vb
@@ -63,7 +63,7 @@ End Class]]>.Value
             Dim expectedOperationTree = <![CDATA[
 ISwitchOperation (1 cases, Exit Label Id: 0) (OperationKind.Switch, Type: null, IsInvalid) (Syntax: 'Select Case ... End Select')
   Switch expression: 
-    IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Program')
+    IOperation:  (OperationKind.None, Type: Program, IsInvalid) (Syntax: 'Program')
   Sections:
       ISwitchCaseOperation (1 case clauses, 1 statements) (OperationKind.SwitchCase, Type: null) (Syntax: 'Case 1')
           Clauses:
@@ -346,7 +346,7 @@ IForToLoopOperation (LoopKind.ForTo, Continue Label Id: 0, Exit Label Id: 1, Che
     IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: 'Program')
       Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
       Operand: 
-        IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: 'Program')
+        IOperation:  (OperationKind.None, Type: Program, IsInvalid) (Syntax: 'Program')
   StepValue: 
     IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32, IsInvalid, IsImplicit) (Syntax: 'x')
       Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/AnonymousTypesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/AnonymousTypesTests.vb
@@ -664,7 +664,7 @@ IAnonymousObjectCreationOperation (OperationKind.AnonymousObjectCreation, Type: 
             Instance Receiver: 
               IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: <anonymous type: $0 As System.Xml.Linq.XElement>, IsInvalid, IsImplicit) (Syntax: 'New With {< ... some-name>}')
         Right: 
-          IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: '<some-name></some-name>')
+          IOperation:  (OperationKind.None, Type: System.Xml.Linq.XElement, IsInvalid) (Syntax: '<some-name></some-name>')
 ]]>.Value
 
             Dim expectedDiagnostics = <![CDATA[
@@ -695,7 +695,7 @@ IAnonymousObjectCreationOperation (OperationKind.AnonymousObjectCreation, Type: 
             Instance Receiver: 
               IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: <anonymous type: aa As System.String>, IsImplicit) (Syntax: 'New With {< ... -name>.@aa}')
         Right: 
-          IOperation:  (OperationKind.None, Type: null) (Syntax: '<some-name> ... e-name>.@aa')
+          IOperation:  (OperationKind.None, Type: System.String) (Syntax: '<some-name> ... e-name>.@aa')
 ]]>.Value
 
             Dim expectedDiagnostics = String.Empty
@@ -722,7 +722,7 @@ IAnonymousObjectCreationOperation (OperationKind.AnonymousObjectCreation, Type: 
             Instance Receiver: 
               IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: <anonymous type: $0 As System.String>, IsInvalid, IsImplicit) (Syntax: 'New With {< ... me>.@<a-a>}')
         Right: 
-          IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: '<some-name  ... ame>.@<a-a>')
+          IOperation:  (OperationKind.None, Type: System.String, IsInvalid) (Syntax: '<some-name  ... ame>.@<a-a>')
 ]]>.Value
 
             Dim expectedDiagnostics = <![CDATA[
@@ -766,7 +766,7 @@ IBlockOperation (4 statements, 2 locals) (OperationKind.Block, Type: null, IsInv
                       Instance Receiver: 
                         IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: <anonymous type: $0 As System.Collections.Generic.IEnumerable(Of System.Xml.Linq.XElement)>, IsInvalid, IsImplicit) (Syntax: 'New With {<a/>.<_>}')
                   Right: 
-                    IOperation:  (OperationKind.None, Type: null, IsInvalid) (Syntax: '<a/>.<_>')
+                    IOperation:  (OperationKind.None, Type: System.Collections.Generic.IEnumerable(Of System.Xml.Linq.XElement), IsInvalid) (Syntax: '<a/>.<_>')
   IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDeclarationGroup, Type: null) (Syntax: 'Dim ok = Ne ... {<a/>.<__>}')
     IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null) (Syntax: 'ok = New Wi ... {<a/>.<__>}')
       Declarators:
@@ -783,7 +783,7 @@ IBlockOperation (4 statements, 2 locals) (OperationKind.Block, Type: null, IsInv
                       Instance Receiver: 
                         IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: <anonymous type: __ As System.Collections.Generic.IEnumerable(Of System.Xml.Linq.XElement)>, IsImplicit) (Syntax: 'New With {<a/>.<__>}')
                   Right: 
-                    IOperation:  (OperationKind.None, Type: null) (Syntax: '<a/>.<__>')
+                    IOperation:  (OperationKind.None, Type: System.Collections.Generic.IEnumerable(Of System.Xml.Linq.XElement)) (Syntax: '<a/>.<__>')
   ILabeledOperation (Label: exit) (OperationKind.Labeled, Type: null, IsImplicit) (Syntax: 'End Sub')
     Statement: 
       null


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/57531, and brings the same behavior to VB.