### PR TITLE
Update several ExpressionCompiler unit tests for inferred delegate types

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -1494,8 +1494,10 @@ class C
     int this[int x, int y] { set { } }
     int this[int x, int y, int z] { get { return 0; } set { } }
 
-    int M() { return 0; }
-        }
+    int M1() { return 0; }
+    int M2() { return 0; }
+    int M2(int i) { return i; }
+}
 ";
             var compilation0 = CreateCompilation(
                 source,
@@ -1504,7 +1506,7 @@ class C
 
             WithRuntimeInstance(compilation0, runtime =>
             {
-                var context = CreateMethodContext(runtime, "C.M");
+                var context = CreateMethodContext(runtime, "C.M1");
 
                 CheckResultFlags(context, "F", DkmClrCompilationResultFlags.None);
                 CheckResultFlags(context, "RF", DkmClrCompilationResultFlags.ReadOnlyResult);
@@ -1522,11 +1524,12 @@ class C
                 CheckResultFlags(context, "this[1, 2]", DkmClrCompilationResultFlags.None, "error CS0154: The property or indexer 'C.this[int, int]' cannot be used in this context because it lacks the get accessor");
                 CheckResultFlags(context, "this[1, 2, 3]", DkmClrCompilationResultFlags.None);
 
-                CheckResultFlags(context, "M()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "M1()", DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
 
                 CheckResultFlags(context, "null", DkmClrCompilationResultFlags.ReadOnlyResult);
                 CheckResultFlags(context, "1", DkmClrCompilationResultFlags.ReadOnlyResult);
-                CheckResultFlags(context, "M", DkmClrCompilationResultFlags.None, "error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?");
+                CheckResultFlags(context, "M1", DkmClrCompilationResultFlags.ReadOnlyResult);
+                CheckResultFlags(context, "M2", DkmClrCompilationResultFlags.None, "error CS8917: The delegate type could not be inferred.");
                 CheckResultFlags(context, "typeof(C)", DkmClrCompilationResultFlags.ReadOnlyResult);
                 CheckResultFlags(context, "new C()", DkmClrCompilationResultFlags.ReadOnlyResult);
             });
@@ -1687,20 +1690,43 @@ class C
             var source =
 @"class C
 {
-    void M()
+    void M1()
     {
     }
+    void M2() { }
+    void M2(int i) { }
 }";
             ResultProperties resultProperties;
             string error;
             var testData = Evaluate(
                 source,
                 OutputKind.DynamicallyLinkedLibrary,
-                methodName: "C.M",
-                expr: "this.M",
+                methodName: "C.M1",
+                expr: "this.M2",
                 resultProperties: out resultProperties,
                 error: out error);
-            Assert.Equal("error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?", error);
+            Assert.Equal("error CS8917: The delegate type could not be inferred.", error);
+
+            testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C.M1",
+                expr: "this.M1",
+                resultProperties: out resultProperties,
+                error: out error);
+            Assert.Equal(DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
+            var methodData = testData.GetMethodData("<>x.<>m0");
+            var method = (MethodSymbol)methodData.Method;
+            Assert.Equal(SpecialType.System_Object, method.ReturnType.SpecialType);
+            methodData.VerifyIL(
+@"{
+  // Code size       13 (0xd)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldftn      ""void C.M1()""
+  IL_0007:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_000c:  ret
+}");
         }
 
         [Fact]
@@ -1709,25 +1735,44 @@ class C
             var source =
 @"class C
 {
-    static void M()
+    static void M1()
     {
         object o;
     }
+    static void M2() { }
+    static void M2(int i) { }
 }";
             var compilation0 = CreateCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtime =>
             {
                 var context = CreateMethodContext(
                     runtime,
-                    methodName: "C.M");
+                    methodName: "C.M1");
                 string error;
                 var testData = new CompilationTestData();
                 var result = context.CompileAssignment(
                     target: "o",
-                    expr: "M",
+                    expr: "M2",
                     error: out error,
                     testData: testData);
-                Assert.Equal("error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?", error);
+                Assert.Equal("error CS8917: The delegate type could not be inferred.", error);
+                testData = new CompilationTestData();
+                context.CompileAssignment(
+                    target: "o",
+                    expr: "M1",
+                    error: out error,
+                    testData: testData);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+@"{
+  // Code size       14 (0xe)
+  .maxstack  2
+  .locals init (object V_0) //o
+  IL_0000:  ldnull
+  IL_0001:  ldftn      ""void C.M1()""
+  IL_0007:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_000c:  stloc.0
+  IL_000d:  ret
+}");
             });
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ResultPropertiesTests.cs
@@ -377,6 +377,8 @@ class C
     void Test()
     {
     }
+    static void F() { }
+    static void F(int i) { }
 }
 ";
             var comp = CreateCompilation(source, options: TestOptions.DebugDll);
@@ -385,7 +387,7 @@ class C
                 var context = CreateMethodContext(runtime, methodName: "C.Test");
 
                 VerifyErrorResultProperties(context, "x => x");
-                VerifyErrorResultProperties(context, "Test");
+                VerifyErrorResultProperties(context, "F");
                 VerifyErrorResultProperties(context, "Missing");
                 VerifyErrorResultProperties(context, "C");
             });


### PR DESCRIPTION
See #58198.