### PR TITLE
Support initializers in semi auto property

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1563,6 +1563,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (accessor.Property.CreateBackingFieldForFieldKeyword() is { } backingField)
                         {
+                            backingField.BoundToFieldKeyword();
                             expression = BindNonMethod(node, backingField, diagnostics, LookupResultKind.Viable, indexed: false, isError: false);
                         }
                     }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -142,8 +142,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Optional data collected during testing only.
         /// Used for instance for nullable analysis (<see cref="NullableWalker.NullableAnalysisData"/>)
-        /// and inferred delegate types (<see cref="InferredDelegateTypeData"/>).
-        /// and semi auto implemented properties (<see cref="SourcePropertySymbolBase.AccessorBindingData"/>
+        /// and inferred delegate types (<see cref="InferredDelegateTypeData"/>)
+        /// and semi auto implemented properties (<see cref="SourcePropertySymbolBase.AccessorBindingData"/>.
         /// </summary>
         internal object? TestOnlyCompilationData;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -36,7 +36,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-
         protected const string DefaultIndexerName = "Item";
 
         /// <summary>
@@ -410,7 +409,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If the backing field is unknown, set it to null.
         /// </summary>
         /// <remarks>
-        /// This should be called only if we're sure the backing field can't be non-null value.
+        /// This should be called only if we're sure the backing field can't become non-null value if it's not already.
         /// </remarks>
         internal void MarkBackingFieldAsCalculated()
         {
@@ -450,7 +449,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // If binding both the getter and setter didn't get a backing field, set it to null so that we don't re-calculate.
-            Interlocked.CompareExchange(ref _lazyBackingFieldSymbol, null, _lazyBackingFieldSymbolSentinel);
+            MarkBackingFieldAsCalculated();
 
             void noteAccessorBinding()
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -414,7 +414,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal void MarkBackingFieldAsCalculated()
         {
             Interlocked.CompareExchange(ref _lazyBackingFieldSymbol, null, _lazyBackingFieldSymbolSentinel);
-            ((SynthesizedBackingFieldSymbol)_lazyBackingFieldSymbol)?.MarkIsBoundToFieldKeywordAsCalculated();
+            // PROTOTYPE(semi-autoprops): Is calling MarkIsBoundToFieldKeywordAsCalculated needed here?
+            ((SynthesizedBackingFieldSymbol?)_lazyBackingFieldSymbol)?.MarkIsBoundToFieldKeywordAsCalculated();
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                               isReadOnly: (HasGetAccessor && !HasSetAccessor) || IsInitOnly,
                                               this.IsStatic,
                                               hasInitializer: (_propertyFlags & Flags.HasInitializer) != 0,
-                                              isCreatedForfieldKeyword: isCreatedForFieldKeyword,
+                                              isCreatedForFieldKeyword: isCreatedForFieldKeyword,
                                               isEarlyConstructed: isEarlyConstructed);
                 Interlocked.CompareExchange(ref _lazyBackingFieldSymbol, backingField, _lazyBackingFieldSymbolSentinel);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Emit;
@@ -18,11 +19,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class SynthesizedBackingFieldSymbol : FieldSymbolWithAttributesAndModifiers
     {
+        [Flags]
+        private enum Flags
+        {
+            HasInitializer = 1 << 0,
+            IsCreatedForFieldKeyword = 1 << 1,
+            IsEarlyConstructed = 1 << 2,
+        }
+
         private readonly SourcePropertySymbolBase _property;
         private readonly string _name;
-        internal bool HasInitializer { get; }
-        internal bool IsCreatedForFieldKeyword { get; }
-        internal bool IsEarlyConstructed { get; }
+        private readonly Flags _backingFieldFlags;
+
+        internal bool HasInitializer => (_backingFieldFlags & Flags.HasInitializer) != 0;
+        internal bool IsCreatedForFieldKeyword => (_backingFieldFlags & Flags.IsCreatedForFieldKeyword) != 0;
+        internal bool IsEarlyConstructed => (_backingFieldFlags & Flags.IsEarlyConstructed) != 0;
+
         protected override DeclarationModifiers Modifiers { get; }
 
         public SynthesizedBackingFieldSymbol(
@@ -43,9 +55,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 (isStatic ? DeclarationModifiers.Static : DeclarationModifiers.None);
 
             _property = property;
-            HasInitializer = hasInitializer;
-            IsCreatedForFieldKeyword = isCreatedForfieldKeyword;
-            IsEarlyConstructed = isEarlyConstructed;
+            if (hasInitializer)
+            {
+                _backingFieldFlags |= Flags.HasInitializer;
+            }
+
+            if (isCreatedForfieldKeyword)
+            {
+                _backingFieldFlags |= Flags.IsCreatedForFieldKeyword;
+            }
+
+
+            if (isEarlyConstructed)
+            {
+                _backingFieldFlags |= Flags.IsEarlyConstructed;
+            }
 
             // If it's not early constructed, it must have been created for field keyword.
             Debug.Assert(IsEarlyConstructed || IsCreatedForFieldKeyword);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool isReadOnly,
             bool isStatic,
             bool hasInitializer,
-            bool isCreatedForfieldKeyword,
+            bool isCreatedForFieldKeyword,
             bool isEarlyConstructed)
         {
             Debug.Assert(!string.IsNullOrEmpty(name));
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _backingFieldFlags |= Flags.HasInitializer;
             }
 
-            if (isCreatedForfieldKeyword)
+            if (isCreatedForFieldKeyword)
             {
                 _backingFieldFlags |= Flags.IsCreatedForFieldKeyword;
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PropertyFieldKeywordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PropertyFieldKeywordTests.cs
@@ -382,11 +382,11 @@ public class C
 ").VerifyDiagnostics();
             VerifyTypeIL(comp, "C", @"
 .class public auto ansi beforefieldinit C
-	extends [netstandard]System.Object
+	extends [mscorlib]System.Object
 {
 	// Fields
 	.field private int32 '<P>k__BackingField'
-	.custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+	.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
 		01 00 00 00
 	)
 	// Methods
@@ -422,7 +422,7 @@ public class C
 		IL_0001: ldc.i4.s 10
 		IL_0003: stfld int32 C::'<P>k__BackingField'
 		IL_0008: ldarg.0
-		IL_0009: call instance void [netstandard]System.Object::.ctor()
+		IL_0009: call instance void [mscorlib]System.Object::.ctor()
 		IL_000e: ret
 	} // end of method C::.ctor
 	// Properties
@@ -638,11 +638,11 @@ public class C
 ").VerifyDiagnostics();
             VerifyTypeIL(comp, "C", @"
     .class public auto ansi beforefieldinit C
-	extends [netstandard]System.Object
+	extends [mscorlib]System.Object
 {
 	// Fields
 	.field private int32 '<P>k__BackingField'
-	.custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+	.custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
 		01 00 00 00
 	)
 	// Methods
@@ -676,7 +676,7 @@ public class C
 		IL_0001: ldc.i4.s 10
 		IL_0003: stfld int32 C::'<P>k__BackingField'
 		IL_0008: ldarg.0
-		IL_0009: call instance void [netstandard]System.Object::.ctor()
+		IL_0009: call instance void [mscorlib]System.Object::.ctor()
 		IL_000e: ret
 	} // end of method C::.ctor
 	// Properties


### PR DESCRIPTION
@AlekseyTs I interpreted https://github.com/dotnet/roslyn/pull/57076#issuecomment-1001802053 as "let's start reviewing API usages"

This PR is currently focused on usages of `IsAutoProperty`, specifically adjusting the `CheckInitializer` call.

This caused the number of accessor binding to change in some cases. I can't think of a way that we can reduce the number back.

I didn't continue reviewing other API usages to keep the PR more focused and minimal as possible.

Test plan: https://github.com/dotnet/roslyn/issues/57012
Proposal: https://github.com/dotnet/csharplang/issues/140