### PR TITLE
Fix removal and addition of analyzer in same batch

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -597,8 +597,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                     // Project reference adding...
                     solutionChanges.UpdateSolutionForProjectAction(
-                Id,
-                newSolution: solutionChanges.Solution.AddProjectReferences(Id, _projectReferencesAddedInBatch));
+                        Id,
+                        newSolution: solutionChanges.Solution.AddProjectReferences(Id, _projectReferencesAddedInBatch));
                     ClearAndZeroCapacity(_projectReferencesAddedInBatch);
 
                     // Project reference removing...

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
@@ -10,7 +10,6 @@ using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
@@ -21,14 +20,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
     [Export(typeof(HostDiagnosticUpdateSource))]
     internal sealed class HostDiagnosticUpdateSource : AbstractHostDiagnosticUpdateSource
     {
-        private readonly Lazy<VisualStudioWorkspaceImpl> _workspace;
+        private readonly Lazy<VisualStudioWorkspace> _workspace;
 
         private readonly object _gate = new();
         private readonly Dictionary<ProjectId, HashSet<object>> _diagnosticMap = new();
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-        public HostDiagnosticUpdateSource(Lazy<VisualStudioWorkspaceImpl> workspace, IDiagnosticUpdateSourceRegistrationService registrationService)
+        public HostDiagnosticUpdateSource(Lazy<VisualStudioWorkspace> workspace, IDiagnosticUpdateSourceRegistrationService registrationService)
         {
             _workspace = workspace;
 

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Dim exportProvider = composition.ExportProviderFactory.CreateExportProvider()
 
             Using workspace = New TestWorkspace(composition:=composition)
-                Dim lazyWorkspace = New Lazy(Of VisualStudioWorkspaceImpl)(
+                Dim lazyWorkspace = New Lazy(Of VisualStudioWorkspace)(
                                     Function()
                                         Return Nothing
                                     End Function)
@@ -50,7 +50,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Dim composition = s_compositionWithMockDiagnosticUpdateSourceRegistrationService
             Dim exportProvider = composition.ExportProviderFactory.CreateExportProvider()
 
-            Dim lazyWorkspace = New Lazy(Of VisualStudioWorkspaceImpl)(
+            Dim lazyWorkspace = New Lazy(Of VisualStudioWorkspace)(
                                     Function()
                                         Return Nothing
                                     End Function)

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
@@ -5,6 +5,8 @@
 Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.[Shared].TestHooks
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
 Imports Roslyn.Test.Utilities
@@ -31,6 +33,96 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 ' In the end, we should have exactly one reference
                 Assert.Single(environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences)
             End Using
+        End Function
+
+        <WpfTheory>
+        <CombinatorialData>
+        Public Async Function LoadDiagnosticsRemovedOnAnalyzerReferenceRemoval(removeInBatch As Boolean) As Task
+            Using environment = New TestEnvironment(GetType(TestDynamicFileInfoProviderThatProducesNoFiles))
+                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "Project", LanguageNames.CSharp, CancellationToken.None)
+                Dim analyzerPath = "Z:\TestAnalyzer" + Guid.NewGuid().ToString() + ".dll"
+
+                project.AddAnalyzerReference(analyzerPath)
+
+                ' Force there to be errors trying to load the missing DLL
+                Dim analyzers = environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences.Single().GetAnalyzers(LanguageNames.CSharp)
+                Assert.Empty(analyzers)
+
+                Assert.Single(Await GetDiagnostics(environment), Function(d) d.Id = AnalyzerHelper.WRN_UnableToLoadAnalyzerIdCS)
+
+                Using If(removeInBatch, project.CreateBatchScope(), Nothing)
+                    project.RemoveAnalyzerReference(analyzerPath)
+                End Using
+
+                Assert.Empty(Await GetDiagnostics(environment))
+            End Using
+        End Function
+
+        <WpfTheory>
+        <CombinatorialData>
+        Public Async Function LoadDiagnosticsRemovedOnProjectRemoval(removeInBatch As Boolean) As Task
+            Using environment = New TestEnvironment(GetType(TestDynamicFileInfoProviderThatProducesNoFiles))
+                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "Project", LanguageNames.CSharp, CancellationToken.None)
+                Dim analyzerPath = "Z:\TestAnalyzer" + Guid.NewGuid().ToString() + ".dll"
+
+                project.AddAnalyzerReference(analyzerPath)
+
+                ' Force there to be errors trying to load the missing DLL
+                Dim analyzers = environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences.Single().GetAnalyzers(LanguageNames.CSharp)
+                Assert.Empty(analyzers)
+                Assert.Single(Await GetDiagnostics(environment), Function(d) d.Id = AnalyzerHelper.WRN_UnableToLoadAnalyzerIdCS)
+
+                Using If(removeInBatch, project.CreateBatchScope(), Nothing)
+                    project.RemoveFromWorkspace()
+                End Using
+
+                Assert.Empty(Await GetDiagnostics(environment))
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function LoadDiagnosticsStayIfRemoveAndAddInBatch() As Task
+            Using environment = New TestEnvironment(GetType(TestDynamicFileInfoProviderThatProducesNoFiles))
+                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "Project", LanguageNames.CSharp, CancellationToken.None)
+                Dim analyzerPath = "Z:\TestAnalyzer" + Guid.NewGuid().ToString() + ".dll"
+
+                project.AddAnalyzerReference(analyzerPath)
+
+                ' Force there to be errors trying to load the missing DLL
+                Dim analyzers = environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences.Single().GetAnalyzers(LanguageNames.CSharp)
+                Assert.Empty(analyzers)
+                Assert.Single(Await GetDiagnostics(environment), Function(d) d.Id = AnalyzerHelper.WRN_UnableToLoadAnalyzerIdCS)
+
+                Using project.CreateBatchScope()
+                    project.RemoveAnalyzerReference(analyzerPath)
+                    project.AddAnalyzerReference(analyzerPath)
+                End Using
+
+                ' We should still have a diagnostic; the real point of this assertion isn't that
+                ' we keep it around immediately, but we don't accidentally screw up the batching and 
+                ' lose the diagnostic permanently.
+                Assert.Single(Await GetDiagnostics(environment), Function(d) d.Id = AnalyzerHelper.WRN_UnableToLoadAnalyzerIdCS)
+            End Using
+        End Function
+
+        Private Shared Async Function GetDiagnostics(environment As TestEnvironment) As Task(Of ImmutableArray(Of DiagnosticData))
+            ' Wait for diagnostics to be updated asynchronously
+            Dim waiter = environment.ExportProvider.GetExportedValue(Of AsynchronousOperationListenerProvider).GetWaiter(FeatureAttribute.DiagnosticService)
+            Await waiter.ExpeditedWaitAsync()
+
+            Dim diagnosticService = environment.ExportProvider.GetExportedValue(Of IDiagnosticService)
+            Dim diagnostics = Await diagnosticService.GetDiagnosticsAsync(
+                environment.Workspace,
+                project:=Nothing,
+                document:=Nothing,
+                includeSuppressedDiagnostics:=True,
+                forPullDiagnostics:=False,
+                InternalDiagnosticsOptions.NormalDiagnosticMode,
+                CancellationToken.None)
+            Return diagnostics
         End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
@@ -1,0 +1,36 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Collections.Immutable
+Imports System.Threading
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
+    <[UseExportProvider]>
+    Public Class AnalyzerReferenceTests
+        <WpfFact>
+        Public Async Function RemoveAndReAddInSameBatchWorksCorrectly() As Task
+            Using environment = New TestEnvironment(GetType(TestDynamicFileInfoProviderThatProducesNoFiles))
+                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "Project", LanguageNames.CSharp, CancellationToken.None)
+                Const analyzerPath = "Z:\TestAnalyzer.dll"
+
+                project.AddAnalyzerReference(analyzerPath)
+
+                Using project.CreateBatchScope()
+                    project.RemoveAnalyzerReference(analyzerPath)
+                    project.AddAnalyzerReference(analyzerPath)
+                    project.RemoveAnalyzerReference(analyzerPath)
+                    project.AddAnalyzerReference(analyzerPath)
+                End Using
+
+                ' In the end, we should have exactly one reference
+                Assert.Single(environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences)
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -67,9 +67,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
                 GetType(VsMetadataServiceFactory),
                 GetType(VisualStudioMetadataReferenceManagerFactory),
                 GetType(MockWorkspaceEventListenerProvider),
-                GetType(MockDiagnosticUpdateSourceRegistrationService),
                 GetType(HostDiagnosticUpdateSource),
-                GetType(HierarchyItemToProjectIdMap))
+                GetType(HierarchyItemToProjectIdMap),
+                GetType(DiagnosticService))
 
         Private ReadOnly _workspace As VisualStudioWorkspaceImpl
         Private ReadOnly _projectFilePaths As New List(Of String)


### PR DESCRIPTION
If we had an analyzer reference being removed and re-added in the same batch, we would throw exceptions.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1264575

While doing this, discovered a few other issues so **commit-at-a-time recommended**.