### PR TITLE
use RTM version of nuget packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -207,7 +207,7 @@
       is expected by the NET SDK used in the Workspace.MSBuild UnitTests. In order to test against the same verion of NuGet
       as our configured SDK, we must set the version to be the same.
      -->
-    <NuGetCommonVersion>6.0.0-rc.258</NuGetCommonVersion>
+    <NuGetCommonVersion>6.0.0</NuGetCommonVersion>
     <NuGetConfigurationVersion>$(NuGetCommonVersion)</NuGetConfigurationVersion>
     <NuGetFrameworksVersion>$(NuGetCommonVersion)</NuGetFrameworksVersion>
     <NuGetPackagingVersion>$(NuGetCommonVersion)</NuGetPackagingVersion>


### PR DESCRIPTION
fixup for https://github.com/dotnet/roslyn/compare/main...allisonchou:Revert57613

We now target the RTM version of the SDK so we need to target the RTM version of nuget for testing.