### PR TITLE
CodeFixContext cleanup

### DIFF
--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateDeconstructMethodCodeFixProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateDeconstructMethod
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             // Not supported in REPL
-            if (context.Project.IsSubmission)
+            if (context.Document.Project.IsSubmission)
             {
                 return;
             }

--- a/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/CodeFixService.cs
@@ -510,9 +510,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                         }
                     }
                 },
-                verifyArguments: false,
                 isBlocking,
-                cancellationToken: cancellationToken);
+                cancellationToken);
 
             var task = fixer.RegisterCodeFixesAsync(context) ?? Task.CompletedTask;
             await task.ConfigureAwait(false);
@@ -781,7 +780,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                         fixes.Add(new CodeFix(document.Project, action, applicableDiagnostics));
                     }
                 },
-                verifyArguments: false,
                 cancellationToken: cancellationToken);
 
             var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();

--- a/src/Features/Core/Portable/CodeFixes/GenerateMember/AbstractGenerateMemberCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/GenerateMember/AbstractGenerateMemberCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.GenerateMember
         {
             // TODO: https://github.com/dotnet/roslyn/issues/5777
             // Not supported in REPL for now.
-            if (context.Project.IsSubmission)
+            if (context.Document.Project.IsSubmission)
             {
                 return;
             }

--- a/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             var projectDiagnostics = diagnostics.Where(d => !d.Location.IsInSource).ToImmutableArray();
             if (!projectDiagnostics.IsEmpty)
             {
-                var suppressionFixes = await _suppressionFixProvider.GetFixesAsync(context.Project, projectDiagnostics, context.CancellationToken).ConfigureAwait(false);
+                var suppressionFixes = await _suppressionFixProvider.GetFixesAsync(context.Document.Project, projectDiagnostics, context.CancellationToken).ConfigureAwait(false);
                 RegisterSuppressionFixes(context, suppressionFixes);
             }
         }

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -15,33 +16,27 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     /// <summary>
     /// Context for code fixes provided by a <see cref="CodeFixProvider"/>.
     /// </summary>
-    public struct CodeFixContext : ITypeScriptCodeFixContext
+    public readonly struct CodeFixContext : ITypeScriptCodeFixContext
     {
         private readonly Document _document;
-        private readonly Project _project;
         private readonly TextSpan _span;
         private readonly ImmutableArray<Diagnostic> _diagnostics;
         private readonly CancellationToken _cancellationToken;
         private readonly Action<CodeAction, ImmutableArray<Diagnostic>> _registerCodeFix;
 
         /// <summary>
-        /// Document corresponding to the <see cref="CodeFixContext.Span"/> to fix.
+        /// Document corresponding to the <see cref="Span"/> to fix.
         /// </summary>
         public Document Document => _document;
 
         /// <summary>
-        /// Project corresponding to the diagnostics to fix.
-        /// </summary>
-        internal Project Project => _project;
-
-        /// <summary>
-        /// Text span within the <see cref="CodeFixContext.Document"/> to fix.
+        /// Text span within the <see cref="Document"/> to fix.
         /// </summary>
         public TextSpan Span => _span;
 
         /// <summary>
         /// Diagnostics to fix.
-        /// NOTE: All the diagnostics in this collection have the same <see cref="CodeFixContext.Span"/>.
+        /// NOTE: All the diagnostics in this collection have the same <see cref="Span"/>.
         /// </summary>
         public ImmutableArray<Diagnostic> Diagnostics => _diagnostics;
 
@@ -76,7 +71,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             ImmutableArray<Diagnostic> diagnostics,
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
             CancellationToken cancellationToken)
-            : this(document, span, diagnostics, registerCodeFix, verifyArguments: true, cancellationToken: cancellationToken)
+            : this(document ?? throw new ArgumentNullException(nameof(document)),
+                   span,
+                   VerifyDiagnosticsArgument(diagnostics, span),
+                   registerCodeFix ?? throw new ArgumentNullException(nameof(registerCodeFix)),
+                   isBlocking: false,
+                   cancellationToken)
         {
         }
 
@@ -96,7 +96,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             Diagnostic diagnostic,
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
             CancellationToken cancellationToken)
