### PR TITLE
Merge FixIdDefinition with the same name

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer_DiagnosticIds.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer_DiagnosticIds.cs
@@ -33,24 +33,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         public static readonly FixIdDefinition? UseExplicitTypeDiagnosticId;
 
         [Export]
-        [FixId(IDEDiagnosticIds.AddQualificationDiagnosticId)]
-        [Name(IDEDiagnosticIds.AddQualificationDiagnosticId)]
-        [Order(After = IDEDiagnosticIds.UseObjectInitializerDiagnosticId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [LocalizedName(typeof(CSharpFeaturesResources), nameof(CSharpFeaturesResources.Apply_this_qualification_preferences))]
-        public static readonly FixIdDefinition? AddQualificationDiagnosticId;
-
-        [Export]
-        [FixId(IDEDiagnosticIds.RemoveQualificationDiagnosticId)]
-        [Name(IDEDiagnosticIds.RemoveQualificationDiagnosticId)]
-        [Order(After = IDEDiagnosticIds.UseObjectInitializerDiagnosticId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [LocalizedName(typeof(CSharpFeaturesResources), nameof(CSharpFeaturesResources.Apply_this_qualification_preferences))]
-        public static readonly FixIdDefinition? RemoveQualificationDiagnosticId;
-
-        [Export]
         [FixId(IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId)]
         [Name(IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId)]
         [Order(After = IDEDiagnosticIds.InlineDeclarationDiagnosticId)]
@@ -67,42 +49,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         [HelpLink("https://www.microsoft.com")]
         [LocalizedName(typeof(CSharpFeaturesResources), nameof(CSharpFeaturesResources.Add_remove_braces_for_single_line_control_statements))]
         public static readonly FixIdDefinition? AddBracesDiagnosticId;
-
-        [Export]
-        [FixId(IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId)]
-        [Name(IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId)]
-        [Order(After = IDEDiagnosticIds.AddBracesDiagnosticId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [LocalizedName(typeof(AnalyzersResources), nameof(AnalyzersResources.Add_accessibility_modifiers))]
-        public static readonly FixIdDefinition? AddAccessibilityModifiersDiagnosticId;
-
-        [Export]
-        [FixId(IDEDiagnosticIds.OrderModifiersDiagnosticId)]
-        [Name(IDEDiagnosticIds.OrderModifiersDiagnosticId)]
-        [Order(After = IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [LocalizedName(typeof(CSharpFeaturesResources), nameof(CSharpFeaturesResources.Sort_accessibility_modifiers))]
-        public static readonly FixIdDefinition? OrderModifiersDiagnosticId;
-
-        [Export]
-        [FixId(IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId)]
-        [Name(IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId)]
-        [Order(After = IDEDiagnosticIds.AddQualificationDiagnosticId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [LocalizedName(typeof(CSharpFeaturesResources), nameof(CSharpFeaturesResources.Make_private_field_readonly_when_possible))]
-        public static readonly FixIdDefinition? MakeFieldReadonlyDiagnosticId;
-
-        [Export]
-        [FixId(IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId)]
-        [Name(IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId)]
-        [Order(After = IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Remove_unnecessary_casts))]
-        public static readonly FixIdDefinition? RemoveUnnecessaryCastDiagnosticId;
 
         [Export]
         [FixId(IDEDiagnosticIds.UseExpressionBodyForConstructorsDiagnosticId)]
@@ -193,62 +139,5 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         [HelpLink("https://www.microsoft.com")]
         [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Remove_unused_variables))]
         public static readonly FixIdDefinition? CS0219;
-
-        [Export]
-        [FixId(IDEDiagnosticIds.UseObjectInitializerDiagnosticId)]
-        [Name(IDEDiagnosticIds.UseObjectInitializerDiagnosticId)]
-        [Order(After = IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Apply_object_collection_initialization_preferences))]
-        public static readonly FixIdDefinition? UseObjectInitializerDiagnosticId;
-
-        [Export]
-        [FixId(IDEDiagnosticIds.UseCollectionInitializerDiagnosticId)]
-        [Name(IDEDiagnosticIds.UseCollectionInitializerDiagnosticId)]
-        [Order(After = IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Apply_object_collection_initialization_preferences))]
-        public static readonly FixIdDefinition? UseCollectionInitializerDiagnosticId;
-
-        [Export]
-        [FixId(FormatDocumentFixId)]
-        [Name(FormatDocumentFixId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [ExportMetadata("EnableByDefault", true)]
-        [LocalizedName(typeof(ServicesVSResources), nameof(ServicesVSResources.Format_document))]
-        public static readonly FixIdDefinition? FormatDocument;
-
-        [Export]
-        [FixId(RemoveUnusedImportsFixId)]
-        [Name(RemoveUnusedImportsFixId)]
-        [Order(After = FormatDocumentFixId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [ExportMetadata("EnableByDefault", true)]
-        [LocalizedName(typeof(CSharpVSResources), nameof(CSharpVSResources.Remove_unnecessary_usings))]
-        public static readonly FixIdDefinition? RemoveUnusedImports;
-
-        [Export]
-        [FixId(SortImportsFixId)]
-        [Name(SortImportsFixId)]
-        [Order(After = RemoveUnusedImportsFixId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [ExportMetadata("EnableByDefault", true)]
-        [LocalizedName(typeof(CSharpVSResources), nameof(CSharpVSResources.Sort_usings))]
-        public static readonly FixIdDefinition? SortImports;
-
-        [Export]
-        [FixId(IDEDiagnosticIds.FileHeaderMismatch)]
-        [Name(IDEDiagnosticIds.FileHeaderMismatch)]
-        [Order(After = SortImportsFixId)]
-        [ConfigurationKey("unused")]
-        [HelpLink("https://www.microsoft.com")]
-        [ExportMetadata("EnableByDefault", true)]
-        [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Apply_file_header_preferences))]
-        public static readonly FixIdDefinition? FileHeaderMismatch;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/CodeCleanup/AbstractCodeCleanUpFixer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeCleanup/AbstractCodeCleanUpFixer.cs
@@ -35,9 +35,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
     /// </summary>
     internal abstract class AbstractCodeCleanUpFixer : ICodeCleanUpFixer
     {
-        protected const string FormatDocumentFixId = nameof(FormatDocumentFixId);
-        protected const string RemoveUnusedImportsFixId = nameof(RemoveUnusedImportsFixId);
-        protected const string SortImportsFixId = nameof(SortImportsFixId);
+        protected internal const string FormatDocumentFixId = nameof(FormatDocumentFixId);
+        protected internal const string RemoveUnusedImportsFixId = nameof(RemoveUnusedImportsFixId);
+        protected internal const string SortImportsFixId = nameof(SortImportsFixId);
 
         private readonly IThreadingContext _threadingContext;
         private readonly VisualStudioWorkspaceImpl _workspace;

--- a/src/VisualStudio/Core/Def/Implementation/CodeCleanup/CommonCodeCleanUpFixerDiagnosticIds.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeCleanup/CommonCodeCleanUpFixerDiagnosticIds.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.Language.CodeCleanUp;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
+{
+    internal sealed class CommonCodeCleanUpFixerDiagnosticIds
+    {
+        [Export]
+        [FixId(IDEDiagnosticIds.AddQualificationDiagnosticId)]
+        [Name(IDEDiagnosticIds.AddQualificationDiagnosticId)]
+        [Order(After = IDEDiagnosticIds.UseObjectInitializerDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [LocalizedName(typeof(AnalyzersResources), nameof(AnalyzersResources.Add_this_or_Me_qualification))]
+        public static readonly FixIdDefinition? AddQualificationDiagnosticId;
+
+        [Export]
+        [FixId(IDEDiagnosticIds.RemoveQualificationDiagnosticId)]
+        [Name(IDEDiagnosticIds.RemoveQualificationDiagnosticId)]
+        [Order(After = IDEDiagnosticIds.UseObjectInitializerDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [LocalizedName(typeof(AnalyzersResources), nameof(AnalyzersResources.Add_this_or_Me_qualification))]
+        public static readonly FixIdDefinition? RemoveQualificationDiagnosticId;
+
+        [Export]
+        [FixId(IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId)]
+        [Name(IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId)]
+        [Order(After = IDEDiagnosticIds.AddBracesDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [LocalizedName(typeof(AnalyzersResources), nameof(AnalyzersResources.Add_accessibility_modifiers))]
+        public static readonly FixIdDefinition? AddAccessibilityModifiersDiagnosticId;
+
+        [Export]
+        [FixId(IDEDiagnosticIds.OrderModifiersDiagnosticId)]
+        [Name(IDEDiagnosticIds.OrderModifiersDiagnosticId)]
+        [Order(After = IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [LocalizedName(typeof(AnalyzersResources), nameof(AnalyzersResources.Order_modifiers))]
+        public static readonly FixIdDefinition? OrderModifiersDiagnosticId;
+
+        [Export]
+        [FixId(IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId)]
+        [Name(IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId)]
+        [Order(After = IDEDiagnosticIds.AddQualificationDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [LocalizedName(typeof(AnalyzersResources), nameof(AnalyzersResources.Make_field_readonly))]
+        public static readonly FixIdDefinition? MakeFieldReadonlyDiagnosticId;
+
+        [Export]
+        [FixId(IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId)]
+        [Name(IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId)]
+        [Order(After = IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Remove_unnecessary_casts))]
+        public static readonly FixIdDefinition? RemoveUnnecessaryCastDiagnosticId;
+
+        [Export]
+        [FixId(IDEDiagnosticIds.UseObjectInitializerDiagnosticId)]
+        [Name(IDEDiagnosticIds.UseObjectInitializerDiagnosticId)]
+        [Order(After = IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Apply_object_collection_initialization_preferences))]
+        public static readonly FixIdDefinition? UseObjectInitializerDiagnosticId;
+
+        [Export]
+        [FixId(IDEDiagnosticIds.UseCollectionInitializerDiagnosticId)]
+        [Name(IDEDiagnosticIds.UseCollectionInitializerDiagnosticId)]
+        [Order(After = IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Apply_object_collection_initialization_preferences))]
+        public static readonly FixIdDefinition? UseCollectionInitializerDiagnosticId;
+
+        [Export]
+        [FixId(AbstractCodeCleanUpFixer.FormatDocumentFixId)]
+        [Name(AbstractCodeCleanUpFixer.FormatDocumentFixId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [ExportMetadata("EnableByDefault", true)]
+        [LocalizedName(typeof(ServicesVSResources), nameof(ServicesVSResources.Format_document))]
+        public static readonly FixIdDefinition? FormatDocument;
+
+        [Export]
+        [FixId(AbstractCodeCleanUpFixer.RemoveUnusedImportsFixId)]
+        [Name(AbstractCodeCleanUpFixer.RemoveUnusedImportsFixId)]
+        [Order(After = AbstractCodeCleanUpFixer.FormatDocumentFixId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [ExportMetadata("EnableByDefault", true)]
+        [LocalizedName(typeof(ServicesVSResources), nameof(ServicesVSResources.Remove_unnecessary_usings))]
+        public static readonly FixIdDefinition? RemoveUnusedImports;
+
+        [Export]
+        [FixId(AbstractCodeCleanUpFixer.SortImportsFixId)]
+        [Name(AbstractCodeCleanUpFixer.SortImportsFixId)]
+        [Order(After = AbstractCodeCleanUpFixer.RemoveUnusedImportsFixId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [ExportMetadata("EnableByDefault", true)]
+        [LocalizedName(typeof(ServicesVSResources), nameof(ServicesVSResources.Sort_usings))]
+        public static readonly FixIdDefinition? SortImports;
+
+        [Export]
+        [FixId(IDEDiagnosticIds.FileHeaderMismatch)]
+        [Name(IDEDiagnosticIds.FileHeaderMismatch)]
+        [Order(After = AbstractCodeCleanUpFixer.SortImportsFixId)]
+        [ConfigurationKey("unused")]
+        [HelpLink("https://www.microsoft.com")]
+        [ExportMetadata("EnableByDefault", true)]
+        [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Apply_file_header_preferences))]
+        public static readonly FixIdDefinition? FileHeaderMismatch;
+    }
+}

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1881,4 +1881,10 @@ Additional information: {1}</value>
     <value>Stack Trace {0}</value>
     <comment>Header for numbered stack trace view tabs</comment>
   </data>
+  <data name="Remove_unnecessary_usings" xml:space="preserve">
+    <value>Remove unnecessary usings</value>
+  </data>
+  <data name="Sort_usings" xml:space="preserve">
+    <value>Sort usings</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">Odebrat nepoužívané odkazy</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">Přejmenovat {0} na {1}</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Některé barvy barevného schématu se přepsaly změnami na stránce možností Prostředí &gt; Písma a barvy. Pokud chcete zrušit všechna přizpůsobení, vyberte na stránce Písma a barvy možnost Použít výchozí.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">Nicht verwendete Verweise entfernen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">"{0}" in "{1}" umbenennen</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Einige Farbschemafarben werden durch Änderungen überschrieben, die auf der Optionsseite "Umgebung" &gt; "Schriftarten und Farben" vorgenommen wurden. Wählen Sie auf der Seite "Schriftarten und Farben" die Option "Standardwerte verwenden" aus, um alle Anpassungen rückgängig zu machen.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">Quitar referencias sin usar</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">Cambiar nombre de {0} a {1}</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Algunos de los colores de la combinación se reemplazan por los cambios realizados en la página de opciones de Entorno &gt; Fuentes y colores. Elija "Usar valores predeterminados" en la página Fuentes y colores para revertir todas las personalizaciones.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">Supprimer les références inutilisées</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">Renommer {0} en {1}</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Certaines couleurs du modèle de couleurs sont substituées à la suite des changements apportés dans la page d'options Environnement &gt; Polices et couleurs. Choisissez Utiliser les valeurs par défaut dans la page Polices et couleurs pour restaurer toutes les personnalisations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">Rimuovi riferimenti inutilizzati</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">Rinomina {0} in {1}</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Alcuni colori della combinazione colori sono sostituiti dalle modifiche apportate nella pagina di opzioni Ambiente &gt; Tipi di carattere e colori. Scegliere `Usa impostazioni predefinite` nella pagina Tipi di carattere e colori per ripristinare tutte le personalizzazioni.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">未使用の参照を削除する</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">{0} の名前を {1} に変更</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">一部の配色パターンの色は、[環境] &gt; [フォントおよび色] オプション ページで行われた変更によって上書きされます。[フォントおよび色] オプション ページで [既定値を使用] を選択すると、すべてのカスタマイズが元に戻ります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">사용하지 않는 참조 제거</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">{0} 이름을 {1}(으)로 바꾸기</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">색 구성표의 일부 색이 [환경] &gt; [글꼴 및 색] 옵션 페이지에서 변경한 내용에 따라 재정의됩니다. 모든 사용자 지정을 되돌리려면 [글꼴 및 색] 페이지에서 '기본값 사용'을 선택하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">Usuń nieużywane odwołania</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">Zmień nazwę {0} na {1}</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Niektóre kolory w schemacie kolorów są przesłaniane przez zmiany wprowadzone na stronie opcji Środowisko &gt; Czcionki i kolory. Wybierz pozycję „Użyj ustawień domyślnych” na stronie Czcionki i kolory, aby wycofać wszystkie dostosowania.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">Remover as Referências Não Usadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">Renomear {0} para {1}</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Algumas cores do esquema de cores estão sendo substituídas pelas alterações feitas na página de Ambiente &gt; Opções de Fontes e Cores. Escolha 'Usar Padrões' na página Fontes e Cores para reverter todas as personalizações.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">Удалить неиспользуемые ссылки</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">Переименовать {0} в {1}</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Некоторые цвета цветовой схемы переопределяются изменениями, сделанными на странице "Среда" &gt; "Шрифты и цвета". Выберите "Использовать значения по умолчанию" на странице "Шрифты и цвета", чтобы отменить все настройки.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">Kullanılmayan Başvuruları Kaldır</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">{0} öğesini {1} olarak yeniden adlandır</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">Bazı renk düzeni renkleri, Ortam &gt; Yazı Tipleri ve Renkler seçenek sayfasında yapılan değişiklikler tarafından geçersiz kılınıyor. Tüm özelleştirmeleri geri döndürmek için Yazı Tipleri ve Renkler sayfasında `Varsayılanları Kullan` seçeneğini belirleyin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">删除未使用的引用</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">将 {0} 重命名为 {1}</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">在“环境”&gt;“字体和颜色”选项页中所做的更改将替代某些配色方案颜色。在“字体和颜色”页中选择“使用默认值”，还原所有自定义项。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1052,6 +1052,11 @@
         <target state="translated">移除未使用的參考</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_unnecessary_usings">
+        <source>Remove unnecessary usings</source>
+        <target state="new">Remove unnecessary usings</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rename_0_to_1">
         <source>Rename {0} to {1}</source>
         <target state="translated">將 {0} 重新命名為 {1}</target>
@@ -1225,6 +1230,11 @@
       <trans-unit id="Some_color_scheme_colors_are_being_overridden_by_changes_made_in_the_Environment_Fonts_and_Colors_options_page_Choose_Use_Defaults_in_the_Fonts_and_Colors_page_to_revert_all_customizations">
         <source>Some color scheme colors are being overridden by changes made in the Environment &gt; Fonts and Colors options page. Choose `Use Defaults` in the Fonts and Colors page to revert all customizations.</source>
         <target state="translated">[環境] &gt; [字型和色彩選項] 頁面中所做的變更覆寫了某些色彩配置的色彩。請選擇 [字型和色彩] 頁面中的 [使用預設] 來還原所有自訂。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Sort_usings">
+        <source>Sort usings</source>
+        <target state="new">Sort usings</target>
         <note />
       </trans-unit>
       <trans-unit id="Stack_Trace_Explorer">

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCodeCleanupFixer_DiagnosticIds.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCodeCleanupFixer_DiagnosticIds.vb
@@ -5,67 +5,12 @@
 Imports System.ComponentModel.Composition
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
-Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedVariable
 Imports Microsoft.VisualStudio.Language.CodeCleanUp
 Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.LanguageService
     Partial Friend Class VisualBasicCodeCleanUpFixer
-        <Export>
-        <FixId(IDEDiagnosticIds.AddQualificationDiagnosticId)>
-        <Name(IDEDiagnosticIds.AddQualificationDiagnosticId)>
-        <Order(After:=IDEDiagnosticIds.UseObjectInitializerDiagnosticId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <LocalizedName(GetType(VBFeaturesResources), NameOf(VBFeaturesResources.Apply_Me_qualification_preferences))>
-        Public Shared ReadOnly AddQualificationDiagnosticId As FixIdDefinition
-
-        <Export>
-        <FixId(IDEDiagnosticIds.RemoveQualificationDiagnosticId)>
-        <Name(IDEDiagnosticIds.RemoveQualificationDiagnosticId)>
-        <Order(After:=IDEDiagnosticIds.UseObjectInitializerDiagnosticId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <LocalizedName(GetType(VBFeaturesResources), NameOf(VBFeaturesResources.Apply_Me_qualification_preferences))>
-        Public Shared ReadOnly RemoveQualificationDiagnosticId As FixIdDefinition
-
-        <Export>
-        <FixId(IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId)>
-        <Name(IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId)>
-        <Order(After:=IDEDiagnosticIds.AddBracesDiagnosticId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <LocalizedName(GetType(AnalyzersResources), NameOf(AnalyzersResources.Add_accessibility_modifiers))>
-        Public Shared ReadOnly AddAccessibilityModifiersDiagnosticId As FixIdDefinition
-
-        <Export>
-        <FixId(IDEDiagnosticIds.OrderModifiersDiagnosticId)>
-        <Name(IDEDiagnosticIds.OrderModifiersDiagnosticId)>
-        <Order(After:=IDEDiagnosticIds.AddAccessibilityModifiersDiagnosticId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <LocalizedName(GetType(FeaturesResources), NameOf(FeaturesResources.Sort_accessibility_modifiers))>
-        Public Shared ReadOnly OrderModifiersDiagnosticId As FixIdDefinition
-
-        <Export>
-        <FixId(IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId)>
-        <Name(IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId)>
-        <Order(After:=IDEDiagnosticIds.AddQualificationDiagnosticId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <LocalizedName(GetType(VBFeaturesResources), NameOf(VBFeaturesResources.Make_private_field_ReadOnly_when_possible))>
-        Public Shared ReadOnly MakeFieldReadOnlyDiagnosticId As FixIdDefinition
-
-        <Export>
-        <FixId(IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId)>
-        <Name(IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId)>
-        <Order(After:=IDEDiagnosticIds.MakeFieldReadonlyDiagnosticId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <LocalizedName(GetType(FeaturesResources), NameOf(FeaturesResources.Remove_unnecessary_casts))>
-        Public Shared ReadOnly RemoveUnnecessaryCastDiagnosticId As FixIdDefinition
-
         <Export>
         <FixId(VisualBasicRemoveUnusedVariableCodeFixProvider.BC42024)>
         <Name(VisualBasicRemoveUnusedVariableCodeFixProvider.BC42024)>
@@ -74,62 +19,5 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.LanguageService
         <HelpLink("https://www.microsoft.com")>
         <LocalizedName(GetType(FeaturesResources), NameOf(FeaturesResources.Remove_unused_variables))>
         Public Shared ReadOnly BC42024 As FixIdDefinition
-
-        <Export>
-        <FixId(IDEDiagnosticIds.UseObjectInitializerDiagnosticId)>
-        <Name(IDEDiagnosticIds.UseObjectInitializerDiagnosticId)>
-        <Order(After:=IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <LocalizedName(GetType(FeaturesResources), NameOf(FeaturesResources.Apply_object_collection_initialization_preferences))>
-        Public Shared ReadOnly UseObjectInitializerDiagnosticId As FixIdDefinition
-
-        <Export>
-        <FixId(IDEDiagnosticIds.UseCollectionInitializerDiagnosticId)>
-        <Name(IDEDiagnosticIds.UseCollectionInitializerDiagnosticId)>
-        <Order(After:=IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <LocalizedName(GetType(FeaturesResources), NameOf(FeaturesResources.Apply_object_collection_initialization_preferences))>
-        Public Shared ReadOnly UseCollectionInitializerDiagnosticId As FixIdDefinition
-
-        <Export>
-        <FixId(FormatDocumentFixId)>
-        <Name(FormatDocumentFixId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <ExportMetadata("EnableByDefault", True)>
-        <LocalizedName(GetType(ServicesVSResources), NameOf(ServicesVSResources.Format_document))>
-        Public Shared ReadOnly FormatDocument As FixIdDefinition
-
-        <Export>
-        <FixId(RemoveUnusedImportsFixId)>
-        <Name(RemoveUnusedImportsFixId)>
-        <Order(After:=FormatDocumentFixId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <ExportMetadata("EnableByDefault", True)>
-        <LocalizedName(GetType(BasicVSResources), NameOf(BasicVSResources.Remove_unnecessary_Imports))>
-        Public Shared ReadOnly RemoveUnusedImports As FixIdDefinition
-
-        <Export>
-        <FixId(SortImportsFixId)>
-        <Name(SortImportsFixId)>
-        <Order(After:=RemoveUnusedImportsFixId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <ExportMetadata("EnableByDefault", True)>
-        <LocalizedName(GetType(BasicVSResources), NameOf(BasicVSResources.Sort_imports))>
-        Public Shared ReadOnly SortImports As FixIdDefinition
-
-        <Export>
-        <FixId(IDEDiagnosticIds.FileHeaderMismatch)>
-        <Name(IDEDiagnosticIds.FileHeaderMismatch)>
-        <Order(After:=SortImportsFixId)>
-        <ConfigurationKey("unused")>
-        <HelpLink("https://www.microsoft.com")>
-        <ExportMetadata("EnableByDefault", True)>
-        <LocalizedName(GetType(FeaturesResources), NameOf(FeaturesResources.Apply_file_header_preferences))>
-        Public Shared ReadOnly FileHeaderMismatch As FixIdDefinition
     End Class
 End Namespace


### PR DESCRIPTION
When multiple fixes are exported with the same name, the editor cannot differentiate and configuration changes cannot be saved.

https://developercommunity.visualstudio.com/t/Configure-Code-Cleanup-selections-are-/1571097
Fixes [AB#1429876](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1429876)