### PR TITLE
Handle Array/Collection initializers case for implicit object creation analyzer

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationTests.cs
@@ -666,5 +666,71 @@ class C
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
             }.RunAsync();
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitObjectCreation)]
+        public async Task TestWithArrayInitializerExpression()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void bar()
+    {
+        var a = new C[]
+        {
+            new [|C|](),
+            new [|C|](),
+        };
+    }
+}",
+                FixedCode = @"
+class C
+{
+    void bar()
+    {
+        var a = new C[]
+        {
+            new(),
+            new(),
+        };
+    }
+}",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitObjectCreation)]
+        public async Task TestWithCollectionInitializerExpression()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class C
+{
+    void bar()
+    {
+        var a = new System.Collections.Generic.List<C>
+        {
+            new [|C|](),
+            new [|C|](),
+        };
+    }
+}",
+                FixedCode = @"
+class C
+{
+    void bar()
+    {
+        var a = new System.Collections.Generic.List<C>
+        {
+            new(),
+            new(),
+        };
+    }
+}",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
     }
 }


### PR DESCRIPTION
Added cases for `ArrayInitializerExpression` and `CollectionInitializerExpression`:
```csharp
class C
{
    void bar()
    {
        var a = new C[]
        {
            new [|C|](),
            new [|C|](),
        };
    }
}
```

```csharp
class C
{
    void bar()
    {
        var a = new List<C>
        {
            new [|C|](),
            new [|C|](),
        };
    }
}
```
Above example should also work with any kind of collection that has a single generic argument (`HashSet`, etc).

Did I miss any additional cases to cover around iteration initializers?