### PR TITLE
Add IXamlEditAndContinueSolutionProvider for XAML Language Service

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Implementation/IXamlEditAndContinueSolutionProvider.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/IXamlEditAndContinueSolutionProvider.cs
@@ -4,11 +4,12 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue;
 
 namespace Microsoft.VisualStudio.LanguageServices.Xaml
 {
     /// <summary>
-    /// A copy of IEditAndContinueSolutionProvider that's usable by the XAML Language Service
+    /// A copy of <see cref="IEditAndContinueSolutionProvider"/> that's usable by the XAML Language Service
     /// </summary>
     internal interface IXamlEditAndContinueSolutionProvider
     {

--- a/src/VisualStudio/Xaml/Impl/Implementation/IXamlEditAndContinueSolutionProvider.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/IXamlEditAndContinueSolutionProvider.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml
+{
+    /// <summary>
+    /// A copy of IEditAndContinueSolutionProvider that's usable by the XAML Language Service
+    /// </summary>
+    internal interface IXamlEditAndContinueSolutionProvider
+    {
+        event Action<Solution>? SolutionCommitted;
+    }
+}

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlEditAndContinueSolutionProvider.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlEditAndContinueSolutionProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.VisualStudio.LanguageServices.Xaml
 {
     /// <summary>
-    /// Exports IXamlEditAndContinueSolutionProvider for the XAML Language Service in Visual Studio.
+    /// Exports <see cref="IXamlEditAndContinueSolutionProvider"/> for the XAML Language Service in Visual Studio.
     /// </summary>
     [Export(typeof(IXamlEditAndContinueSolutionProvider))]
     internal class XamlEditAndContinueSolutionProvider : IXamlEditAndContinueSolutionProvider, IDisposable

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlEditAndContinueSolutionProvider.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlEditAndContinueSolutionProvider.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.VisualStudio.LanguageServices.Xaml
+{
+    /// <summary>
+    /// Exports IXamlEditAndContinueSolutionProvider for the XAML Language Service in Visual Studio.
+    /// </summary>
+    [Export(typeof(IXamlEditAndContinueSolutionProvider))]
+    internal class XamlEditAndContinueSolutionProvider : IXamlEditAndContinueSolutionProvider, IDisposable
+    {
+        private readonly IEnumerable<IEditAndContinueSolutionProvider> _editAndContinueSolutionProviders;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public XamlEditAndContinueSolutionProvider([ImportMany] IEnumerable<IEditAndContinueSolutionProvider> editAndContinueSolutionProviders)
+        {
+            _editAndContinueSolutionProviders = editAndContinueSolutionProviders;
+
+            foreach (var provider in _editAndContinueSolutionProviders)
+            {
+                provider.SolutionCommitted += OnEditAndContinueSolutionCommitted;
+            }
+        }
+
+        public event Action<Solution>? SolutionCommitted;
+
+        public void Dispose()
+        {
+            foreach (var provider in _editAndContinueSolutionProviders)
+            {
+                provider.SolutionCommitted -= OnEditAndContinueSolutionCommitted;
+            }
+        }
+
+        private void OnEditAndContinueSolutionCommitted(Solution solution)
+        {
+            SolutionCommitted?.Invoke(solution);
+        }
+    }
+}


### PR DESCRIPTION
Adds and implements IXamlEditAndContinueSolutionProvider, which exposes the internal IEditAndContinueSolutionProvider to the XAML Language Service in Visual Studio. This allows XAML editing and hot reload to know exactly what Solution is used for a C# Hot Reload/Edit And Continue.

This follows the PR by @tmat that added IEditAndContinueSolutionProvider:
#55889

Which was for this work item:
#55683
