### PR TITLE
Ignore function types in return type inference

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3248,7 +3248,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> boundInitializerExpressions = BindArrayInitializerExpressions(initializer, diagnostics, dimension: 1, rank: rank);
 
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-            TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo, unwrapFunctionType: true);
+            TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo, out _);
             diagnostics.Add(node, useSiteInfo);
 
             if ((object)bestType == null || bestType.IsVoidType()) // Dev10 also reports ERR_ImplicitlyTypedArrayNoBestType for void.
@@ -3275,7 +3275,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> boundInitializerExpressions = BindArrayInitializerExpressions(initializer, diagnostics, dimension: 1, rank: 1);
 
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-            TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo, unwrapFunctionType: true);
+            TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo, out _);
             diagnostics.Add(node, useSiteInfo);
 
             if ((object)bestType == null || bestType.IsVoidType())

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -3248,7 +3248,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> boundInitializerExpressions = BindArrayInitializerExpressions(initializer, diagnostics, dimension: 1, rank: rank);
 
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-            TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo);
+            TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo, unwrapFunctionType: true);
             diagnostics.Add(node, useSiteInfo);
 
             if ((object)bestType == null || bestType.IsVoidType()) // Dev10 also reports ERR_ImplicitlyTypedArrayNoBestType for void.
@@ -3275,7 +3275,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> boundInitializerExpressions = BindArrayInitializerExpressions(initializer, diagnostics, dimension: 1, rank: 1);
 
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-            TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo);
+            TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo, unwrapFunctionType: true);
             diagnostics.Add(node, useSiteInfo);
 
             if ((object)bestType == null || bestType.IsVoidType())

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -51,7 +51,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static TypeSymbol? InferBestType(
             ImmutableArray<BoundExpression> exprs,
             ConversionsBase conversions,
-            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
+            bool unwrapFunctionType)
         {
             // SPEC:    7.5.2.14 Finding the best common type of a set of expressions
             // SPEC:    In some cases, a common type needs to be inferred for a set of expressions. In particular, the element types of implicitly typed arrays and
@@ -87,7 +88,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = GetBestType(builder, conversions, ref useSiteInfo);
             builder.Free();
 
-            return (result as FunctionTypeSymbol)?.GetInternalDelegateType() ?? result;
+            if (unwrapFunctionType && result is FunctionTypeSymbol functionType)
+            {
+                return functionType.GetInternalDelegateType();
+            }
+            return result;
         }
 
         /// <remarks>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> exprs,
             ConversionsBase conversions,
             ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
-            bool unwrapFunctionType)
+            out bool inferredFromFunctionType)
         {
             // SPEC:    7.5.2.14 Finding the best common type of a set of expressions
             // SPEC:    In some cases, a common type needs to be inferred for a set of expressions. In particular, the element types of implicitly typed arrays and
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (type.IsErrorType())
                     {
+                        inferredFromFunctionType = false;
                         return type;
                     }
 
@@ -88,10 +89,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = GetBestType(builder, conversions, ref useSiteInfo);
             builder.Free();
 
-            if (unwrapFunctionType && result is FunctionTypeSymbol functionType)
+            if (result is FunctionTypeSymbol functionType)
             {
+                inferredFromFunctionType = true;
                 return functionType.GetInternalDelegateType();
             }
+
+            inferredFromFunctionType = false;
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2926,7 +2926,12 @@ OuterBreak:
             // the anonymous function is explicitly typed.  Make an inference from the
             // delegate parameters to the return type.
 
-            return anonymousFunction.InferReturnType(_conversions, fixedDelegate, ref useSiteInfo, allowInferenceFromFunctionType: false);
+            var returnType = anonymousFunction.InferReturnType(_conversions, fixedDelegate, ref useSiteInfo, out bool inferredFromFunctionType);
+            if (inferredFromFunctionType)
+            {
+                return default;
+            }
+            return returnType;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2926,7 +2926,7 @@ OuterBreak:
             // the anonymous function is explicitly typed.  Make an inference from the
             // delegate parameters to the return type.
 
-            return anonymousFunction.InferReturnType(_conversions, fixedDelegate, ref useSiteInfo, allowInferredFromFunctionType: false);
+            return anonymousFunction.InferReturnType(_conversions, fixedDelegate, ref useSiteInfo, allowInferenceFromFunctionType: false);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1310,6 +1310,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
+            Debug.Assert(inferredReturnType.Type is not FunctionTypeSymbol);
+
             LowerBoundInference(inferredReturnType, returnType, ref useSiteInfo);
             return true;
         }
