### PR TITLE
Call InitializeTelemetrySession on background thread

### DIFF
--- a/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
+++ b/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.VisualStudio.Shell;
 
@@ -23,9 +24,9 @@ namespace Microsoft.VisualStudio.LanguageServices
         private IGlobalOperationNotificationService _notificationService;
         private readonly Dictionary<string, GlobalOperationRegistration> _operations = new();
 
-        public SolutionEventMonitor(VisualStudioWorkspace workspace)
+        public SolutionEventMonitor(HostWorkspaceServices services)
         {
-            if (workspace.Services.GetService<IGlobalOperationNotificationService>() is GlobalOperationNotificationService notificationService)
+            if (services.GetService<IGlobalOperationNotificationService>() is GlobalOperationNotificationService notificationService)
             {
                 // subscribe to events only if it is normal service. if it is one from unit test or other, don't bother to subscribe
                 _notificationService = notificationService;


### PR DESCRIPTION
Fixes [AB#1449211](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1449211).

InitializeTelemetrySession accessed options which triggered assembly load that caused deadlock.

As per [AB#296981](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/296981), the `TelemetryService.DefaultSession` property must be accessed on UI thread but the rest of Roslyn telemetry service initialization can be run on background thread. 