### PR TITLE
Add update project version fixer for 'newlines in interpolations'

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -1100,7 +1100,7 @@ class Test
                  [|}|]y"";
     }
 }",
-                LanguageVersion.Preview,
+                expected: LanguageVersion.Preview,
                 new CSharpParseOptions(LanguageVersion.CSharp8));
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -1086,5 +1086,22 @@ class C
                 expected: LanguageVersion.CSharp9,
                 new CSharpParseOptions(LanguageVersion.CSharp8));
         }
+
+        [Fact]
+        public async Task UpgradeProjectForNewLinesInInterpolations()
+        {
+            await TestLanguageVersionUpgradedAsync(@"
+class Test
+{
+    void M()
+    {
+        var v = $""x{
+                    1 + 1
+                 [|}|]y"";
+    }
+}",
+                LanguageVersion.Preview,
+                new CSharpParseOptions(LanguageVersion.CSharp8));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -1087,7 +1087,7 @@ class C
                 new CSharpParseOptions(LanguageVersion.CSharp8));
         }
 
-        [Fact]
+        [Fact, WorkItem(57154, "https://github.com/dotnet/roslyn/issues/57154")]
         public async Task UpgradeProjectForNewLinesInInterpolations()
         {
             await TestLanguageVersionUpgradedAsync(@"

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
                 "CS8912", // error CS8912: Inheriting from a record with a sealed 'Object.ToString' is not supported in C# {0}. Please use language version '{1}' or greater.
                 "CS8704", // error CS8704: 'Test1' does not implement interface member 'I1.M1()'. 'Test1.M1()' cannot implicitly implement a non-public member in C# 9.0. Please use language version 'preview' or greater.
                 "CS8957", // error CS8957: Conditional expression is not valid in language version '8.0' because a common type was not found between 'int' and '<null>'. To use a target-typed conversion, upgrade to language version '9.0' or greater.
-                "CS8967", // error CS8967: Newlines inside a non-verbatim interpolated string are not supported in C# 8.0. Please use language version preview or greater.	ClassLibrary1	C:\github\repo_find_refs\ClassLibrary1\TestClass.cs	6	Active
+                "CS8967", // error CS8967: Newlines inside a non-verbatim interpolated string are not supported in C# 8.0. Please use language version preview or greater.
             });
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
                 "CS8912", // error CS8912: Inheriting from a record with a sealed 'Object.ToString' is not supported in C# {0}. Please use language version '{1}' or greater.
                 "CS8704", // error CS8704: 'Test1' does not implement interface member 'I1.M1()'. 'Test1.M1()' cannot implicitly implement a non-public member in C# 9.0. Please use language version 'preview' or greater.
                 "CS8957", // error CS8957: Conditional expression is not valid in language version '8.0' because a common type was not found between 'int' and '<null>'. To use a target-typed conversion, upgrade to language version '9.0' or greater.
+                "CS8967", // error CS8967: Newlines inside a non-verbatim interpolated string are not supported in C# 8.0. Please use language version preview or greater.	ClassLibrary1	C:\github\repo_find_refs\ClassLibrary1\TestClass.cs	6	Active
             });
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/57154