### PR TITLE
Mitigate the GeneratorDriver missync issue while capturing dumps

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -20,14 +20,11 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 {
     internal static class FatalError
     {
-        /// <summary>
-        /// A delegate type for our NonFatalHandler; this is necessary since this file must build on .NET 2.0 where
-        /// multi-parameter Action hadn't been invented yet.
-        /// </summary>
-        public delegate void NonFatalHandlerDelegate(Exception exception, bool forceDump);
-
         private static Action<Exception>? s_fatalHandler;
-        private static NonFatalHandlerDelegate? s_nonFatalHandler;
+
+#if !NET20
+        private static Action<Exception, bool>? s_nonFatalHandler;
+#endif
 
 #pragma warning disable IDE0052 // Remove unread private members - We want to hold onto last exception to make investigation easier
         private static Exception? s_reportedException;
@@ -56,12 +53,14 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
+#if !NET20
+
         /// <summary>
         /// Set by the host to a fail fast trigger, 
         /// if the host desires to NOT crash the process on a non fatal exception.
         /// </summary>
         [DisallowNull]
-        public static NonFatalHandlerDelegate? NonFatalHandler
+        public static Action<Exception, bool>? NonFatalHandler
         {
             get
             {
@@ -77,6 +76,8 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 }
             }
         }
+
+#endif
 
         // Same as setting the Handler property except that it avoids the assert.  This is useful in 
         // test code which needs to verify the handler is called in specific cases and will continually
@@ -134,6 +135,8 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             return ReportAndPropagate(exception);
         }
 
+#if !NET20
+
         /// <summary>
         /// Use in an exception filter to report a non-fatal error (by calling <see cref="NonFatalHandler"/>) and catch
         /// the exception, unless the operation was cancelled.
@@ -181,6 +184,8 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             return ReportAndCatch(exception);
         }
 
+#endif
+
         /// <summary>
         /// Use in an exception filter to report a fatal error without catching the exception.
         /// The error is reported by calling <see cref="Handler"/>.
@@ -192,6 +197,8 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             Report(exception, s_fatalHandler);
             return false;
         }
+
+#if !NET20
 
         /// <summary>
         /// Report a non-fatal error.
@@ -206,16 +213,18 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         [DebuggerHidden]
         public static bool ReportAndCatch(Exception exception)
         {
-            Report(exception, static (exception) => s_nonFatalHandler?.Invoke(exception, forceDump: false));
+            Report(exception, static (exception) => s_nonFatalHandler?.Invoke(exception, false));
             return true;
         }
 
         [DebuggerHidden]
         public static bool ReportWithDumpAndCatch(Exception exception)
         {
-            Report(exception, static (exception) => s_nonFatalHandler?.Invoke(exception, forceDump: true));
+            Report(exception, static (exception) => s_nonFatalHandler?.Invoke(exception, true));
             return true;
         }
+
+#endif
 
         private static readonly object s_reportedMarker = new();
 

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ProjectExternalErrorReporter.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             if (errorId == null)
             {
                 // record NFW to see who violates contract.
-                WatsonReporter.ReportNonFatal(new Exception("errorId is null"));
+                FatalError.ReportAndCatch(new Exception("errorId is null"));
                 return false;
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         {
             // Set both handlers to non-fatal Watson. Never fail-fast the ServiceHub process.
             // Any exception that is not recovered from shall be propagated and communicated to the client.
-            var nonFatalHandler = new FatalError.NonFatalHandlerDelegate(ReportNonFatal);
+            var nonFatalHandler = WatsonReporter.ReportNonFatal;
             var fatalHandler = new Action<Exception>(static (exception) => ReportNonFatal(exception, forceDump: false));
 
             FatalError.Handler = fatalHandler;

--- a/src/VisualStudio/Core/Def/Interactive/VsInteractiveWindowPackage.cs
+++ b/src/VisualStudio/Core/Def/Interactive/VsInteractiveWindowPackage.cs
@@ -51,16 +51,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
 
             // Set both handlers to non-fatal Watson. Never fail-fast the VS process.
             // Any exception that is not recovered from shall be propagated.
-            var nonFatalHandler = new Action<Exception>(WatsonReporter.ReportNonFatal);
-            var fatalHandler = nonFatalHandler;
-
-            InteractiveHostFatalError.Handler = fatalHandler;
-            InteractiveHostFatalError.NonFatalHandler = nonFatalHandler;
+            var nonFatalHandler = new Action<Exception>(static (exception) => WatsonReporter.ReportNonFatal(exception, forceDump: false));
+            InteractiveHostFatalError.Handler = nonFatalHandler;
+            InteractiveHostFatalError.NonFatalHandler = WatsonReporter.ReportNonFatal;
 
             // Load the Roslyn package so that its FatalError handlers are hooked up.
             shell.LoadPackage(Guids.RoslynPackageId, out var roslynPackage);
 
             // Explicitly set up FatalError handlers for the InteractiveWindowPackage.
+            var fatalHandler = nonFatalHandler;
             SetErrorHandlers(typeof(IInteractiveWindow).Assembly, fatalHandler, nonFatalHandler);
             SetErrorHandlers(typeof(IVsInteractiveWindow).Assembly, fatalHandler, nonFatalHandler);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -83,7 +84,17 @@ namespace Microsoft.CodeAnalysis
                     var oldText = _oldState.AdditionalText;
                     var newText = _newState.AdditionalText;
 
-                    return generatorDriver.ReplaceAdditionalText(oldText, newText);
+                    try
+                    {
+                        return generatorDriver.ReplaceAdditionalText(oldText, newText);
+                    }
+                    catch (ArgumentException ex) when (FatalError.ReportWithDumpAndCatch(ex))
+                    {
+                        // For some reason, our generator driver has gotten out of sync; by returning null here we force
+                        // ourselves to create a new driver in FinalizeCompilationAsync. This is the investigation for
+                        // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1423058.
+                        return null;
+                    }
                 }
             }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/ServiceHubDocumentTrackingService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ServiceHubDocumentTrackingService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Remote
             Debug.Fail(message);
 
             // record NFW to see who violates contract.
-            WatsonReporter.ReportNonFatal(new InvalidOperationException(message));
+            FatalError.ReportAndCatch(new InvalidOperationException(message));
         }
     }
 }


### PR DESCRIPTION
This mitigates https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1423058 which is happening because somehow our tracked project state is getting out of sync with our GeneratorDriver; when we're transforming GeneratorDrivers we already have a mechanism to throw out the driver and simply re-create it later; that's not ideal from a performance perspective but it's better than throwing exceptions and breaking features.

This will also force dumps to be created in this situation, even if that's something not being requested via the telemetry service. Since we've discovered that the telemetry service won't correctly let us request dumps for out-of-process work.