### PR TITLE
[LSP] Use test accessor task instead of async operation to wait for LSP server shutdown in tests

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -404,8 +404,7 @@ namespace Roslyn.Test.Utilities
             var registrationService = workspace.GetService<LspWorkspaceRegistrationService>();
             var globalOptions = workspace.GetService<IGlobalOptionService>();
             var lspMiscFilesWorkspace = new LspMiscellaneousFilesWorkspace(NoOpLspLogger.Instance);
-            var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
-            return new RequestExecutionQueue(NoOpLspLogger.Instance, registrationService, lspMiscFilesWorkspace, globalOptions, listenerProvider, ProtocolConstants.RoslynLspLanguages, serverName: "Tests", "TestClient");
+            return new RequestExecutionQueue(NoOpLspLogger.Instance, registrationService, lspMiscFilesWorkspace, globalOptions, ProtocolConstants.RoslynLspLanguages, serverName: "Tests", "TestClient");
         }
 
         private static string GetDocumentFilePathFromName(string documentName)

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.DocumentChangeTracker.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.DocumentChangeTracker.cs
@@ -61,6 +61,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             public bool IsComplete() => _queue._queue.IsCompleted && _queue._queue.IsEmpty;
 
+            public async Task WaitForProcessingToStop()
+            {
+                await _queue._queueProcessingTask.ConfigureAwait(false);
+            }
+
             /// <summary>
             /// Test only method to validate that remaining items in the queue are cancelled.
             /// This directly mutates the queue in an unsafe way, so ensure that all relevant queue operations

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.DocumentChangeTracker.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.DocumentChangeTracker.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             public bool IsComplete() => _queue._queue.IsCompleted && _queue._queue.IsEmpty;
 
-            public async Task WaitForProcessingToStop()
+            public async Task WaitForProcessingToStopAsync()
             {
                 await _queue._queueProcessingTask.ConfigureAwait(false);
             }

--- a/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
+++ b/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
@@ -87,7 +87,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 workspaceRegistrationService,
                 lspMiscellaneousFilesWorkspace,
                 globalOptions,
-                listenerProvider,
                 supportedLanguages,
                 userVisibleServerName,
                 TelemetryServerName);

--- a/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
@@ -27,34 +27,34 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
         [Fact]
         public async Task LanguageServerQueueEmptyOnShutdownMessage()
         {
-            await using var languageServerTarget = CreateLanguageServer(out var jsonRpc, out var listenerProvider);
+            await using var languageServerTarget = CreateLanguageServer(out var jsonRpc);
             AssertServerAlive(languageServerTarget);
 
             await languageServerTarget.ShutdownAsync(CancellationToken.None).ConfigureAwait(false);
-            await AssertServerQueueClosed(languageServerTarget, listenerProvider).ConfigureAwait(false);
+            await AssertServerQueueClosed(languageServerTarget).ConfigureAwait(false);
             Assert.False(jsonRpc.IsDisposed);
         }
 
         [Fact]
         public async Task LanguageServerCleansUpOnExitMessage()
         {
-            await using var languageServerTarget = CreateLanguageServer(out var jsonRpc, out var listenerProvider);
+            await using var languageServerTarget = CreateLanguageServer(out var jsonRpc);
             AssertServerAlive(languageServerTarget);
 
             await languageServerTarget.ShutdownAsync(CancellationToken.None).ConfigureAwait(false);
             await languageServerTarget.ExitAsync(CancellationToken.None).ConfigureAwait(false);
-            await AssertServerQueueClosed(languageServerTarget, listenerProvider).ConfigureAwait(false);
+            await AssertServerQueueClosed(languageServerTarget).ConfigureAwait(false);
             Assert.True(jsonRpc.IsDisposed);
         }
 
         [Fact]
         public async Task LanguageServerCleansUpOnUnexpectedJsonRpcDisconnectAsync()
         {
-            await using var languageServerTarget = CreateLanguageServer(out var jsonRpc, out var listenerProvider);
+            await using var languageServerTarget = CreateLanguageServer(out var jsonRpc);
             AssertServerAlive(languageServerTarget);
 
             jsonRpc.Dispose();
-            await AssertServerQueueClosed(languageServerTarget, listenerProvider).ConfigureAwait(false);
+            await AssertServerQueueClosed(languageServerTarget).ConfigureAwait(false);
             Assert.True(jsonRpc.IsDisposed);
         }
 
