### PR TITLE
Make sure Index and Range are acceptable before offering refactorings

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.InfoCache.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.InfoCache.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             public static bool TryCreate(Compilation compilation, [NotNullWhen(true)] out InfoCache? infoCache)
             {
                 var indexType = compilation.GetBestTypeByMetadataName("System.Index");
-                if (indexType == null)
+                if (indexType == null || !indexType.IsAccessibleWithin(compilation.Assembly))
                 {
                     infoCache = null;
                     return false;

--- a/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.InfoCache.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.InfoCache.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             public static bool TryCreate(Compilation compilation, [NotNullWhen(true)] out InfoCache? infoCache)
             {
                 var rangeType = compilation.GetBestTypeByMetadataName("System.Range");
-                if (rangeType == null)
+                if (rangeType == null || !rangeType.IsAccessibleWithin(compilation.Assembly))
                 {
                     infoCache = null;
                     return false;

--- a/src/Analyzers/CSharp/Tests/UseIndexOrRangeOperator/UseIndexOperatorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseIndexOrRangeOperator/UseIndexOperatorTests.cs
@@ -511,6 +511,43 @@ class C
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp20,
                 TestCode = source,
                 FixedCode = source,
+                LanguageVersion = LanguageVersion.CSharp8,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIndexOperator)]
+        public async Task TestMissingWithInaccessibleSystemIndex()
+        {
+            var source =
+@"
+class C
+{
+    void Goo(string[] s)
+    {
+        var v = s[s.Length - 1];
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp20,
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalProjects =
+                    {
+                        ["AdditionalProject"] =
+                        {
+                            Sources =
+                            {
+                                "namespace System { internal struct Index { } }"
+                            }
+                        }
+                    },
+                    AdditionalProjectReferences = { "AdditionalProject" },
+                },
+                FixedCode = source,
+                LanguageVersion = LanguageVersion.CSharp8,
             }.RunAsync();
         }
 

--- a/src/Analyzers/CSharp/Tests/UseIndexOrRangeOperator/UseRangeOperatorTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseIndexOrRangeOperator/UseRangeOperatorTests.cs
@@ -94,7 +94,43 @@ class C
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp20,
                 TestCode = source,
                 FixedCode = source,
-                LanguageVersion = LanguageVersion.CSharp7,
+                LanguageVersion = LanguageVersion.CSharp8,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseRangeOperator)]
+        public async Task TestNotWithInaccessibleSystemRange()
+        {
+            var source =
+@"
+class C
+{
+    void Goo(string s)
+    {
+        var v = s.Substring(1, s.Length - 1);
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp20,
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalProjects =
+                    {
+                        ["AdditionalProject"] =
+                        {
+                            Sources =
+                            {
+                                "namespace System { internal struct Range { } }"
+                            }
+                        }
+                    },
+                    AdditionalProjectReferences = { "AdditionalProject" },
+                },
+                FixedCode = source,
+                LanguageVersion = LanguageVersion.CSharp8,
             }.RunAsync();
         }
 


### PR DESCRIPTION
Fixes an issue where downstream code referencing Microsoft.CodeAnalysis offers the Use Range Syntax refactoring even though the types defined in Roslyn are `internal`.