### PR TITLE
Add missing test for CallerArgumentExpression

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -5757,7 +5757,7 @@ ABC
         [InlineData("out")]
         [InlineData("ref")]
         [InlineData("in")]
-        public void CallerArgumentExpression_OnRefParameter(string refType)
+        public void CallerArgumentExpression_OnRefParameter01(string refType)
         {
             var comp = CreateCompilation(@$"
 using System.Runtime.CompilerServices;
@@ -5774,6 +5774,49 @@ void M(int i, [CallerArgumentExpression(""i"")] {refType} string s)
                 // void M(int i, [CallerArgumentExpression("i")] ref string s)
                 Diagnostic(ErrorCode.ERR_BadCallerArgumentExpressionParamWithoutDefaultValue, "CallerArgumentExpression").WithLocation(5, 16)
             );
+        }
+
+        [Theory]
+        [InlineData("out")]
+        [InlineData("ref")]
+        public void CallerArgumentExpression_OnRefParameter02(string refType)
+        {
+            var comp = CreateCompilation(@$"
+using System.Runtime.CompilerServices;
+#pragma warning disable CS8321
+
+void M(int i, [CallerArgumentExpression(""i"")] {refType} string s = null)
+{{
+    {(refType == "out" ? "s = null;" : "")}
+}}
+", targetFramework: TargetFramework.NetCoreApp);
+
+            comp.VerifyDiagnostics(
+                // (5,16): error CS8964: The CallerArgumentExpressionAttribute may only be applied to parameters with default values
+                // void M(int i, [CallerArgumentExpression("i")] out string s = null)
+                Diagnostic(ErrorCode.ERR_BadCallerArgumentExpressionParamWithoutDefaultValue, "CallerArgumentExpression").WithLocation(5, 16),
+                // (5,47): error CS1741: A ref or out parameter cannot have a default value
+                // void M(int i, [CallerArgumentExpression("i")] out string s = null)
+                Diagnostic(ErrorCode.ERR_RefOutDefaultValue, "out").WithLocation(5, 47)
+            );
+        }
+
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void CallerArgumentExpression_OnRefParameter03()
+        {
+            var comp = CreateCompilation(@"
+using System;
+using System.Runtime.CompilerServices;
+
+M(1 + 1);
+
+void M(int i, [CallerArgumentExpression(""i"")] in string s = ""default value"")
+{
+    Console.WriteLine(s);
+}
+", targetFramework: TargetFramework.NetCoreApp);
+
+            CompileAndVerify(comp, expectedOutput: "1 + 1").VerifyDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -5797,7 +5797,7 @@ void M(int i, [CallerArgumentExpression(""i"")] {refType} string s = null)
                 Diagnostic(ErrorCode.ERR_BadCallerArgumentExpressionParamWithoutDefaultValue, "CallerArgumentExpression").WithLocation(5, 16),
                 // (5,47): error CS1741: A ref or out parameter cannot have a default value
                 // void M(int i, [CallerArgumentExpression("i")] out string s = null)
-                Diagnostic(ErrorCode.ERR_RefOutDefaultValue, "out").WithLocation(5, 47)
+                Diagnostic(ErrorCode.ERR_RefOutDefaultValue, refType).WithLocation(5, 47)
             );
         }
 

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
@@ -920,7 +920,7 @@ End Module
 value").VerifyDiagnostics()
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(CoreClrOnly))>
         Public Sub TestCallerArgumentExpression_OnByRefParameter01()
             Dim source As String = "
 Imports System.Runtime.CompilerServices
@@ -935,7 +935,7 @@ End Module
             compilation.AssertTheseDiagnostics()
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(CoreClrOnly))>
         Public Sub TestCallerArgumentExpression_OnByRefParameter02()
             Dim source As String = "
 Imports System

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_CallerArgumentExpression.vb
@@ -919,6 +919,42 @@ End Module
             CompileAndVerify(compilation, expectedOutput:="<default>
 value").VerifyDiagnostics()
         End Sub
+
+        <Fact>
+        Public Sub TestCallerArgumentExpression_OnByRefParameter01()
+            Dim source As String = "
+Imports System.Runtime.CompilerServices
+Module Program
+    Private Const p As String = NameOf(p)
+    Sub Log(p As Integer, <CallerArgumentExpression(p)> ByRef arg As String)
+    End Sub
+End Module
+"
+
+            Dim compilation = CreateCompilation(source, targetFramework:=TargetFramework.NetCoreApp, references:={Net451.MicrosoftVisualBasic}, options:=TestOptions.ReleaseDll, parseOptions:=TestOptions.RegularLatest)
+            compilation.AssertTheseDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub TestCallerArgumentExpression_OnByRefParameter02()
+            Dim source As String = "
+Imports System
+Imports System.Runtime.CompilerServices
+Module Program
+    Sub Main()
+        Log(1 + 1)
+    End Sub
+
+    Private Const p As String = NameOf(p)
+    Sub Log(p As Integer, <CallerArgumentExpression(p)> Optional ByRef arg As String = ""<default-value>"")
+        Console.WriteLine(arg)
+    End Sub
+End Module
+"
+
+            Dim compilation = CreateCompilation(source, targetFramework:=TargetFramework.NetCoreApp, references:={Net451.MicrosoftVisualBasic}, options:=TestOptions.ReleaseExe, parseOptions:=TestOptions.RegularLatest)
+            CompileAndVerify(compilation, expectedOutput:="1 + 1").VerifyDiagnostics()
+        End Sub
 #End Region
 
 #Region "CallerArgumentExpression - Attributes"


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/52745.
