### PR TITLE
Skip correct TestLargeStringConcatenation test

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -3468,9 +3468,7 @@ class C
 
         // Attempting to call `ConstantValue` on every constituent string component times out the IOperation runner.
         // Instead, we manually validate just the top level
-        [ConditionalFact(typeof(NoIOperationValidation),
-            AlwaysSkip = "https://github.com/dotnet/roslyn/issues/57806"),
-            WorkItem(43019, "https://github.com/dotnet/roslyn/issues/43019")]
+        [ConditionalFact(typeof(NoIOperationValidation), WorkItem(43019, "https://github.com/dotnet/roslyn/issues/43019")]
         public void TestLargeStringConcatenation()
         {
             // When the compiler folds string concatenations using an O(n^2) algorithm, this program cannot be

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -3468,7 +3468,7 @@ class C
 
         // Attempting to call `ConstantValue` on every constituent string component times out the IOperation runner.
         // Instead, we manually validate just the top level
-        [ConditionalFact(typeof(NoIOperationValidation), WorkItem(43019, "https://github.com/dotnet/roslyn/issues/43019")]
+        [ConditionalFact(typeof(NoIOperationValidation)), WorkItem(43019, "https://github.com/dotnet/roslyn/issues/43019")]
         public void TestLargeStringConcatenation()
         {
             // When the compiler folds string concatenations using an O(n^2) algorithm, this program cannot be

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -1504,7 +1504,7 @@ End Module
             Next
         End Sub
 
-        <ConditionalFact(GetType(NoIOperationValidation)), WorkItem(43019, "https://github.com/dotnet/roslyn/issues/43019"), WorkItem(37572, "https://github.com/dotnet/roslyn/issues/37572")>
+        <ConditionalFact(GetType(NoIOperationValidation), AlwaysSkip:="https://github.com/dotnet/roslyn/issues/57806"), WorkItem(43019, "https://github.com/dotnet/roslyn/issues/43019"), WorkItem(37572, "https://github.com/dotnet/roslyn/issues/37572")>
         Public Sub TestLargeStringConcatenation()
 
             Dim mid = New StringBuilder()


### PR DESCRIPTION
In the PR I put out yesterday to disable TestLargeStringConcatenation (https://github.com/dotnet/roslyn/pull/58035), I accidentally disabled the C# test instead of the VB test. 🤦

Link to the tracking issue: https://github.com/dotnet/roslyn/issues/57806