### PR TITLE
Try to find a test that fails when GetProjectStateDiagnosticsAsync changes

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -203,15 +203,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 if (documentId != null)
                 {
-                    // file doesn't exist in current solution
-                    var document = project.Solution.GetDocument(documentId);
-                    if (document == null)
-                    {
-                        return ImmutableArray<DiagnosticData>.Empty;
-                    }
-
-                    var result = await state.GetAnalysisDataAsync(document, avoidLoadingData: false, cancellationToken).ConfigureAwait(false);
-                    return result.GetDocumentDiagnostics(documentId, kind);
+                    // Try to find a test that fails from this change
+                    return ImmutableArray<DiagnosticData>.Empty;
                 }
 
                 Contract.ThrowIfFalse(kind == AnalysisKind.NonLocal);


### PR DESCRIPTION
I need to update tests for #58363 but can't find a test that depends on correct behavior in this block of code. Hopefully CI can point me in the right direction.