### PR TITLE
Implement GetTypesByMetadataName

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -3281,7 +3281,7 @@ public class C {}
             var current = CreateEmptyCompilation(@"", new[] { corlibReference });
             current.VerifyDiagnostics();
 
-            var type = current.GetTypeByMetadataName("C");
+            var type = ((Compilation)current).GetTypeByMetadataName("C");
             Assert.NotNull(type);
 
             var corlibAssembly = current.GetAssemblyOrModuleSymbol(corlibReference).GetPublicSymbol();
@@ -3308,7 +3308,7 @@ namespace System
             var current = CreateEmptyCompilation(@"", new[] { otherReference, corlibReference });
             current.VerifyDiagnostics();
 
-            var type = current.GetTypeByMetadataName("C");
+            var type = ((Compilation)current).GetTypeByMetadataName("C");
             Assert.Null(type);
         }
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1033,8 +1033,6 @@ namespace Microsoft.CodeAnalysis
         /// those that can only be referenced via an extern alias) using its canonical CLR metadata name.
         /// This lookup follows the following order:
         /// <list type="number">
-        /// </list>
-        /// <list type="number">
         /// <item><description>If the type is found in the compilation's assembly, that type is returned.</description></item>
         /// <item><description>Next the core library (the library that defines <c>System.Object</c> is searched. If the type is found there, that type is returned.</description></item>
         /// <item><description>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1051,7 +1051,7 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Gets all types with the compilation's assembly and all referenced assemblies that have the
-        /// given canonical CLR metadta name.
+        /// given canonical CLR metadata name.
         /// </summary>
         /// <returns>Empty array if no types match. Otherwise, all types that match the name, current assembly first if present.</returns>
         public ImmutableArray<INamedTypeSymbol> GetTypesByMetadataName(string fullyQualifiedMetadataName)

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1034,7 +1034,7 @@ namespace Microsoft.CodeAnalysis
         /// This lookup follows the following order:
         /// <list type="number">
         /// <item><description>If the type is found in the compilation's assembly, that type is returned.</description></item>
-        /// <item><description>Next the core library (the library that defines <c>System.Object</c> is searched. If the type is found there, that type is returned.</description></item>
+        /// <item><description>Next, the core library (the library that defines <c>System.Object</c>) is searched. If the type is found there, that type is returned.</description></item>
         /// <item><description>
         /// Finally, all remaining referenced assemblies are searched. If one and only one type matching the provided metadata name is found, that
         /// single type is returned. Accessibility is ignored for this check.
@@ -1045,7 +1045,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// Since VB does not have the concept of extern aliases, it considers all referenced assemblies.
         /// <br/>
