### PR TITLE
Add missing delegate casts

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationDialog.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationDialog.xaml.cs
@@ -56,9 +56,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
             modifiersListView = CreateAutomationDelegatingListView(nameof(SymbolSpecificationViewModel.ModifierList));
             modifiersContentControl.Content = modifiersListView;
 
-            symbolKindsListView.AddHandler(PreviewKeyDownEvent, HandleSymbolKindsPreviewKeyDown, true);
-            accessibilitiesListView.AddHandler(PreviewKeyDownEvent, HandleAccessibilitiesPreviewKeyDown, true);
-            modifiersListView.AddHandler(PreviewKeyDownEvent, HandleModifiersPreviewKeyDown, true);
+#pragma warning disable IDE0004 // Remove unnecessary cast - without the cast the delegate type would be Action<object, KeyEventArgs>.
+            symbolKindsListView.AddHandler(PreviewKeyDownEvent, (KeyEventHandler)HandleSymbolKindsPreviewKeyDown, true);
+            accessibilitiesListView.AddHandler(PreviewKeyDownEvent, (KeyEventHandler)HandleAccessibilitiesPreviewKeyDown, true);
+            modifiersListView.AddHandler(PreviewKeyDownEvent, (KeyEventHandler)HandleModifiersPreviewKeyDown, true);
+#pragma warning restore
         }
 
         private AutomationDelegatingListView CreateAutomationDelegatingListView(string itemsSourceName)


### PR DESCRIPTION
The casts were incorrectly removed in https://github.com/dotnet/roslyn/commit/4ef3640b94354ed14a228dd2716020af1ba4cc68

The IDE incorrectly reports them as unnecessary (filed https://github.com/dotnet/roslyn/issues/58171).
![image](https://user-images.githubusercontent.com/41759/145096792-7d57e464-0067-4d9f-9437-f8840d231212.png)


Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1434559