### PR TITLE
Simplify WorkCoordinator

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -271,11 +271,21 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         ProcessSolutionEvent(args, eventName);
                         break;
                     case WorkspaceChangeKind.ProjectAdded:
+                        Contract.ThrowIfNull(args.ProjectId);
+                        EnqueueEvent(args.NewSolution, args.ProjectId, InvocationReasons.DocumentAdded, eventName);
+                        break;
+
                     case WorkspaceChangeKind.ProjectChanged:
                     case WorkspaceChangeKind.ProjectReloaded:
-                    case WorkspaceChangeKind.ProjectRemoved:
-                        ProcessProjectEvent(args, eventName);
+                        Contract.ThrowIfNull(args.ProjectId);
+                        EnqueueEvent(args.OldSolution, args.NewSolution, args.ProjectId, eventName);
                         break;
+
+                    case WorkspaceChangeKind.ProjectRemoved:
+                        Contract.ThrowIfNull(args.ProjectId);
+                        EnqueueEvent(args.OldSolution, args.ProjectId, InvocationReasons.DocumentRemoved, eventName);
+                        break;
+
                     case WorkspaceChangeKind.DocumentAdded:
                     case WorkspaceChangeKind.DocumentReloaded:
                     case WorkspaceChangeKind.DocumentChanged:
@@ -338,31 +348,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // If an additional file or .editorconfig has changed we need to reanalyze the entire project.
                         Contract.ThrowIfNull(e.ProjectId);
                         EnqueueEvent(e.NewSolution, e.ProjectId, InvocationReasons.AdditionalDocumentChanged, eventName);
-                        break;
-
-                    default:
-                        throw ExceptionUtilities.UnexpectedValue(e.Kind);
-                }
-            }
-
-            private void ProcessProjectEvent(WorkspaceChangeEventArgs e, string eventName)
-            {
-                switch (e.Kind)
-                {
-                    case WorkspaceChangeKind.ProjectAdded:
-                        Contract.ThrowIfNull(e.ProjectId);
-                        EnqueueEvent(e.NewSolution, e.ProjectId, InvocationReasons.DocumentAdded, eventName);
-                        break;
-
-                    case WorkspaceChangeKind.ProjectRemoved:
-                        Contract.ThrowIfNull(e.ProjectId);
-                        EnqueueEvent(e.OldSolution, e.ProjectId, InvocationReasons.DocumentRemoved, eventName);
-                        break;
-
-                    case WorkspaceChangeKind.ProjectChanged:
-                    case WorkspaceChangeKind.ProjectReloaded:
-                        Contract.ThrowIfNull(e.ProjectId);
-                        EnqueueEvent(e.OldSolution, e.NewSolution, e.ProjectId, eventName);
                         break;
 
                     default:

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -264,12 +264,22 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 switch (args.Kind)
                 {
                     case WorkspaceChangeKind.SolutionAdded:
+                        EnqueueEvent(args.NewSolution, InvocationReasons.DocumentAdded, eventName);
+                        break;
+
                     case WorkspaceChangeKind.SolutionChanged:
                     case WorkspaceChangeKind.SolutionReloaded:
-                    case WorkspaceChangeKind.SolutionRemoved:
-                    case WorkspaceChangeKind.SolutionCleared:
-                        ProcessSolutionEvent(args, eventName);
+                        EnqueueEvent(args.OldSolution, args.NewSolution, eventName);
                         break;
+
+                    case WorkspaceChangeKind.SolutionRemoved:
+                        EnqueueEvent(args.OldSolution, InvocationReasons.SolutionRemoved, eventName);
+                        break;
+
+                    case WorkspaceChangeKind.SolutionCleared:
+                        EnqueueEvent(args.OldSolution, InvocationReasons.DocumentRemoved, eventName);
+                        break;
+
                     case WorkspaceChangeKind.ProjectAdded:
                         Contract.ThrowIfNull(args.ProjectId);
                         EnqueueEvent(args.NewSolution, args.ProjectId, InvocationReasons.DocumentAdded, eventName);
@@ -348,32 +358,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         // If an additional file or .editorconfig has changed we need to reanalyze the entire project.
                         Contract.ThrowIfNull(e.ProjectId);
                         EnqueueEvent(e.NewSolution, e.ProjectId, InvocationReasons.AdditionalDocumentChanged, eventName);
-                        break;
-
-                    default:
-                        throw ExceptionUtilities.UnexpectedValue(e.Kind);
-                }
-            }
-
-            private void ProcessSolutionEvent(WorkspaceChangeEventArgs e, string eventName)
-            {
-                switch (e.Kind)
-                {
-                    case WorkspaceChangeKind.SolutionAdded:
-                        EnqueueEvent(e.NewSolution, InvocationReasons.DocumentAdded, eventName);
-                        break;
-
-                    case WorkspaceChangeKind.SolutionRemoved:
-                        EnqueueEvent(e.OldSolution, InvocationReasons.SolutionRemoved, eventName);
-                        break;
-
-                    case WorkspaceChangeKind.SolutionCleared:
-                        EnqueueEvent(e.OldSolution, InvocationReasons.DocumentRemoved, eventName);
-                        break;
-
-                    case WorkspaceChangeKind.SolutionChanged:
-                    case WorkspaceChangeKind.SolutionReloaded:
-                        EnqueueEvent(e.OldSolution, e.NewSolution, eventName);
                         break;
 
                     default:


### PR DESCRIPTION
Inlining and renaming to improve clarity in WorkCoordinator.

Commit-by-commit may help with the review.