### PR TITLE
Avoid duplicate syntax node callbacks for record declarations

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5139,8 +5139,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal abstract override Func<SyntaxNode, bool> GetSyntaxNodesToAnalyzeFilter(SyntaxNode declaredNode, ISymbol declaredSymbol);
-
-        internal override bool IsSynthesizedRecordConstructor(ISymbol symbol) => (symbol as Symbols.PublicModel.MethodSymbol)?.UnderlyingMethodSymbol is SynthesizedRecordConstructor;
+        internal abstract override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode declaredNode, ISymbol declaredSymbol);
 
         protected internal override SyntaxNode GetTopmostNodeForDiagnosticAnalysis(ISymbol symbol, SyntaxNode declaringSyntax)
         {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5140,6 +5140,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal abstract override Func<SyntaxNode, bool> GetSyntaxNodesToAnalyzeFilter(SyntaxNode declaredNode, ISymbol declaredSymbol);
 
+        internal override bool IsSynthesizedRecordConstructor(ISymbol symbol) => symbol is SynthesizedRecordConstructor;
+
         protected internal override SyntaxNode GetTopmostNodeForDiagnosticAnalysis(ISymbol symbol, SyntaxNode declaringSyntax)
         {
             switch (symbol.Kind)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5139,7 +5139,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal abstract override Func<SyntaxNode, bool> GetSyntaxNodesToAnalyzeFilter(SyntaxNode declaredNode, ISymbol declaredSymbol);
-        internal abstract override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode declaredNode, ISymbol declaredSymbol);
+        internal abstract override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode node, ISymbol containingSymbol);
 
         protected internal override SyntaxNode GetTopmostNodeForDiagnosticAnalysis(ISymbol symbol, SyntaxNode declaringSyntax)
         {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5140,7 +5140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal abstract override Func<SyntaxNode, bool> GetSyntaxNodesToAnalyzeFilter(SyntaxNode declaredNode, ISymbol declaredSymbol);
 
-        internal override bool IsSynthesizedRecordConstructor(ISymbol symbol) => symbol is SynthesizedRecordConstructor;
+        internal override bool IsSynthesizedRecordConstructor(ISymbol symbol) => (symbol as Symbols.PublicModel.MethodSymbol)?.UnderlyingMethodSymbol is SynthesizedRecordConstructor;
 
         protected internal override SyntaxNode GetTopmostNodeForDiagnosticAnalysis(ISymbol symbol, SyntaxNode declaringSyntax)
         {

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -2352,6 +2352,11 @@ foundParent:;
             throw ExceptionUtilities.Unreachable;
         }
 
+        internal override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode declaredNode, ISymbol declaredSymbol)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// The incremental binder is used when binding statements. Whenever a statement
         /// is bound, it checks the bound node cache to see if that statement was bound, 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -2352,9 +2352,9 @@ foundParent:;
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode declaredNode, ISymbol declaredSymbol)
+        internal override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode node, ISymbol containingSymbol)
         {
-            throw new NotImplementedException();
+            throw ExceptionUtilities.Unreachable;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -2528,5 +2528,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return null;
         }