-        /// Because accessibility to the current assembly is ignored when searching for types that match the provided metadata name, this means if multiple referenced
+        /// Because accessibility to the current assembly is ignored when searching for types that match the provided metadata name, if multiple referenced
         /// assemblies define the same type symbol (as often happens when users copy well-known types from the BCL or other sources) then this API will return null,
         /// even if all but one of those symbols would be otherwise inaccessible to user-written code in the current assembly. If it is not an error for a type to exist
         /// in multiple referenced assemblies, consider using <see cref="GetTypesByMetadataName(string)" /> instead and filtering the results for the symbol required.

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -9,6 +9,7 @@ const Microsoft.CodeAnalysis.WellKnownGeneratorOutputs.ImplementationSourceOutpu
 const Microsoft.CodeAnalysis.WellKnownGeneratorOutputs.SourceOutput = "SourceOutput" -> string!
 const Microsoft.CodeAnalysis.WellKnownMemberNames.PrintMembersMethodName = "PrintMembers" -> string!
 Microsoft.CodeAnalysis.Compilation.EmitDifference(Microsoft.CodeAnalysis.Emit.EmitBaseline! baseline, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Emit.SemanticEdit>! edits, System.Func<Microsoft.CodeAnalysis.ISymbol!, bool>! isAddedSymbol, System.IO.Stream! metadataStream, System.IO.Stream! ilStream, System.IO.Stream! pdbStream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.Emit.EmitDifferenceResult!
+Microsoft.CodeAnalysis.Compilation.GetTypesByMetadataName(string! fullyQualifiedMetadataName) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol!>
 Microsoft.CodeAnalysis.Emit.EmitDifferenceResult.ChangedTypes.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.TypeDefinitionHandle>
 Microsoft.CodeAnalysis.Emit.EmitDifferenceResult.UpdatedMethods.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.Metadata.MethodDefinitionHandle>
 Microsoft.CodeAnalysis.Emit.SemanticEditKind.Replace = 4 -> Microsoft.CodeAnalysis.Emit.SemanticEditKind

--- a/src/Compilers/VisualBasic/Test/Symbol/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/CompilationAPITests.vb
@@ -1,0 +1,176 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
+
+    Public Class CompilationAPITests
+        Inherits BasicTestBase
+
+        <Fact()>
+        Public Sub GetTypesByMetadtaName_NotInSourceNotInReferences()
+            Dim comp = CreateCompilation("")
+            comp.AssertNoDiagnostics()
+
+            Dim types = comp.GetTypesByMetadataName("N.C`1")
+            Assert.Empty(types)
+        End Sub
+
+        <Theory, CombinatorialData>
+        Public Sub GetTypesByMetadtaName_SingleInSourceNotInReferences(useMetadataReferences As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+            Dim referenceComp = CreateCompilation("")
+
+            Dim source =
+$"Namespace N
+    {accessibility} Class C(Of T)
+    End Class
+End Namespace"
+
+            Dim comp = CreateCompilation(source, {If(useMetadataReferences, referenceComp.ToMetadataReference(), referenceComp.EmitToImageReference())})
+            comp.AssertNoDiagnostics()
+
+            Dim types = comp.GetTypesByMetadataName("N.C`1")
+
+            Assert.Single(types)
+            AssertEx.Equal("N.C(Of T)", types(0).ToTestDisplayString())
+        End Sub
+
+        <Theory, CombinatorialData>
+        Public Sub GetTypesByMetadtaName_MultipleInSourceNotInReferences(useMetadataReferences As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+            Dim referenceComp = CreateCompilation("")
+
+            Dim source =
+$"Namespace N
+    {accessibility} Class C(Of T)
+    End Class
+    {accessibility} Class C(Of T)
+    End Class
+End Namespace"
+
+            Dim comp = CreateCompilation(source, {If(useMetadataReferences, referenceComp.ToMetadataReference(), referenceComp.EmitToImageReference())})
+            comp.AssertTheseDiagnostics(
+<expected>
+BC30179: class 'C' and class 'C' conflict in namespace 'N'.
+    <%= accessibility %> Class C(Of T)
+                 ~
+</expected>)
+
+            Dim types = comp.GetTypesByMetadataName("N.C`1")
+
+            Assert.Single(types)
+            AssertEx.Equal("N.C(Of T)", types(0).ToTestDisplayString())
+            Assert.Equal(2, types(0).Locations.Length)
+        End Sub
+
+        <Theory, CombinatorialData>
+        Public Sub GetTypesByMetadtaName_SingleInSourceSingleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+            Dim source =
+$"Namespace N
+    {accessibility} Class C(Of T)
+    End Class
+End Namespace"
+
+            Dim referenceComp = CreateCompilation(source)
+            Dim comp = CreateCompilation(source, {If(useMetadataReference, referenceComp.ToMetadataReference(), referenceComp.EmitToImageReference())})
+            comp.AssertNoDiagnostics()
+
+            Dim types = comp.GetTypesByMetadataName("N.C`1")
+
+            Assert.Equal(2, types.Length)
+            AssertEx.Equal("N.C(Of T)", types(0).ToTestDisplayString())
+            Assert.Same(comp.Assembly, types(0).ContainingAssembly)
+            AssertEx.Equal("N.C(Of T)", types(1).ToTestDisplayString())
+            If (useMetadataReference) Then
+                Assert.Same(referenceComp.Assembly, types(1).ContainingAssembly)
+            Else
+                Assert.False(types(1).IsInSource())
+            End If
+        End Sub
+
+        <Theory, CombinatorialData>
+        Public Sub GetTypesByMetadtaName_NotInSourceSingleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+            Dim source =
+$"Namespace N
+    {accessibility} Class C(Of T)
+    End Class
+End Namespace"
+
+            Dim referenceComp = CreateCompilation(source)
+            Dim comp = CreateCompilation("", {GetReference(useMetadataReference, referenceComp)})
+            comp.AssertNoDiagnostics()
+
+            Dim types = comp.GetTypesByMetadataName("N.C`1")
+
+            Assert.Single(types)
+            AssertEx.Equal("N.C(Of T)", types(0).ToTestDisplayString())
+            If (useMetadataReference) Then
+                Assert.Same(referenceComp.Assembly, types(0).ContainingAssembly)
+            Else
+                Assert.False(types(0).IsInSource())
+            End If
+        End Sub
+
+        Private Shared Function GetReference(useMetadataReference As Boolean, referenceComp As VisualBasicCompilation) As MetadataReference
+            Return If(useMetadataReference, referenceComp.ToMetadataReference(), referenceComp.EmitToImageReference())
+        End Function
+
+        <Theory, CombinatorialData>
+        Public Sub GetTypesByMetadtaName_NotInSourceMultipleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+            Dim source =
+$"Namespace N
+    {accessibility} Class C(Of T)
+    End Class
+End Namespace"
+
+            Dim referenceComp1 = CreateCompilation(source)
+            Dim referenceComp2 = CreateCompilation(source)
+            Dim comp = CreateCompilation("", {GetReference(useMetadataReference, referenceComp1), GetReference(useMetadataReference, referenceComp2)})
+            comp.AssertNoDiagnostics()
+
+            Dim types = comp.GetTypesByMetadataName("N.C`1")
+
+            Assert.Equal(2, types.Length)
+            AssertEx.Equal("N.C(Of T)", types(0).ToTestDisplayString())
+            AssertEx.Equal("N.C(Of T)", types(1).ToTestDisplayString())
+            If (useMetadataReference) Then
+                Assert.Same(referenceComp1.Assembly, types(0).ContainingAssembly)
+                Assert.Same(referenceComp2.Assembly, types(1).ContainingAssembly)
+            Else
+                Assert.False(types(0).IsInSource())
+                Assert.False(types(1).IsInSource())
+            End If
+        End Sub
+
+        <Theory, CombinatorialData>
+        Public Sub GetTypesByMetadtaName_SingleInSourceMultipleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+            Dim source =
+$"Namespace N
+    {accessibility} Class C(Of T)
+    End Class
+End Namespace"
+
+            Dim referenceComp1 = CreateCompilation(source)
+            Dim referenceComp2 = CreateCompilation(source)
+            Dim comp = CreateCompilation(source, {GetReference(useMetadataReference, referenceComp1), GetReference(useMetadataReference, referenceComp2)})
+            comp.AssertNoDiagnostics()
+
+            Dim types = comp.GetTypesByMetadataName("N.C`1")
+
+            Assert.Equal(3, types.Length)
+            AssertEx.Equal("N.C(Of T)", types(0).ToTestDisplayString())
+            Assert.Same(comp.Assembly, types(0).ContainingAssembly)
+            AssertEx.Equal("N.C(Of T)", types(1).ToTestDisplayString())
+            AssertEx.Equal("N.C(Of T)", types(2).ToTestDisplayString())
+            If (useMetadataReference) Then
+                Assert.Same(referenceComp1.Assembly, types(1).ContainingAssembly)
+                Assert.Same(referenceComp2.Assembly, types(2).ContainingAssembly)
+            Else
+                Assert.False(types(1).IsInSource())
+                Assert.False(types(2).IsInSource())
+            End If
+        End Sub
+    End Class
+End Namespace

--- a/src/Compilers/VisualBasic/Test/Symbol/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/CompilationAPITests.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         Inherits BasicTestBase
 
         <Fact()>
-        Public Sub GetTypesByMetadtaName_NotInSourceNotInReferences()
+        Public Sub GetTypesByMetadataName_NotInSourceNotInReferences()
             Dim comp = CreateCompilation("")
             comp.AssertNoDiagnostics()
 
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         End Sub
 
         <Theory, CombinatorialData>
-        Public Sub GetTypesByMetadtaName_SingleInSourceNotInReferences(useMetadataReferences As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+        Public Sub GetTypesByMetadataName_SingleInSourceNotInReferences(useMetadataReferences As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
             Dim referenceComp = CreateCompilation("")
 
             Dim source =
@@ -39,7 +39,7 @@ End Namespace"
         End Sub
 
         <Theory, CombinatorialData>
-        Public Sub GetTypesByMetadtaName_MultipleInSourceNotInReferences(useMetadataReferences As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+        Public Sub GetTypesByMetadataName_MultipleInSourceNotInReferences(useMetadataReferences As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
             Dim referenceComp = CreateCompilation("")
 
             Dim source =
@@ -66,7 +66,7 @@ BC30179: class 'C' and class 'C' conflict in namespace 'N'.
         End Sub
 
         <Theory, CombinatorialData>
-        Public Sub GetTypesByMetadtaName_SingleInSourceSingleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+        Public Sub GetTypesByMetadataName_SingleInSourceSingleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
             Dim source =
 $"Namespace N
     {accessibility} Class C(Of T)
@@ -90,7 +90,7 @@ End Namespace"
         End Sub
 
         <Theory, CombinatorialData>
-        Public Sub GetTypesByMetadtaName_NotInSourceSingleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+        Public Sub GetTypesByMetadataName_NotInSourceSingleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
             Dim source =
 $"Namespace N
     {accessibility} Class C(Of T)
@@ -116,7 +116,7 @@ End Namespace"
         End Function
 
         <Theory, CombinatorialData>
-        Public Sub GetTypesByMetadtaName_NotInSourceMultipleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+        Public Sub GetTypesByMetadataName_NotInSourceMultipleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
             Dim source =
 $"Namespace N
     {accessibility} Class C(Of T)
@@ -150,7 +150,7 @@ End Namespace"
         End Sub
 
         <Theory, CombinatorialData>
-        Public Sub GetTypesByMetadtaName_SingleInSourceMultipleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
+        Public Sub GetTypesByMetadataName_SingleInSourceMultipleInReferences(useMetadataReference As Boolean, <CombinatorialValues("Public", "Friend")> accessibility As String)
             Dim source =
 $"Namespace N
     {accessibility} Class C(Of T)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/CompilationExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/CompilationExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal static class CompilationExtensions
@@ -33,42 +35,33 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         /// <returns>The symbol to use for code analysis; otherwise, <see langword="null"/>.</returns>
         public static INamedTypeSymbol? GetBestTypeByMetadataName(this Compilation compilation, string fullyQualifiedMetadataName)
         {
-            // Try to get the unique type with this name, ignoring accessibility
-            var type = compilation.GetTypeByMetadataName(fullyQualifiedMetadataName);
+            INamedTypeSymbol? type = null;
 
-            // Otherwise, try to get the unique type with this name originally defined in 'compilation'
-            type ??= compilation.Assembly.GetTypeByMetadataName(fullyQualifiedMetadataName);
-
-            // Otherwise, try to get the unique accessible type with this name from a reference
-            if (type is null)
+            foreach (var currentType in compilation.GetTypesByMetadataName(fullyQualifiedMetadataName))
             {
-                foreach (var module in compilation.Assembly.Modules)
+                if (ReferenceEquals(currentType.ContainingAssembly, compilation.Assembly))
                 {
-                    foreach (var referencedAssembly in module.ReferencedAssemblySymbols)
-                    {
-                        var currentType = referencedAssembly.GetTypeByMetadataName(fullyQualifiedMetadataName);
-                        if (currentType is null)
-                            continue;
-
-                        switch (currentType.GetResultantVisibility())
-                        {
-                            case Utilities.SymbolVisibility.Public:
-                            case Utilities.SymbolVisibility.Internal when referencedAssembly.GivesAccessTo(compilation.Assembly):
-                                break;
-
-                            default:
-                                continue;
-                        }
-
-                        if (type is object)
-                        {
-                            // Multiple visible types with the same metadata name are present
-                            return null;
-                        }
-
-                        type = currentType;
-                    }
+                    Debug.Assert(type is null);
+                    return currentType;
                 }
+
+                switch (currentType.GetResultantVisibility())
+                {
+                    case Utilities.SymbolVisibility.Public:
+                    case Utilities.SymbolVisibility.Internal when currentType.ContainingAssembly.GivesAccessTo(compilation.Assembly):
+                        break;
+
+                    default:
+                        continue;
+                }
+
+                if (type is object)
+                {
+                    // Multiple visible types with the same metadata name are present
+                    return null;
+                }
+
+                type = currentType;
             }
 
             return type;


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/57802. Implements the GetTypesByMetadataName API, which returns all named types in the current compilation and referenced assemblies that match the given CLR metatdata name. Also updates the IDE's GetBestTypeByMetadataName to use this API under the hood, rather than the existing manual walk they were doing, simplyfing that codepath and proving out the API itself.
