### PR TITLE
Nullable enable GetTypeByMetadataName

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1562,7 +1562,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal TypeSymbol GetTypeByReflectionType(Type type, BindingDiagnosticBag diagnostics)
         {
             var result = Assembly.GetTypeByReflectionType(type, includeReferences: true);
-            if ((object)result == null)
+            if (result is null)
             {
                 var errorType = new ExtendedErrorTypeSymbol(this, type.Name, 0, CreateReflectionTypeNotFoundError(type));
                 diagnostics.Add(errorType.ErrorInfo, NoLocation.Singleton);

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1590,9 +1590,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (HostObjectType != null && _lazyHostObjectTypeSymbol is null)
             {
-                TypeSymbol symbol = Assembly.GetTypeByReflectionType(HostObjectType, includeReferences: true);
+                TypeSymbol? symbol = Assembly.GetTypeByReflectionType(HostObjectType, includeReferences: true);
 
-                if ((object)symbol == null)
+                if (symbol is null)
                 {
                     MetadataTypeName mdName = MetadataTypeName.FromNamespaceAndTypeName(HostObjectType.Namespace ?? String.Empty,
                                                                                         HostObjectType.Name,

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.PortableExecutable;
@@ -565,12 +566,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return GetSpecialType(SpecialTypes.GetTypeFromMetadataName(type));
         }
 
+#nullable enable
         /// <summary>
         /// Lookup a type within the assembly using the canonical CLR metadata name of the type.
         /// </summary>
         /// <param name="fullyQualifiedMetadataName">Type name.</param>
         /// <returns>Symbol for the type or null if type cannot be found or is ambiguous. </returns>
-        public NamedTypeSymbol GetTypeByMetadataName(string fullyQualifiedMetadataName)
+        public NamedTypeSymbol? GetTypeByMetadataName(string fullyQualifiedMetadataName)
         {
             if (fullyQualifiedMetadataName == null)
             {
@@ -606,16 +608,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// In cases a type could not be found because of ambiguity, we return two of the candidates that caused the ambiguity.
         /// </param>
         /// <returns>Null if the type can't be found.</returns>
-        internal NamedTypeSymbol GetTypeByMetadataName(
+        internal NamedTypeSymbol? GetTypeByMetadataName(
             string metadataName,
             bool includeReferences,
             bool isWellKnownType,
             out (AssemblySymbol, AssemblySymbol) conflicts,
             bool useCLSCompliantNameArityEncoding = false,
-            DiagnosticBag warnings = null,
+            DiagnosticBag? warnings = null,
             bool ignoreCorLibraryDuplicatedTypes = false)
         {
-            NamedTypeSymbol type;
+            NamedTypeSymbol? type;
             MetadataTypeName mdName;
 
             if (metadataName.IndexOf('+') >= 0)
@@ -626,7 +628,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 type = GetTopLevelTypeByMetadataName(ref mdName, assemblyOpt: null, includeReferences: includeReferences, isWellKnownType: isWellKnownType,
                     conflicts: out conflicts, warnings: warnings, ignoreCorLibraryDuplicatedTypes: ignoreCorLibraryDuplicatedTypes);
 
-                for (int i = 1; (object)type != null && !type.IsErrorType() && i < parts.Length; i++)
+                for (int i = 1; type is object && !type.IsErrorType() && i < parts.Length; i++)
                 {
                     mdName = MetadataTypeName.FromTypeName(parts[i]);
                     NamedTypeSymbol temp = type.LookupMetadataType(ref mdName);
@@ -640,7 +642,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     conflicts: out conflicts, warnings: warnings, ignoreCorLibraryDuplicatedTypes: ignoreCorLibraryDuplicatedTypes);
             }
 
-            return ((object)type == null || type.IsErrorType()) ? null : type;
+            return (type is null || type.IsErrorType()) ? null : type;
         }
 
         private static readonly char[] s_nestedTypeNameSeparators = new char[] { '+' };
@@ -652,7 +654,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="type">The type to resolve.</param>
         /// <param name="includeReferences">Use referenced assemblies for resolution.</param>
         /// <returns>The resolved symbol if successful or null on failure.</returns>
-        internal TypeSymbol GetTypeByReflectionType(Type type, bool includeReferences)
+        internal TypeSymbol? GetTypeByReflectionType(Type type, bool includeReferences)
         {
             System.Reflection.TypeInfo typeInfo = type.GetTypeInfo();
 
@@ -663,8 +665,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (typeInfo.IsArray)
             {
-                TypeSymbol symbol = GetTypeByReflectionType(typeInfo.GetElementType(), includeReferences);
-                if ((object)symbol == null)
+                TypeSymbol? symbol = GetTypeByReflectionType(typeInfo.GetElementType()!, includeReferences);
+                if (symbol is null)
                 {
                     return null;
                 }
@@ -675,8 +677,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (typeInfo.IsPointer)
             {
-                TypeSymbol symbol = GetTypeByReflectionType(typeInfo.GetElementType(), includeReferences);
-                if ((object)symbol == null)
+                TypeSymbol? symbol = GetTypeByReflectionType(typeInfo.GetElementType()!, includeReferences);
+                if (symbol is null)
                 {
                     return null;
                 }
@@ -707,8 +709,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 int i = nestedTypes.Count - 1;
-                var symbol = (NamedTypeSymbol)GetTypeByReflectionType(nestedTypes[i].AsType(), includeReferences);
-                if ((object)symbol == null)
+                var symbol = (NamedTypeSymbol?)GetTypeByReflectionType(nestedTypes[i].AsType(), includeReferences);
+                if (symbol is null)
                 {
                     return null;
                 }
@@ -719,13 +721,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     MetadataTypeName mdName = MetadataTypeName.FromTypeName(nestedTypes[i].Name, forcedArity: forcedArity);
 
                     symbol = symbol.LookupMetadataType(ref mdName);
-                    if ((object)symbol == null || symbol.IsErrorType())
+                    if (symbol is null || symbol.IsErrorType())
                     {
                         return null;
                     }
 
                     symbol = ApplyGenericArguments(symbol, genericArguments, ref typeArgumentIndex, includeReferences);
-                    if ((object)symbol == null)
+                    if (symbol is null)
                     {
                         return null;
                     }
@@ -744,9 +746,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     typeInfo.Name,
                     forcedArity: typeInfo.GenericTypeArguments.Length);
 
-                NamedTypeSymbol symbol = GetTopLevelTypeByMetadataName(ref mdName, assemblyId, includeReferences, isWellKnownType: false, conflicts: out var _);
+                NamedTypeSymbol? symbol = GetTopLevelTypeByMetadataName(ref mdName, assemblyId, includeReferences, isWellKnownType: false, conflicts: out var _);
 
-                if ((object)symbol == null || symbol.IsErrorType())
+                if (symbol is null || symbol.IsErrorType())
                 {
                     return null;
                 }
@@ -759,7 +761,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private NamedTypeSymbol ApplyGenericArguments(NamedTypeSymbol symbol, Type[] typeArguments, ref int currentTypeArgument, bool includeReferences)
+        private NamedTypeSymbol? ApplyGenericArguments(NamedTypeSymbol symbol, Type[] typeArguments, ref int currentTypeArgument, bool includeReferences)
         {
             int remainingTypeArguments = typeArguments.Length - currentTypeArgument;
 
@@ -776,7 +778,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             for (int i = 0; i < length; i++)
             {
                 var argSymbol = GetTypeByReflectionType(typeArguments[currentTypeArgument++], includeReferences);
-                if ((object)argSymbol == null)
+                if (argSymbol is null)
                 {
                     return null;
                 }
@@ -786,13 +788,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return symbol.ConstructIfGeneric(typeArgumentSymbols.ToImmutableAndFree());
         }
 
-        internal NamedTypeSymbol GetTopLevelTypeByMetadataName(
+        internal NamedTypeSymbol? GetTopLevelTypeByMetadataName(
             ref MetadataTypeName metadataName,
-            AssemblyIdentity assemblyOpt,
+            AssemblyIdentity? assemblyOpt,
             bool includeReferences,
             bool isWellKnownType,
             out (AssemblySymbol, AssemblySymbol) conflicts,
-            DiagnosticBag warnings = null, // this is set to collect ambiguity warning for well-known types before C# 7
+            DiagnosticBag? warnings = null, // this is set to collect ambiguity warning for well-known types before C# 7
             bool ignoreCorLibraryDuplicatedTypes = false)
         {
             // Type from this assembly always wins.
@@ -805,7 +807,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(warnings is null || isWellKnownType);
 
             conflicts = default;
-            NamedTypeSymbol result;
+            NamedTypeSymbol? result;
 
             // First try this assembly
             result = GetTopLevelTypeByMetadataName(this, ref metadataName, assemblyOpt);
@@ -816,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // ignore any types of the same name that might be in referenced assemblies (prefer the current assembly):
-            if ((object)result != null || !includeReferences)
+            if (result is object || !includeReferences)
             {
                 return result;
             }
@@ -829,7 +831,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 !CorLibrary.IsMissing &&
                 !isWellKnownTypeBeforeCSharp7 && !ignoreCorLibraryDuplicatedTypes)
             {
-                NamedTypeSymbol corLibCandidate = GetTopLevelTypeByMetadataName(CorLibrary, ref metadataName, assemblyOpt);
+                NamedTypeSymbol? corLibCandidate = GetTopLevelTypeByMetadataName(CorLibrary, ref metadataName, assemblyOpt);
                 skipCorLibrary = true;
 
                 if (isValidCandidate(corLibCandidate, isWellKnownType))
@@ -863,7 +865,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     continue;
                 }
 
-                NamedTypeSymbol candidate = GetTopLevelTypeByMetadataName(assembly, ref metadataName, assemblyOpt);
+                NamedTypeSymbol? candidate = GetTopLevelTypeByMetadataName(assembly, ref metadataName, assemblyOpt);
 
                 if (!isValidCandidate(candidate, isWellKnownType))
                 {
@@ -872,7 +874,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 Debug.Assert(!TypeSymbol.Equals(candidate, result, TypeCompareKind.ConsiderEverything));
 
-                if ((object)result != null)
+                if (result is object)
                 {
                     // duplicate
                     if (ignoreCorLibraryDuplicatedTypes)
@@ -910,7 +912,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             assemblies.Free();
             return result;
 
-            bool isValidCandidate(NamedTypeSymbol candidate, bool isWellKnownType)
+            bool isValidCandidate([NotNullWhen(true)] NamedTypeSymbol? candidate, bool isWellKnownType)
             {
                 return candidate is not null
                     && (!isWellKnownType || IsValidWellKnownType(candidate))
@@ -923,9 +925,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (object)type.ContainingAssembly == CorLibrary;
         }
 
-        private bool IsValidWellKnownType(NamedTypeSymbol result)
+        private bool IsValidWellKnownType(NamedTypeSymbol? result)
         {
-            if ((object)result == null || result.TypeKind == TypeKind.Error)
+            if (result is null || result.TypeKind == TypeKind.Error)
             {
                 return false;
             }
@@ -936,7 +938,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result.DeclaredAccessibility == Accessibility.Public || IsSymbolAccessible(result, this);
         }
 
-        private static NamedTypeSymbol GetTopLevelTypeByMetadataName(AssemblySymbol assembly, ref MetadataTypeName metadataName, AssemblyIdentity assemblyOpt)
+        private static NamedTypeSymbol? GetTopLevelTypeByMetadataName(AssemblySymbol assembly, ref MetadataTypeName metadataName, AssemblyIdentity? assemblyOpt)
         {
             var result = assembly.LookupTopLevelMetadataType(ref metadataName, digThroughForwardedTypes: false);
             if (!IsAcceptableMatchForGetTypeByMetadataName(result))
@@ -956,6 +958,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return candidate.Kind != SymbolKind.ErrorType || !(candidate is MissingMetadataTypeSymbol);
         }
+#nullable disable
 
         /// <summary>
         /// Lookup member declaration in predefined CorLib type in this Assembly. Only valid if this 

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/AssemblySymbol.cs
@@ -98,10 +98,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
             return false;
         }
 
-        INamedTypeSymbol IAssemblySymbol.GetTypeByMetadataName(string metadataName)
+#nullable enable
+        INamedTypeSymbol? IAssemblySymbol.GetTypeByMetadataName(string metadataName)
         {
             return UnderlyingAssemblySymbol.GetTypeByMetadataName(metadataName).GetPublicSymbol();
         }
+#nullable disable
 
         #region ISymbol Members
 


### PR DESCRIPTION
In preparation for working on https://github.com/dotnet/roslyn/issues/57802, I nullable-enabled the implementation of GetTypeByMetadataName in C# as I was reading through it to understand how it currently works.