@@ -2924,7 +2926,7 @@ OuterBreak:
             // the anonymous function is explicitly typed.  Make an inference from the
             // delegate parameters to the return type.
 
-            return anonymousFunction.InferReturnType(_conversions, fixedDelegate, ref useSiteInfo);
+            return anonymousFunction.InferReturnType(_conversions, fixedDelegate, ref useSiteInfo, allowInferredFromFunctionType: false);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2542,7 +2542,7 @@ outerDefault:
                 BoundLambda lambda = ((UnboundLambda)node).BindForReturnTypeInference(d);
 
                 // - an inferred return type X exists for E in the context of the parameter list of D(§7.5.2.12), and an identity conversion exists from X to Y
-                var x = lambda.GetInferredReturnType(ref useSiteInfo, allowInferenceFromFunctionType: true);
+                var x = lambda.GetInferredReturnType(ref useSiteInfo, out _);
                 if (x.HasType && Conversions.HasIdentityConversion(x.Type, y))
                 {
                     return true;
@@ -2965,7 +2965,7 @@ outerDefault:
                             return true;
                         }
 
-                        var x = lambda.InferReturnType(Conversions, d1, ref useSiteInfo, allowInferenceFromFunctionType: true);
+                        var x = lambda.InferReturnType(Conversions, d1, ref useSiteInfo, out _);
                         if (!x.HasType)
                         {
                             return true;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2542,7 +2542,7 @@ outerDefault:
                 BoundLambda lambda = ((UnboundLambda)node).BindForReturnTypeInference(d);
 
                 // - an inferred return type X exists for E in the context of the parameter list of D(§7.5.2.12), and an identity conversion exists from X to Y
-                var x = lambda.GetInferredReturnType(ref useSiteInfo);
+                var x = lambda.GetInferredReturnType(ref useSiteInfo, allowInferredFromFunctionType: true);
                 if (x.HasType && Conversions.HasIdentityConversion(x.Type, y))
                 {
                     return true;
@@ -2965,7 +2965,7 @@ outerDefault:
                             return true;
                         }
 
-                        var x = lambda.InferReturnType(Conversions, d1, ref useSiteInfo);
+                        var x = lambda.InferReturnType(Conversions, d1, ref useSiteInfo, allowInferredFromFunctionType: true);
                         if (!x.HasType)
                         {
                             return true;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2542,7 +2542,7 @@ outerDefault:
                 BoundLambda lambda = ((UnboundLambda)node).BindForReturnTypeInference(d);
 
                 // - an inferred return type X exists for E in the context of the parameter list of D(§7.5.2.12), and an identity conversion exists from X to Y
-                var x = lambda.GetInferredReturnType(ref useSiteInfo, allowInferredFromFunctionType: true);
+                var x = lambda.GetInferredReturnType(ref useSiteInfo, allowInferenceFromFunctionType: true);
                 if (x.HasType && Conversions.HasIdentityConversion(x.Type, y))
                 {
                     return true;
@@ -2965,7 +2965,7 @@ outerDefault:
                             return true;
                         }
 
-                        var x = lambda.InferReturnType(Conversions, d1, ref useSiteInfo, allowInferredFromFunctionType: true);
+                        var x = lambda.InferReturnType(Conversions, d1, ref useSiteInfo, allowInferenceFromFunctionType: true);
                         if (!x.HasType)
                         {
                             return true;

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -88,10 +88,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             );
         }
 
-        public TypeWithAnnotations GetInferredReturnType(ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool allowInferredFromFunctionType)
+        public TypeWithAnnotations GetInferredReturnType(ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool allowInferenceFromFunctionType)
         {
             // Nullability (and conversions) are ignored.
-            return GetInferredReturnType(conversions: null, nullableState: null, ref useSiteInfo, allowInferredFromFunctionType);
+            return GetInferredReturnType(conversions: null, nullableState: null, ref useSiteInfo, allowInferenceFromFunctionType);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// uses that state to set the inferred nullability of variables in the enclosing scope. `conversions` is
         /// only needed when nullability is inferred.
         /// </summary>
-        public TypeWithAnnotations GetInferredReturnType(ConversionsBase? conversions, NullableWalker.VariableState? nullableState, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool allowInferredFromFunctionType)
+        public TypeWithAnnotations GetInferredReturnType(ConversionsBase? conversions, NullableWalker.VariableState? nullableState, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool allowInferenceFromFunctionType)
         {
             if (!InferredReturnType.UseSiteDiagnostics.IsEmpty)
             {
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 returnTypes.Free();
             }
 
-            if (!allowInferredFromFunctionType && inferredReturnType.InferredFromFunctionType)
+            if (!allowInferenceFromFunctionType && inferredReturnType.InferredFromFunctionType)
             {
                 return default;
             }
@@ -440,8 +440,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             => Data.HasExplicitReturnType(out refKind, out returnType);
         public bool HasExplicitlyTypedParameterList { get { return Data.HasExplicitlyTypedParameterList; } }
         public int ParameterCount { get { return Data.ParameterCount; } }
-        public TypeWithAnnotations InferReturnType(ConversionsBase conversions, NamedTypeSymbol delegateType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool allowInferredFromFunctionType)
-            => BindForReturnTypeInference(delegateType).GetInferredReturnType(conversions, _nullableState, ref useSiteInfo, allowInferredFromFunctionType);
+        public TypeWithAnnotations InferReturnType(ConversionsBase conversions, NamedTypeSymbol delegateType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, bool allowInferenceFromFunctionType)
+            => BindForReturnTypeInference(delegateType).GetInferredReturnType(conversions, _nullableState, ref useSiteInfo, allowInferenceFromFunctionType);
 
         public RefKind RefKind(int index) { return Data.RefKind(index); }
         public void GenerateAnonymousFunctionConversionError(BindingDiagnosticBag diagnostics, TypeSymbol targetType) { Data.GenerateAnonymousFunctionConversionError(diagnostics, targetType); }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
 
             TypeSymbol inferredType =
-                (inferType ? BestTypeInferrer.InferBestType(placeholders, _conversions, ref discardedUseSiteInfo) : null)
+                (inferType ? BestTypeInferrer.InferBestType(placeholders, _conversions, ref discardedUseSiteInfo, unwrapFunctionType: true) : null)
                     ?? node.Type?.SetUnknownNullabilityForReferenceTypes();
 
             var inferredTypeWithAnnotations = TypeWithAnnotations.Create(inferredType);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
 
             TypeSymbol inferredType =
-                (inferType ? BestTypeInferrer.InferBestType(placeholders, _conversions, ref discardedUseSiteInfo, unwrapFunctionType: true) : null)
+                (inferType ? BestTypeInferrer.InferBestType(placeholders, _conversions, ref discardedUseSiteInfo, out _) : null)
                     ?? node.Type?.SetUnknownNullabilityForReferenceTypes();
 
             var inferredTypeWithAnnotations = TypeWithAnnotations.Create(inferredType);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -6452,7 +6452,8 @@ Test4(() => () => 4);
         public void TypeInference_04()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 using System.Linq.Expressions;
 delegate int D();
 class Program
@@ -6480,7 +6481,8 @@ class Program
         public void TypeInference_05()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 using System.Linq.Expressions;
 delegate int D();
 class Program
@@ -6508,7 +6510,8 @@ class Program
         public void TypeInference_06()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 using System.Linq.Expressions;
 class Program
 {
@@ -6526,18 +6529,18 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (10,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                // (11,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M1(() => F);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<T>)").WithLocation(10, 9),
-                // (11,9): error CS0411: The type arguments for method 'Program.M2<T>(Expression<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<T>)").WithLocation(11, 9),
+                // (12,9): error CS0411: The type arguments for method 'Program.M2<T>(Expression<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M2(() => F);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Linq.Expressions.Expression<System.Func<T>>)").WithLocation(11, 9),
-                // (12,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Linq.Expressions.Expression<System.Func<T>>)").WithLocation(12, 9),
+                // (13,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M1(() => () => 1);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<T>)").WithLocation(12, 9),
-                // (13,9): error CS0411: The type arguments for method 'Program.M2<T>(Expression<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<T>)").WithLocation(13, 9),
+                // (14,9): error CS0411: The type arguments for method 'Program.M2<T>(Expression<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M2(() => () => 2);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Linq.Expressions.Expression<System.Func<T>>)").WithLocation(13, 9)
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Linq.Expressions.Expression<System.Func<T>>)").WithLocation(14, 9)
             };
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             comp.VerifyDiagnostics(expectedDiagnostics);
@@ -6552,7 +6555,8 @@ class Program
         public void TypeInference_07()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 using System.Linq.Expressions;
 class Program
 {
@@ -6573,24 +6577,24 @@ class Program
 
             var expectedDiagnostics = new[]
             {
-                // (11,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                // (12,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M1(() => () => F);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<System.Func<T>>)").WithLocation(11, 9),
-                // (12,9): error CS0411: The type arguments for method 'Program.M2<T>(Func<Expression<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<System.Func<T>>)").WithLocation(12, 9),
+                // (13,9): error CS0411: The type arguments for method 'Program.M2<T>(Func<Expression<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M2(() => () => F);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(12, 9),
-                // (13,9): error CS0411: The type arguments for method 'Program.M3<T>(Expression<Func<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(13, 9),
+                // (14,9): error CS0411: The type arguments for method 'Program.M3<T>(Expression<Func<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M3(() => () => F);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M3").WithArguments("Program.M3<T>(System.Linq.Expressions.Expression<System.Func<System.Func<T>>>)").WithLocation(13, 9),
-                // (14,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M3").WithArguments("Program.M3<T>(System.Linq.Expressions.Expression<System.Func<System.Func<T>>>)").WithLocation(14, 9),
+                // (15,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M1(() => () => () => 1);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<System.Func<T>>)").WithLocation(14, 9),
-                // (15,9): error CS0411: The type arguments for method 'Program.M2<T>(Func<Expression<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<System.Func<T>>)").WithLocation(15, 9),
+                // (16,9): error CS0411: The type arguments for method 'Program.M2<T>(Func<Expression<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M2(() => () => () => 2);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(15, 9),
-                // (16,9): error CS0411: The type arguments for method 'Program.M3<T>(Expression<Func<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(16, 9),
+                // (17,9): error CS0411: The type arguments for method 'Program.M3<T>(Expression<Func<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M3(() => () => () => 3);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M3").WithArguments("Program.M3<T>(System.Linq.Expressions.Expression<System.Func<System.Func<T>>>)").WithLocation(16, 9)
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M3").WithArguments("Program.M3<T>(System.Linq.Expressions.Expression<System.Func<System.Func<T>>>)").WithLocation(17, 9)
             };
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
             comp.VerifyDiagnostics(expectedDiagnostics);
@@ -6605,7 +6609,8 @@ class Program
         public void TypeInference_08()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 using System.Linq.Expressions;
 delegate int D();
 class Program
@@ -6636,7 +6641,8 @@ class Program
         public void TypeInference_09()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 delegate void D<T>(object x, T y);
 class Program
 {
@@ -6660,7 +6666,8 @@ class Program
         public void TypeInference_10()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 delegate void D1<T>(object x, T y);
 delegate T D2<T>();
 class Program
@@ -6685,7 +6692,8 @@ class Program
         public void TypeInference_11()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 delegate T D1<T>();
 delegate T D2<T>(ref object o);
 class Program
@@ -6710,7 +6718,8 @@ class Program
         public void TypeInference_12()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 delegate int D();
 class Program
 {
@@ -6732,7 +6741,8 @@ class Program
         public void TypeInference_13()
         {
             var source =
-@"using System;
+@"#nullable enable
+using System;
 delegate void D();
 class C<T> { }
 static class E

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -6424,8 +6424,8 @@ Test3(() => () => 3);
 Test4(() => () => 4);
 ";
 
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (6,6): warning CS8321: The local function 'Test3' is declared but never used
                 // void Test3<T>(Func<Func<T>> exp) {}
                 Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Test3").WithArguments("Test3").WithLocation(6, 6),
@@ -6437,14 +6437,14 @@ Test4(() => () => 4);
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Test3").WithArguments("Test3<T>(System.Func<System.Func<T>>)").WithLocation(11, 1),
                 // (12,1): error CS0411: The type arguments for method 'Test4<T>(Func<Expression<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 // Test4(() => () => 4);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Test4").WithArguments("Test4<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(12, 1));
-
-            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
-            CompileAndVerify(source);
-
-            // PROTOTYPE: Test with Func<D>.
-            // PROTOTYPE: Test with D<T> instead of Func<T>.
-            // PROTOTYPE: Test with T and () => () => 1, and Func<T> and () => () => () => 2.
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Test4").WithArguments("Test4<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(12, 1)
+            };
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
@@ -6524,8 +6524,8 @@ class Program
     }
 }";
 
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (10,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M1(() => F);
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<T>)").WithLocation(10, 9),
@@ -6537,10 +6537,14 @@ class Program
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<T>)").WithLocation(12, 9),
                 // (13,9): error CS0411: The type arguments for method 'Program.M2<T>(Expression<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M2(() => () => 2);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Linq.Expressions.Expression<System.Func<T>>)").WithLocation(13, 9));
-
-            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
-            CompileAndVerify(source);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Linq.Expressions.Expression<System.Func<T>>)").WithLocation(13, 9)
+            };
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
@@ -6567,8 +6571,8 @@ class Program
     }
 }";
 
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (11,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M1(() => () => F);
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<System.Func<T>>)").WithLocation(11, 9),
@@ -6586,10 +6590,14 @@ class Program
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(15, 9),
                 // (16,9): error CS0411: The type arguments for method 'Program.M3<T>(Expression<Func<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         M3(() => () => () => 3);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M3").WithArguments("Program.M3<T>(System.Linq.Expressions.Expression<System.Func<System.Func<T>>>)").WithLocation(16, 9));
