### PR TITLE
Extract Method: top level method that is static should create a static extraction

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
@@ -291,6 +291,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 }
             }
 
+            if (destination is CodeGenerationDestination.CompilationUnit)
+            {
+                if (method.IsStatic)
+                {
+                    tokens.Add(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+                }
+            }
+
             if (destination != CodeGenerationDestination.InterfaceType)
             {
                 if (CodeGenerationMethodInfo.GetIsAsyncMethod(method))


### PR DESCRIPTION
Fixes: #58013