### PR TITLE
IDE change to handle /warnaserror with Warning analyzer bulk configur…

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticDescriptorExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticDescriptorExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                  reportDiagnostic == ReportDiagnostic.Default))
             {
                 if (analyzerConfigOptions.Value.TreeOptions.TryGetValue(descriptor.Id, out reportDiagnostic) && reportDiagnostic != ReportDiagnostic.Default ||
-                    TryGetSeverityFromBulkConfiguration(descriptor, analyzerConfigOptions.Value, out reportDiagnostic))
+                    TryGetSeverityFromBulkConfiguration(descriptor, compilationOptions, analyzerConfigOptions.Value, out reportDiagnostic))
                 {
                     Debug.Assert(reportDiagnostic != ReportDiagnostic.Default);
                     effectiveSeverity = reportDiagnostic;
@@ -144,6 +144,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         /// </summary>
         private static bool TryGetSeverityFromBulkConfiguration(
             DiagnosticDescriptor descriptor,
+            CompilationOptions compilationOptions,
             AnalyzerConfigOptionsResult analyzerConfigOptions,
             out ReportDiagnostic severity)
         {
@@ -166,6 +167,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (analyzerConfigOptions.AnalyzerOptions.TryGetValue(categoryBasedKey, out var value) &&
                 EditorConfigSeverityStrings.TryParse(value, out severity))
             {
+                // '/warnaserror' should bump Warning bulk configuration to Error.
+                if (severity == ReportDiagnostic.Warn && compilationOptions.GeneralDiagnosticOption == ReportDiagnostic.Error)
+                    severity = ReportDiagnostic.Error;
+
                 return true;
             }
 
@@ -174,6 +179,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (analyzerConfigOptions.AnalyzerOptions.TryGetValue(DotnetAnalyzerDiagnosticSeverityKey, out value) &&
                 EditorConfigSeverityStrings.TryParse(value, out severity))
             {
+                // '/warnaserror' should bump Warning bulk configuration to Error.
+                if (severity == ReportDiagnostic.Warn && compilationOptions.GeneralDiagnosticOption == ReportDiagnostic.Error)
+                    severity = ReportDiagnostic.Error;
+
                 return true;
             }
 


### PR DESCRIPTION
…ation in editorconfig

Underlying issue: #55541
Corresponding batch compiler fix: #58460
This change fixes the code that computes effective severity for Analyzers node. We also need to update the code that computes effective severity for EditorConfig UX, I will file a separate issue for the same.

NOTE: We have #52720 to track avoiding code duplication for computing effective severity between EditorConfig UX and other parts of the IDE