### PR TITLE
Fix featureflag name for .net 6 host in UI

### DIFF
--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -31,7 +31,7 @@
 "Title"="C#/VB LSP semantic tokens experience"
 "PreviewPaneChannels"="IntPreview,int.main"
 
-[$RootKey$\FeatureFlags\Roslyn\OOPCoreClr]
+[$RootKey$\FeatureFlags\Roslyn\ServiceHubCore]
 "Description"="Run C#/VB out-of-process code analysis on .Net 6 ServiceHub host."
 "Value"=dword:00000000
 "Title"="Run C#/VB code analysis on .Net 6 (requires restart)"


### PR DESCRIPTION
The featureflag name was [changed](https://github.com/dotnet/roslyn/blob/9aac29d81ed13fe2d704e45d18de44309be30730/src/Workspaces/Remote/Core/RemoteHostOptions.cs#L50) but I forgot to fix it for the the UI.

Meanwhile, you can still change the value via commandline
``` VsRegEdit.exe set [VS folder] HKCU "FeatureFlags\Roslyn\ServiceHubCore" Value dword 1```

