### PR TITLE
Exclude service config files for .Net 6 host from ServiceHub folder

### DIFF
--- a/src/Setup/DevDivVsix/ServiceHubConfig/Roslyn.VisualStudio.Setup.ServiceHub.csproj
+++ b/src/Setup/DevDivVsix/ServiceHubConfig/Roslyn.VisualStudio.Setup.ServiceHub.csproj
@@ -27,10 +27,11 @@
           Outputs="$(_SwrFilePath)">
 
     <ItemGroup>
+      <!-- We are shipping a copy of config files for Roslyn desktop services in ServiceHub folder, which is to mitigate an issue where the VsixDiscoveryService is 
+           flaky and occasionally not finding the Roslyn services properly. However, we can't do the same for services running on .Net Core host because the config
+           file location is used as default path to resolve service assemblies. -->
       <_ServiceHubConfigFiles Include="@(ServiceHubService)" FileSuffix="64" />
       <_ServiceHubConfigFiles Include="@(ServiceHubService)" FileSuffix="64S" />
-      <_ServiceHubConfigFiles Include="@(ServiceHubService)" FileSuffix="Core64" />
-      <_ServiceHubConfigFiles Include="@(ServiceHubService)" FileSuffix="Core64S" />
       <_FileEntries Include='file source="$(IntermediateOutputPath)%(_ServiceHubConfigFiles.Identity)%(_ServiceHubConfigFiles.FileSuffix).servicehub.service.json"'/>
     </ItemGroup>
 


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1450962

We have been shipping a copy of the service config files in ServiceHub folder as a mitigation for some flakiness issue in ServiceHub. But when we added services for .Net 6 host, their config files can't be copied to a different location from where the actual assemblies are located. Still this didn't become a problem until recently, when a change in ServiceHub causes the config in ServiceHub folder to be preferred over the copy we ship in Roslyn folder (that behavior is reverted in [this PR](https://devdiv.visualstudio.com/DevDiv/_git/DevCore/pullrequest/371351)).

This PR simply exclude service config files for Roslyn's .net 6 services to from being deployed in ServiceHub folder.