### PR TITLE
Simplify implementation of SourceGeneratedFileItemSource

### DIFF
--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
@@ -159,6 +159,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         {
             lock (_gate)
             {
+                // We should not have an existing computation active
+                Contract.ThrowIfTrue(_cancellationSeries.HasActiveToken);
+
                 var cancellationToken = _cancellationSeries.CreateNext();
                 var asyncToken = _asyncListener.BeginAsyncOperation(nameof(SourceGeneratedFileItemSource) + "." + nameof(BeforeExpand));
 
@@ -202,7 +205,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         {
             lock (_gate)
             {
-                _cancellationSeries.CreateNext();
+                _cancellationSeries.CreateNext(new CancellationToken(canceled: true));
                 _workspace.WorkspaceChanged -= OnWorkpaceChanged;
                 _resettableDelay = null;
             }

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/SourceGeneratedFileItems/SourceGeneratedFileItemSource.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.Internal.VisualStudio.PlatformUI;
@@ -29,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         /// The returned collection of items. Can only be mutated on the UI thread, as other parts of WPF are subscribed to the change
         /// events and expect that.
         /// </summary>
-        private readonly BulkObservableCollectionWithInit<BaseItem> _items = new();
+        private readonly BulkObservableCollectionWithInit<BaseItem> _items;
 
         /// <summary>
         /// Gate to guard mutation of <see cref="_resettableDelay"/>.
@@ -41,6 +42,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
         public SourceGeneratedFileItemSource(SourceGeneratorItem parentGeneratorItem, Workspace workspace, IAsynchronousOperationListener asyncListener, IThreadingContext threadingContext)
         {
+            // Construction of BulkObservableCollection requires the main thread
+            threadingContext.ThrowIfNotOnUIThread();
+            _items = new BulkObservableCollectionWithInit<BaseItem>();
+
             _parentGeneratorItem = parentGeneratorItem;
             _workspace = workspace;
             _asyncListener = asyncListener;

--- a/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CancellationSeries.cs
@@ -26,7 +26,7 @@ namespace Roslyn.Utilities
     /// </remarks>
     internal sealed class CancellationSeries : IDisposable
     {
-        private CancellationTokenSource? _cts = new();
+        private CancellationTokenSource? _cts;
 
         private readonly CancellationToken _superToken;
 
@@ -37,6 +37,10 @@ namespace Roslyn.Utilities
         /// issued token and causes any subsequent tokens to be issued in a cancelled state.</param>
         public CancellationSeries(CancellationToken token = default)
         {
+            // Initialize with a pre-cancelled source to ensure HasActiveToken has the correct state
+            _cts = new CancellationTokenSource();
+            _cts.Cancel();
+
             _superToken = token;
 
 #if DEBUG
@@ -54,6 +58,12 @@ namespace Roslyn.Utilities
                 $"Instance of CancellationSeries not disposed before being finalized{Environment.NewLine}Stack at construction:{Environment.NewLine}{_ctorStack}");
         }
 #endif
+
+        /// <summary>
+        /// Determines if the cancellation series has an active token which has not been cancelled.
+        /// </summary>
+        public bool HasActiveToken
+            => _cts is { IsCancellationRequested: false };
 
         /// <summary>
         /// Creates the next <see cref="CancellationToken"/> in the series, ensuring the last issued


### PR DESCRIPTION
During investigation of #56826, two small simplifications were identified to aid in code clarity.

* Use `CancellationSeries` instead of manually manipulating a sequence of `CancellationTokenSource`
* Ensure `SourceGeneratedFileItemSource` is constructed on the main thread, since it uses `Dispatcher.CurrentDispatcher` for initializing a field