### PR TITLE
Fix deadlock switching the project context dropdown

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1331,61 +1331,69 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // Note: this method does not actually call into any workspace code here to change the workspace's context. The assumption is updating the running document table or
             // IVsHierarchies will raise the appropriate events which we are subscribed to.
 
+            var hierarchy = GetHierarchy(documentId.ProjectId);
+            if (hierarchy == null)
+            {
+                // If we don't have a hierarchy then there's nothing we can do
+                return;
+            }
+
+            // The hierarchy might be supporting multitargeting; in that case, let's update the context. Unfortunately the IVsHierarchies that support this
+            // don't necessarily let us read it first, so we have to fire-and-forget here.
+            string? projectSystemNameForProjectId = null;
+
             using (_gate.DisposableWait())
             {
-                var hierarchy = GetHierarchy(documentId.ProjectId);
-                if (hierarchy == null)
-                {
-                    // If we don't have a hierarchy then there's nothing we can do
-                    return;
-                }
-
-                // The hierarchy might be supporting multitargeting; in that case, let's update the context. Unfortunately the IVsHierarchies that support this
-                // don't necessarily let us read it first, so we have to fire-and-forget here.
                 foreach (var (projectSystemName, projects) in _projectSystemNameToProjectsMap)
                 {
                     if (projects.Any(p => p.Id == documentId.ProjectId))
                     {
-                        hierarchy.SetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID8.VSHPROPID_ActiveIntellisenseProjectContext, projectSystemName);
-
-                        // We've updated that property, but we still need to continue the rest of this process to ensure the Running Document Table is updated
-                        // and any shared asset projects are also updated.
-                        break;
+                        projectSystemNameForProjectId = projectSystemName;
                     }
                 }
-
-                var filePath = GetFilePath(documentId);
-                if (filePath == null)
-                {
-                    return;
-                }
-
-                var itemId = hierarchy.TryGetItemId(filePath);
-                if (itemId != VSConstants.VSITEMID_NIL)
-                {
-                    // Is this owned by a shared asset project? If so, we need to put the shared asset project into the running document table, and need to set the
-                    // current hierarchy as the active context of that shared hierarchy. This is kept as a loop that we do multiple times in the case that you
-                    // have multiple pointers. This used to be the case for multitargeting projects, but that was now handled by setting the active context property
-                    // above. Some project systems out there might still be supporting it, so we'll support it too.
-                    while (SharedProjectUtilities.TryGetItemInSharedAssetsProject(hierarchy, itemId, out var sharedHierarchy, out var sharedItemId) &&
-                           hierarchy != sharedHierarchy)
-                    {
-                        // Ensure the shared context is set correctly
-                        if (sharedHierarchy.GetActiveProjectContext() != hierarchy)
-                        {
-                            ErrorHandler.ThrowOnFailure(sharedHierarchy.SetActiveProjectContext(hierarchy));
-                        }
-
-                        // We now need to ensure the outer project is also set up
-                        hierarchy = sharedHierarchy;
-                        itemId = sharedItemId;
-                    }
-                }
-
-                // Update the ownership of the file in the Running Document Table
-                var project = (IVsProject3)hierarchy;
-                project.TransferItem(filePath, filePath, punkWindowFrame: null);
             }
+
+            if (projectSystemNameForProjectId is null)
+            {
+                // Project must have been removed asynchronously
+                return;
+            }
+
+            // The hierarchy might be supporting multitargeting; in that case, let's update the context. Unfortunately the IVsHierarchies that support this
+            // don't necessarily let us read it first, so we have to fire-and-forget here.
+            hierarchy.SetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID8.VSHPROPID_ActiveIntellisenseProjectContext, projectSystemNameForProjectId);
+
+            var filePath = GetFilePath(documentId);
+            if (filePath == null)
+            {
+                return;
+            }
+
+            var itemId = hierarchy.TryGetItemId(filePath);
+            if (itemId != VSConstants.VSITEMID_NIL)
+            {
+                // Is this owned by a shared asset project? If so, we need to put the shared asset project into the running document table, and need to set the
+                // current hierarchy as the active context of that shared hierarchy. This is kept as a loop that we do multiple times in the case that you
+                // have multiple pointers. This used to be the case for multitargeting projects, but that was now handled by setting the active context property
+                // above. Some project systems out there might still be supporting it, so we'll support it too.
+                while (SharedProjectUtilities.TryGetItemInSharedAssetsProject(hierarchy, itemId, out var sharedHierarchy, out var sharedItemId) &&
+                       hierarchy != sharedHierarchy)
+                {
+                    // Ensure the shared context is set correctly
+                    if (sharedHierarchy.GetActiveProjectContext() != hierarchy)
+                    {
+                        ErrorHandler.ThrowOnFailure(sharedHierarchy.SetActiveProjectContext(hierarchy));
+                    }
+
+                    // We now need to ensure the outer project is also set up
+                    hierarchy = sharedHierarchy;
+                    itemId = sharedItemId;
+                }
+            }
+
+            // Update the ownership of the file in the Running Document Table
+            var project = (IVsProject3)hierarchy;
+            project.TransferItem(filePath, filePath, punkWindowFrame: null);
         }
 
         internal bool TryGetHierarchy(ProjectId projectId, [NotNullWhen(returnValue: true)] out IVsHierarchy? hierarchy)


### PR DESCRIPTION
We were acquiring the workspace lock and then calling into third-party code that raises various events; we respond to those events by trying to acquire the lock again and updating the workspace. This worked because previously the workspace lock allowed reentrancy.

Looking at the code, it's not clear why I ever took the lock for the entire operation. The only bit that needed the lock was a small bit looking at _projectSystemNameToProjectsMap; everything else was either immutable state, or not using our state anymore at all. It's safe to just remove the outer lock, as long as we deal with the fact the project might disappear at any time, which is easier to do. This is also just restoring this code to good hygiene, which is never to call third party code while still holding a lock.

Fixes [AB#1433413](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1433413)