### PR TITLE
Update hosted VS 2017 usage to 2019

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -284,7 +284,7 @@ stages:
       dependsOn:
         - OfficialBuild
       pool:
-        vmImage: vs2017-win2016
+        vmImage: windows-2019
 
 - stage: insert
   dependsOn:

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.1.21103.13",
+    "version": "6.0.100-preview.3.21202.5",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.1.21103.13",
+    "dotnet": "6.0.100-preview.3.21202.5",
     "vs": {
       "version": "16.8"
     },


### PR DESCRIPTION
The windows-2016 environment is deprecated and will be removed on March 15, 2022. For more details, see https://github.com/actions/virtual-environments/issues/4312