### PR TITLE
Search less files when searching in global suppressions.

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AliasSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AliasSymbols.vb
@@ -229,6 +229,83 @@ namespace N
             Await TestAPIAndFeature(input, kind, host)
         End Function
 
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestAliasReferenceInGlobalSuppression_WithAttributeSuffix(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using $$AliasToC = N.[|C|];
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("RuleCategory", "RuleId", Scope = "member", Target = "~M:N.[|C|].Goo")]
+
+namespace N
+{
+    class {|Definition:C|}
+    {
+        void Goo()
+        {
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestAliasReferenceInGlobalSuppression_WithUsing(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using $$AliasToC = N.[|C|];
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("RuleCategory", "RuleId", Scope = "member", Target = "~M:N.[|C|].Goo")]
+
+namespace N
+{
+    class {|Definition:C|}
+    {
+        void Goo()
+        {
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestAliasReferenceInGlobalSuppression_WithUsing_WithAttributeSuffix(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using $$AliasToC = N.[|C|];
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessageAttribute("RuleCategory", "RuleId", Scope = "member", Target = "~M:N.[|C|].Goo")]
+
+namespace N
+{
+    class {|Definition:C|}
+    {
+        void Goo()
+        {
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
         <WorkItem(55894, "https://github.com/dotnet/roslyn/issues/55894")>
         <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestGlobalAlias1(kind As TestKind, host As TestHost) As Task

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         /// <summary>
         /// Finds all the documents in the provided project that contain a global attribute in them.
         /// </summary>
-        protected static Task<ImmutableArray<Document>> FindDocumentsWithGlobalAttributesAsync(
+        protected static Task<ImmutableArray<Document>> FindDocumentsWithGlobalSuppressMessageAttributeAsync(
             Project project,
             IImmutableSet<Document>? documents,
             CancellationToken cancellationToken)
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             return FindDocumentsAsync(project, documents, async (d, c) =>
             {
                 var info = await SyntaxTreeIndex.GetRequiredIndexAsync(d, c).ConfigureAwait(false);
-                return info.ContainsGlobalAttributes;
+                return info.ContainsGlobalSuppressMessageAttribute;
             }, cancellationToken);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder_GlobalSuppressions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder_GlobalSuppressions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
 
             // Check if we have any relevant global attributes in this document.
             var info = await SyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
-            if (!info.ContainsGlobalAttributes)
+            if (!info.ContainsGlobalSuppressMessageAttribute)
                 return ImmutableArray<FinderLocation>.Empty;
 
             var suppressMessageAttribute = semanticModel.Compilation.SuppressMessageAttributeType();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             result.AddRange(await FindDocumentsAsync(
                 project, documents, containingType.SpecialType.ToPredefinedType(), cancellationToken).ConfigureAwait(false));
 
-            result.AddRange(await FindDocumentsWithGlobalAttributesAsync(
+            result.AddRange(await FindDocumentsWithGlobalSuppressMessageAttributeAsync(
                 project, documents, cancellationToken).ConfigureAwait(false));
 
             result.AddRange(symbol.MethodKind == MethodKind.Constructor

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/EventSymbolReferenceFinder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             CancellationToken cancellationToken)
         {
             var documentsWithName = await FindDocumentsAsync(project, documents, cancellationToken, symbol.Name).ConfigureAwait(false);
-            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalAttributesAsync(project, documents, cancellationToken).ConfigureAwait(false);
+            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
             return documentsWithName.Concat(documentsWithGlobalAttributes);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/FieldSymbolReferenceFinder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             CancellationToken cancellationToken)
         {
             var documentsWithName = await FindDocumentsAsync(project, documents, cancellationToken, symbol.Name).ConfigureAwait(false);
-            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalAttributesAsync(project, documents, cancellationToken).ConfigureAwait(false);
+            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
             return documentsWithName.Concat(documentsWithGlobalAttributes);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             result.AddRange(await FindDocumentsAsync(
                 project, documents, symbol.SpecialType.ToPredefinedType(), cancellationToken).ConfigureAwait(false));
 
-            result.AddRange(await FindDocumentsWithGlobalAttributesAsync(
+            result.AddRange(await FindDocumentsWithGlobalSuppressMessageAttributeAsync(
                 project, documents, cancellationToken).ConfigureAwait(false));
 
             return result.ToImmutable();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamespaceSymbolReferenceFinder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 }
             }
 
-            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalAttributesAsync(project, documents, cancellationToken).ConfigureAwait(false);
+            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
             result.AddRange(documentsWithGlobalAttributes);
 
             return result.ToImmutable();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OperatorSymbolReferenceFinder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         {
             var op = symbol.GetPredefinedOperator();
             var documentsWithOp = await FindDocumentsAsync(project, documents, op, cancellationToken).ConfigureAwait(false);
-            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalAttributesAsync(project, documents, cancellationToken).ConfigureAwait(false);
+            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
             return documentsWithOp.Concat(documentsWithGlobalAttributes);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/OrdinaryMethodReferenceFinder.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 ? await FindDocumentsWithAwaitExpressionAsync(project, documents, cancellationToken).ConfigureAwait(false)
                 : ImmutableArray<Document>.Empty;
 
-            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalAttributesAsync(project, documents, cancellationToken).ConfigureAwait(false);
+            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
             return ordinaryDocuments.Concat(forEachDocuments, deconstructDocuments, awaitExpressionDocuments, documentsWithGlobalAttributes);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertyAccessorSymbolReferenceFinder.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                     cancellationToken).ConfigureAwait(false);
             }
 
-            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalAttributesAsync(project, documents, cancellationToken).ConfigureAwait(false);
+            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
             return documentsWithName.Concat(propertyDocuments, documentsWithGlobalAttributes);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/PropertySymbolReferenceFinder.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 ? await FindDocumentWithIndexerMemberCrefAsync(project, documents, cancellationToken).ConfigureAwait(false)
                 : ImmutableArray<Document>.Empty;
 
-            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalAttributesAsync(project, documents, cancellationToken).ConfigureAwait(false);
+            var documentsWithGlobalAttributes = await FindDocumentsWithGlobalSuppressMessageAttributeAsync(project, documents, cancellationToken).ConfigureAwait(false);
             return ordinaryDocuments.Concat(forEachDocuments, elementAccessDocument, indexerMemberCrefDocument, documentsWithGlobalAttributes);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsAwait,
                 bool containsTupleExpressionOrTupleType,
                 bool containsImplicitObjectCreation,
-                bool containsGlobalAttributes,
+                bool containsGlobalSuppressMessageAttribute,
                 bool containsConversion)
                 : this(predefinedTypes, predefinedOperators,
                        ConvertToContainingNodeFlag(
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                          containsAwait,
                          containsTupleExpressionOrTupleType,
                          containsImplicitObjectCreation,
-                         containsGlobalAttributes,
+                         containsGlobalSuppressMessageAttribute,
                          containsConversion))
             {
             }
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsAwait,
                 bool containsTupleExpressionOrTupleType,
                 bool containsImplicitObjectCreation,
-                bool containsGlobalAttributes,
+                bool containsGlobalSuppressMessageAttribute,
                 bool containsConversion)
             {
                 var containingNodes = ContainingNodes.None;
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 containingNodes |= containsAwait ? ContainingNodes.ContainsAwait : 0;
                 containingNodes |= containsTupleExpressionOrTupleType ? ContainingNodes.ContainsTupleExpressionOrTupleType : 0;
                 containingNodes |= containsImplicitObjectCreation ? ContainingNodes.ContainsImplicitObjectCreation : 0;
-                containingNodes |= containsGlobalAttributes ? ContainingNodes.ContainsGlobalAttributes : 0;
+                containingNodes |= containsGlobalSuppressMessageAttribute ? ContainingNodes.ContainsGlobalSuppressMessageAttribute : 0;
                 containingNodes |= containsConversion ? ContainingNodes.ContainsConversion : 0;
 
                 return containingNodes;
@@ -137,8 +137,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             public bool ContainsTupleExpressionOrTupleType
                 => (_containingNodes & ContainingNodes.ContainsTupleExpressionOrTupleType) == ContainingNodes.ContainsTupleExpressionOrTupleType;
 
-            public bool ContainsGlobalAttributes
-                => (_containingNodes & ContainingNodes.ContainsGlobalAttributes) == ContainingNodes.ContainsGlobalAttributes;
+            public bool ContainsGlobalSuppressMessageAttribute
+                => (_containingNodes & ContainingNodes.ContainsGlobalSuppressMessageAttribute) == ContainingNodes.ContainsGlobalSuppressMessageAttribute;
 
             public bool ContainsConversion
                 => (_containingNodes & ContainingNodes.ContainsConversion) == ContainingNodes.ContainsConversion;
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 ContainsAwait = 1 << 9,
                 ContainsTupleExpressionOrTupleType = 1 << 10,
                 ContainsImplicitObjectCreation = 1 << 11,
-                ContainsGlobalAttributes = 1 << 12,
+                ContainsGlobalSuppressMessageAttribute = 1 << 12,
                 ContainsConversion = 1 << 13,
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public bool ContainsElementAccessExpression => _contextInfo.ContainsElementAccessExpression;
         public bool ContainsIndexerMemberCref => _contextInfo.ContainsIndexerMemberCref;
         public bool ContainsTupleExpressionOrTupleType => _contextInfo.ContainsTupleExpressionOrTupleType;
-        public bool ContainsGlobalAttributes => _contextInfo.ContainsGlobalAttributes;
+        public bool ContainsGlobalSuppressMessageAttribute => _contextInfo.ContainsGlobalSuppressMessageAttribute;
         public bool ContainsConversion => _contextInfo.ContainsConversion;
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal sealed partial class SyntaxTreeIndex : IObjectWritable
     {
         private const string PersistenceName = "<SyntaxTreeIndex>";
-        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("25");
+        private static readonly Checksum SerializationFormatChecksum = Checksum.Create("26");
 
         public readonly Checksum? Checksum;
 


### PR DESCRIPTION
The current approach to finding FAR results in global suppressions is to make *all* documents with jsut a *global attribute* in it eligible for searching.  This means any doc that has a `[assembly: ...]` attribute it in is searched (regardless of what attribute it actually is).

This is doubly problematic as to search the doc we need the semantic-model for it, which requires getting the compilation for that project, which requires parsing all the files in the project.  In a project like roslyn, we have enough of these attributes scattered everywhere to make it so that we effectively have to create most of the compilations for all our projects just to get no results.

This PR changes our logic to only search docs that actually have a global attribute whose name could match `SuppressMessageAttribute`.  This means most projects have no hits and we produce no compilations.

--

Note: this might mean we might something.  For example, if the user has a global alias to SuppressMessageAttribute.  But at that point, things are so esoteric i don't think we care at all, and the perf win here is substantive enough to warrant it.  If we do want to support such a corner case in the future, we always could, by using a similar mechanism we have in other places where we keep track if alias names and check those.  But for this the complexit is likely never going to be worth it given how this should not arise in practice.