### PR TITLE
Include any class with methods with attributes in RunTests

### DIFF
--- a/src/Tools/ExternalAccess/RazorTest/RazorPredefinedProviderNameTests.cs
+++ b/src/Tools/ExternalAccess/RazorTest/RazorPredefinedProviderNameTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.UnitTests
 {
     public class RazorPredefinedProviderNameTests
     {
-        [Theory]
+        [Theory(Skip = "https://github.com/dotnet/roslyn/issues/58263")]
         [InlineData(typeof(PredefinedCodeFixProviderNames), typeof(RazorPredefinedCodeFixProviderNames))]
         [InlineData(typeof(PredefinedCodeRefactoringProviderNames), typeof(RazorPredefinedCodeRefactoringProviderNames))]
         internal void RoslynNamesExistAndValuesMatchInRazorNamesClass(Type roslynProviderNamesType, Type razorProviderNamesType)

--- a/src/Tools/Source/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/Source/RunTests/AssemblyScheduler.cs
@@ -300,11 +300,6 @@ namespace RunTests
                     continue;
                 }
 
-                if (MethodAttributes.Public != (methodDefinition.Attributes & MethodAttributes.Public))
-                {
-                    continue;
-                }
-
                 count++;
             }
 


### PR DESCRIPTION
This resolves the issue where `ExternalAccess.Razor` tests don't run in CI. RunTests assumed that only public methods could be test methods, but it turns out internal methods can be too.

FYI @pawchen @JoeRobich
