### PR TITLE
Fix unused param (IDE0060) false positive

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1503,6 +1503,36 @@ class C
 }");
         }
 
+        [WorkItem(56317, "https://github.com/dotnet/roslyn/issues/56317")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task NotImplementedException_NoDiagnostic4()
+        {
+            await TestDiagnosticMissingAsync(
+@"using System;
+
+class C
+{
+    private int Goo(int [|i|])
+        => throw new NotImplementedException();
+}");
+        }
+
+        [WorkItem(56317, "https://github.com/dotnet/roslyn/issues/56317")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task NotImplementedException_NoDiagnostic5()
+        {
+            await TestDiagnosticMissingAsync(
+@"using System;
+
+class C
+{
+    private int Goo(int [|i|])
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
         [WorkItem(41236, "https://github.com/dotnet/roslyn/issues/41236")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
         public async Task NotImplementedException_MultipleStatements1()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/OperationExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/OperationExtensions.cs
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="operation">The starting operation.</param>
         /// <returns>The inner non conversion operation or the starting operation if it wasn't a conversion operation.</returns>
-        public static IOperation WalkDownConversion(this IOperation? operation)
+        public static IOperation? WalkDownConversion(this IOperation? operation)
         {
             while (operation is IConversionOperation conversionOperation)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/OperationExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/OperationExtensions.cs
@@ -370,5 +370,20 @@ namespace Microsoft.CodeAnalysis
 
         public static bool IsNullLiteral(this IOperation operand)
             => operand is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } };
+
+        /// <summary>
+        /// Walks down consecutive conversion operations until an operand is reached that isn't a conversion operation.
+        /// </summary>
+        /// <param name="operation">The starting operation.</param>
+        /// <returns>The inner non conversion operation or the starting operation if it wasn't a conversion operation.</returns>
+        public static IOperation WalkDownConversion(this IOperation? operation)
+        {
+            while (operation is IConversionOperation conversionOperation)
+            {
+                operation = conversionOperation.Operand;
+            }
+
+            return operation;
+        }
     }
 }


### PR DESCRIPTION
Fixes #56317

#42408 handled bailing out reporting unused params for methods that only have a throw operation in its body. It missed a case where the throw might be wrapped within a conversion wrapped within a return operation, which happens when the method returns a non-void type.