### PR TITLE
Inline Diagnostics Multi-Line Error Bug

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
                 }
 
                 // Need to get the SnapshotPoint to be able to get the IWpfTextViewLine
-                var point = tagMappingSpan.Span.Start.GetPoint(TextView.TextSnapshot, PositionAffinity.Predecessor);
+                var point = tagMappingSpan.Span.End.GetPoint(TextView.TextSnapshot, PositionAffinity.Predecessor);
                 if (point == null)
                 {
                     continue;


### PR DESCRIPTION
Creates a point using the end of the span instead of the start to not interfere in the multi-line error case.

![image](https://user-images.githubusercontent.com/40616383/146613682-81fa1299-5dda-4cfe-a0d2-07990edc9b6f.png)

to

<img width="752" alt="image" src="https://user-images.githubusercontent.com/40616383/146613904-132c1bdf-84e5-4823-a3fc-ff09de3d5d5b.png">
