### PR TITLE
Adjust tests for Windows 11 changes

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9515,19 +9515,18 @@ using System.Diagnostics; // Unused.
         [InlineData("a.cs /out:com1.dll")]
         [InlineData("a.cs /doc:..\\lpt2.xml")]
         [InlineData("a.cs /pdb:..\\prn.pdb")]
-        [ConditionalTheory(typeof(WindowsOnly))]
+        [Theory]
         public void ReservedDeviceNameAsFileName(string commandLine)
         {
             var parsedArgs = DefaultParse(commandLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries), WorkingDirectory);
-            if (ExecutionConditionUtil.IsWindows11OrGreater)
-            {
-                // Windows 11 and greater removed the restrictions around the file names
-                Assert.Equal(0, parsedArgs.Errors.Length);
-            }
-            else
+            if (ExecutionConditionUtil.OperatingSystemRestrictsFileNames)
             {
                 Assert.Equal(1, parsedArgs.Errors.Length);
                 Assert.Equal((int)ErrorCode.FTL_InvalidInputFileName, parsedArgs.Errors.First().Code);
+            }
+            else
+            {
+                Assert.Equal(0, parsedArgs.Errors.Length);
             }
         }
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -9511,32 +9511,24 @@ using System.Diagnostics; // Unused.
         }
 
         [WorkItem(650083, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/650083")]
-        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/55730")]
-        public void ReservedDeviceNameAsFileName()
+        [InlineData("a.cs /t:library /appconfig:.\\aux.config")]
+        [InlineData("a.cs /out:com1.dll")]
+        [InlineData("a.cs /doc:..\\lpt2.xml")]
+        [InlineData("a.cs /pdb:..\\prn.pdb")]
+        [ConditionalTheory(typeof(WindowsOnly))]
+        public void ReservedDeviceNameAsFileName(string commandLine)
         {
-            var parsedArgs = DefaultParse(new[] { "com9.cs", "/t:library " }, WorkingDirectory);
-            Assert.Equal(0, parsedArgs.Errors.Length);
-
-            parsedArgs = DefaultParse(new[] { "a.cs", "/t:library ", "/appconfig:.\\aux.config" }, WorkingDirectory);
-            Assert.Equal(1, parsedArgs.Errors.Length);
-            Assert.Equal((int)ErrorCode.FTL_InvalidInputFileName, parsedArgs.Errors.First().Code);
-
-
-            parsedArgs = DefaultParse(new[] { "a.cs", "/out:com1.dll " }, WorkingDirectory);
-            Assert.Equal(1, parsedArgs.Errors.Length);
-            Assert.Equal((int)ErrorCode.FTL_InvalidInputFileName, parsedArgs.Errors.First().Code);
-
-            parsedArgs = DefaultParse(new[] { "a.cs", "/doc:..\\lpt2.xml:  " }, WorkingDirectory);
-            Assert.Equal(1, parsedArgs.Errors.Length);
-            Assert.Equal((int)ErrorCode.FTL_InvalidInputFileName, parsedArgs.Errors.First().Code);
-
-            parsedArgs = DefaultParse(new[] { "a.cs", "/debug+", "/pdb:.\\prn.pdb" }, WorkingDirectory);
-            Assert.Equal(1, parsedArgs.Errors.Length);
-            Assert.Equal((int)ErrorCode.FTL_InvalidInputFileName, parsedArgs.Errors.First().Code);
-
-            parsedArgs = DefaultParse(new[] { "a.cs", "@con.rsp" }, WorkingDirectory);
-            Assert.Equal(1, parsedArgs.Errors.Length);
-            Assert.Equal((int)ErrorCode.ERR_OpenResponseFile, parsedArgs.Errors.First().Code);
+            var parsedArgs = DefaultParse(commandLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries), WorkingDirectory);
+            if (ExecutionConditionUtil.IsWindows11OrGreater)
+            {
+                // Windows 11 and greater removed the restrictions around the file names
+                Assert.Equal(0, parsedArgs.Errors.Length);
+            }
+            else
+            {
+                Assert.Equal(1, parsedArgs.Errors.Length);
+                Assert.Equal((int)ErrorCode.FTL_InvalidInputFileName, parsedArgs.Errors.First().Code);
+            }
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineParser.cs
@@ -275,8 +275,14 @@ namespace Microsoft.CodeAnalysis
             {
                 try
                 {
-                    // Check some ancient reserved device names, such as COM1,..9, LPT1..9, PRN, CON, or AUX etc., and bail out earlier
-                    // Win32 API - GetFullFileName - will resolve them, say 'COM1', as "\\.\COM1" 
+                    // Windows 10 and earlier placed restrictions on file names that originally appeared as device 
+                    // names. For example COM1, PRN, CON, AUX, etc ... Files could not be created with those names even 
+                    // with extensions like .txt. When those restricted names are passed to GetFullPath the 
+                    // runtime will escape them with \\.\. For example GetFullPath("aux.txt") will return "\\.\aux.txt".
+                    // The compiler detects these illegal names and bails out early
+                    //
+                    // Windows 11 removed this restriction though and hence the names are now legal. Cannot find documentation
+                    // to support this but experimentally it can be validated. 
                     resolvedPath = Path.GetFullPath(resolvedPath);
                     // preserve possible invalid path info for diagnostic purpose
                     invalidPath = resolvedPath;

--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -158,7 +158,6 @@ namespace Roslyn.Test.Utilities
 #endif
 
         public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
-        public static bool IsWindows11OrGreater => IsWindows && Environment.OSVersion.Version.Build >= 22_000;
         public static bool IsUnix => !IsWindows;
         public static bool IsMacOS => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
@@ -170,6 +169,19 @@ namespace Roslyn.Test.Utilities
         public static bool IsCoreClrUnix => IsCoreClr && IsUnix;
         public static bool IsMonoOrCoreClr => IsMono || IsCoreClr;
         public static bool RuntimeSupportsCovariantReturnsOfClasses => Type.GetType("System.Runtime.CompilerServices.RuntimeFeature")?.GetField("CovariantReturnsOfClasses") != null;
+
+        private static readonly Lazy<bool> s_operatingSystemRestrictsFileNames = new Lazy<bool>(() =>
+        {
+            var tempDir = Path.GetTempPath();
+            var path = Path.GetFullPath(Path.Combine(tempDir, "aux.txt"));
+            return path.StartsWith(@"\\.\", StringComparison.Ordinal);
+        });
+
+        /// <summary>
+        /// Is this a version of Windows that has ancient restrictions on file names. For example 
+        /// prevents file names that are aux, com1, etc ...
+        /// </summary>
+        public static bool OperatingSystemRestrictsFileNames => s_operatingSystemRestrictsFileNames.Value;
     }
 
     public enum ExecutionArchitecture

--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -158,6 +158,7 @@ namespace Roslyn.Test.Utilities
 #endif
 
         public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
+        public static bool IsWindows11OrGreater => IsWindows && Environment.OSVersion.Version.Build >= 22_000;
         public static bool IsUnix => !IsWindows;
         public static bool IsMacOS => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7383,17 +7383,17 @@ End Module
             parsedArgs.Errors.Verify()
 
             parsedArgs = DefaultParse({"/out:com1.exe", "a.vb"}, _baseDirectory)
-            If ExecutionConditionUtil.IsWindows11OrGreater Then
-                parsedArgs.Errors.Verify()
-            Else
+            If ExecutionConditionUtil.OperatingSystemRestrictsFileNames Then
                 parsedArgs.Errors.Verify(Diagnostic(ERRID.FTL_InvalidInputFileName).WithArguments("\\.\com1").WithLocation(1, 1))
+            Else
+                parsedArgs.Errors.Verify()
             End If
 
             parsedArgs = DefaultParse({"/doc:..\lpt2.xml", "a.vb"}, _baseDirectory)
-            If ExecutionConditionUtil.IsWindows11OrGreater Then
-                parsedArgs.Errors.Verify()
-            Else
+            If ExecutionConditionUtil.OperatingSystemRestrictsFileNames Then
                 parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments("..\lpt2.xml", "The system cannot find the path specified").WithLocation(1, 1))
+            Else
+                parsedArgs.Errors.Verify()
             End If
 
             parsedArgs = DefaultParse({"/SdkPath:..\aux", "com.vb"}, _baseDirectory)

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7383,14 +7383,22 @@ End Module
             parsedArgs.Errors.Verify()
 
             parsedArgs = DefaultParse({"/out:com1.exe", "a.vb"}, _baseDirectory)
-            parsedArgs.Errors.Verify(Diagnostic(ERRID.FTL_InvalidInputFileName).WithArguments("\\.\com1").WithLocation(1, 1))
+            If ExecutionConditionUtil.IsWindows11OrGreater Then
+                parsedArgs.Errors.Verify()
+            Else
+                parsedArgs.Errors.Verify(Diagnostic(ERRID.FTL_InvalidInputFileName).WithArguments("\\.\com1").WithLocation(1, 1))
+            End If
 
             parsedArgs = DefaultParse({"/doc:..\lpt2.xml", "a.vb"}, _baseDirectory)
-            parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments("..\lpt2.xml", "The system cannot find the path specified").WithLocation(1, 1))
+            If ExecutionConditionUtil.IsWindows11OrGreater Then
+                parsedArgs.Errors.Verify()
+            Else
+                parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_XMLCannotWriteToXMLDocFile2).WithArguments("..\lpt2.xml", "The system cannot find the path specified").WithLocation(1, 1))
+            End If
 
             parsedArgs = DefaultParse({"/SdkPath:..\aux", "com.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.WRN_CannotFindStandardLibrary1).WithArguments("System.dll").WithLocation(1, 1),
-                                     Diagnostic(ERRID.ERR_LibNotFound).WithArguments("Microsoft.VisualBasic.dll").WithLocation(1, 1))
+                                 Diagnostic(ERRID.ERR_LibNotFound).WithArguments("Microsoft.VisualBasic.dll").WithLocation(1, 1))
 
         End Sub
 


### PR DESCRIPTION
Windows 11 appears to have removed the restrictions on legal file names
that was introduced in 1974. For example file names like con, prn, com1,
etc ... More info here.

https://www.howtogeek.com/fyi/windows-10-still-wont-let-you-use-these-file-names-reserved-in-1974/

This broke a number of tests that were verifying we errored correctly in
those scenarios. The verification was done by running `Path.GetFullPath`
on the file names and then checking them for the escape sequence that
Windows added.

```c#
// Windows 10
WriteLine(Path.GetFullPath("aux.txt")); // \\.\aux.txt

// Windows 11
WriteLine(Path.GetFullPath("aux.txt")); // c:\users\jaredpar\aux.txt
```

This PR adjusts those tests to correctly pass when run on Windows 11.

closes #55730