+
+        internal override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode declaredNode, ISymbol declaredSymbol)
+        {
+            // Skip the topmost record declaration syntax node when analyzing synthesized record declaration constructor
+            // to avoid duplicate syntax node callbacks.
+            // We will analyze this node when analyzing the record declaration type symbol.
+            if (declaredNode.Kind() is SyntaxKind.RecordDeclaration or SyntaxKind.RecordStructDeclaration &&
+                declaredSymbol.GetSymbol() is SynthesizedRecordConstructor)
+            {
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -2529,13 +2529,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode declaredNode, ISymbol declaredSymbol)
+        internal override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode node, ISymbol containingSymbol)
         {
             // Skip the topmost record declaration syntax node when analyzing synthesized record declaration constructor
             // to avoid duplicate syntax node callbacks.
             // We will analyze this node when analyzing the record declaration type symbol.
-            if (declaredNode.Kind() is SyntaxKind.RecordDeclaration or SyntaxKind.RecordStructDeclaration &&
-                declaredSymbol.GetSymbol() is SynthesizedRecordConstructor)
+            if (node is RecordDeclarationSyntax && containingSymbol.Kind is SymbolKind.Method)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -5680,7 +5680,6 @@ class Attr1 : System.Attribute {}
 
             Assert.Equal(1, analyzer.FireCount0);
             Assert.Equal(1, analyzer.FireCountRecordStructDeclarationA);
-            Assert.Equal(1, analyzer.FireCountRecordStructDeclarationACtor);
             Assert.Equal(1, analyzer.FireCount3);
             Assert.Equal(1, analyzer.FireCountSimpleBaseTypeI1onA);
             Assert.Equal(1, analyzer.FireCount5);
@@ -5697,7 +5696,6 @@ class Attr1 : System.Attribute {}
         {
             public int FireCount0;
             public int FireCountRecordStructDeclarationA;
-            public int FireCountRecordStructDeclarationACtor;
             public int FireCount3;
             public int FireCountSimpleBaseTypeI1onA;
             public int FireCount5;
@@ -5812,9 +5810,6 @@ class Attr1 : System.Attribute {}
                 {
                     case "A":
                         Interlocked.Increment(ref FireCountRecordStructDeclarationA);
-                        break;
-                    case "A..ctor([System.Int32 X = 0])":
-                        Interlocked.Increment(ref FireCountRecordStructDeclarationACtor);
                         break;
                     default:
                         Assert.True(false);
@@ -6390,7 +6385,6 @@ interface I1 {}
 
             Assert.Equal(1, analyzer.FireCount0);
             Assert.Equal(0, analyzer.FireCountRecordStructDeclarationA);
-            Assert.Equal(0, analyzer.FireCountRecordStructDeclarationACtor);
             Assert.Equal(1, analyzer.FireCount3);
             Assert.Equal(0, analyzer.FireCountSimpleBaseTypeI1onA);
             Assert.Equal(1, analyzer.FireCount5);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -26281,11 +26281,9 @@ class Attr3 : System.Attribute {}
             Assert.Equal(1, analyzer.FireCount7);
             Assert.Equal(1, analyzer.FireCount8);
             Assert.Equal(1, analyzer.FireCount9);
-            Assert.Equal(1, analyzer.FireCount10);
             Assert.Equal(1, analyzer.FireCount11);
             Assert.Equal(1, analyzer.FireCount12);
             Assert.Equal(1, analyzer.FireCount13);
-            Assert.Equal(1, analyzer.FireCount14);
             Assert.Equal(1, analyzer.FireCount15);
             Assert.Equal(1, analyzer.FireCount16);
             Assert.Equal(1, analyzer.FireCount17);
@@ -26317,11 +26315,9 @@ class Attr3 : System.Attribute {}
             public int FireCount7;
             public int FireCount8;
             public int FireCount9;
-            public int FireCount10;
             public int FireCount11;
             public int FireCount12;
             public int FireCount13;
-            public int FireCount14;
             public int FireCount15;
             public int FireCount16;
             public int FireCount17;
@@ -26483,9 +26479,6 @@ class Attr3 : System.Attribute {}
 
                 switch (context.ContainingSymbol.ToTestDisplayString())
                 {
-                    case "B..ctor([System.Int32 Y = 1])":
-                        Interlocked.Increment(ref FireCount10);
-                        break;
                     case "B":
                         Interlocked.Increment(ref FireCount11);
                         break;
@@ -26494,9 +26487,6 @@ class Attr3 : System.Attribute {}
                         break;
                     case "C":
                         Interlocked.Increment(ref FireCount13);
-                        break;
-                    case "A..ctor([System.Int32 X = 0])":
-                        Interlocked.Increment(ref FireCount14);
                         break;
                     default:
                         Assert.True(false);
@@ -27543,11 +27533,9 @@ interface I1 {}
             Assert.Equal(1, analyzer.FireCount7);
             Assert.Equal(0, analyzer.FireCount8);
             Assert.Equal(1, analyzer.FireCount9);
-            Assert.Equal(0, analyzer.FireCount10);
             Assert.Equal(0, analyzer.FireCount11);
             Assert.Equal(0, analyzer.FireCount12);
             Assert.Equal(0, analyzer.FireCount13);
-            Assert.Equal(0, analyzer.FireCount14);
             Assert.Equal(1, analyzer.FireCount15);
             Assert.Equal(1, analyzer.FireCount16);
             Assert.Equal(0, analyzer.FireCount17);

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -882,7 +882,7 @@ namespace Microsoft.CodeAnalysis
         /// <see cref="ShouldSkipSyntaxNodeAnalysis(SyntaxNode, ISymbol)"/>.
         /// </summary>
         internal virtual Func<SyntaxNode, bool>? GetSyntaxNodesToAnalyzeFilter(SyntaxNode declaredNode, ISymbol declaredSymbol) => null;
-        
+
         /// <summary>
         /// Determines if the given syntax node with the given containing symbol should be analyzed or not.
         /// Note that only the given syntax node will be filtered out from analysis, this API will be invoked separately

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -875,6 +875,8 @@ namespace Microsoft.CodeAnalysis
 
         internal virtual Func<SyntaxNode, bool>? GetSyntaxNodesToAnalyzeFilter(SyntaxNode declaredNode, ISymbol declaredSymbol) => null;
 
+        internal abstract bool IsSynthesizedRecordConstructor(ISymbol symbol);
+
         /// <summary>
         /// Takes a Symbol and syntax for one of its declaring syntax reference and returns the topmost syntax node to be used by syntax analyzer.
         /// </summary>

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -873,8 +873,23 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal abstract void ComputeDeclarationsInNode(SyntaxNode node, ISymbol associatedSymbol, bool getSymbol, ArrayBuilder<DeclarationInfo> builder, CancellationToken cancellationToken, int? levelsToCompute = null);
 
+        /// <summary>
+        /// Gets a filter that determines whether or not a given syntax node and its descendants should be analyzed for the given
+        /// declared node and declared symbol. We have scenarios where certain syntax nodes declare multiple symbols,
+        /// for example record declarations, and we want to avoid duplicate syntax node callbacks for such nodes.
+        /// Note that the predicate returned by this method filters out both the node and all its descendants from analysis.
+        /// If you wish to skip analysis just for a specific node, but not its descendants, then add the required logic in
+        /// <see cref="ShouldSkipSyntaxNodeAnalysis(SyntaxNode, ISymbol)"/>.
+        /// </summary>
         internal virtual Func<SyntaxNode, bool>? GetSyntaxNodesToAnalyzeFilter(SyntaxNode declaredNode, ISymbol declaredSymbol) => null;
-        internal virtual bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode declaredNode, ISymbol declaredSymbol) => false;
+        
+        /// <summary>
+        /// Determines if the given syntax node with the given containing symbol should be analyzed or not.
+        /// Note that only the given syntax node will be filtered out from analysis, this API will be invoked separately
+        /// for each of its descendants. If you wish to skip analysis of the node and all its descendants, then add the required
+        /// logic to <see cref="GetSyntaxNodesToAnalyzeFilter(SyntaxNode, ISymbol)"/>.
+        /// </summary>
+        internal virtual bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode node, ISymbol containingSymbol) => false;
 
         /// <summary>
         /// Takes a Symbol and syntax for one of its declaring syntax reference and returns the topmost syntax node to be used by syntax analyzer.

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -874,8 +874,7 @@ namespace Microsoft.CodeAnalysis
         internal abstract void ComputeDeclarationsInNode(SyntaxNode node, ISymbol associatedSymbol, bool getSymbol, ArrayBuilder<DeclarationInfo> builder, CancellationToken cancellationToken, int? levelsToCompute = null);
 
         internal virtual Func<SyntaxNode, bool>? GetSyntaxNodesToAnalyzeFilter(SyntaxNode declaredNode, ISymbol declaredSymbol) => null;
-
-        internal abstract bool IsSynthesizedRecordConstructor(ISymbol symbol);
+        internal virtual bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode declaredNode, ISymbol declaredSymbol) => false;
 
         /// <summary>
         /// Takes a Symbol and syntax for one of its declaring syntax reference and returns the topmost syntax node to be used by syntax analyzer.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2824,6 +2824,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel semanticModel,
             AnalyzerExecutor analyzerExecutor)
         {
+            // Skip syntax nodes when analyzing record declaration constructor to avoid duplicate syntax node callbacks.
+            // We will analyze these nodes while analyzing the record declaration type symbol.
+            if (declaredSymbol is IMethodSymbol method &&
+                method.ContainingType.IsRecord &&
+                method.MethodKind == MethodKind.Constructor)
+            {
+                return ImmutableArray<SyntaxNode>.Empty;
+            }
+
             // Eliminate descendant member declarations within declarations.
             // There will be separate symbols declared for the members.
             HashSet<SyntaxNode>? descendantDeclsToSkip = null;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2865,48 +2865,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             Func<SyntaxNode, bool>? additionalFilter = semanticModel.GetSyntaxNodesToAnalyzeFilter(declaredNode, declaredSymbol);
+            bool shouldAddNode(SyntaxNode node) => (descendantDeclsToSkip == null || !descendantDeclsToSkip.Contains(node)) && (additionalFilter is null || additionalFilter(node));
             var nodeBuilder = ArrayBuilder<SyntaxNode>.GetInstance();
-            foreach (var node in declaredNode.DescendantNodesAndSelf(descendIntoChildren, descendIntoTrivia: true))
+            foreach (var node in declaredNode.DescendantNodesAndSelf(descendIntoChildren: shouldAddNode, descendIntoTrivia: true))
             {
-                // Skip nodes in descendantDeclsToSkip.
-                if (descendantDeclsToSkip?.Contains(node) == true)
-                    continue;
-
-                if (shouldSkipNodeAndDescendants(node))
+                if (shouldAddNode(node) &&
+                    !semanticModel.ShouldSkipSyntaxNodeAnalysis(node, declaredSymbol) &&
+                    (!isPartialDeclAnalysis || analysisScope.ShouldAnalyze(node)))
                 {
-                    // Add child nodes to descendantDeclsToSkip to ensure nodes descendants are also skipped.
-                    descendantDeclsToSkip ??= new HashSet<SyntaxNode>();
-                    foreach (var childNode in node.ChildNodes())
-                        descendantDeclsToSkip.Add(childNode);
-
-                    continue;
+                    nodeBuilder.Add(node);
                 }
-
-                // Skip analysis of declared node if required.
-                // NOTE: This filter does not skip descendants.
-                if (node == declaredNode && semanticModel.ShouldSkipSyntaxNodeAnalysis(declaredNode, declaredSymbol))
-                    continue;
-
-                nodeBuilder.Add(node);
             }
 
             return nodeBuilder.ToImmutableAndFree();
-
-            bool descendIntoChildren(SyntaxNode node) =>
-                descendantDeclsToSkip is null || !descendantDeclsToSkip.Contains(node);
-
-            bool shouldSkipNodeAndDescendants(SyntaxNode node)
-            {
-                // Skip node and descendants by applying language specific additional filter.
-                if (additionalFilter is not null && !additionalFilter(node))
-                    return true;
-
-                // Skip node and descendants if we are doing partial analysis and the current node is outside the analysis scope.
-                if (isPartialDeclAnalysis && !analysisScope.ShouldAnalyze(node))
-                    return true;
-
-                return false;
-            }
         }
 
         private static bool IsEquivalentSymbol(ISymbol declaredSymbol, ISymbol? otherSymbol)

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -3425,6 +3425,11 @@ _Default:
             VisualBasicDeclarationComputer.ComputeDeclarationsInNode(Me, node, getSymbol, builder, cancellationToken)
         End Sub
 
+        Friend Overrides Function IsSynthesizedRecordConstructor(symbol As ISymbol) As Boolean
+            ' VB does not support records.
+            Return False
+        End Function
+
         Protected Overrides Function GetTopmostNodeForDiagnosticAnalysis(symbol As ISymbol, declaringSyntax As SyntaxNode) As SyntaxNode
             Select Case symbol.Kind
                 Case SymbolKind.Namespace

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -3425,11 +3425,6 @@ _Default:
             VisualBasicDeclarationComputer.ComputeDeclarationsInNode(Me, node, getSymbol, builder, cancellationToken)
         End Sub
 
-        Friend Overrides Function IsSynthesizedRecordConstructor(symbol As ISymbol) As Boolean
-            ' VB does not support records.
-            Return False
-        End Function
-
         Protected Overrides Function GetTopmostNodeForDiagnosticAnalysis(symbol As ISymbol, declaringSyntax As SyntaxNode) As SyntaxNode
             Select Case symbol.Kind
                 Case SymbolKind.Namespace


### PR DESCRIPTION
Fixes #53136

Verified that the added unit test fails with duplicate diagnostics before the product fix.