### PR TITLE
Fix event hookup at the end of a document

### DIFF
--- a/src/EditorFeatures/CSharp/EventHookup/EventHookupSessionManager.cs
+++ b/src/EditorFeatures/CSharp/EventHookup/EventHookupSessionManager.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
             if (_toolTipPresenter == null &&
                 CurrentSession == analyzedSession &&
                 caretPoint.HasValue &&
-                analyzedSession.TrackingSpan.GetSpan(CurrentSession.TextView.TextSnapshot).Contains(caretPoint.Value))
+                IsCaretWithinSpanOrAtEnd(analyzedSession.TrackingSpan, analyzedSession.TextView.TextSnapshot, caretPoint.Value))
             {
                 // Create a tooltip presenter that stays alive, even when the user types, without tracking the mouse.
                 _toolTipPresenter = _toolTipService.CreatePresenter(analyzedSession.TextView,
@@ -78,6 +78,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
                 analyzedSession.TextView.Caret.PositionChanged += Caret_PositionChanged;
                 CurrentSession.Dismissed += () => { analyzedSession.TextView.Caret.PositionChanged -= Caret_PositionChanged; };
             }
+        }
+
+        private static bool IsCaretWithinSpanOrAtEnd(ITrackingSpan trackingSpan, ITextSnapshot textSnapshot, SnapshotPoint caretPoint)
+        {
+            var snapshotSpan = trackingSpan.GetSpan(textSnapshot);
+
+            // If the caret is within the span, then we want to show the tooltip
+            if (snapshotSpan.Contains(caretPoint))
+            {
+                return true;
+            }
+
+            // Otherwise if the span is empty, and at the end of the file, and the caret
+            // is also at the end of the file, then show the tooltip.
+            if (snapshotSpan.IsEmpty &&
+                snapshotSpan.Start.Position == caretPoint.Position &&
+                caretPoint.Position == textSnapshot.Length)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         internal void BeginSession(

--- a/src/EditorFeatures/CSharp/EventHookup/EventHookupSessionManager_EventHookupSession.cs
+++ b/src/EditorFeatures/CSharp/EventHookup/EventHookupSessionManager_EventHookupSession.cs
@@ -114,7 +114,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.EventHookup
                 {
                     var position = textView.GetCaretPoint(subjectBuffer).Value.Position;
                     _trackingPoint = textView.TextSnapshot.CreateTrackingPoint(position, PointTrackingMode.Negative);
-                    _trackingSpan = textView.TextSnapshot.CreateTrackingSpan(new Span(position, 1), SpanTrackingMode.EdgeInclusive);
+
+                    // If the caret is at the end of the document we just create an empty span
+                    var length = textView.TextSnapshot.Length > position + 1 ? 1 : 0;
+                    _trackingSpan = textView.TextSnapshot.CreateTrackingSpan(new Span(position, length), SpanTrackingMode.EdgeInclusive);
 
                     var asyncToken = asyncListener.BeginAsyncOperation(GetType().Name + ".Start");
 

--- a/src/EditorFeatures/CSharpTest/EventHookup/EventHookupCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EventHookup/EventHookupCommandHandlerTests.cs
@@ -1049,6 +1049,37 @@ void CurrentDomain_UnhandledException(object sender, System.UnhandledExceptionEv
             testState.AssertCodeIs(expectedCode);
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.EventHookup)]
+        public async Task EventHookupAtEndOfDocument()
+        {
+            var markup = @"
+
+System.AppDomain.CurrentDomain.UnhandledException +$$";
+            using var testState = EventHookupTestState.CreateTestState(markup);
+            testState.SendTypeChar('=');
+
+            await testState.WaitForAsynchronousOperationsAsync();
+            testState.AssertShowing("CurrentDomain_UnhandledException");
+
+            var expectedCode = @"
+
+System.AppDomain.CurrentDomain.UnhandledException +=";
+            testState.AssertCodeIs(expectedCode);
+
+            testState.SendTab();
+            await testState.WaitForAsynchronousOperationsAsync();
+
+            expectedCode = @"
+
+System.AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+
+void CurrentDomain_UnhandledException(object sender, System.UnhandledExceptionEventArgs e)
+{
+    throw new System.NotImplementedException();
+}";
+            testState.AssertCodeIs(expectedCode);
+        }
+
         private static OptionsCollection QualifyMethodAccessWithNotification(NotificationOption2 notification)
             => new OptionsCollection(LanguageNames.CSharp) { { CodeStyleOptions2.QualifyMethodAccess, true, notification } };
     }


### PR DESCRIPTION
Noticed this while reproing https://github.com/dotnet/roslyn/issues/58474

Before:
(note the double equals signs, and no other functionality. I only pressed the equals key once
![PlusEqualsBug](https://user-images.githubusercontent.com/754264/147311959-b0039e63-273a-4189-bd93-9f5471334dc6.gif)

After:
![PlusEqualsFixed](https://user-images.githubusercontent.com/754264/147311965-154909a4-d1e3-44de-8e06-51c231752862.gif)

