### PR TITLE
Ensure that getting the checksum for a project cone is resilient to its project references being missing

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
@@ -88,7 +88,16 @@ namespace Microsoft.CodeAnalysis
                     return;
 
                 foreach (var refProject in projectState.ProjectReferences)
-                    AddReferencedProjects(result, refProject.ProjectId);
+                {
+                    // Note: it's possible in the workspace to see project-ids that don't have a corresponding project
+                    // state.  While not desirable, we allow project's to have refs to projects that no longer exist
+                    // anymore.  This state is expected to be temporary until the project is explicitly told by the
+                    // host to remove the reference.  We do not expose this through the full Solution/Project which
+                    // filters out this case already (in Project.ProjectReferences). However, becausde we're at the
+                    // ProjectState level it cannot do that filtering unless examined through us (the SolutionState).
+                    if (this.ProjectStates.ContainsKey(refProject.ProjectId))
+                        AddReferencedProjects(result, refProject.ProjectId);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1436227

Comment in code explains the scenario.  But effectively it is part of our underlying green project tree that it can represent links between states that are stale and refer to states the current green state doesn't contain.  The red layer on top already ensures the right state is shown to any consumer from that layer, however we have code what was walking the green state and crashed here.

I don't love that the green layer can be in a place like this, but it's been part of the nature of this system for a while.