### PR TITLE
Fix Integration test MetadataReference

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
@@ -62,14 +62,6 @@ End Class");
             VisualStudio.Editor.Verify.CurrentTokenType("identifier");
         }
 
-        public void PackageReference()
-        {
-            var project = new ProjectUtils.Project(ProjectName);
-            var referenceAssemblies = new ProjectUtils.PackageReference("Microsoft.NETFramework.ReferenceAssemblies", "1.0.2");
-            VisualStudio.SolutionExplorer.AddPackageReference(project, referenceAssemblies);
-            VisualStudio.SolutionExplorer.RestoreNuGetPackages(project);
-        }
-
         public virtual void ProjectReference()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
@@ -64,16 +64,10 @@ End Class");
 
         public void PackageReference()
         {
-            var systemTextJson = new ProjectUtils.PackageReference("System.Text.Json", "6.0.0");
             var project = new ProjectUtils.Project(ProjectName);
-            VisualStudio.SolutionExplorer.AddPackageReference(project, systemTextJson);
+            var referenceAssemblies = new ProjectUtils.PackageReference("Microsoft.NETFramework.ReferenceAssemblies", "1.0.2");
+            VisualStudio.SolutionExplorer.AddPackageReference(project, referenceAssemblies);
             VisualStudio.SolutionExplorer.RestoreNuGetPackages(project);
-            VisualStudio.Editor.SetText("class C { System.Text.Json.JsonElement p; }");
-            VisualStudio.Editor.PlaceCaret("JsonElement");
-            VisualStudio.Editor.Verify.CurrentTokenType("struct name");
-            VisualStudio.SolutionExplorer.RemovePackageReference(project, systemTextJson);
-            VisualStudio.SolutionExplorer.RestoreNuGetPackages(project);
-            VisualStudio.Editor.Verify.CurrentTokenType("identifier");
         }
 
         public virtual void ProjectReference()

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
@@ -62,6 +62,20 @@ End Class");
             VisualStudio.Editor.Verify.CurrentTokenType("identifier");
         }
 
+        public void PackageReference()
+        {
+            var systemTextJson = new ProjectUtils.PackageReference("System.Text.Json", "6.0.0");
+            var project = new ProjectUtils.Project(ProjectName);
+            VisualStudio.SolutionExplorer.AddPackageReference(project, systemTextJson);
+            VisualStudio.SolutionExplorer.RestoreNuGetPackages(project);
+            VisualStudio.Editor.SetText("class C { System.Text.Json.JsonElement p; }");
+            VisualStudio.Editor.PlaceCaret("JsonElement");
+            VisualStudio.Editor.Verify.CurrentTokenType("struct name");
+            VisualStudio.SolutionExplorer.RemovePackageReference(project, systemTextJson);
+            VisualStudio.SolutionExplorer.RestoreNuGetPackages(project);
+            VisualStudio.Editor.Verify.CurrentTokenType("identifier");
+        }
+
         public virtual void ProjectReference()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
@@ -49,7 +49,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             // https://github.com/dotnet/roslyn/issues/34264
             VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout);
             VisualStudio.SolutionExplorer.OpenFile(project, "Class1.cs");
-            base.PackageReference();
+            PackageReference();
+            base.MetadataReference();
         }
 
         [WpfFact]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
@@ -49,7 +49,9 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             // https://github.com/dotnet/roslyn/issues/34264
             VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout);
             VisualStudio.SolutionExplorer.OpenFile(project, "Class1.cs");
-            PackageReference();
+            var referenceAssemblies = new ProjectUtils.PackageReference("Microsoft.NETFramework.ReferenceAssemblies.net461", "1.0.2");
+            VisualStudio.SolutionExplorer.AddPackageReference(project, referenceAssemblies);
+            VisualStudio.SolutionExplorer.RestoreNuGetPackages(project);
             base.MetadataReference();
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
@@ -31,7 +31,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             base.OpenCSharpThenVBSolution();
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/55711"), Trait(Traits.Feature, Traits.Features.Workspace)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Workspace)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
         [WorkItem(34264, "https://github.com/dotnet/roslyn/issues/34264")]
         public override void MetadataReference()
@@ -40,7 +40,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             VisualStudio.SolutionExplorer.EditProjectFile(project);
             VisualStudio.Editor.SetText(@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
 </Project>");
             VisualStudio.SolutionExplorer.SaveAll();

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
@@ -40,7 +40,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             VisualStudio.SolutionExplorer.EditProjectFile(project);
             VisualStudio.Editor.SetText(@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 </Project>");
             VisualStudio.SolutionExplorer.SaveAll();
@@ -49,9 +49,6 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             // https://github.com/dotnet/roslyn/issues/34264
             VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout);
             VisualStudio.SolutionExplorer.OpenFile(project, "Class1.cs");
-            var referenceAssemblies = new ProjectUtils.PackageReference("Microsoft.NETFramework.ReferenceAssemblies.net461", "1.0.2");
-            VisualStudio.SolutionExplorer.AddPackageReference(project, referenceAssemblies);
-            VisualStudio.SolutionExplorer.RestoreNuGetPackages(project);
             base.MetadataReference();
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
@@ -40,7 +40,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             VisualStudio.SolutionExplorer.EditProjectFile(project);
             VisualStudio.Editor.SetText(@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 </Project>");
             VisualStudio.SolutionExplorer.SaveAll();
@@ -49,7 +49,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             // https://github.com/dotnet/roslyn/issues/34264
             VisualStudio.Workspace.WaitForAllAsyncOperations(Helper.HangMitigatingTimeout);
             VisualStudio.SolutionExplorer.OpenFile(project, "Class1.cs");
-            base.MetadataReference();
+            base.PackageReference();
         }
 
         [WpfFact]


### PR DESCRIPTION
The reason for the test failure is:
![image](https://user-images.githubusercontent.com/24360909/147688204-d4a5ef11-5a6e-43e7-aa73-8db7ed5b6281.png)

Net461 SDK is not installed by the workload by default.
Therefore in the CI, all the referenced assemblies could not be found
![image](https://user-images.githubusercontent.com/24360909/147688315-8d73a299-b182-4207-97f2-2a81b319aef2.png)

Simply change it to Net462 would fix the problem
Closes #55711
