### PR TITLE
Enqueue additional and analyzer config documents in WorkCoordinator

### DIFF
--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -335,6 +335,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
 
             Assert.Equal(expectedDocumentEvents, worker.SyntaxDocumentIds.Count);
             Assert.Equal(expectedDocumentEvents, worker.DocumentIds.Count);
+
+            Assert.Equal(1, worker.NonSourceDocumentIds.Count);
         }
 
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
@@ -701,22 +703,26 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
 
             var expectedDocumentSyntaxEvents = 5;
             var expectedDocumentSemanticEvents = 5;
+            var expectedNonSourceDocumentEvents = 1;
 
             var ncfile = DocumentInfo.Create(DocumentId.CreateNewId(project.Id), "D6");
 
             var worker = await ExecuteOperation(workspace, w => w.OnAdditionalDocumentAdded(ncfile));
             Assert.Equal(expectedDocumentSyntaxEvents, worker.SyntaxDocumentIds.Count);
             Assert.Equal(expectedDocumentSemanticEvents, worker.DocumentIds.Count);
+            Assert.Equal(expectedNonSourceDocumentEvents, worker.NonSourceDocumentIds.Count);
 
             worker = await ExecuteOperation(workspace, w => w.ChangeAdditionalDocument(ncfile.Id, SourceText.From("//")));
 
             Assert.Equal(expectedDocumentSyntaxEvents, worker.SyntaxDocumentIds.Count);
             Assert.Equal(expectedDocumentSemanticEvents, worker.DocumentIds.Count);
+            Assert.Equal(expectedNonSourceDocumentEvents, worker.NonSourceDocumentIds.Count);
 
             worker = await ExecuteOperation(workspace, w => w.OnAdditionalDocumentRemoved(ncfile.Id));
 
             Assert.Equal(expectedDocumentSyntaxEvents, worker.SyntaxDocumentIds.Count);
             Assert.Equal(expectedDocumentSemanticEvents, worker.DocumentIds.Count);
+            Assert.Empty(worker.NonSourceDocumentIds);
         }
 
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
@@ -1619,7 +1625,7 @@ class C
             public static readonly IncrementalAnalyzerProviderMetadata Crawler = new IncrementalAnalyzerProviderMetadata(new Dictionary<string, object> { { "WorkspaceKinds", new[] { SolutionCrawlerWorkspaceKind } }, { "HighPriorityForActiveFile", false }, { "Name", "TestAnalyzer" } });
         }
 
-        private class Analyzer : IIncrementalAnalyzer
+        private class Analyzer : IIncrementalAnalyzer2
         {
             public static readonly Option<bool> TestOption = new Option<bool>("TestOptions", "TestOption", defaultValue: true);
 
@@ -1628,6 +1634,7 @@ class C
 
             public readonly HashSet<DocumentId> SyntaxDocumentIds = new HashSet<DocumentId>();
             public readonly HashSet<DocumentId> DocumentIds = new HashSet<DocumentId>();
+            public readonly HashSet<DocumentId> NonSourceDocumentIds = new HashSet<DocumentId>();
             public readonly HashSet<ProjectId> ProjectIds = new HashSet<ProjectId>();
 
             public readonly HashSet<DocumentId> InvalidateDocumentIds = new HashSet<DocumentId>();
@@ -1653,6 +1660,7 @@ class C
 
                 SyntaxDocumentIds.Clear();
                 DocumentIds.Clear();
+                NonSourceDocumentIds.Clear();
                 ProjectIds.Clear();
 
                 InvalidateDocumentIds.Clear();
@@ -1679,6 +1687,12 @@ class C
             {
                 this.SyntaxDocumentIds.Add(document.Id);
                 Process(document.Id, cancellationToken);
+                return Task.CompletedTask;
+            }
+
+            public Task AnalyzeNonSourceDocumentAsync(TextDocument textDocument, InvocationReasons reasons, CancellationToken cancellationToken)
+            {
+                this.NonSourceDocumentIds.Add(textDocument.Id);
                 return Task.CompletedTask;
             }
 
@@ -1731,6 +1745,15 @@ class C
                 => Task.CompletedTask;
 
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            public Task NonSourceDocumentOpenAsync(TextDocument textDocument, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            public Task NonSourceDocumentCloseAsync(TextDocument textDocument, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            public Task NonSourceDocumentResetAsync(TextDocument textDocument, CancellationToken cancellationToken)
                 => Task.CompletedTask;
             #endregion
         }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -474,7 +474,13 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private async Task EnqueueWorkItemAsync(Project project, InvocationReasons invocationReasons)
             {
-                foreach (var documentId in project.DocumentIds.Concat(project.AdditionalDocumentIds).Concat(project.AnalyzerConfigDocumentIds))
+                foreach (var documentId in project.DocumentIds)
+                    await EnqueueWorkItemAsync(project, documentId, document: null, invocationReasons).ConfigureAwait(false);
+
+                foreach (var documentId in project.AdditionalDocumentIds)
+                    await EnqueueWorkItemAsync(project, documentId, document: null, invocationReasons).ConfigureAwait(false);
+
+                foreach (var documentId in project.AnalyzerConfigDocumentIds)
                     await EnqueueWorkItemAsync(project, documentId, document: null, invocationReasons).ConfigureAwait(false);
             }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -439,7 +439,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 _shutdownToken.ThrowIfCancellationRequested();
 
                 var priorityService = project.GetLanguageService<IWorkCoordinatorPriorityService>();
-                var isLowPriority = priorityService != null && await priorityService.IsLowPriorityAsync(GetRequiredDocument(project, documentId, document), _shutdownToken).ConfigureAwait(false);
+                document ??= project.GetDocument(documentId);
+                var isLowPriority = priorityService != null && document != null && await priorityService.IsLowPriorityAsync(document, _shutdownToken).ConfigureAwait(false);
 
                 var currentMember = GetSyntaxPath(changedMember);
 
@@ -473,7 +474,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private async Task EnqueueWorkItemAsync(Project project, InvocationReasons invocationReasons)
             {
-                foreach (var documentId in project.DocumentIds)
+                foreach (var documentId in project.DocumentIds.Concat(project.AdditionalDocumentIds).Concat(project.AnalyzerConfigDocumentIds))
                     await EnqueueWorkItemAsync(project, documentId, document: null, invocationReasons).ConfigureAwait(false);
             }
 


### PR DESCRIPTION
Fixes #53192
Currently, work coordinator only enqueues source document IDs for project analysis work items. This means we don't analyze the additional documents, which can now report standalone diagnostics through RegisterAdditionalFileAction. This PR fixes this by enqueuing project's additional document IDs and analyzer config document IDs.