### PR TITLE
Skip flaky test Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics.BinaryOperators.TestLargeStringConcatenation

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -3468,7 +3468,9 @@ class C
 
         // Attempting to call `ConstantValue` on every constituent string component times out the IOperation runner.
         // Instead, we manually validate just the top level
-        [ConditionalFact(typeof(NoIOperationValidation)), WorkItem(43019, "https://github.com/dotnet/roslyn/issues/43019")]
+        [ConditionalFact(typeof(NoIOperationValidation),
+            AlwaysSkip = "https://github.com/dotnet/roslyn/issues/57806"),
+            WorkItem(43019, "https://github.com/dotnet/roslyn/issues/43019")]
         public void TestLargeStringConcatenation()
         {
             // When the compiler folds string concatenations using an O(n^2) algorithm, this program cannot be


### PR DESCRIPTION
The flakiness of this test is heavily impacting CI, so skipping it for now to unblock flow.