### PR TITLE
Allow valid metadata name characters in source generator hint names

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/AdditionalSourcesCollectionTests.cs
@@ -15,7 +15,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
 using Xunit;
+
 namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 {
     public class AdditionalSourcesCollectionTests
@@ -24,6 +26,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [Theory]
         [InlineData("abc")] // abc.cs
         [InlineData("abc.cs")] //abc.cs
+        [InlineData("abc+nested.cs")] //abc+nested.cs
+        [InlineData("abc`1.cs")] //abc`1.cs
         [InlineData("abc.vb")] // abc.vb.cs
         [InlineData("abc.generated.cs")]
         [InlineData("abc_-_")]
@@ -32,6 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
         [InlineData("abc(1).cs")]
         [InlineData("abc[1].cs")]
         [InlineData("abc{1}.cs")]
+        [WorkItem(58476, "https://github.com/dotnet/roslyn/issues/58476")]
         public void HintName_ValidValues(string hintName)
         {
             AdditionalSourcesCollection asc = new AdditionalSourcesCollection(".cs");

--- a/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(hintName));
             }
 
-            // allow any identifier character or [.,-_ ()[]{}]
+            // allow any identifier character or [.,-+`_ ()[]{}]
             for (int i = 0; i < hintName.Length; i++)
             {
                 char c = hintName[i];
@@ -44,6 +44,8 @@ namespace Microsoft.CodeAnalysis
                     && c != '.'
                     && c != ','
                     && c != '-'
+                    && c != '+'
+                    && c != '`'
                     && c != '_'
                     && c != ' '
                     && c != '('


### PR DESCRIPTION
Fixes #58476