-
-            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
-            CompileAndVerify(source);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M3").WithArguments("Program.M3<T>(System.Linq.Expressions.Expression<System.Func<System.Func<T>>>)").WithLocation(16, 9)
+            };
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -3340,11 +3340,19 @@ class Program
         F((string s) => { });
     }
 }";
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
+
+            var expectedDiagnostics = new[]
+            {
                 // (8,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.F<T>(Action<T>)' and 'Program.F(StringAction)'
                 //         F((string s) => { });
-                Diagnostic(ErrorCode.ERR_AmbigCall, "F").WithArguments("Program.F<T>(System.Action<T>)", "Program.F(StringAction)").WithLocation(8, 9));
+                Diagnostic(ErrorCode.ERR_AmbigCall, "F").WithArguments("Program.F<T>(System.Action<T>)", "Program.F(StringAction)").WithLocation(8, 9)
+            };
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -3364,11 +3372,19 @@ class Program
         F1(M);
     }
 }";
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
+
+            var expectedDiagnostics = new[]
+            {
                 // (10,9): error CS0411: The type arguments for method 'Program.F0<T>(Action<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         F0(M);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F0").WithArguments("Program.F0<T>(System.Action<T>)").WithLocation(10, 9));
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F0").WithArguments("Program.F0<T>(System.Action<T>)").WithLocation(10, 9)
+            };
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -3387,14 +3403,22 @@ class Program
         F(M);
     }
 }";
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
+
+            var expectedDiagnostics = new[]
+            {
                 // (9,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.F<T>(Action<T>)' and 'Program.F<T>(MyAction<T>)'
                 //         F((string s) => { });
                 Diagnostic(ErrorCode.ERR_AmbigCall, "F").WithArguments("Program.F<T>(System.Action<T>)", "Program.F<T>(MyAction<T>)").WithLocation(9, 9),
                 // (10,9): error CS0411: The type arguments for method 'Program.F<T>(Action<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         F(M);
-                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F").WithArguments("Program.F<T>(System.Action<T>)").WithLocation(10, 9));
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "F").WithArguments("Program.F<T>(System.Action<T>)").WithLocation(10, 9)
+            };
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -3414,14 +3438,22 @@ class Program
         F((string s) => { });
     }
 }";
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
+
+            var expectedDiagnostics = new[]
+            {
                 // (10,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.F(Action<string>)' and 'Program.F(StringAction)'
                 //         F(M);
                 Diagnostic(ErrorCode.ERR_AmbigCall, "F").WithArguments("Program.F(System.Action<string>)", "Program.F(StringAction)").WithLocation(10, 9),
                 // (11,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.F(Action<string>)' and 'Program.F(StringAction)'
                 //         F((string s) => { });
-                Diagnostic(ErrorCode.ERR_AmbigCall, "F").WithArguments("Program.F(System.Action<string>)", "Program.F(StringAction)").WithLocation(11, 9));
+                Diagnostic(ErrorCode.ERR_AmbigCall, "F").WithArguments("Program.F(System.Action<string>)", "Program.F(StringAction)").WithLocation(11, 9)
+            };
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(expectedDiagnostics);
+            comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -6371,6 +6403,346 @@ class Program
                 // (25,9): warning CS8602: Dereference of a possibly null reference.
                 //         y4.ToString();
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y4").WithLocation(25, 9));
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_03()
+        {
+            var source =
+@"using System;
+using System.Linq.Expressions;
+
+void Test1<T>(Func<T> exp) {}
+void Test2<T>(Expression<Func<T>> exp) {}
+void Test3<T>(Func<Func<T>> exp) {}
+void Test4<T>(Func<Expression<Func<T>>> exp) {}
+
+Test1(() => 1);
+Test2(() => 2);
+Test3(() => () => 3);
+Test4(() => () => 4);
+";
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (6,6): warning CS8321: The local function 'Test3' is declared but never used
+                // void Test3<T>(Func<Func<T>> exp) {}
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Test3").WithArguments("Test3").WithLocation(6, 6),
+                // (7,6): warning CS8321: The local function 'Test4' is declared but never used
+                // void Test4<T>(Func<Expression<Func<T>>> exp) {}
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Test4").WithArguments("Test4").WithLocation(7, 6),
+                // (11,1): error CS0411: The type arguments for method 'Test3<T>(Func<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                // Test3(() => () => 3);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Test3").WithArguments("Test3<T>(System.Func<System.Func<T>>)").WithLocation(11, 1),
+                // (12,1): error CS0411: The type arguments for method 'Test4<T>(Func<Expression<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                // Test4(() => () => 4);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Test4").WithArguments("Test4<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(12, 1));
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+
+            // PROTOTYPE: Test with Func<D>.
+            // PROTOTYPE: Test with D<T> instead of Func<T>.
+            // PROTOTYPE: Test with T and () => () => 1, and Func<T> and () => () => () => 2.
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_04()
+        {
+            var source =
+@"using System;
+using System.Linq.Expressions;
+delegate int D();
+class Program
+{
+    static int F() => 0;
+    static void M1<T>(T t, Func<T> f) { }
+    static void M2<T>(T t, Expression<Func<T>> e) { }
+    static void Main()
+    {
+        D d = null;
+        M1(d, () => F);
+        M2(d, () => F);
+        M1(d, () => () => 1);
+        M2(d, () => () => 2);
+    }
+}";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular9);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_05()
+        {
+            var source =
+@"using System;
+using System.Linq.Expressions;
+delegate int D();
+class Program
+{
+    static int F() => 0;
+    static void M1<T>(ref T t, Func<T> f) { }
+    static void M2<T>(ref T t, Expression<Func<T>> e) { }
+    static void Main()
+    {
+        D d = null;
+        M1(ref d, () => F);
+        M2(ref d, () => F);
+        M1(ref d, () => () => 1);
+        M2(ref d, () => () => 2);
+    }
+}";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular9);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_06()
+        {
+            var source =
+@"using System;
+using System.Linq.Expressions;
+class Program
+{
+    static int F() => 0;
+    static void M1<T>(Func<T> f) { }
+    static void M2<T>(Expression<Func<T>> e) { }
+    static void Main()
+    {
+        M1(() => F);
+        M2(() => F);
+        M1(() => () => 1);
+        M2(() => () => 2);
+    }
+}";
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (10,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(() => F);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<T>)").WithLocation(10, 9),
+                // (11,9): error CS0411: The type arguments for method 'Program.M2<T>(Expression<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M2(() => F);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Linq.Expressions.Expression<System.Func<T>>)").WithLocation(11, 9),
+                // (12,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(() => () => 1);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<T>)").WithLocation(12, 9),
+                // (13,9): error CS0411: The type arguments for method 'Program.M2<T>(Expression<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M2(() => () => 2);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Linq.Expressions.Expression<System.Func<T>>)").WithLocation(13, 9));
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_07()
+        {
+            var source =
+@"using System;
+using System.Linq.Expressions;
+class Program
+{
+    static int F() => 0;
+    static void M1<T>(Func<Func<T>> f) { }
+    static void M2<T>(Func<Expression<Func<T>>> e) { }
+    static void M3<T>(Expression<Func<Func<T>>> e) { }
+    static void Main()
+    {
+        M1(() => () => F);
+        M2(() => () => F);
+        M3(() => () => F);
+        M1(() => () => () => 1);
+        M2(() => () => () => 2);
+        M3(() => () => () => 3);
+    }
+}";
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (11,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(() => () => F);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<System.Func<T>>)").WithLocation(11, 9),
+                // (12,9): error CS0411: The type arguments for method 'Program.M2<T>(Func<Expression<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M2(() => () => F);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(12, 9),
+                // (13,9): error CS0411: The type arguments for method 'Program.M3<T>(Expression<Func<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M3(() => () => F);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M3").WithArguments("Program.M3<T>(System.Linq.Expressions.Expression<System.Func<System.Func<T>>>)").WithLocation(13, 9),
+                // (14,9): error CS0411: The type arguments for method 'Program.M1<T>(Func<Func<T>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M1(() => () => () => 1);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M1").WithArguments("Program.M1<T>(System.Func<System.Func<T>>)").WithLocation(14, 9),
+                // (15,9): error CS0411: The type arguments for method 'Program.M2<T>(Func<Expression<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M2(() => () => () => 2);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M2").WithArguments("Program.M2<T>(System.Func<System.Linq.Expressions.Expression<System.Func<T>>>)").WithLocation(15, 9),
+                // (16,9): error CS0411: The type arguments for method 'Program.M3<T>(Expression<Func<Func<T>>>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         M3(() => () => () => 3);
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M3").WithArguments("Program.M3<T>(System.Linq.Expressions.Expression<System.Func<System.Func<T>>>)").WithLocation(16, 9));
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_08()
+        {
+            var source =
+@"using System;
+using System.Linq.Expressions;
+delegate int D();
+class Program
+{
+    static int F() => 0;
+    static void M1<T>(T t, Func<Func<T>> f) { }
+    static void M2<T>(T t, Func<Expression<Func<T>>> e) { }
+    static void M3<T>(T t, Expression<Func<Func<T>>> e) { }
+    static void Main()
+    {
+        D d = null;
+        M1(d, () => () => F);
+        M2(d, () => () => F);
+        M3(d, () => () => F);
+        M1(d, () => () => () => 1);
+        M2(d, () => () => () => 2);
+        M3(d, () => () => () => 3);
+    }
+}";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular9);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_09()
+        {
+            var source =
+@"using System;
+delegate void D<T>(object x, T y);
+class Program
+{
+    static void F(object x, int y) { }
+    static void M<T>(T t, Func<T> f) { }
+    static void Main()
+    {
+        D<int> d = null;
+        M(d, () => F);
+        M(d, () => (object x, int y) => { });
+    }
+}";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular9);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_10()
+        {
+            var source =
+@"using System;
+delegate void D1<T>(object x, T y);
+delegate T D2<T>();
+class Program
+{
+    static void F(object x, int y) { }
+    static void M<T>(T t, D2<T> d) { }
+    static void Main()
+    {
+        D1<int> d = null;
+        M(d, () => F);
+        M(d, () => (object x, int y) => { });
+    }
+}";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular9);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_11()
+        {
+            var source =
+@"using System;
+delegate T D1<T>();
+delegate T D2<T>(ref object o);
+class Program
+{
+    static int F() => 0;
+    static void M<T>(T t, D2<T> d) { }
+    static void Main()
+    {
+        D1<int> d = null;
+        M(d, (ref object o) => F);
+        M(d, (ref object o) => () => 1);
+    }
+}";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular9);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+        }
+
+        [WorkItem(57517, "https://github.com/dotnet/roslyn/issues/57517")]
+        [Fact]
+        public void TypeInference_12()
+        {
+            var source =
+@"using System;
+delegate int D();
+class Program
+{
+    static void M<T>(T t, Func<bool, T> f) { }
+    static void Main()
+    {
+        D d = null;
+        M(d, (bool b) => { if (b) return () => 1; return () => 2; });
+    }
+}";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular9);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
+        }
+
+        [WorkItem(57630, "https://github.com/dotnet/roslyn/issues/57630")]
+        [Fact]
+        public void TypeInference_13()
+        {
+            var source =
+@"using System;
+delegate void D();
+class C<T> { }
+static class E
+{
+    public static void F<T>(this C<T> c, Func<T> f) { }
+}
+class Program
+{
+    static void Main()
+    {
+        var c = new C<D>();
+        c.F(() => () => { });
+    }
+}";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular9);
+            CompileAndVerify(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(source);
         }
 
         [Fact]


### PR DESCRIPTION
With C#10 currently, there is a potential breaking change from C#9 in type inference when inferring from the return type of a lambda expression _when the return value is another lambda expression or a method group_.

See examples in [https://github.com/dotnet/roslyn/issues/57517#issuecomment-964289629](https://github.com/dotnet/roslyn/issues/57517#issuecomment-964289629) and [https://github.com/dotnet/roslyn/issues/57630](https://github.com/dotnet/roslyn/issues/57630).

To avoid the breaking change, type inference is updated to _not infer from the return type of a lambda if the return value is another lambda or method group_. This effectively reverts the type inference behavior _for those cases_ to the C#9 behavior.

Fixes https://github.com/dotnet/roslyn/issues/57630.

See also https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1437668.