### PR TITLE
Address various minor param-nullchecking issues

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6187,11 +6187,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_NullCheckingOnByRefParameter" xml:space="preserve">
     <value>By-reference parameter '{0}' cannot be null-checked.</value>
   </data>
-  <data name="WRN_NullCheckingOnNullableValueType" xml:space="preserve">
-    <value>Nullable value type '{0}' is null-checked and will throw if null.</value>
+  <data name="WRN_NullCheckingOnNullableType" xml:space="preserve">
+    <value>Nullable type '{0}' is null-checked and will throw if null.</value>
   </data>
-  <data name="WRN_NullCheckingOnNullableValueType_Title" xml:space="preserve">
-    <value>Nullable value type is null-checked and will throw if null.</value>
+  <data name="WRN_NullCheckingOnNullableType_Title" xml:space="preserve">
+    <value>Nullable type is null-checked and will throw if null.</value>
   </data>
   <data name="ERR_ReAbstractionInNoPIAType" xml:space="preserve">
     <value>Type '{0}' cannot be embedded because it has a re-abstraction of a member from base interface. Consider setting the 'Embed Interop Types' property to false.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2012,7 +2012,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_NonNullableValueTypeIsNullChecked = 8992,
         WRN_NullCheckedHasDefaultNull = 8993,
         ERR_NullCheckingOnByRefParameter = 8994,
-        WRN_NullCheckingOnNullableValueType = 8995,
+        WRN_NullCheckingOnNullableType = 8995,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint:
                 case ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment:
                 case ErrorCode.WRN_NullCheckedHasDefaultNull:
-                case ErrorCode.WRN_NullCheckingOnNullableValueType:
+                case ErrorCode.WRN_NullCheckingOnNullableType:
                 case ErrorCode.WRN_ParameterConditionallyDisallowsNull:
                 case ErrorCode.WRN_NullReferenceInitializer:
                 case ErrorCode.WRN_ShouldNotReturn:

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -280,7 +280,7 @@
                 case ErrorCode.WRN_CompileTimeCheckedOverflow:
                 case ErrorCode.WRN_MethGrpToNonDel:
                 case ErrorCode.WRN_NullCheckedHasDefaultNull:
-                case ErrorCode.WRN_NullCheckingOnNullableValueType:
+                case ErrorCode.WRN_NullCheckingOnNullableType:
                 case ErrorCode.WRN_LowerCaseTypeName:
                     return true;
                 default:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -802,16 +802,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 diagnostics.Add(useSiteInfo.DiagnosticInfo, location);
             }
-            if (parameter.Type.IsValueType && !parameter.Type.IsPointerOrFunctionPointer())
+            if (parameter.TypeWithAnnotations.NullableAnnotation.IsAnnotated()
+                || parameter.Type.IsNullableTypeOrTypeParameter())
             {
-                if (!parameter.Type.IsNullableTypeOrTypeParameter())
-                {
-                    diagnostics.Add(ErrorCode.ERR_NonNullableValueTypeIsNullChecked, location, parameter);
-                }
-                else
-                {
-                    diagnostics.Add(ErrorCode.WRN_NullCheckingOnNullableValueType, location, parameter);
-                }
+                diagnostics.Add(ErrorCode.WRN_NullCheckingOnNullableType, location, parameter);
+            }
+            else if (parameter.Type.IsValueType && !parameter.Type.IsPointerOrFunctionPointer())
+            {
+                diagnostics.Add(ErrorCode.ERR_NonNullableValueTypeIsNullChecked, location, parameter);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1293,7 +1293,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         var overrideParam = overrideParameters[i + overrideParameterOffset];
                         var baseParam = baseParameters[i];
-                        if (notNullIfParameterNotNull.Contains(overrideParam.Name) && NullableWalker.GetParameterState(baseParam.TypeWithAnnotations, baseParam.FlowAnalysisAnnotations).IsNotNull)
+                        if (notNullIfParameterNotNull.Contains(overrideParam.Name) && NullableWalker.GetParameterState(baseParam.TypeWithAnnotations, baseParam.FlowAnalysisAnnotations, baseParam.IsNullChecked).IsNotNull)
                         {
                             return outputType.AsNotAnnotated();
                         }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -143,6 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         PercentEqualsToken = 8283,
         /// <summary>Represents <c>??=</c> token.</summary>
         QuestionQuestionEqualsToken = 8284,
+        /// <summary>Represents <c>!!</c> token.</summary>
         ExclamationExclamationToken = 8285,
 
         // Keywords

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1542,14 +1542,14 @@
         <target state="new">Parameter is null-checked but is null by default.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType">
-        <source>Nullable value type '{0}' is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type '{0}' is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType">
+        <source>Nullable type '{0}' is null-checked and will throw if null.</source>
+        <target state="new">Nullable type '{0}' is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_NullCheckingOnNullableValueType_Title">
-        <source>Nullable value type is null-checked and will throw if null.</source>
-        <target state="new">Nullable value type is null-checked and will throw if null.</target>
+      <trans-unit id="WRN_NullCheckingOnNullableType_Title">
+        <source>Nullable type is null-checked and will throw if null.</source>
+        <target state="new">Nullable type is null-checked and will throw if null.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ParameterNotNullIfNotNull">

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenNullCheckedParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenNullCheckedParameterTests.cs
@@ -1882,7 +1882,7 @@ class Derived : Base
     public void M1(string x) { }
     public void M2(string x!!) { }
 }";
