### PR TITLE
Remove extra EnsureEditableDocuments  calls

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1171,7 +1171,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private void ApplyTextDocumentChange(DocumentId documentId, SourceText newText)
         {
-            EnsureEditableDocuments(documentId);
             var containedDocument = TryGetContainedDocument(documentId);
 
             if (containedDocument != null)
@@ -1441,9 +1440,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 throw new Exception("A file was reloaded during the source control checkout.");
             }
         }
-
-        public void EnsureEditableDocuments(params DocumentId[] documents)
-            => this.EnsureEditableDocuments((IEnumerable<DocumentId>)documents);
 
         internal override bool CanAddProjectReference(ProjectId referencingProject, ProjectId referencedProject)
         {


### PR DESCRIPTION
Remove single check for EnsureEditableDocuments on each document. This was duplicating the work that the call in TryApplyChanges does, and can have conflicts with linked files.

For example:
1. If file A.cs is renamed to B.cs and is in 2 projects
2. Each project will go through and apply changes (lets call P1 and P2)
3. P1 goes through and calls: ApplyTextChange > EnsureEditable > Rename File (File is now B.cs on disk)
4. P2 goes through to do the same as P1, but A.cs no longer exists so EnsureEditable will fail (can't check status of a file that doesn't exist)

We should be doing all the work to check edit status upfront so it doesn't collide with the actual edits we need to do. TryApplyChanges is already overridden and does that. This change just removes the extra work we were doing that also created problems for renaming files.

Fixes #56467 