### PR TITLE
Fix null ref in navbars

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarSelectedItems.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarSelectedItems.cs
@@ -8,6 +8,8 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal class NavigationBarSelectedTypeAndMember : IEquatable<NavigationBarSelectedTypeAndMember>
     {
+        public static readonly NavigationBarSelectedTypeAndMember Empty = new(typeItem: null, memberItem: null);
+
         public NavigationBarItem? TypeItem { get; }
         public bool ShowTypeItemGrayed { get; }
         public NavigationBarItem? MemberItem { get; }

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -115,6 +115,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             StartModelUpdateAndSelectedItemUpdateTasks();
         }
 
+        public TestAccessor GetTestAccessor() => new TestAccessor(this);
+
         private void OnEventSourceChanged(object? sender, TaggerEventArgs e)
         {
             StartModelUpdateAndSelectedItemUpdateTasks();
@@ -250,6 +252,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 
             // Now that the edit has been done, refresh to make sure everything is up-to-date.
             StartModelUpdateAndSelectedItemUpdateTasks();
+        }
+
+        public struct TestAccessor
+        {
+            private readonly NavigationBarController _navigationBarController;
+
+            public TestAccessor(NavigationBarController navigationBarController)
+            {
+                _navigationBarController = navigationBarController;
+            }
+
+            public Task<NavigationBarModel?> GetModelAsync()
+                => _navigationBarController._computeModelQueue.WaitUntilCurrentBatchCompletesAsync();
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigationBar/NavigationBarController.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         /// The last full information we have presented. If we end up wanting to present the same thing again, we can
         /// just skip doing that as the UI will already know about this.
         /// </summary>
-        private (ImmutableArray<NavigationBarProjectItem> projectItems, NavigationBarProjectItem? selectedProjectItem, NavigationBarModel model, NavigationBarSelectedTypeAndMember selectedInfo) _lastPresentedInfo;
+        private (ImmutableArray<NavigationBarProjectItem> projectItems, NavigationBarProjectItem? selectedProjectItem, NavigationBarModel? model, NavigationBarSelectedTypeAndMember selectedInfo) _lastPresentedInfo;
 
         /// <summary>
         /// Source of events that should cause us to update the nav bar model with new information.
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         /// compute the model once for every batch.  The <c>bool</c> type parameter isn't used, but is provided as this
         /// type is generic.
         /// </summary>
-        private readonly AsyncBatchingWorkQueue<bool, NavigationBarModel> _computeModelQueue;
+        private readonly AsyncBatchingWorkQueue<bool, NavigationBarModel?> _computeModelQueue;
 
         /// <summary>
         /// Queue to batch up work to do to determine the selected item.  Used so we can batch up a lot of events and
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             _uiThreadOperationExecutor = uiThreadOperationExecutor;
             _asyncListener = asyncListener;
 
-            _computeModelQueue = new AsyncBatchingWorkQueue<bool, NavigationBarModel>(
+            _computeModelQueue = new AsyncBatchingWorkQueue<bool, NavigationBarModel?>(
                 TimeSpan.FromMilliseconds(TaggerConstants.ShortDelay),
                 ComputeModelAndSelectItemAsync,
                 EqualityComparer<bool>.Default,

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -370,8 +370,13 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             }
 
             private bool ShouldSkipTagProduction()
-                => _dataSource.Options.Any(option => !_dataSource.GlobalOptions.GetOption(option)) ||
-                   _dataSource.PerLanguageOptions.Any(option => !_dataSource.GlobalOptions.GetOption(option, _subjectBuffer.GetLanguageName()));
+            {
+                if (_dataSource.Options.Any(option => !_dataSource.GlobalOptions.GetOption(option)))
+                    return true;
+
+                var languageName = _subjectBuffer.GetLanguageName();
+                return _dataSource.PerLanguageOptions.Any(option => languageName == null || !_dataSource.GlobalOptions.GetOption(option, languageName));
+            }
 
             private Task ProduceTagsAsync(TaggerContext<TTag> context, CancellationToken cancellationToken)
             {


### PR DESCRIPTION
Found by TS/JS.  Their project system spins up asynchronously and so there can be time periods when .js files are both known to have the right content type, but there is no doc available for them yet.  This was causing a null to propagate through non-NRT annotated code, eventually crashing things.  I have fixed the issue and manually tested the JS scenario.

View with whitspace off.