-            var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetCoreApp);
+            var verifier = CompileAndVerify(source, verify: Verification.Skipped, targetFramework: TargetFramework.NetCoreApp);
             verifier.VerifyDiagnostics();
 
             verifier.VerifyIL("Base.M1", @"
@@ -1934,7 +1934,7 @@ class Derived : Base
     public void M1(string x!!) { }
     void Base.M2(string x!!) { }
 }";
-            var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetCoreApp);
+            var verifier = CompileAndVerify(source);
             verifier.VerifyDiagnostics();
 
             verifier.VerifyIL("Derived.M1", @"
@@ -1987,7 +1987,7 @@ catch (ArgumentNullException)
 record Record(string Prop1!!, string Prop2!!);
 record struct RecordStruct(string Prop1!!, string Prop2!!);
 ";
-            var verifier = CompileAndVerify(new[] { source, IsExternalInitTypeDefinition }, expectedOutput: "1234");
+            var verifier = CompileAndVerify(new[] { source, IsExternalInitTypeDefinition }, verify: Verification.Skipped, expectedOutput: "1234");
             verifier.VerifyDiagnostics();
 
             verifier.VerifyIL("Record..ctor(string, string)", @"

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenNullCheckedParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenNullCheckedParameterTests.cs
@@ -1818,6 +1818,7 @@ class C
         {
             var source =
 @"
+#nullable enable
 class Base
 {
     public virtual void M1(string x!!) { }
@@ -1865,10 +1866,11 @@ class Derived : Base
         }
 
         [Fact]
-        public void Implementation_NullCheckedDifference()
+        public void Implementation_NullCheckedDifference1()
         {
             var source =
 @"
+#nullable enable
 interface Base
 {
     public void M1(string x!!) { }
@@ -1905,6 +1907,46 @@ class Derived : Base
   IL_0000:  ret
 }");
             verifier.VerifyIL("Derived.M2", @"
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldarg.1
+  IL_0001:  ldstr      ""x""
+  IL_0006:  call       ""ThrowIfNull""
+  IL_000b:  ret
+}");
+        }
+
+        [Fact]
+        public void Implementation_NullCheckedDifference2()
+        {
+            var source =
+@"
+#nullable enable
+interface Base
+{
+    void M1(string x);
+    void M2(string x);
+}
+
+class Derived : Base
+{
+    public void M1(string x!!) { }
+    void Base.M2(string x!!) { }
+}";
+            var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetCoreApp);
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("Derived.M1", @"
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldarg.1
+  IL_0001:  ldstr      ""x""
+  IL_0006:  call       ""ThrowIfNull""
+  IL_000b:  ret
+}");
+            verifier.VerifyIL("Derived.Base.M2", @"
 {
   // Code size       12 (0xc)
   .maxstack  2

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenNullCheckedParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenNullCheckedParameterTests.cs
@@ -1322,6 +1322,44 @@ class C
         }
 
         [Fact]
+        public void TestNullCheckedAsyncIterator()
+        {
+            var source = @"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class C
+{
+    async IAsyncEnumerable<char> GetChars(string s!!, Task t)
+    {
+        foreach (var c in s)
+        {
+            await t;
+            yield return c;
+        }
+    }
+}";
+            var compilation = CompileAndVerify(CreateCompilationWithTasksExtensions(new[] { source, AsyncStreamsTypes }, parseOptions: TestOptions.RegularPreview));
+            compilation.VerifyIL("C.GetChars", @"
+{
+  // Code size       33 (0x21)
+  .maxstack  3
+  IL_0000:  ldc.i4.s   -2
+  IL_0002:  newobj     ""C.<GetChars>d__0..ctor(int)""
+  IL_0007:  ldarg.1
+  IL_0008:  ldstr      ""s""
+  IL_000d:  call       ""ThrowIfNull""
+  IL_0012:  dup
+  IL_0013:  ldarg.1
+  IL_0014:  stfld      ""string C.<GetChars>d__0.<>3__s""
+  IL_0019:  dup
+  IL_001a:  ldarg.2
+  IL_001b:  stfld      ""System.Threading.Tasks.Task C.<GetChars>d__0.<>3__t""
+  IL_0020:  ret
+}");
+        }
+
+        [Fact]
         public void TestNullCheckedIteratorInLocalFunction()
         {
             var source = @"
@@ -1595,9 +1633,9 @@ class C
 }";
             var verifier = CompileAndVerify(source);
             verifier.VerifyDiagnostics(
-                // (4,25): warning CS8995: Nullable value type 'T?' is null-checked and will throw if null.
+                // (4,25): warning CS8995: Nullable type 'T?' is null-checked and will throw if null.
                 //     public void M<T>(T? t!!) where T : struct
-                Diagnostic(ErrorCode.WRN_NullCheckingOnNullableValueType, "t").WithArguments("T?").WithLocation(4, 25));
+                Diagnostic(ErrorCode.WRN_NullCheckingOnNullableType, "t").WithArguments("T?").WithLocation(4, 25));
             verifier.VerifyIL("C.M<T>", @"
 {
   // Code size       21 (0x15)
@@ -1626,9 +1664,9 @@ class C
 }";
             var verifier = CompileAndVerify(source);
             verifier.VerifyDiagnostics(
-                // (4,24): warning CS8995: Nullable value type 'int?' is null-checked and will throw if null.
+                // (4,24): warning CS8995: Nullable type 'int?' is null-checked and will throw if null.
                 //     public void M(int? i!!) // 1
-                Diagnostic(ErrorCode.WRN_NullCheckingOnNullableValueType, "i").WithArguments("int?").WithLocation(4, 24));
+                Diagnostic(ErrorCode.WRN_NullCheckingOnNullableType, "i").WithArguments("int?").WithLocation(4, 24));
             verifier.VerifyIL("C.M(int?)", @"
 {
   // Code size       21 (0x15)
@@ -1737,6 +1775,144 @@ class C
 }");
             verifier.VerifyMissing("ThrowIfNull");
             verifier.VerifyMissing("Throw");
+        }
+
+        [Fact]
+        public void UserDefinedConversion()
+        {
+            var source = @"
+class C
+{
+    public static bool operator ==(C c1, C c2) => false;
+    public static bool operator !=(C c1, C c2) => false;
+    public override bool Equals(object obj) => false;
+    public override int GetHashCode() => 0;
+
+    public static void M(C c!!)
+    {
+        if (c == null) { System.Console.Write(1); }
+    }
+}
+";
+            var verifier = CompileAndVerify(source);
+            verifier.VerifyDiagnostics();
+            verifier.VerifyIL("C.M", @"
+{
+  // Code size       27 (0x1b)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldstr      ""c""
+  IL_0006:  call       ""ThrowIfNull""
+  IL_000b:  ldarg.0
+  IL_000c:  ldnull
+  IL_000d:  call       ""bool C.op_Equality(C, C)""
+  IL_0012:  brfalse.s  IL_001a
+  IL_0014:  ldc.i4.1
+  IL_0015:  call       ""void System.Console.Write(int)""
+  IL_001a:  ret
+}");
+        }
+
+        [Fact]
+        public void Override_NullCheckedDifference()
+        {
+            var source =
+@"
+class Base
+{
+    public virtual void M1(string x!!) { }
+    public virtual void M2(string x) { }
+}
+
+class Derived : Base
+{
+    public override void M1(string x) { }
+    public override void M2(string x!!) { }
+}";
+            var verifier = CompileAndVerify(source);
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("Base.M1", @"
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldarg.1
+  IL_0001:  ldstr      ""x""
+  IL_0006:  call       ""ThrowIfNull""
+  IL_000b:  ret
+}");
+            verifier.VerifyIL("Base.M2", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+            verifier.VerifyIL("Derived.M1", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+            verifier.VerifyIL("Derived.M2", @"
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldarg.1
+  IL_0001:  ldstr      ""x""
+  IL_0006:  call       ""ThrowIfNull""
+  IL_000b:  ret
+}");
+        }
+
+        [Fact]
+        public void Implementation_NullCheckedDifference()
+        {
+            var source =
+@"
+interface Base
+{
+    public void M1(string x!!) { }
+    public void M2(string x) { }
+}
+
+class Derived : Base
+{
+    public void M1(string x) { }
+    public void M2(string x!!) { }
+}";
+            var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetCoreApp);
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("Base.M1", @"
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldarg.1
+  IL_0001:  ldstr      ""x""
+  IL_0006:  call       ""ThrowIfNull""
+  IL_000b:  ret
+}");
+            verifier.VerifyIL("Base.M2", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+            verifier.VerifyIL("Derived.M1", @"
+{
+  // Code size        1 (0x1)
+  .maxstack  0
+  IL_0000:  ret
+}");
+            verifier.VerifyIL("Derived.M2", @"
+{
+  // Code size       12 (0xc)
+  .maxstack  2
+  IL_0000:  ldarg.1
+  IL_0001:  ldstr      ""x""
+  IL_0006:  call       ""ThrowIfNull""
+  IL_000b:  ret
+}");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenNullCheckedParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenNullCheckedParameterTests.cs
@@ -1914,5 +1914,79 @@ class Derived : Base
   IL_000b:  ret
 }");
         }
+
+        [Fact]
+        public void RecordPrimaryConstructor()
+        {
+            var source =
+@"
+using System;
+
+Console.Write(new Record(""1"", ""0"").Prop1);
+try
+{
+    new Record(null, ""a"");
+}
+catch (ArgumentNullException)
+{
+    Console.Write(2);
+}
+
+Console.Write(new RecordStruct(""3"", ""0"").Prop1);
+try
+{
+    new RecordStruct(""b"", null);
+}
+catch (ArgumentNullException)
+{
+    Console.Write(4);
+}
+
+record Record(string Prop1!!, string Prop2!!);
+record struct RecordStruct(string Prop1!!, string Prop2!!);
+";
+            var verifier = CompileAndVerify(new[] { source, IsExternalInitTypeDefinition }, expectedOutput: "1234");
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("Record..ctor(string, string)", @"
+{
+  // Code size       43 (0x2b)
+  .maxstack  2
+  IL_0000:  ldarg.1
+  IL_0001:  ldstr      ""Prop1""
+  IL_0006:  call       ""ThrowIfNull""
+  IL_000b:  ldarg.2
+  IL_000c:  ldstr      ""Prop2""
+  IL_0011:  call       ""ThrowIfNull""
+  IL_0016:  ldarg.0
+  IL_0017:  ldarg.1
+  IL_0018:  stfld      ""string Record.<Prop1>k__BackingField""
+  IL_001d:  ldarg.0
+  IL_001e:  ldarg.2
+  IL_001f:  stfld      ""string Record.<Prop2>k__BackingField""
+  IL_0024:  ldarg.0
+  IL_0025:  call       ""object..ctor()""
+  IL_002a:  ret
+}");
+
+            verifier.VerifyIL("RecordStruct..ctor(string, string)", @"
+{
+  // Code size       37 (0x25)
+  .maxstack  2
+  IL_0000:  ldarg.1
+  IL_0001:  ldstr      ""Prop1""
+  IL_0006:  call       ""ThrowIfNull""
+  IL_000b:  ldarg.2
+  IL_000c:  ldstr      ""Prop2""
+  IL_0011:  call       ""ThrowIfNull""
+  IL_0016:  ldarg.0
+  IL_0017:  ldarg.1
+  IL_0018:  stfld      ""string RecordStruct.<Prop1>k__BackingField""
+  IL_001d:  ldarg.0
+  IL_001e:  ldarg.2
+  IL_001f:  stfld      ""string RecordStruct.<Prop2>k__BackingField""
+  IL_0024:  ret
+}");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_NullCheckedParameters.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_NullCheckedParameters.cs
@@ -2422,7 +2422,7 @@ class Program
             comp.VerifyDiagnostics(
                     // (4,29): warning CS8721: Nullable value type 'int?' is null-checked and will throw if null.
                     //     public void Method(int? x!!) { }
-                    Diagnostic(ErrorCode.WRN_NullCheckingOnNullableValueType, "x").WithArguments("int?").WithLocation(4, 29));
+                    Diagnostic(ErrorCode.WRN_NullCheckingOnNullableType, "x").WithArguments("int?").WithLocation(4, 29));
             var tree = comp.SyntaxTrees.Single();
             var node = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
             comp.VerifyOperationTree(node, expectedOperationTree: @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullCheckedParameterTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullCheckedParameterTests.cs
@@ -1008,7 +1008,7 @@ class Program
         }
 
         [Fact]
-        public void TestNullCheckedParameterUpdatesFlowState()
+        public void TestNullCheckedParameterUpdatesFlowState1()
         {
             var source =
 @"
@@ -1026,6 +1026,27 @@ class Program
                 // (6,22): warning CS8995: Nullable type 'string?' is null-checked and will throw if null.
                 //     string M(string? s!!) // 1
                 Diagnostic(ErrorCode.WRN_NullCheckingOnNullableType, "s").WithArguments("string?").WithLocation(6, 22));
+        }
+
+        [Fact]
+        public void TestNullCheckedParameterUpdatesFlowState2()
+        {
+            var source =
+@"
+#nullable enable
+
+class Program
+{
+    int M(int? x!!) // 1
+    {
+        return x.Value;
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyDiagnostics(
+                // (6,16): warning CS8995: Nullable type 'int?' is null-checked and will throw if null.
+                //     int M(int? x!!) // 1
+                Diagnostic(ErrorCode.WRN_NullCheckingOnNullableType, "x").WithArguments("int?").WithLocation(6, 16));
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -7963,5 +7963,33 @@ End Class";
                 SymbolDisplayPartKind.ParameterName,
                 SymbolDisplayPartKind.Punctuation);
         }
+
+        [Fact]
+        public void TestNullCheckedParameter()
+        {
+            var source = @"
+class C
+{
+    void M(string s!!)
+    {
+    }
+}
+";
+
+            var comp = CreateCompilation(source);
+            var methodSymbol = comp.GetMember<MethodSymbol>("C.M").GetPublicSymbol();
+
+            Verify(methodSymbol.ToDisplayParts(s_memberSignatureDisplayFormat), "void C.M(string s)",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -271,7 +271,7 @@ class X
                         case ErrorCode.WRN_CallerArgumentExpressionAttributeHasInvalidParameterName:
                         case ErrorCode.WRN_CallerArgumentExpressionAttributeSelfReferential:
                         case ErrorCode.WRN_NullCheckedHasDefaultNull:
-                        case ErrorCode.WRN_NullCheckingOnNullableValueType:
+                        case ErrorCode.WRN_NullCheckingOnNullableType:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:
@@ -413,7 +413,7 @@ class X
                 // Nullable-unrelated warnings in the C# 8 range should be added to this array.
                 var nullableUnrelatedWarnings = new[]
                 {
-                    ErrorCode.WRN_NullCheckingOnNullableValueType,
+                    ErrorCode.WRN_NullCheckingOnNullableType,
                     ErrorCode.WRN_NullCheckedHasDefaultNull,
                     ErrorCode.WRN_MissingNonNullTypesContextForAnnotation,
                     ErrorCode.WRN_MissingNonNullTypesContextForAnnotationInGeneratedCode,

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -4472,6 +4472,19 @@ class C { }",
 
         [Theory]
         [CombinatorialData]
+        public async Task NullCheckedParameterClassification(TestHost testHost)
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M(string s!!) { }
+}",
+                testHost);
+        }
+
+        [Theory]
+        [CombinatorialData]
         [WorkItem(57184, "https://github.com/dotnet/roslyn/issues/57184")]
         public async Task MethodGroupClassifications(TestHost testHost)
         {


### PR DESCRIPTION
- Addresses several test plan items
- Make `string? s!!` a warning just as `int? x!!` is a warning. [notes](https://github.com/RikkiGibson/csharplang/blob/d60ae8eab8dced5c1a57470abb6b4518c5a1a89f/meetings/2019/LDM-2019-07-10.md#param)
- Give a non-null initial flow state for parameters with `!!`. https://github.com/dotnet/roslyn/issues/36024#issuecomment-976434866