### PR TITLE
Remove usage of weak-value-source for smart-open-scope references

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.Factory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.Factory.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             if (_singleton == null)
             {
-                var temporaryStorage = workspaceServices.GetService<ITemporaryStorageService>();
+                var temporaryStorage = workspaceServices.GetRequiredService<ITemporaryStorageService>();
                 Interlocked.CompareExchange(ref _singleton, new VisualStudioMetadataReferenceManager(_serviceProvider, temporaryStorage), null);
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.Factory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.Factory.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Shell;
@@ -19,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     [ExportWorkspaceServiceFactory(typeof(VisualStudioMetadataReferenceManager), ServiceLayer.Host), Shared]
     internal class VisualStudioMetadataReferenceManagerFactory : IWorkspaceServiceFactory
     {
-        private VisualStudioMetadataReferenceManager _singleton;
+        private VisualStudioMetadataReferenceManager? _singleton;
         private readonly IServiceProvider _serviceProvider;
 
         [ImportingConstructor]
@@ -32,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (_singleton == null)
             {
                 var temporaryStorage = workspaceServices.GetService<ITemporaryStorageService>();
-                Interlocked.CompareExchange(ref _singleton, new VisualStudioMetadataReferenceManager(workspaceServices.Workspace, _serviceProvider, temporaryStorage), null);
+                Interlocked.CompareExchange(ref _singleton, new VisualStudioMetadataReferenceManager(_serviceProvider, temporaryStorage), null);
             }
 
             return _singleton;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -36,7 +36,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private readonly MetadataCache _metadataCache;
         private readonly ImmutableArray<string> _runtimeDirectories;
-        private readonly Workspace _workspace;
         private readonly ITemporaryStorageService _temporaryStorageService;
 
         internal IVsXMLMemberIndexService XmlMemberIndexService { get; }
@@ -53,7 +52,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private readonly ReaderWriterLockSlim _readerWriterLock = new();
 
         internal VisualStudioMetadataReferenceManager(
-            Workspace workspace,
             IServiceProvider serviceProvider,
             ITemporaryStorageService temporaryStorageService)
         {
@@ -68,7 +66,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             FileChangeService = (IVsFileChangeEx)serviceProvider.GetService(typeof(SVsFileChangeEx));
             Assumes.Present(FileChangeService);
-            _workspace = workspace;
             _temporaryStorageService = temporaryStorageService;
             Assumes.Present(_temporaryStorageService);
         }
@@ -130,10 +127,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             if (VsSmartScopeCandidate(key.FullPath) && TryCreateAssemblyMetadataFromMetadataImporter(key, out var newMetadata))
             {
-                ValueSource<Optional<AssemblyMetadata>> metadataValueSource = _workspace.Options.GetOption(WorkspaceConfigurationOptions.DisableReferenceManagerWeakRuntimeReferences)
-                    ? new ConstantValueSource<Optional<AssemblyMetadata>>(newMetadata)
-                    : new WeakValueSource<AssemblyMetadata>(newMetadata);
-
+                var metadataValueSource = new ConstantValueSource<Optional<AssemblyMetadata>>(newMetadata);
                 if (!_metadataCache.GetOrAddMetadata(key, metadataValueSource, out metadata))
                 {
                     newMetadata.Dispose();

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceConfigurationOptions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceConfigurationOptions.cs
@@ -29,13 +29,6 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Disables holding onto the assembly references for runtime (not user/nuget/etc.) dlls weakly.
         /// </summary>
-        public static readonly Option<bool> DisableReferenceManagerWeakRuntimeReferences = new(
-            nameof(WorkspaceConfigurationOptions), nameof(DisableReferenceManagerWeakRuntimeReferences), defaultValue: false,
-            new FeatureFlagStorageLocation("Roslyn.DisableReferenceManagerWeakRuntimeReferences"));
-
-        /// <summary>
-        /// Disables holding onto the assembly references for runtime (not user/nuget/etc.) dlls weakly.
-        /// </summary>
         public static readonly Option<bool> DisableCompilationTrackerWeakCompilationReferences = new(
             nameof(WorkspaceConfigurationOptions), nameof(DisableCompilationTrackerWeakCompilationReferences), defaultValue: false,
             new FeatureFlagStorageLocation("Roslyn.DisableCompilationTrackerWeakCompilationReferences"));
@@ -43,7 +36,6 @@ namespace Microsoft.CodeAnalysis
         ImmutableArray<IOption> IOptionProvider.Options { get; } = ImmutableArray.Create<IOption>(
             DisableRecoverableTrees,
             DisableProjectCacheService,
-            DisableReferenceManagerWeakRuntimeReferences,
             DisableCompilationTrackerWeakCompilationReferences);
 
         [ImportingConstructor]


### PR DESCRIPTION
A/B testing (2000 people in each group) revealed no interesting change from just turning this off.  My theory here is that for projecs that reference dlls from standard runtime locations, there is very little removal of said dlls, and the compiler ends up rooting all these assemblies anyways through any metadata symbols we have.

Also, because we are using the open-scope-system, the platform effectively does hteir memory mapping once and keeps that memory around forever (in case other components need it, or roslyn needs it again).  So that is also effectively a fixed cost that won't ever be given back.