### PR TITLE
Do less work during CI checkout

### DIFF
--- a/eng/pipelines/checkout-unix-task.yml
+++ b/eng/pipelines/checkout-unix-task.yml
@@ -6,6 +6,6 @@ steps:
       set -x
       git init
       git remote add origin "$(Build.Repository.Uri)"
-      git fetch --progress --no-tags --depth=1 origin "$(Build.SourceVersion)"
-      git checkout "$(Build.SourceVersion)"
+      git fetch --no-auto-gc --no-recurse-submodules --no-show-forced-updates --no-tags --depth=1 origin "$(Build.SourceVersion)"
+      git -c advice.detachedHead=false checkout --no-progress "$(Build.SourceVersion)"
     displayName: Shallow Checkout

--- a/eng/pipelines/checkout-windows-task.yml
+++ b/eng/pipelines/checkout-windows-task.yml
@@ -6,6 +6,6 @@ steps:
       @echo on
       git init
       git remote add origin "$(Build.Repository.Uri)"
-      git fetch --progress --no-tags --depth=1 origin "$(Build.SourceVersion)"
-      git checkout "$(Build.SourceVersion)"
+      git fetch --no-auto-gc --no-recurse-submodules --no-show-forced-updates --no-tags --depth=1 origin "$(Build.SourceVersion)"
+      git -c advice.detachedHead=false checkout --no-progress "$(Build.SourceVersion)"
     displayName: Shallow Checkout


### PR DESCRIPTION
Disable various git features during the shallow clone and checkout actions in an attempt to save some time during CI builds.

---

We are considering a similar checkout for dotnet/project-system. I'm curious if these changes have a greater (or any) impact on a larger repo, such as Roslyn.