### PR TITLE
Don't capture dumps for out-of-sync generator drivers

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         return generatorDriver.ReplaceAdditionalText(oldText, newText);
                     }
-                    catch (ArgumentException ex) when (FatalError.ReportWithDumpAndCatch(ex))
+                    catch (ArgumentException ex) when (FatalError.ReportAndCatch(ex))
                     {
                         // For some reason, our generator driver has gotten out of sync; by returning null here we force
                         // ourselves to create a new driver in FinalizeCompilationAsync. This is the investigation for


### PR DESCRIPTION
We understand the root cause now, so we won't need this.