### PR TITLE
Clear prior build errors for additional and analyzer config docs at s…

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -383,7 +383,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             }
 
             // Remove all document errors
-            foreach (var documentId in project.DocumentIds)
+            foreach (var documentId in project.DocumentIds.Concat(project.AdditionalDocumentIds).Concat(project.AnalyzerConfigDocumentIds))
             {
                 ClearBuildOnlyDocumentErrors(solution, projectId, documentId);
             }


### PR DESCRIPTION
…tart of build

Fixes [AB#1424584](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1424584)

The primary issue is that the lingering compiler warning CS0169 from prior solution snapshot is reported in `Index.razor`, which is an Additional document, not a regular source document. Existing code in clearing build diagnostics at start of a build was only clearing diagnostics with location in source documents. Doing the same for additional documents fixes this issue.