### PR TITLE
Modify timeout to avoid flaky integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/Helper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Helper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// <summary>
         /// A long timeout used to avoid hangs in tests, where a test failure manifests as an operation never occurring.
         /// </summary>
-        public static readonly TimeSpan HangMitigatingTimeout = TimeSpan.FromSeconds(15);
+        public static readonly TimeSpan HangMitigatingTimeout = TimeSpan.FromMinutes(1);
 
         private static IUIAutomation2? _automation;
 


### PR DESCRIPTION
Sam found that the timeout was reduced back in September but is too short. This PR restores the timeout to its original value.