### PR TITLE
Fix VisualStudioActiveDocumentTracker to handle frames without text b…

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioActiveDocumentTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioActiveDocumentTracker.cs
@@ -155,6 +155,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             else if (existingFrame.TextBuffer == null)
             {
                 // If no text buffer is associated with existing frame, remove the existing frame and add the new one.
+                // Note that we do not need to disconnect the existing frame here. It will get disconnected along with
+                // the new frame whenever the document is closed or de-activated.
                 _visibleFrames = _visibleFrames.Remove(existingFrame);
                 _visibleFrames = _visibleFrames.Add(new FrameListener(this, frame));
             }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioActiveDocumentTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioActiveDocumentTracker.cs
@@ -147,8 +147,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             _activeFrame = frame;
 
-            if (!_visibleFrames.Any(f => f.Frame == frame))
+            var existingFrame = _visibleFrames.FirstOrDefault(f => f.Frame == frame);
+            if (existingFrame == null)
             {
+                _visibleFrames = _visibleFrames.Add(new FrameListener(this, frame));
+            }
+            else if (existingFrame.TextBuffer == null)
+            {
+                // If no text buffer is associated with existing frame, remove the existing frame and add the new one.
+                _visibleFrames = _visibleFrames.Remove(existingFrame);
                 _visibleFrames = _visibleFrames.Add(new FrameListener(this, frame));
             }
 
@@ -210,7 +217,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             private readonly VisualStudioActiveDocumentTracker _documentTracker;
             private readonly uint _frameEventsCookie;
 
-            private readonly ITextBuffer? _textBuffer;
+            internal ITextBuffer? TextBuffer { get; }
 
             public FrameListener(VisualStudioActiveDocumentTracker service, IVsWindowFrame frame)
             {
@@ -225,11 +232,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 {
                     if (docData is IVsTextBuffer bufferAdapter)
                     {
-                        _textBuffer = _documentTracker._editorAdaptersFactoryService.GetDocumentBuffer(bufferAdapter);
+                        TextBuffer = _documentTracker._editorAdaptersFactoryService.GetDocumentBuffer(bufferAdapter);
 
-                        if (_textBuffer != null && !_textBuffer.ContentType.IsOfType(ContentTypeNames.RoslynContentType))
+                        if (TextBuffer != null && !TextBuffer.ContentType.IsOfType(ContentTypeNames.RoslynContentType))
                         {
-                            _textBuffer.Changed += NonRoslynTextBuffer_Changed;
+                            TextBuffer.Changed += NonRoslynTextBuffer_Changed;
                         }
                     }
                 }
@@ -244,12 +251,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             /// </summary>
             public DocumentId? GetDocumentId(Workspace workspace)
             {
-                if (_textBuffer == null)
+                if (TextBuffer == null)
                 {
                     return null;
                 }
 
-                var textContainer = _textBuffer.AsTextContainer();
+                var textContainer = TextBuffer.AsTextContainer();
                 return workspace.GetDocumentIdInCurrentContext(textContainer);
             }
 
@@ -283,9 +290,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 _documentTracker.AssertIsForeground();
                 _documentTracker.RemoveFrame(this);
 
-                if (_textBuffer != null)
+                if (TextBuffer != null)
                 {
-                    _textBuffer.Changed -= NonRoslynTextBuffer_Changed;
+                    TextBuffer.Changed -= NonRoslynTextBuffer_Changed;
                 }
 
                 if (_frameEventsCookie != VSConstants.VSCOOKIE_NIL)


### PR DESCRIPTION
…uffer

There are cases where we get multiple `IVsSelectionEvents.OnElementValueChanged` callbacks for the same frame, some of which do not have `__VSFPROPID.VSFPROPID_DocData` leading to null text buffer. This leads to `TryGetActiveDocument` to return null even when we have an active frame. We now handle this case and ensure we swap a visible frame without text buffer when possible.

Related fix done last month: https://github.com/dotnet/roslyn/pull/57206