### PR TITLE
Support CodeClass2.Parts returning parts in source generated files 

### DIFF
--- a/src/VisualStudio/CSharp/Test/CodeModel/AbstractFileCodeElementTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/AbstractFileCodeElementTests.cs
@@ -23,14 +23,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
     public abstract class AbstractFileCodeElementTests : IDisposable
     {
         private readonly string _contents;
-        private (TestWorkspace workspace, VisualStudioWorkspace extraWorkspaceToDisposeButNotUse, FileCodeModel fileCodeModel)? _workspaceAndCodeModel;
+        private (TestWorkspace workspace, FileCodeModel fileCodeModel)? _workspaceAndCodeModel;
 
         protected AbstractFileCodeElementTests(string contents)
         {
             _contents = contents;
         }
 
-        public (TestWorkspace workspace, VisualStudioWorkspace extraWorkspaceToDisposeButNotUse, FileCodeModel fileCodeModel) WorkspaceAndCodeModel
+        public (TestWorkspace workspace, FileCodeModel fileCodeModel) WorkspaceAndCodeModel
         {
             get
             {
@@ -41,11 +41,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
         protected TestWorkspace GetWorkspace()
         {
             return WorkspaceAndCodeModel.workspace;
-        }
-
-        private VisualStudioWorkspace GetExtraWorkspaceToDisposeButNotUse()
-        {
-            return WorkspaceAndCodeModel.extraWorkspaceToDisposeButNotUse;
         }
 
         protected FileCodeModel GetCodeModel()
@@ -62,7 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
         protected Microsoft.CodeAnalysis.Document GetCurrentDocument()
             => GetCurrentProject().Documents.Single();
 
-        protected static (TestWorkspace workspace, VisualStudioWorkspace extraWorkspaceToDisposeButNotUse, FileCodeModel fileCodeModel) CreateWorkspaceAndFileCodeModelAsync(string file)
+        protected static (TestWorkspace workspace, FileCodeModel fileCodeModel) CreateWorkspaceAndFileCodeModelAsync(string file)
             => FileCodeModelTestHelpers.CreateWorkspaceAndFileCodeModel(file);
 
         protected CodeElement GetCodeElement(params object[] path)
@@ -86,7 +81,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
 
         public void Dispose()
         {
-            GetExtraWorkspaceToDisposeButNotUse().Dispose();
             GetWorkspace().Dispose();
         }
 

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeModelTestHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeModelTestHelpers.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
                     visualStudioWorkspaceMock,
                     workspace.ExportProvider.GetExportedValue<ProjectCodeModelFactory>());
 
-                var codeModel = FileCodeModel.Create(state, null, document, new MockTextManagerAdapter()).Handle;
+                var codeModel = FileCodeModel.Create(state, null, document, isSourceGeneratorOutput: false, new MockTextManagerAdapter()).Handle;
 
                 return (workspace, codeModel);
             }

--- a/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModel.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
     internal interface IProjectCodeModel
     {
         EnvDTE.FileCodeModel GetOrCreateFileCodeModel(string filePath, object? parent);
+        EnvDTE.FileCodeModel CreateFileCodeModel(CodeAnalysis.SourceGeneratedDocument sourceGeneratedDocument);
         EnvDTE.CodeModel GetOrCreateRootCodeModel(Project parent);
         void OnSourceFileRemoved(string fileName);
         void OnSourceFileRenaming(string filePath, string newFilePath);

--- a/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModel.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
@@ -12,7 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {
     internal interface IProjectCodeModel
     {
-        EnvDTE.FileCodeModel GetOrCreateFileCodeModel(string filePath, object parent);
+        EnvDTE.FileCodeModel GetOrCreateFileCodeModel(string filePath, object? parent);
         EnvDTE.CodeModel GetOrCreateRootCodeModel(Project parent);
         void OnSourceFileRemoved(string fileName);
         void OnSourceFileRenaming(string filePath, string newFilePath);

--- a/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeModel/IProjectCodeModelFactory.cs
@@ -15,5 +15,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
     {
         IProjectCodeModel CreateProjectCodeModel(ProjectId id, ICodeModelInstanceFactory codeModelInstanceFactory);
         EnvDTE.FileCodeModel GetOrCreateFileCodeModel(ProjectId id, string filePath);
+        EnvDTE.FileCodeModel CreateFileCodeModel(SourceGeneratedDocument sourceGeneratedDocument);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1417,7 +1417,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             base.Dispose(finalize);
         }
 
-        public void EnsureEditableDocuments(IEnumerable<DocumentId> documents)
+        public virtual void EnsureEditableDocuments(IEnumerable<DocumentId> documents)
         {
             var queryEdit = (IVsQueryEditQuerySave2)ServiceProvider.GlobalProvider.GetService(typeof(SVsQueryEditQuerySave));
 

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -30,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         private readonly Dictionary<string, CacheEntry> _cache = new Dictionary<string, CacheEntry>(StringComparer.OrdinalIgnoreCase);
         private readonly object _cacheGate = new object();
 
-        private EnvDTE.CodeModel _rootCodeModel;
+        private EnvDTE.CodeModel? _rootCodeModel;
         private bool _zombied;
 
         internal CodeModelProjectCache(IThreadingContext threadingContext, ProjectId projectId, ICodeModelInstanceFactory codeModelInstanceFactory, ProjectCodeModelFactory projectFactory, IServiceProvider serviceProvider, HostLanguageServices languageServices, VisualStudioWorkspace workspace)
@@ -85,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             return cacheEntry?.ComHandle;
         }
 
-        public ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel> GetOrCreateFileCodeModel(string filePath, object parent)
+        public ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel> GetOrCreateFileCodeModel(string filePath, object? parent)
         {
             // First try
             {

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
     /// </summary>
     internal sealed partial class CodeModelProjectCache
     {
-        private readonly CodeModelState _state;
         private readonly ProjectId _projectId;
         private readonly ICodeModelInstanceFactory _codeModelInstanceFactory;
 
@@ -31,9 +30,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         private EnvDTE.CodeModel? _rootCodeModel;
         private bool _zombied;
 
+        internal CodeModelState State { get; }
+
         internal CodeModelProjectCache(IThreadingContext threadingContext, ProjectId projectId, ICodeModelInstanceFactory codeModelInstanceFactory, ProjectCodeModelFactory projectFactory, IServiceProvider serviceProvider, HostLanguageServices languageServices, VisualStudioWorkspace workspace)
         {
-            _state = new CodeModelState(threadingContext, serviceProvider, languageServices, workspace, projectFactory);
+            State = new CodeModelState(threadingContext, serviceProvider, languageServices, workspace, projectFactory);
             _projectId = projectId;
             _codeModelInstanceFactory = codeModelInstanceFactory;
         }
@@ -99,7 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
 
             // Check that we know about this file!
-            var documentId = _state.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).Where(id => id.ProjectId == _projectId).FirstOrDefault();
+            var documentId = State.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).Where(id => id.ProjectId == _projectId).FirstOrDefault();
             if (documentId == null)
             {
                 // Matches behavior of native (C#) implementation
@@ -107,7 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
 
             // Create object (outside of lock)
-            var newFileCodeModel = FileCodeModel.Create(_state, parent, documentId, new TextManagerAdapter());
+            var newFileCodeModel = FileCodeModel.Create(State, parent, documentId, isSourceGeneratorOutput: false, new TextManagerAdapter());
             var newCacheEntry = new CacheEntry(newFileCodeModel);
 
             // Second try (object might have been added by another thread at this point!)
@@ -141,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             if (_rootCodeModel == null)
             {
-                _rootCodeModel = RootCodeModel.Create(_state, parent, _projectId);
+                _rootCodeModel = RootCodeModel.Create(State, parent, _projectId);
             }
 
             return _rootCodeModel;

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -31,14 +31,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
     {
         internal static ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel> Create(
             CodeModelState state,
-            object parent,
+            object? parent,
             DocumentId documentId,
             ITextManagerAdapter textManagerAdapter)
         {
             return new FileCodeModel(state, parent, documentId, textManagerAdapter).GetComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>();
         }
 
-        private readonly ComHandle<object, object> _parentHandle;
+        private readonly ComHandle<object?, object?> _parentHandle;
 
         /// <summary>
         /// Don't use directly. Instead, call <see cref="GetDocumentId()"/>.
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         private FileCodeModel(
             CodeModelState state,
-            object parent,
+            object? parent,
             DocumentId documentId,
             ITextManagerAdapter textManagerAdapter)
             : base(state)
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             RoslynDebug.AssertNotNull(documentId);
             RoslynDebug.AssertNotNull(textManagerAdapter);
 
-            _parentHandle = new ComHandle<object, object>(parent);
+            _parentHandle = new ComHandle<object?, object?>(parent);
             _documentId = documentId;
             TextManagerAdapter = textManagerAdapter;
 
@@ -609,14 +609,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             get { return NamespaceCollection.Create(this.State, this, this, SyntaxNodeKey.Empty); }
         }
 
-#nullable disable
-
-        public EnvDTE.ProjectItem Parent
+        public EnvDTE.ProjectItem? Parent
         {
             get { return _parentHandle.Object as EnvDTE.ProjectItem; }
         }
-
-#nullable restore
 
         public void Remove(object element)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModel.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
@@ -110,5 +109,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         EnvDTE.FileCodeModel IProjectCodeModel.GetOrCreateFileCodeModel(string filePath, object parent)
             => this.GetOrCreateFileCodeModel(filePath, parent).Handle;
+
+        public EnvDTE.FileCodeModel CreateFileCodeModel(SourceGeneratedDocument sourceGeneratedDocument)
+        {
+            // Unlike for "regular" documents, we make no effort to cache these between callers or hold them for longer lifetimes with
+            // events.
+            return FileCodeModel.Create(GetCodeModelCache().State, parent: null, sourceGeneratedDocument.Id, isSourceGeneratorOutput: true, new TextManagerAdapter()).Handle;
+        }
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
@@ -38,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         private readonly AsyncBatchingWorkQueue<DocumentId> _documentsToFireEventsFor;
 
         [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public ProjectCodeModelFactory(
             VisualStudioWorkspace visualStudioWorkspace,
             [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
@@ -218,6 +218,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         public EnvDTE.FileCodeModel GetOrCreateFileCodeModel(ProjectId id, string filePath)
             => GetProjectCodeModel(id).GetOrCreateFileCodeModel(filePath).Handle;
 
+        public EnvDTE.FileCodeModel CreateFileCodeModel(SourceGeneratedDocument sourceGeneratedDocument)
+            => GetProjectCodeModel(sourceGeneratedDocument.Project.Id).CreateFileCodeModel(sourceGeneratedDocument);
+
         public void ScheduleDeferredCleanupTask(Action<CancellationToken> a)
         {
             _ = _threadingContext.RunWithShutdownBlockAsync(async cancellationToken =>

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.Runtime.InteropServices
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -1253,6 +1254,36 @@ class C
                     ' so the underlying node key is still valid.
                     Assert.Equal("D", codeElement.Name)
                 End Sub)
+        End Sub
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub CanAccessPartialPartsInSourceGeneratedFiles()
+            Dim code =
+<Workspace>
+    <Project Language=<%= LanguageName %> CommonReferences="true">
+        <Document>partial class C { }</Document>
+        <DocumentFromSourceGenerator>partial class C { void M() { } }</DocumentFromSourceGenerator>
+    </Project>
+</Workspace>
+
+            Using state = CreateCodeModelTestState(code)
+                Dim workspace = state.VisualStudioWorkspace
+                Dim fileCodeModel = state.FileCodeModel
+
+                Dim codeClass = DirectCast(Assert.Single(fileCodeModel.CodeElements()), EnvDTE80.CodeClass2)
+                Dim parts = codeClass.Parts.Cast(Of EnvDTE.CodeClass).ToList()
+                Assert.Equal(2, parts.Count)
+
+                ' Grab the part that isn't the one we started with
+                Dim generatedPart = Assert.Single(parts, Function(p) p IsNot codeClass)
+
+                ' Confirm we can inspect members
+                Dim member = DirectCast(Assert.Single(generatedPart.Members), EnvDTE.CodeFunction)
+                Assert.Equal("M", member.Name)
+
+                ' We are unable to change things in generated files
+                Assert.Throws(Of COMException)(Sub() member.AddParameter("Test", "System.Object"))
+            End Using
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -1013,12 +1013,12 @@ class D
 </Workspace>
 
             Using originalWorkspaceAndFileCodeModel = CreateCodeModelTestState(GetWorkspaceDefinition(oldCode))
-                Using changedworkspace = TestWorkspace.Create(changedDefinition, composition:=VisualStudioTestCompositions.LanguageServices)
+                Using changedWorkspace = TestWorkspace.Create(changedDefinition, composition:=CodeModelTestHelpers.Composition)
 
                     Dim originalDocument = originalWorkspaceAndFileCodeModel.Workspace.CurrentSolution.GetDocument(originalWorkspaceAndFileCodeModel.Workspace.Documents(0).Id)
                     Dim originalTree = Await originalDocument.GetSyntaxTreeAsync()
 
-                    Dim changeDocument = changedworkspace.CurrentSolution.GetDocument(changedworkspace.Documents(0).Id)
+                    Dim changeDocument = changedWorkspace.CurrentSolution.GetDocument(changedWorkspace.Documents(0).Id)
                     Dim changeTree = Await changeDocument.GetSyntaxTreeAsync()
 
                     Dim codeModelEvent = originalWorkspaceAndFileCodeModel.CodeModelService.CollectCodeModelEvents(originalTree, changeTree)

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/FileCodeModelTests.vb
@@ -1011,7 +1011,7 @@ End Class
     </Workspace>
 
             Using originalWorkspaceAndFileCodeModel = CreateCodeModelTestState(GetWorkspaceDefinition(oldCode))
-                Using changedworkspace = TestWorkspace.Create(changedDefinition, composition:=VisualStudioTestCompositions.LanguageServices)
+                Using changedworkspace = TestWorkspace.Create(changedDefinition, composition:=CodeModelTestHelpers.Composition)
 
                     Dim originalDocument = originalWorkspaceAndFileCodeModel.Workspace.CurrentSolution.GetDocument(originalWorkspaceAndFileCodeModel.Workspace.Documents(0).Id)
                     Dim originalTree = Await originalDocument.GetSyntaxTreeAsync()

--- a/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
@@ -3,13 +3,11 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Runtime.ExceptionServices
-Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
-Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser.Mocks
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
     <[UseExportProvider]>
@@ -45,7 +43,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
                 Dim vsWorkspace = New MockVisualStudioWorkspace(workspace)
                 Dim mockComponentModel = New MockComponentModel(workspace.ExportProvider)
                 mockComponentModel.ProvideService(Of VisualStudioWorkspace)(vsWorkspace)
-                Dim mockServiceProvider = New MockServiceProvider(mockComponentModel)
+                Dim mockServiceProvider = New Mocks.MockServiceProvider(mockComponentModel)
                 Dim libraryManager = CreateLibraryManager(mockServiceProvider, mockComponentModel, vsWorkspace)
 
                 result = New TestState(workspace, vsWorkspace, libraryManager)

--- a/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/AbstractObjectBrowserTests.vb
@@ -6,7 +6,9 @@ Imports System.Runtime.ExceptionServices
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.ComponentModelHost
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser
+Imports Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
@@ -36,14 +38,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ObjectBrowser
 
         <HandleProcessCorruptedStateExceptions()>
         Friend Function CreateLibraryManager(definition As XElement) As TestState
-            Dim workspace = TestWorkspace.Create(definition, composition:=VisualStudioTestCompositions.LanguageServices)
+            Dim workspace = TestWorkspace.Create(definition, composition:=CodeModelTestHelpers.Composition)
             Dim result As TestState = Nothing
 
             Try
-                Dim vsWorkspace = New MockVisualStudioWorkspace(workspace)
+                Dim vsWorkspace = New MockVisualStudioWorkspace(workspace.ExportProvider)
+                vsWorkspace.SetWorkspace(workspace)
                 Dim mockComponentModel = New MockComponentModel(workspace.ExportProvider)
                 mockComponentModel.ProvideService(Of VisualStudioWorkspace)(vsWorkspace)
-                Dim mockServiceProvider = New Mocks.MockServiceProvider(mockComponentModel)
+                Dim mockServiceProvider = workspace.ExportProvider.GetExportedValue(Of MockServiceProvider)
                 Dim libraryManager = CreateLibraryManager(mockServiceProvider, mockComponentModel, vsWorkspace)
 
                 result = New TestState(workspace, vsWorkspace, libraryManager)

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
@@ -6,14 +6,11 @@ Imports System.Runtime.CompilerServices
 Imports System.Runtime.ExceptionServices
 Imports System.Runtime.InteropServices
 Imports EnvDTE
-Imports EnvDTE80
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.ExternalElements
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements
@@ -25,6 +22,11 @@ Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
     Friend Module CodeModelTestHelpers
+
+        Public ReadOnly Composition As TestComposition = VisualStudioTestCompositions.LanguageServices.AddParts(
+            GetType(MockServiceProvider),
+            GetType(MockVisualStudioWorkspace),
+            GetType(ProjectCodeModelFactory))
 
         Public SystemWindowsFormsPath As String
         Public SystemDrawingPath As String
@@ -44,13 +46,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
         <HandleProcessCorruptedStateExceptions()>
         Public Function CreateCodeModelTestState(definition As XElement) As CodeModelTestState
-            Dim workspace = TestWorkspace.Create(definition, composition:=VisualStudioTestCompositions.LanguageServices)
+            Dim workspace = TestWorkspace.Create(definition, composition:=Composition)
 
             Dim result As CodeModelTestState = Nothing
             Try
-                Dim mockComponentModel = New MockComponentModel(workspace.ExportProvider)
-                Dim mockServiceProvider = New MockServiceProvider(mockComponentModel)
-                Dim mockVisualStudioWorkspace = New MockVisualStudioWorkspace(workspace)
                 WrapperPolicy.s_ComWrapperFactory = MockComWrapperFactory.Instance
 
                 ' The Code Model test infrastructure assumes that a test workspace only ever contains a single project.
@@ -59,31 +58,33 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
                 Dim threadingContext = workspace.ExportProvider.GetExportedValue(Of IThreadingContext)
                 Dim listenerProvider = workspace.ExportProvider.GetExportedValue(Of AsynchronousOperationListenerProvider)()
+                Dim visualStudioWorkspace = workspace.ExportProvider.GetExportedValue(Of MockVisualStudioWorkspace)()
+                visualStudioWorkspace.SetWorkspace(workspace)
 
                 Dim state = New CodeModelState(
                     threadingContext,
-                    mockServiceProvider,
+                    workspace.ExportProvider.GetExportedValue(Of MockServiceProvider),
                     project.LanguageServices,
-                    mockVisualStudioWorkspace,
-                    New ProjectCodeModelFactory(
-                        mockVisualStudioWorkspace,
-                        mockServiceProvider,
-                        threadingContext,
-                        listenerProvider))
+                    visualStudioWorkspace,
+                    workspace.ExportProvider.GetExportedValue(Of ProjectCodeModelFactory))
 
                 Dim projectCodeModel = DirectCast(state.ProjectCodeModelFactory.CreateProjectCodeModel(project.Id, Nothing), ProjectCodeModel)
+
+                Dim firstFileCodeModel As ComHandle(Of EnvDTE80.FileCodeModel2, Implementation.CodeModel.FileCodeModel)? = Nothing
 
                 For Each document In project.Documents
                     ' Note that a parent is not specified below. In Visual Studio, this would normally be an EnvDTE.Project instance.
                     Dim fcm = projectCodeModel.GetOrCreateFileCodeModel(document.FilePath, parent:=Nothing)
                     fcm.Object.TextManagerAdapter = New MockTextManagerAdapter()
-                    mockVisualStudioWorkspace.SetFileCodeModel(document.Id, fcm)
+
+                    If Not firstFileCodeModel.HasValue Then
+                        firstFileCodeModel = fcm
+                    End If
                 Next
 
                 Dim root = New ComHandle(Of EnvDTE.CodeModel, RootCodeModel)(RootCodeModel.Create(state, Nothing, project.Id))
-                Dim firstFCM = mockVisualStudioWorkspace.GetFileCodeModelComHandle(project.DocumentIds.First())
 
-                result = New CodeModelTestState(workspace, mockVisualStudioWorkspace, root, firstFCM, state.CodeModelService)
+                result = New CodeModelTestState(workspace, state.Workspace, root, firstFileCodeModel.Value, state.CodeModelService)
             Finally
                 If result Is Nothing Then
                     workspace.Dispose()
@@ -92,28 +93,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
             Return result
         End Function
-
-        Public Class MockServiceProvider
-            Implements IServiceProvider
-
-            Private ReadOnly _componentModel As MockComponentModel
-
-            Public Sub New(componentModel As MockComponentModel)
-                _componentModel = componentModel
-            End Sub
-
-            Public Function GetService(serviceType As Type) As Object Implements IServiceProvider.GetService
-                If serviceType = GetType(SComponentModel) Then
-                    Return Me._componentModel
-                End If
-
-                If serviceType = GetType(EnvDTE.IVsExtensibility) Then
-                    Return Nothing
-                End If
-
-                Throw New NotImplementedException($"No service exists for {serviceType.FullName}")
-            End Function
-        End Class
 
         Friend Class MockComWrapperFactory
             Implements IComWrapperFactory

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestState.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestState.vb
@@ -86,7 +86,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
             If Not Me._disposedValue Then
                 If disposing Then
-                    VisualStudioWorkspace.Dispose()
+                    ' Ensure the existing project is removed from the ProjectCodeModelFactory; we otherwise later might try updating any state
+                    ' for it.
+                    Dim projectId = Workspace.CurrentSolution.ProjectIds.Single()
+                    Dim projectCodeModel = Workspace.ExportProvider.GetExportedValue(Of ProjectCodeModelFactory)().GetProjectCodeModel(projectId)
+                    projectCodeModel.OnProjectClosed()
+
                     Workspace.Dispose()
                 End If
             End If

--- a/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockVisualStudioWorkspace.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockVisualStudioWorkspace.vb
@@ -2,35 +2,51 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.ComponentModel.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.FindSymbols
+Imports Microsoft.CodeAnalysis.Host
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.VisualStudio.Composition
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Interop
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectBrowser.Lists
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
+    <PartNotDiscoverable>
+    <Export(GetType(VisualStudioWorkspace))>
+    <Export(GetType(VisualStudioWorkspaceImpl))>
+    <Export(GetType(MockVisualStudioWorkspace))>
     Friend Class MockVisualStudioWorkspace
-        Inherits VisualStudioWorkspace
+        Inherits VisualStudioWorkspaceImpl
 
-        Private ReadOnly _workspace As TestWorkspace
-        Private ReadOnly _fileCodeModels As New Dictionary(Of DocumentId, ComHandle(Of EnvDTE80.FileCodeModel2, FileCodeModel))
+        Private _workspace As TestWorkspace
 
-        Public Sub New(workspace As TestWorkspace)
-            MyBase.New(workspace.Services.HostServices)
+        <ImportingConstructor>
+        <System.Diagnostics.CodeAnalysis.SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be marked with 'ObsoleteAttribute'", Justification:="Used in test code: https://github.com/dotnet/roslyn/issues/42814")>
+        Public Sub New(exportProvider As ExportProvider)
+            MyBase.New(exportProvider, exportProvider.GetExportedValue(Of MockServiceProvider))
 
-            _workspace = workspace
-            SetCurrentSolution(workspace.CurrentSolution)
+        End Sub
+
+        Public Sub SetWorkspace(testWorkspace As TestWorkspace)
+            _workspace = testWorkspace
+            SetCurrentSolution(testWorkspace.CurrentSolution)
+
+            ' HACK: ensure this service is created so it can be used during disposal
+            Me.Services.GetService(Of IWorkspaceEventListenerService)()
         End Sub
 
         Public Overrides Function CanApplyChange(feature As ApplyChangesKind) As Boolean
             Return _workspace.CanApplyChange(feature)
         End Function
 
-        Protected Overrides Sub OnDocumentTextChanged(document As Document)
-            Assert.True(_workspace.TryApplyChanges(_workspace.CurrentSolution.WithDocumentText(document.Id, document.GetTextAsync().Result)))
+        Protected Overrides Sub ApplyDocumentTextChanged(documentId As DocumentId, newText As SourceText)
+            Assert.True(_workspace.TryApplyChanges(_workspace.CurrentSolution.WithDocumentText(documentId, newText)))
             SetCurrentSolution(_workspace.CurrentSolution)
         End Sub
 
@@ -44,20 +60,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
             SetCurrentSolution(_workspace.CurrentSolution)
         End Sub
 
-        Public Overrides Function GetHierarchy(projectId As ProjectId) As Microsoft.VisualStudio.Shell.Interop.IVsHierarchy
-            Return Nothing
-        End Function
-
-        Friend Overrides Function GetProjectGuid(projectId As ProjectId) As Guid
-            Return Guid.Empty
-        End Function
-
         Friend Overrides Function OpenInvisibleEditor(documentId As DocumentId) As IInvisibleEditor
             Return New MockInvisibleEditor(documentId, _workspace)
-        End Function
-
-        Public Overrides Function GetFileCodeModel(documentId As DocumentId) As EnvDTE.FileCodeModel
-            Return _fileCodeModels(documentId).Handle
         End Function
 
         Public Overrides Function TryGoToDefinition(symbol As ISymbol, project As Project, cancellationToken As CancellationToken) As Boolean
@@ -80,17 +84,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
             Throw New NotImplementedException()
         End Function
 
-        Friend Sub SetFileCodeModel(id As DocumentId, fileCodeModel As ComHandle(Of EnvDTE80.FileCodeModel2, FileCodeModel))
-            _fileCodeModels.Add(id, fileCodeModel)
+        Public Overrides Sub EnsureEditableDocuments(documents As IEnumerable(Of DocumentId))
+            ' Nothing to do here
         End Sub
-
-        Friend Function GetFileCodeModelComHandle(id As DocumentId) As ComHandle(Of EnvDTE80.FileCodeModel2, FileCodeModel)
-            Return _fileCodeModels(id)
-        End Function
-
-        Friend Overrides Function TryGetRuleSetPathForProject(projectId As ProjectId) As String
-            Throw New NotImplementedException()
-        End Function
     End Class
 
     Public Class MockInvisibleEditor

--- a/src/VisualStudio/TestUtilities2/MockServiceProvider.vb
+++ b/src/VisualStudio/TestUtilities2/MockServiceProvider.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
 
         Public Function GetService(serviceType As Type) As Object Implements IServiceProvider.GetService
             Select Case serviceType
-                Case GetType(SVsSolution)
+                Case GetType(SVsSolution), GetType(SVsShell)
                     ' Return a loose mock that just is a big no-op
                     Dim solutionMock As New Mock(Of IVsSolution2)(MockBehavior.Loose)
                     Return solutionMock.Object

--- a/src/VisualStudio/TestUtilities2/MockServiceProvider.vb
+++ b/src/VisualStudio/TestUtilities2/MockServiceProvider.vb
@@ -1,0 +1,69 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.ComponentModel.Composition
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.VisualStudio.ComponentModelHost
+Imports Microsoft.VisualStudio.Shell
+Imports Microsoft.VisualStudio.Shell.Interop
+Imports Moq
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
+
+    <PartNotDiscoverable>
+    <Export>
+    <Export(GetType(SVsServiceProvider))>
+    Friend Class MockServiceProvider
+        Implements IServiceProvider
+        Implements SVsServiceProvider ' The shell service provider actually implements this too for people using that type directly
+        Implements IAsyncServiceProvider
+
+        Private ReadOnly _exportProvider As Composition.ExportProvider
+        Private ReadOnly _fileChangeEx As MockVsFileChangeEx = New MockVsFileChangeEx
+
+        Public MockMonitorSelection As IVsMonitorSelection
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New(exportProvider As Composition.ExportProvider)
+            _exportProvider = exportProvider
+        End Sub
+
+        Public Function GetService(serviceType As Type) As Object Implements IServiceProvider.GetService
+            Select Case serviceType
+                Case GetType(SVsSolution)
+                    ' Return a loose mock that just is a big no-op
+                    Dim solutionMock As New Mock(Of IVsSolution2)(MockBehavior.Loose)
+                    Return solutionMock.Object
+
+                Case GetType(SComponentModel)
+                    Return GetComponentModelMock()
+
+                Case GetType(SVsShellMonitorSelection)
+                    Return MockMonitorSelection
+
+                Case GetType(SVsXMLMemberIndexService)
+                    Return New MockXmlMemberIndexService
+
+                Case GetType(SVsSmartOpenScope)
+                    Return New MockVsSmartOpenScope
+
+                Case GetType(SVsFileChangeEx)
+                    Return _fileChangeEx
+
+                Case Else
+                    Throw New Exception($"{NameOf(MockServiceProvider)} does not implement {serviceType.FullName}.")
+            End Select
+        End Function
+
+        Public Function GetServiceAsync(serviceType As Type) As Task(Of Object) Implements IAsyncServiceProvider.GetServiceAsync
+            Return System.Threading.Tasks.Task.FromResult(GetService(serviceType))
+        End Function
+
+        Friend Function GetComponentModelMock() As IComponentModel
+            Return New MockComponentModel(_exportProvider)
+        End Function
+    End Class
+
+End Namespace

--- a/src/VisualStudio/TestUtilities2/MockVsFileChangeEx.vb
+++ b/src/VisualStudio/TestUtilities2/MockVsFileChangeEx.vb
@@ -9,7 +9,7 @@ Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Task = System.Threading.Tasks.Task
 
-Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
     Friend Class MockVsFileChangeEx
         Implements IVsFileChangeEx
         Implements IVsAsyncFileChangeEx

--- a/src/VisualStudio/TestUtilities2/MockVsSmartOpenScope.vb
+++ b/src/VisualStudio/TestUtilities2/MockVsSmartOpenScope.vb
@@ -1,0 +1,15 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.VisualStudio.Shell.Interop
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
+    Friend Class MockVsSmartOpenScope
+        Implements IVsSmartOpenScope
+
+        Public Function OpenScope(wszScope As String, dwOpenFlags As UInteger, ByRef riid As Guid, ByRef ppIUnk As Object) As Integer Implements IVsSmartOpenScope.OpenScope
+            Throw New NotImplementedException()
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/TestUtilities2/MockXmlMemberIndexService.vb
+++ b/src/VisualStudio/TestUtilities2/MockXmlMemberIndexService.vb
@@ -1,0 +1,19 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.VisualStudio.Shell.Interop
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
+    Friend Class MockXmlMemberIndexService
+        Implements IVsXMLMemberIndexService
+
+        Public Function CreateXMLMemberIndex(pszBinaryName As String, ByRef ppIndex As IVsXMLMemberIndex) As Integer Implements IVsXMLMemberIndexService.CreateXMLMemberIndex
+            Throw New NotImplementedException()
+        End Function
+
+        Public Function GetMemberDataFromXML(pszXML As String, ByRef ppObj As IVsXMLMemberData) As Integer Implements IVsXMLMemberIndexService.GetMemberDataFromXML
+            Throw New NotImplementedException()
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/TestUtilities2/VisualStudioTestCompositions.vb
+++ b/src/VisualStudio/TestUtilities2/VisualStudioTestCompositions.vb
@@ -26,6 +26,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
                 GetType(VisualStudioRemoteHostClientProvider.Factory), ' Do not use ServiceHub in VS unit tests, run services locally.
                 GetType(IStreamingFindUsagesPresenter),                ' TODO: should we be using the actual implementation (https://github.com/dotnet/roslyn/issues/46380)?
                 GetType(HACK_ThemeColorFixer),
-                GetType(INotificationService))
+                GetType(Implementation.Notification.VSNotificationServiceFactory))
     End Class
 End Namespace


### PR DESCRIPTION
Some designers look through the other partial parts of a class to look for methods that match event handler signatures. Here I'm adding limited support so you can get a FileCodeModel and CodeElement for things residing in source generated files.

Unlike regular FileCodeModels that have certain lifetime guarantees and use our COM weak handle magic, this is keeping the implementation simple and just returning a new FileCodeModel any time we need one, under the hopes that the uses of this are rare. If that becomes a problem, we can refactor the CodeModel cache to deal with these, but there is some complexity around when we precisely know the document has gone away. Since CodeModel is very much a legacy API I don't want to spend time adding complexity until we know we need it.

This also doesn't implement any support for raising change events if a generator output changes. Again, if that is needed we can update the diffing code accordingly.