### PR TITLE
Unify the namespace for our FatalError type

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -12,11 +12,7 @@ using System.Threading;
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
 #endif
 
-#if COMPILERCORE
-namespace Microsoft.CodeAnalysis
-#else
 namespace Microsoft.CodeAnalysis.ErrorReporting
-#endif
 {
     internal static class FatalError
     {

--- a/src/Compilers/Core/Portable/InternalUtilities/RoslynParallel.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/RoslynParallel.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Roslyn.Utilities
 {

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Operations;
 using Roslyn.Utilities;
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 

--- a/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 using System.Threading;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -13,6 +13,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis.CommandLine;
 using System.Runtime.InteropServices;
 using System.Collections.Specialized;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.CompilerServer
 {

--- a/src/Compilers/Shared/Csc.cs
+++ b/src/Compilers/Shared/Csc.cs
@@ -8,6 +8,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis.CommandLine;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine
 {

--- a/src/Compilers/Shared/Vbc.cs
+++ b/src/Compilers/Shared/Vbc.cs
@@ -8,6 +8,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis.CommandLine;
+using Microsoft.CodeAnalysis.ErrorReporting;
 
 namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
 {

--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -6,6 +6,7 @@ Imports System.Collections.Concurrent
 Imports System.Collections.Immutable
 Imports System.Threading
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.ErrorReporting
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -10,6 +10,7 @@ Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Emit
+Imports Microsoft.CodeAnalysis.ErrorReporting
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -103,11 +103,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         End Function
 
         Protected Overrides Function GetTypeHandleToTypeMap() As ConcurrentDictionary(Of TypeDefinitionHandle, TypeSymbol)
-            Return moduleSymbol.TypeHandleToTypeMap
+            Return ModuleSymbol.TypeHandleToTypeMap
         End Function
 
         Protected Overrides Function GetTypeRefHandleToTypeMap() As ConcurrentDictionary(Of TypeReferenceHandle, TypeSymbol)
-            Return moduleSymbol.TypeRefHandleToTypeMap
+            Return ModuleSymbol.TypeRefHandleToTypeMap
         End Function
 
         Protected Overrides Function LookupNestedTypeDefSymbol(
@@ -143,10 +143,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         ''' Lookup a type defined in a module of a multi-module assembly.
         ''' </summary>
         Protected Overrides Function LookupTopLevelTypeDefSymbol(moduleName As String, ByRef emittedName As MetadataTypeName, <Out> ByRef isNoPiaLocalType As Boolean) As TypeSymbol
-            For Each m As ModuleSymbol In moduleSymbol.ContainingAssembly.Modules
+            For Each m As ModuleSymbol In ModuleSymbol.ContainingAssembly.Modules
                 If String.Equals(m.Name, moduleName, StringComparison.OrdinalIgnoreCase) Then
-                    If m Is moduleSymbol Then
-                        Return moduleSymbol.LookupTopLevelMetadataType(emittedName, isNoPiaLocalType)
+                    If m Is ModuleSymbol Then
+                        Return ModuleSymbol.LookupTopLevelMetadataType(emittedName, isNoPiaLocalType)
                     Else
                         isNoPiaLocalType = False
                         Return m.LookupTopLevelMetadataType(emittedName)
@@ -155,7 +155,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Next
 
             isNoPiaLocalType = False
-            Return New MissingMetadataTypeSymbol.TopLevel(New MissingModuleSymbolWithName(moduleSymbol.ContainingAssembly, moduleName), emittedName, SpecialType.None)
+            Return New MissingMetadataTypeSymbol.TopLevel(New MissingModuleSymbolWithName(ModuleSymbol.ContainingAssembly, moduleName), emittedName, SpecialType.None)
         End Function
 
         ''' <summary>
@@ -166,7 +166,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         ''' TypeDef row id. 
         ''' </summary>
         Protected Overloads Overrides Function LookupTopLevelTypeDefSymbol(ByRef emittedName As MetadataTypeName, <Out> ByRef isNoPiaLocalType As Boolean) As TypeSymbol
-            Return moduleSymbol.LookupTopLevelMetadataType(emittedName, isNoPiaLocalType)
+            Return ModuleSymbol.LookupTopLevelMetadataType(emittedName, isNoPiaLocalType)
         End Function
 
         Protected Overrides Function GetIndexOfReferencedAssembly(identity As AssemblyIdentity) As Integer
@@ -259,7 +259,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                         interfaceGuid,
                         scope,
                         identifier,
-                        moduleSymbol.ContainingAssembly)
+                        ModuleSymbol.ContainingAssembly)
 
             Catch mrEx As BadImageFormatException
                 result = GetUnsupportedMetadataTypeSymbol(mrEx)
@@ -459,7 +459,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
             ' We're going to use a special decoder that can generate usable symbols for type parameters without full context.
             ' (We're not just using a different type - we're also changing the type context.)
-            Dim memberRefDecoder = New MemberRefMetadataDecoder(moduleSymbol, targetTypeSymbol.OriginalDefinition)
+            Dim memberRefDecoder = New MemberRefMetadataDecoder(ModuleSymbol, targetTypeSymbol.OriginalDefinition)
 
             Dim definition = memberRefDecoder.FindMember(memberRef, methodsOnly)
 
@@ -481,7 +481,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Protected Overrides Sub EnqueueTypeSymbol(typeDefsToSearch As Queue(Of TypeDefinitionHandle), typeSymbolsToSearch As Queue(Of TypeSymbol), typeSymbol As TypeSymbol)
             If typeSymbol IsNot Nothing Then
                 Dim peTypeSymbol As PENamedTypeSymbol = TryCast(typeSymbol, PENamedTypeSymbol)
-                If peTypeSymbol IsNot Nothing AndAlso peTypeSymbol.ContainingPEModule Is moduleSymbol Then
+                If peTypeSymbol IsNot Nothing AndAlso peTypeSymbol.ContainingPEModule Is ModuleSymbol Then
                     typeDefsToSearch.Enqueue(peTypeSymbol.Handle)
                 Else
                     typeSymbolsToSearch.Enqueue(typeSymbol)
@@ -492,7 +492,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Protected Overrides Function GetMethodHandle(method As MethodSymbol) As MethodDefinitionHandle
             Dim peMethod As PEMethodSymbol = TryCast(method, PEMethodSymbol)
-            If peMethod IsNot Nothing AndAlso peMethod.ContainingModule Is moduleSymbol Then
+            If peMethod IsNot Nothing AndAlso peMethod.ContainingModule Is ModuleSymbol Then
                 Return peMethod.Handle
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -7,6 +7,7 @@ Imports System.Collections.Generic
 Imports System.Collections.Immutable
 Imports System.Reflection.Metadata
 Imports System.Runtime.InteropServices
+Imports Microsoft.CodeAnalysis.ErrorReporting
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -9,6 +9,7 @@ Imports System.Collections.ObjectModel
 Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.ErrorReporting
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -3,18 +3,14 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Concurrent
-Imports System.Collections.Generic
 Imports System.Collections.Immutable
-Imports System.Collections.ObjectModel
 Imports System.Runtime.InteropServices
 Imports System.Threading
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.ErrorReporting
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports TypeKind = Microsoft.CodeAnalysis.TypeKind
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionEvaluatorFatalError.cs
@@ -5,12 +5,9 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.Debugger;
 using Roslyn.Utilities;
-
-#if !EXPRESSIONCOMPILER
-using Microsoft.CodeAnalysis.ErrorReporting;
-#endif
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
             // We also must set the handlers for the compiler layer as well.
             var compilerAssembly = typeof(Compilation).Assembly;
-            var compilerFatalErrorType = compilerAssembly.GetType("Microsoft.CodeAnalysis.FatalError", throwOnError: true)!;
+            var compilerFatalErrorType = compilerAssembly.GetType(typeof(FatalError).FullName, throwOnError: true)!;
             var compilerFatalErrorHandlerProperty = compilerFatalErrorType.GetProperty(nameof(FatalError.Handler), BindingFlags.Static | BindingFlags.Public)!;
             var compilerNonFatalErrorHandlerProperty = compilerFatalErrorType.GetProperty(nameof(FatalError.NonFatalHandler), BindingFlags.Static | BindingFlags.Public)!;
             compilerFatalErrorHandlerProperty.SetValue(null, fatalHandler);


### PR DESCRIPTION
For reasons I cannot explain (they date back to before Roslyn was open sourced and I was too lazy to look), we had a different namespace name for the FatalError type in the compiler layer versus the rest of Roslyn. This unifies it to a single name, so that way IDE features like Find References actually work.

I'm starting a longer process of cleaning up this area to give it some love, and this will make the rest of it easier.