### PR TITLE
Ensure we cache the previous item when two items are considered equal

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -205,6 +205,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         }
 
         [Fact]
+        public void Node_Table_Caches_Previous_Object_When_Modification_Considered_Cached()
+        {
+            var builder = NodeStateTable<int>.Empty.ToBuilder();
+            builder.AddEntries(ImmutableArray.Create(1), EntryState.Added);
+            builder.AddEntries(ImmutableArray.Create(2), EntryState.Added);
+            builder.AddEntries(ImmutableArray.Create(3), EntryState.Added);
+            var previousTable = builder.ToImmutableAndFree();
+
+            var expected = ImmutableArray.Create((1, EntryState.Added), (2, EntryState.Added), (3, EntryState.Added));
+            AssertTableEntries(previousTable, expected);
+
+            builder = previousTable.ToBuilder();
+            Assert.True(builder.TryModifyEntry(1, EqualityComparer<int>.Default));           // ((1, EntryState.Cached))
+            Assert.True(builder.TryModifyEntry(4, EqualityComparer<int>.Default));           // ((4, EntryState.Modified))
+            Assert.True(builder.TryModifyEntry(5, new LambdaComparer<int>((i, j) => true))); // ((3, EntryState.Cached))
+            var newTable = builder.ToImmutableAndFree();
+
+            expected = ImmutableArray.Create((1, EntryState.Cached), (4, EntryState.Modified), (3, EntryState.Cached));
+            AssertTableEntries(newTable, expected);
+        }
+
+        [Fact]
         public void Driver_Table_Calls_Into_Node_With_Self()
         {
             DriverStateTable.Builder? passedIn = null;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -186,7 +186,8 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 Debug.Assert(_previous._states[_states.Count].Count == 1);
-                _states.Add(new TableEntry(value, comparer.Equals(_previous._states[_states.Count].GetItem(0), value) ? EntryState.Cached : EntryState.Modified));
+                var (chosen, state) = GetModifiedItemAndState(_previous._states[_states.Count].GetItem(0), value, comparer);
+                _states.Add(new TableEntry(chosen, state));
                 return true;
             }
 
@@ -222,8 +223,8 @@ namespace Microsoft.CodeAnalysis
                     var previous = previousEntry.GetItem(i);
                     var replacement = outputs[i];
 
-                    var entryState = comparer.Equals(previous, replacement) ? EntryState.Cached : EntryState.Modified;
-                    modified.Add(replacement, entryState);
+                    (var chosen, var state) = GetModifiedItemAndState(previous, replacement, comparer);
+                    modified.Add(chosen, state);
                 }
 
                 // removed
@@ -262,6 +263,15 @@ namespace Microsoft.CodeAnalysis
 
                 var hasNonCached = _states.Any(static s => !s.IsCached);
                 return new NodeStateTable<T>(_states.ToImmutableAndFree(), isCompacted: !hasNonCached);
+            }
+
+            private (T chosen, EntryState state) GetModifiedItemAndState(T previous, T replacement, IEqualityComparer<T> comparer)
+            {
+                // when comparing an item to check if its modified we explicitly cache the *previous* item in the case where its 
+                // considered to be equal. This ensures that subsequent comparisons are stable across future generation passes.
+                return comparer.Equals(previous, replacement)
+                    ? (previous, EntryState.Cached)
+                    : (replacement, EntryState.Modified);
             }
         }
 


### PR DESCRIPTION
Fixes a subtle issue for Razor:

When the razor generator is running in 'suppressed' mode, they effectively treat all comparisons as being true, so that the driver just uses what is in the cache without re-calculating anything. Today, in the generator driver we take the _new_ item and place it in the cache when this happens. For compound objects, this can mean that a comparer is not stable across iterations. 

**Consider:**

We have the following compound object:  `(bool check, object state)`

With a comparer like: `(old, @new) => @new.check || old.state.Equals(new.State)`

In the first run the values are `(false, null)` and we have no cache yet, so the comparer will be ignored and we write into the state table: `(false, null)` and the generator logic runs, producing downstream results from the `(false, null)` values. 

In the second iteration we have `(true, object1)`. The comparer will run, return true, and the driver will write in the *new* state of `(true, object1)`. However because the comparer returned true, the actual driver logic is not invoked and the cached values of the previous run are used.

In the third iteration we have `(false, object1)`. The comparer will run, and use the second branch of the logic: however, we will be comparing `object1` to `object1` which will return true. Once again the cached version of the results are used which were generated from `(false, null)` which is incorrect.

Instead when a comparer returns that two object are equal, we return the original item to the cache.

**States:**

Incorrect:
| Input | CompareTo| State | Downstream based on |
| ----- | ------| -- | ------|
| `(false, null)` | `null` | New | `(false, null)` |
| `(true, object1)` | `(false, null)` | Cached | `(false, null)`|
| `(false, object1)` | `(true, object1)` | Cached | `(false, null)` |

Fixed:
| Input | CompareTo| State | Downstream based on |
| ----- | ------| -- | ------|
| `(false, null)` | `null` | New | `(false, null)` |
| `(true, object1)` | `(false, null)` | Cached | `(false, null)`|
| `(false, object1)` | `(false, null)` | Modified | `(false, object1)` |