### PR TITLE
Add scripts to verify if a branch is ready to review

### DIFF
--- a/Verify.cmd
+++ b/Verify.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\build.ps1""" -build -restore -rebuild -pack -test -runAnalyzers -warnAsError %*"

--- a/verify.sh
+++ b/verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+
+# resolve $SOURCE until the file is no longer a symlink
+while [[ -h $source ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+"$scriptroot/eng/build.sh" --build --restore --rebuild --pack --test --runAnalyzers --warnAsError $@


### PR DESCRIPTION
Add a script (`Verify.cmd` on windows and `verify.sh` on *nix) that can be run so a contributor can check if there are any obvious errors in their branch.