### PR TITLE
Do not call IsFullyLoadedAsync from JTF

### DIFF
--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
@@ -176,20 +176,14 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
             }
         }
 
-        public object GetDocumentData(uint grfCreate, string pszMkDocument, IVsHierarchy pHier, uint itemid)
-        {
-            throw new NotImplementedException();
-        }
+        public object? GetDocumentData(uint grfCreate, string pszMkDocument, IVsHierarchy pHier, uint itemid)
+            => null;
 
-        public object GetDocumentView(uint grfCreate, string pszPhysicalView, IVsHierarchy pHier, IntPtr punkDocData, uint itemid)
-        {
-            throw new NotImplementedException();
-        }
+        public object? GetDocumentView(uint grfCreate, string pszPhysicalView, IVsHierarchy pHier, IntPtr punkDocData, uint itemid)
+            => null;
 
-        public string GetEditorCaption(string pszMkDocument, string pszPhysicalView, IVsHierarchy pHier, IntPtr punkDocData, out Guid pguidCmdUI)
-        {
-            throw new NotImplementedException();
-        }
+        public string? GetEditorCaption(string pszMkDocument, string pszPhysicalView, IVsHierarchy pHier, IntPtr punkDocData, out Guid pguidCmdUI)
+            => throw new NotImplementedException();
 
         public bool ShouldDeferUntilIntellisenseIsReady(uint grfCreate, string pszMkDocument, string pszPhysicalView)
             => true;

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
 {
     [Export(typeof(SettingsEditorFactory))]
     [Guid(SettingsEditorFactoryGuidString)]
-    internal sealed class SettingsEditorFactory : IVsEditorFactory, IDisposable
+    internal sealed class SettingsEditorFactory : IVsEditorFactory, IVsEditorFactory4, IDisposable
     {
         public static readonly Guid SettingsEditorFactoryGuid = new(SettingsEditorFactoryGuidString);
         public const string SettingsEditorFactoryGuidString = "68b46364-d378-42f2-9e72-37d86c5f4468";
@@ -175,5 +175,22 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                 return VSConstants.E_NOTIMPL;   // you must return E_NOTIMPL for any unrecognized rguidLogicalView values
             }
         }
+
+        public object GetDocumentData(uint grfCreate, string pszMkDocument, IVsHierarchy pHier, uint itemid)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetDocumentView(uint grfCreate, string pszPhysicalView, IVsHierarchy pHier, IntPtr punkDocData, uint itemid)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetEditorCaption(string pszMkDocument, string pszPhysicalView, IVsHierarchy pHier, IntPtr punkDocData, out Guid pguidCmdUI)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ShouldDeferUntilIntellisenseIsReady(uint grfCreate, string pszMkDocument, string pszPhysicalView) => true;
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorFactory.cs
@@ -191,6 +191,7 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
             throw new NotImplementedException();
         }
 
-        public bool ShouldDeferUntilIntellisenseIsReady(uint grfCreate, string pszMkDocument, string pszPhysicalView) => true;
+        public bool ShouldDeferUntilIntellisenseIsReady(uint grfCreate, string pszMkDocument, string pszPhysicalView)
+            => true;
     }
 }

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/SettingsEditorPane.cs
@@ -95,19 +95,6 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings
                 }
             }
 
-            var statusService = _workspace.Services.GetService<IWorkspaceStatusService>();
-            if (statusService is not null)
-            {
-                // This will show the 'Waiting for Intellisense to initalize' message until the workspace is loaded.
-                _threadingContext.JoinableTaskFactory.Run(async () =>
-                {
-                    if (!await statusService.IsFullyLoadedAsync(CancellationToken.None).ConfigureAwait(false))
-                    {
-                        await statusService.WaitUntilFullyLoadedAsync(CancellationToken.None).ConfigureAwait(false);
-                    }
-                });
-            }
-
             var whitespaceView = GetWhitespaceView();
             var codeStyleView = GetCodeStyleView();
             var analyzerView = GetAnalyzerView();


### PR DESCRIPTION
use IVsEditorFactory4.ShouldDeferUntilIntellisenseIsReady to defer editor creation until the project has finished loading

related to internal feedback item [AB#1435631](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1435631)