### PR TITLE
Revert "Re-enable BuildWithCommandLine test"

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
@@ -50,7 +50,7 @@ class Program
             // TODO: Validate build works as expected
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Build)]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/18204"), Trait(Traits.Feature, Traits.Features.Build)]
         public void BuildWithCommandLine()
         {
             VisualStudio.SolutionExplorer.SaveAll();


### PR DESCRIPTION
It looks like BuildWithCommandLine still isn't working after being re-enabled in https://github.com/dotnet/roslyn/pull/57584.
We should disable it for the time being to prevent the test from blocking the pipeline.