### PR TITLE
Treat doc comments line regular comments in metadata as source

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/TypeDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/TypeDeclarationStructureTests.cs
@@ -99,5 +99,38 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSou
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true),
                 Region("textspan2", "#0", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public async Task WithDocComments()
+        {
+            const string code = @"
+{|hint:{|textspan:/// <summary>This is a doc comment.</summary>
+|}{|#0:public class $$C|}{|textspan2:
+{
+    void M();
+}|}|#0}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true),
+                Region("textspan2", "#0", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public async Task WithMultilineDocComments()
+        {
+            const string code = @"
+{|hint:{|textspan:/// <summary>This is a doc comment.</summary>
+/// <remarks>
+/// Comments are cool
+/// </remarks>
+|}{|#0:public class $$C|}{|textspan2:
+{
+    void M();
+}|}|#0}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true),
+                Region("textspan2", "#0", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
@@ -275,9 +275,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                     return false;
                 }
 
-                var firstComment = startToken.LeadingTrivia.FirstOrNull(t => t.IsKind(SyntaxKind.SingleLineCommentTrivia));
+                var firstComment = startToken.LeadingTrivia.FirstOrNull(t => t.IsKind(SyntaxKind.SingleLineCommentTrivia) || t.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia));
 
-                var startPosition = firstComment.HasValue ? firstComment.Value.SpanStart : startToken.SpanStart;
+                var startPosition = firstComment.HasValue ? firstComment.Value.FullSpan.Start : startToken.SpanStart;
                 var endPosition = endToken.SpanStart;
 
                 // TODO (tomescht): Mark the regions to be collapsed by default.

--- a/src/Features/CSharp/Portable/Structure/Providers/DocumentationCommentStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DocumentationCommentStructureProvider.cs
@@ -20,6 +20,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             BlockStructureOptions options,
             CancellationToken cancellationToken)
         {
+            // In metadata as source we want to treat documentation comments slightly differently, and collapse them
+            // to just "..." in front of the decalaration they're attached to. That happens in CSharpStructureHelper.CollectCommentBlockSpans
+            // so we don't need to do anything here
+            if (options.IsMetadataAsSource)
+            {
+                return;
+            }
+
             var startPos = documentationComment.FullSpan.Start;
 
             // The trailing newline is included in XmlDocCommentSyntax, so we need to strip it.


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/57924