### PR TITLE
Exclude unnecessary sqlite assemblies for .Net 6 host

### DIFF
--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj
@@ -18,18 +18,21 @@
 
   <Target Name="PublishProjectOutputGroup" DependsOnTargets="Publish" Returns="@(_PublishedFiles)">
     <ItemGroup>
-      <!-- Need to include and then update items (https://github.com/microsoft/msbuild/issues/1053) -->
-      <_PublishedFiles Include="$(PublishDir)**\*.*" Exclude="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.*"/>
-      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Extension)' == '.pdb'" />
-
+      <_ExcludedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.*" />
+      <_ExcludedFiles Include="$(PublishDir)**\*.pdb" />
+      <!-- the only assembly we need under runtime folder (runtimes\win-x64\native\e_sqlite3.dll) is handled by the vsix project directly -->
+      <_ExcludedFiles Include="$(PublishDir)\runtimes\**\*.*" />
       <!-- For binaries below, we want to use the version provided by the runtime, not the ones from the NuGet packages -->
-      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'Microsoft.Win32.Registry.dll'" />
-      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'System.Diagnostics.DiagnosticSource.dll'" />
-      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'System.Runtime.CompilerServices.Unsafe.dll'" />
-      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'System.Security.AccessControl.dll'" />
-      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'System.Security.Principal.Windows.dll'" />
-      <_PublishedFiles Remove="@(_PublishedFiles)" Condition="'%(Filename)%(Extension)' == 'System.Threading.Tasks.Dataflow.dll'" />
-
+      <_ExcludedFiles Include="$(PublishDir)\Microsoft.Win32.Registry.dll'" />
+      <_ExcludedFiles Include="$(PublishDir)\System.Diagnostics.DiagnosticSource.dll'" />
+      <_ExcludedFiles Include="$(PublishDir)\System.Runtime.CompilerServices.Unsafe.dll'" />
+      <_ExcludedFiles Include="$(PublishDir)\System.Security.AccessControl.dll'" />
+      <_ExcludedFiles Include="$(PublishDir)\System.Security.Principal.Windows.dll'" />
+      <_ExcludedFiles Include="$(PublishDir)\System.Threading.Tasks.Dataflow.dll'" />
+    </ItemGroup>
+    <ItemGroup>
+      <!-- Need to include and then update items (https://github.com/microsoft/msbuild/issues/1053) -->
+      <_PublishedFiles Include="$(PublishDir)**\*.*" Exclude="@(_ExcludedFiles)"/>
       <!-- Set TargetPath -->
       <_PublishedFiles Update="@(_PublishedFiles)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>


### PR DESCRIPTION
The required file is handled by the vsix project directly (see #57836)