### PR TITLE
Avoid duplicate syntax node callbacks for record declarations

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -2451,27 +2451,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         switch (declaredSymbol.Kind)
                         {
-                            case SymbolKind.Method:
-                                Debug.Assert((object)declaredSymbol.GetSymbol() == (object)ctor);
-                                return (node) =>
-                                       {
-                                           // Accept only nodes that either match, or above/below of a 'parameter list'/'base arguments list'.
-                                           if (node.Parent == recordDeclaration)
-                                           {
-                                               return node == recordDeclaration.ParameterList || node == recordDeclaration.BaseList;
-                                           }
-                                           else if (node.Parent is BaseListSyntax baseList)
-                                           {
-                                               return node == recordDeclaration.PrimaryConstructorBaseTypeIfClass;
-                                           }
-                                           else if (node.Parent is PrimaryConstructorBaseTypeSyntax baseType && baseType == recordDeclaration.PrimaryConstructorBaseTypeIfClass)
-                                           {
-                                               return node == baseType.ArgumentList;
-                                           }
-
-                                           return true;
-                                       };
-
                             case SymbolKind.NamedType:
                                 Debug.Assert((object)declaredSymbol.GetSymbol() == (object)ctor.ContainingSymbol);
                                 // Accept nodes that do not match a 'parameter list'/'base arguments list'.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2824,6 +2824,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel semanticModel,
             AnalyzerExecutor analyzerExecutor)
         {
+            // Skip syntax nodes when analyzing record declaration constructor to avoid duplicate syntax node callbacks.
+            // We will analyze these nodes while analyzing the record declaration type symbol.
+            if (declaredSymbol is IMethodSymbol method &&
+                method.ContainingType.IsRecord &&
+                method.MethodKind == MethodKind.Constructor)
+            {
+                return ImmutableArray<SyntaxNode>.Empty;
+            }
+
             // Eliminate descendant member declarations within declarations.
             // There will be separate symbols declared for the members.
             HashSet<SyntaxNode>? descendantDeclsToSkip = null;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2824,15 +2824,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel semanticModel,
             AnalyzerExecutor analyzerExecutor)
         {
-            // Skip syntax nodes when analyzing record declaration constructor to avoid duplicate syntax node callbacks.
-            // We will analyze these nodes while analyzing the record declaration type symbol.
-            if (declaredSymbol is IMethodSymbol method &&
-                method.ContainingType.IsRecord &&
-                method.MethodKind == MethodKind.Constructor)
-            {
-                return ImmutableArray<SyntaxNode>.Empty;
-            }
-
             // Eliminate descendant member declarations within declarations.
             // There will be separate symbols declared for the members.
             HashSet<SyntaxNode>? descendantDeclsToSkip = null;


### PR DESCRIPTION
My trial to fix #53136 (related to #58482)

Let's see if any tests will fail in CI

cc @mavasani