### PR TITLE
Avoid loading analyzers during unload

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -76,6 +76,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public void ClearAnalyzerReferenceDiagnostics(AnalyzerFileReference analyzerReference, string language, ProjectId projectId)
         {
+            // Perf: if we don't have any diagnostics at all, just return right away; this avoids loading the analyzers
+            // which may have not been loaded if you didn't do too much in your session.
+            if (_analyzerHostDiagnosticsMap.Count == 0)
+                return;
+
             var analyzers = analyzerReference.GetAnalyzers(language);
             ClearAnalyzerDiagnostics(analyzers, projectId);
         }


### PR DESCRIPTION
AnalyzerFileReferences won't actually load their assembly until needed; 359f24a0929e999b35ee56ffa1ebaca2539c3285 fixed the fact we weren't disposing our type that produces AnalyzerFileReferences, but in the process that became another place we'd load the analyzers if they hadn't already been needed. We have some internal performance tests that actually never needed them until close, so this would trigger a load.