### PR TITLE
Don't throw exceptions for file changes after a project is unloaded

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -1148,10 +1148,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public void RemoveFromWorkspace()
         {
-            _documentFileChangeContext.Dispose();
-
             using (_gate.DisposableWait())
             {
+                if (!_workspace.CurrentSolution.ContainsProject(Id))
+                {
+                    throw new InvalidOperationException("The project has already been removed.");
+                }
+
                 // clear tracking to external components
                 foreach (var provider in _eventSubscriptionTracker)
                 {
@@ -1161,6 +1164,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _eventSubscriptionTracker.Clear();
             }
 
+            _documentFileChangeContext.Dispose();
             IReadOnlyList<MetadataReference>? remainingMetadataReferences = null;
 
             _workspace.ApplyChangeToWorkspace(w =>

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/FileChangeTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/FileChangeTests.vb
@@ -1,0 +1,63 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Threading
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
+    <[UseExportProvider]>
+    Public Class FileChangeTests
+        <WpfTheory>
+        <CombinatorialData>
+        Public Async Function FileChangeAfterRemovalInUncommittedBatchIgnored(withDirectoryWatch As Boolean) As Task
+            Using environment = New TestEnvironment()
+                Dim projectInfo = New VisualStudioProjectCreationInfo
+
+                ' If we have a project directory, then we'll also have a watch for the entire directory;
+                ' test both cases
+                If withDirectoryWatch Then
+                    projectInfo.FilePath = "Z:\Project.csproj"
+                End If
+
+                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "project", LanguageNames.CSharp, projectInfo, CancellationToken.None)
+
+                project.AddSourceFile("Z:\Foo.cs")
+
+                Using project.CreateBatchScope()
+                    ' This shouldn't throw
+                    Await environment.RaiseStaleFileChangeAsync("Z:\Foo.cs", Sub() project.RemoveSourceFile("Z:\Foo.cs"))
+                End Using
+            End Using
+        End Function
+
+        <WpfTheory>
+        <CombinatorialData>
+        Public Async Function FileChangeAfterRemoveOfProjectIgnored(withDirectoryWatch As Boolean) As Task
+            Using environment = New TestEnvironment()
+                Dim projectInfo = New VisualStudioProjectCreationInfo
+
+                ' If we have a project directory, then we'll also have a watch for the entire directory;
+                ' test both cases
+                If withDirectoryWatch Then
+                    projectInfo.FilePath = "Z:\Project.csproj"
+                End If
+
+                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "project", LanguageNames.CSharp, projectInfo, CancellationToken.None)
+
+                project.AddSourceFile("Z:\Foo.cs")
+
+                Using project.CreateBatchScope()
+                    ' This shouldn't throw
+                    Await environment.RaiseStaleFileChangeAsync("Z:\Foo.cs", Sub() project.RemoveFromWorkspace())
+                End Using
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -274,12 +274,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             End Function
         End Class
 
-        Friend Async Function RaiseFileChangeAsync(path As String) As Task
+        Friend Async Function GetFileChangeServiceAsync() As Task(Of MockVsFileChangeEx)
             ' Ensure we've pushed everything to the file change watcher
             Dim fileChangeProvider = ExportProvider.GetExportedValue(Of FileChangeWatcherProvider)
             Dim mockFileChangeService = Assert.IsType(Of MockVsFileChangeEx)(ServiceProvider.GetService(GetType(SVsFileChangeEx)))
             Await ExportProvider.GetExportedValue(Of AsynchronousOperationListenerProvider)().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync()
-            mockFileChangeService.FireUpdate(path)
+            Return mockFileChangeService
+        End Function
+
+        Friend Async Function RaiseFileChangeAsync(path As String) As Task
+            Dim service = Await GetFileChangeServiceAsync()
+            service.FireUpdate(path)
+        End Function
+
+        ''' <inheritdoc cref="MockVsFileChangeEx.FireStaleUpdate(String, Action)" />
+        Friend Async Function RaiseStaleFileChangeAsync(path As String, unsubscribingAction As Action) As Task
+            Dim service = Await GetFileChangeServiceAsync()
+            service.FireStaleUpdate(path, unsubscribingAction)
         End Function
 
         Private Class MockVsSmartOpenScope


### PR DESCRIPTION
File change notifications are async, and can come after we've removed the project from the workspace. As of this writing, this has happened approximately 58 million times since 16.0 according to fault telemetry.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1433689