### PR TITLE
Possible change to remove fading entirely from previews

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
         /// </summary>
         /// <param name="diagnosticData">the diagnostic containing the location(s).</param>
         /// <returns>an array of locations that should have the tag applied.</returns>
-        protected internal virtual ImmutableArray<DiagnosticDataLocation> GetLocationsToTag(DiagnosticData diagnosticData)
+        protected internal virtual ImmutableArray<DiagnosticDataLocation> GetLocationsToTag(DiagnosticData diagnosticData, Workspace workspace)
             => diagnosticData.DataLocation is object ? ImmutableArray.Create(diagnosticData.DataLocation) : ImmutableArray<DiagnosticDataLocation>.Empty;
 
         protected override Task ProduceTagsAsync(
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                         //    So we'll eventually reach a point where the diagnostics exactly match the
                         //    editorSnapshot.
 
-                        var diagnosticSpans = this.GetLocationsToTag(diagnosticData)
+                        var diagnosticSpans = this.GetLocationsToTag(diagnosticData, workspace)
                             .Select(location => GetDiagnosticSnapshotSpan(location, diagnosticSnapshot, editorSnapshot, sourceText));
                         foreach (var diagnosticSpan in diagnosticSpans)
                         {

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
@@ -67,8 +67,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
         protected internal override ITagSpan<ClassificationTag> CreateTagSpan(Workspace workspace, bool isLiveUpdate, SnapshotSpan span, DiagnosticData data)
             => new TagSpan<ClassificationTag>(span, _classificationTag);
 
-        protected internal override ImmutableArray<DiagnosticDataLocation> GetLocationsToTag(DiagnosticData diagnosticData)
+        protected internal override ImmutableArray<DiagnosticDataLocation> GetLocationsToTag(DiagnosticData diagnosticData, Workspace workspace)
         {
+            if (!workspace.CurrentSolution.Options.GetOption(Fading.FadingOptions.AllFadingEnabled))
+            {
+                return base.GetLocationsToTag(diagnosticData, workspace);
+            }
+
             // If there are 'unnecessary' locations specified in the property bag, use those instead of the main diagnostic location.
             if (diagnosticData.AdditionalLocations.Length > 0
                 && diagnosticData.Properties != null
@@ -84,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             }
 
             // Default to the base implementation for the diagnostic data
-            return base.GetLocationsToTag(diagnosticData);
+            return base.GetLocationsToTag(diagnosticData, workspace);
 
             static IEnumerable<int> GetLocationIndices(string indicesProperty)
             {

--- a/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
             : base(solution.Workspace.Services.HostServices, WorkspaceKind.Preview)
         {
             var oldSolution = this.CurrentSolution;
-            var newSolution = this.SetCurrentSolution(solution);
+            var newSolution = this.SetCurrentSolution(solution.WithOptions(solution.Options.WithChangedOption(Fading.FadingOptions.AllFadingEnabled, false)));
 
             this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.SolutionChanged, oldSolution, newSolution);
         }

--- a/src/Features/Core/Portable/Fading/FadingOptions.cs
+++ b/src/Features/Core/Portable/Fading/FadingOptions.cs
@@ -24,7 +24,8 @@ namespace Microsoft.CodeAnalysis.Fading
 
             ImmutableArray<IOption> IOptionProvider.Options { get; } = ImmutableArray.Create<IOption>(
                 FadeOutUnusedImports,
-                FadeOutUnreachableCode);
+                FadeOutUnreachableCode,
+                AllFadingEnabled);
         }
 
         private const string FeatureName = "FadingOptions";
@@ -36,5 +37,8 @@ namespace Microsoft.CodeAnalysis.Fading
         public static readonly PerLanguageOption2<bool> FadeOutUnreachableCode = new(
             FeatureName, "FadeOutUnreachableCode", defaultValue: true,
             storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.FadeOutUnreachableCode"));
+
+        public static readonly Option2<bool> AllFadingEnabled = new(
+            FeatureName, "AllFadingEnabled", defaultValue: true);
     }
 }


### PR DESCRIPTION
Fixes #58400 

This adds an option that is not persisted so the diagnostic tagger knows never to fade for unused code. 