@@ -64,14 +64,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             Assert.False(server.GetTestAccessor().GetQueueAccessor().IsComplete());
         }
 
-        private static async Task AssertServerQueueClosed(LanguageServerTarget server, IAsynchronousOperationListenerProvider listenerProvider)
+        private static async Task AssertServerQueueClosed(LanguageServerTarget server)
         {
-            await listenerProvider.GetWaiter(FeatureAttribute.LanguageServer).ExpeditedWaitAsync();
+            await server.GetTestAccessor().GetQueueAccessor().WaitForProcessingToStop().ConfigureAwait(false);
             Assert.True(server.HasShutdownStarted);
             Assert.True(server.GetTestAccessor().GetQueueAccessor().IsComplete());
         }
 
-        private LanguageServerTarget CreateLanguageServer(out JsonRpc serverJsonRpc, out IAsynchronousOperationListenerProvider listenerProvider)
+        private LanguageServerTarget CreateLanguageServer(out JsonRpc serverJsonRpc)
         {
             using var workspace = TestWorkspace.CreateCSharp("", composition: Composition);
 
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             var lspWorkspaceRegistrationService = workspace.GetService<LspWorkspaceRegistrationService>();
             var capabilitiesProvider = workspace.GetService<DefaultCapabilitiesProvider>();
             var globalOptions = workspace.GetService<IGlobalOptionService>();
-            listenerProvider = workspace.GetService<IAsynchronousOperationListenerProvider>();
+            var listenerProvider = workspace.GetService<IAsynchronousOperationListenerProvider>();
 
             serverJsonRpc = new JsonRpc(new HeaderDelimitedMessageHandler(serverStream, serverStream))
             {

--- a/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 
         private static async Task AssertServerQueueClosed(LanguageServerTarget server)
         {
-            await server.GetTestAccessor().GetQueueAccessor().WaitForProcessingToStop().ConfigureAwait(false);
+            await server.GetTestAccessor().GetQueueAccessor().WaitForProcessingToStopAsync().ConfigureAwait(false);
             Assert.True(server.HasShutdownStarted);
             Assert.True(server.GetTestAccessor().GetQueueAccessor().IsComplete());
         }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -173,9 +173,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 
             // The failed request returns to the client before the shutdown completes.
             // Wait for the queue to finish handling the failed request and shutdown.
-            var operations = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<AsynchronousOperationListenerProvider>();
-            var waiter = operations.GetWaiter(FeatureAttribute.LanguageServer);
-            await waiter.ExpeditedWaitAsync();
+            await testLspServer.GetQueueAccessor().WaitForProcessingToStop().ConfigureAwait(false);
 
             // remaining tasks should be canceled
             var areAllItemsCancelled = await testLspServer.GetQueueAccessor().AreAllItemsCancelledUnsafeAsync();

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
 
             // The failed request returns to the client before the shutdown completes.
             // Wait for the queue to finish handling the failed request and shutdown.
-            await testLspServer.GetQueueAccessor().WaitForProcessingToStop().ConfigureAwait(false);
+            await testLspServer.GetQueueAccessor().WaitForProcessingToStopAsync().ConfigureAwait(false);
 
             // remaining tasks should be canceled
             var areAllItemsCancelled = await testLspServer.GetQueueAccessor().AreAllItemsCancelledUnsafeAsync();


### PR DESCRIPTION
Using the async operation listener caused an issue in RPS when they wait for all async operations to be complete.  Since this operation would not complete until VS shutsdown (and the LSP server is shutdown), RPS timed out.

Fixes rps issue in https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/364684#view=discussion

Val build in progress - https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5459216&view=results