### PR TITLE
Don't show nullable annotation in completion items of static field/property

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
@@ -1721,9 +1721,11 @@ class C
         [Trait(Traits.Feature, Traits.Features.Completion)]
         [InlineData(nameof(DayOfWeek), nameof(DayOfWeek.Friday))]
         [InlineData(nameof(DateTime), nameof(DateTime.Now))]
+        [InlineData(nameof(TimeZoneInfo), nameof(TimeZoneInfo.Local))]
         public async Task TestNullableEnum(string typeName, string memberName)
         {
             var markup = $@"
+#nullable enable
 using System;
 class C
 {{
@@ -1742,9 +1744,11 @@ class C
         [Trait(Traits.Feature, Traits.Features.Completion)]
         [InlineData(nameof(DayOfWeek), nameof(DayOfWeek.Friday))]
         [InlineData(nameof(DateTime), nameof(DateTime.Now))]
+        [InlineData(nameof(TimeZoneInfo), nameof(TimeZoneInfo.Local))]
         public async Task TestTypeAlias(string typeName, string memberName)
         {
             var markup = $@"
+#nullable enable
 using AT = System.{typeName};
 
 public class Program

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         private static INamedTypeSymbol? TryGetTypeWithStaticMembers(ITypeSymbol type)
         {
             if (type.TypeKind is TypeKind.Struct or TypeKind.Class)
-                return type as INamedTypeSymbol;
+                return type.WithNullableAnnotation(NullableAnnotation.NotAnnotated) as INamedTypeSymbol;
 
             return null;
         }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
@@ -317,6 +317,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         private static INamedTypeSymbol? TryGetTypeWithStaticMembers(ITypeSymbol type)
         {
+            // The reference type might be nullable, so we need to remove the annotation.
+            // Otherwise, we will end up with items like "string?.Empty".
             if (type.TypeKind is TypeKind.Struct or TypeKind.Class)
                 return type.WithNullableAnnotation(NullableAnnotation.NotAnnotated) as INamedTypeSymbol;
 


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/57636