### PR TITLE
MemberSemanticModel - special case binding CompilationUnit for a simple program.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -9590,7 +9590,7 @@ var x = 1;
 
         [Fact]
         [WorkItem(58521, "https://github.com/dotnet/roslyn/issues/58521")]
-        public void Issue58521()
+        public void BindCompilationUnitInSemanticModelWhenLocalFunctionIsAtTheTop()
         {
             var source = @"
 void F<T>(T t)
@@ -9602,7 +9602,6 @@ void F<T>(T t)
             var tree = compilation.SyntaxTrees[0];
             var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().First(id => id.Identifier.Text == "var");
             var model = compilation.GetSemanticModel(tree);
-            var anonymousType = model.GetSymbolInfo(identifier).Symbol.GetSymbol<TypeSymbol>();
 
             model.GetOperation(identifier);
             Assert.Equal(OperationKind.Literal, model.GetOperation(tree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().Single()).Kind);


### PR DESCRIPTION
Fixes #58521.