-            : this(document, diagnostic.Location.SourceSpan, ImmutableArray.Create(diagnostic), registerCodeFix, verifyArguments: true, cancellationToken: cancellationToken)
+            : this(document ?? throw new ArgumentNullException(nameof(document)),
+                   (diagnostic ?? throw new ArgumentNullException(nameof(diagnostic))).Location.SourceSpan,
+                   ImmutableArray.Create(diagnostic),
+                   registerCodeFix ?? throw new ArgumentNullException(nameof(registerCodeFix)),
+                   isBlocking: false,
+                   cancellationToken)
         {
         }
 
@@ -105,67 +110,17 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             TextSpan span,
             ImmutableArray<Diagnostic> diagnostics,
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
-            bool verifyArguments,
-            CancellationToken cancellationToken)
-            : this(document, document.Project, span, diagnostics, registerCodeFix, verifyArguments, isBlocking: false, cancellationToken)
-        {
-        }
-
-        internal CodeFixContext(
-            Document document,
-            TextSpan span,
-            ImmutableArray<Diagnostic> diagnostics,
-            Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
-            bool verifyArguments,
-            bool isBlocking,
-            CancellationToken cancellationToken)
-            : this(document, document.Project, span, diagnostics, registerCodeFix, verifyArguments, isBlocking, cancellationToken)
-        {
-        }
-
-        private CodeFixContext(
-            Document document,
-            Project project,
-            TextSpan span,
-            ImmutableArray<Diagnostic> diagnostics,
-            Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
-            bool verifyArguments,
             bool isBlocking,
             CancellationToken cancellationToken)
         {
-            if (verifyArguments)
-            {
-                if (document == null)
-                {
-                    throw new ArgumentNullException(nameof(document));
-                }
-
-                if (registerCodeFix == null)
-                {
-                    throw new ArgumentNullException(nameof(registerCodeFix));
-                }
-
-                VerifyDiagnosticsArgument(diagnostics, span);
-            }
+            Debug.Assert(diagnostics.Any(d => d.Location.SourceSpan == span));
 
             _document = document;
-            _project = project;
             _span = span;
             _diagnostics = diagnostics;
             _registerCodeFix = registerCodeFix;
-            _cancellationToken = cancellationToken;
-
             _isBlocking = isBlocking;
-        }
-
-        internal CodeFixContext(
-            Document document,
-            Diagnostic diagnostic,
-            Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
-            bool verifyArguments,
-            CancellationToken cancellationToken)
-            : this(document, diagnostic.Location.SourceSpan, ImmutableArray.Create(diagnostic), registerCodeFix, verifyArguments, cancellationToken)
-        {
+            _cancellationToken = cancellationToken;
         }
 
         /// <summary>
@@ -225,14 +180,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             _registerCodeFix(action, diagnostics);
         }
 
-        private static void VerifyDiagnosticsArgument(ImmutableArray<Diagnostic> diagnostics, TextSpan span)
+        private static ImmutableArray<Diagnostic> VerifyDiagnosticsArgument(ImmutableArray<Diagnostic> diagnostics, TextSpan span)
         {
-            if (diagnostics.IsDefault)
-            {
-                throw new ArgumentException(nameof(diagnostics));
-            }
-
-            if (diagnostics.Length == 0)
+            if (diagnostics.IsDefaultOrEmpty)
             {
                 throw new ArgumentException(WorkspacesResources.At_least_one_diagnostic_must_be_supplied, nameof(diagnostics));
             }
@@ -242,10 +192,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 throw new ArgumentException(WorkspaceExtensionsResources.Supplied_diagnostic_cannot_be_null, nameof(diagnostics));
             }
 
-            if (diagnostics.Any(d => d.Location.SourceSpan != span))
+            if (diagnostics.Any((d, span) => d.Location.SourceSpan != span, span))
             {
                 throw new ArgumentException(string.Format(WorkspacesResources.Diagnostic_must_have_span_0, span.ToString()), nameof(diagnostics));
             }
+
+            return diagnostics;
         }
     }
 

--- a/src/Workspaces/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCodeFixContextExtensions.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCodeFixContextExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
+{
+    internal static class VSTypeScriptCodeFixContextExtensions
+    {
+        public static bool IsBlocking(this CodeFixContext context)
+            => ((ITypeScriptCodeFixContext)context).IsBlocking;
+    }
+}


### PR DESCRIPTION
Simplifies CodeFixContext and corrects argument validation in constructors.
Adds TS External Access helper to replace ITypeScriptCodeFixContext.