### PR TITLE
Fix await completion for expression body lambda

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_AwaitCompletion.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_AwaitCompletion.vb
@@ -358,6 +358,76 @@ public class C
         End Function
 
         <WpfFact>
+        Public Async Function AwaitCompletionAddsAsync_ParenthesizedLambdaExpression_ExpressionBody() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+using System.Threading.Tasks;
+
+public class C
+{
+    public void F()
+    {        
+        Task.Run(() => $$);
+    }
+}
+]]>
+                </Document>)
+                state.SendTypeChars("aw")
+                Await state.AssertSelectedCompletionItem(displayText:="await", isHardSelected:=True)
+
+                state.SendTab()
+                Assert.Equal("
+using System;
+using System.Threading.Tasks;
+
+public class C
+{
+    public void F()
+    {        
+        Task.Run(async () => await);
+    }
+}
+", state.GetDocumentText())
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function AwaitCompletionDoesNotAddAsync_AsyncParenthesizedLambdaExpression_ExpressionBody() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document><![CDATA[
+using System;
+using System.Threading.Tasks;
+
+public class C
+{
+    public void F()
+    {        
+        Task.Run(async () => $$);
+    }
+}
+]]>
+                </Document>)
+                state.SendTypeChars("aw")
+                Await state.AssertSelectedCompletionItem(displayText:="await", isHardSelected:=True)
+
+                state.SendTab()
+                Assert.Equal("
+using System;
+using System.Threading.Tasks;
+
+public class C
+{
+    public void F()
+    {        
+        Task.Run(async () => await);
+    }
+}
+", state.GetDocumentText())
+            End Using
+        End Function
+
+        <WpfFact>
         Public Async Function AwaitCompletionDoesNotAddAsync_NotTask() As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                 <Document><![CDATA[

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/AwaitCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/AwaitCompletionProvider.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 parent = localFunction;
             }
 
-            return parent.Ancestors().FirstOrDefault(node => node.IsAsyncSupportingFunctionSyntax());
+            return parent.AncestorsAndSelf().FirstOrDefault(node => node.IsAsyncSupportingFunctionSyntax());
         }
 
         protected override SyntaxNode? GetExpressionToPlaceAwaitInFrontOf(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1442700

From the feedback:

> Start with this code:
> 
> ```cs
> void Foo()
> {
>     Task.Run(async () => $$
> }
> 
> ```
> 
> Then type await in the Task.Run lambda (include the space after await).
> 
> Expected:
> 
> No change to Foo’s signature.
> 
> Actual:
> 
> Now it’s been updated to
> 
> `async void Foo()`
> 
> 
> This behavior is generating errors (adding async where it shouldn’t be) and doing so arbitrarily far from my current cursor, and it’s really distracting to have to track these down and delete.