### PR TITLE
Correctly handle null array constants from source and metadata

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -1200,6 +1200,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (constructorArgument.IsNull)
                 {
                     setInterpolatedStringHandlerAttributeError(ref arguments);
+                    // null is not a valid parameter name. To get access to the receiver of an instance method, use the empty string as the parameter name.
+                    diagnostics.Add(ErrorCode.ERR_NullInvalidInterpolatedStringHandlerArgumentName, arguments.AttributeSyntaxOpt!.Location);
                     return;
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -1197,6 +1197,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attributeIndex == 1)
             {
+                if (constructorArgument.IsNull)
+                {
+                    setInterpolatedStringHandlerAttributeError(ref arguments);
+                    return;
+                }
+
                 bool hadError = false;
                 parameters = ArrayBuilder<ParameterSymbol?>.GetInstance(constructorArgument.Values.Length);
                 var ordinalsBuilder = ArrayBuilder<int>.GetInstance(constructorArgument.Values.Length);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -6819,7 +6819,7 @@ End Structure
         [Theory]
         [InlineData(@"$""""")]
         [InlineData(@"$"""" + $""""")]
-        public void InterpolatedStringHandlerArgumentAttributeError_NullConstant(string expression)
+        public void InterpolatedStringHandlerArgumentAttributeError_NullConstant_01(string expression)
         {
             var code = @"
 using System.Runtime.CompilerServices;
@@ -6842,6 +6842,36 @@ class C
                 // (8,34): error CS8943: null is not a valid parameter name. To get access to the receiver of an instance method, use the empty string as the parameter name.
                 //     public static void M(int i, [InterpolatedStringHandlerArgumentAttribute(new string[] { null })] CustomHandler c) {}
                 Diagnostic(ErrorCode.ERR_NullInvalidInterpolatedStringHandlerArgumentName, "InterpolatedStringHandlerArgumentAttribute(new string[] { null })").WithLocation(8, 34)
+            );
+
+            var cParam = comp.SourceModule.GlobalNamespace.GetTypeMember("C").GetMethod("M").Parameters.Skip(1).Single();
+            AssertEx.Equal("System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute",
+                           cParam.GetAttributes().Single().AttributeClass.ToTestDisplayString());
+            Assert.Empty(cParam.InterpolatedStringHandlerArgumentIndexes);
+            Assert.True(cParam.HasInterpolatedStringHandlerArgumentError);
+        }
+
+        [Fact, WorkItem(58025, "https://github.com/dotnet/roslyn/issues/58025")]
+        public void InterpolatedStringHandlerArgumentAttributeError_NullConstant_02()
+        {
+            var code = @"
+using System.Runtime.CompilerServices;
+
+C.M(1, $"""");
+
+class C
+{
+    public static void M(int i, [InterpolatedStringHandlerArgumentAttribute((string[])null)] CustomHandler c) {}
+}
+";
+
+            var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: true);
+
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerArgumentAttribute, handler });
+            comp.VerifyDiagnostics(
+                // (4,8): error CS8949: The InterpolatedStringHandlerArgumentAttribute applied to parameter 'CustomHandler' is malformed and cannot be interpreted. Construct an instance of 'CustomHandler' manually.
+                // C.M(1, $"");
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerArgumentAttributeMalformed, @"$""""").WithArguments("CustomHandler", "CustomHandler").WithLocation(4, 8)
             );
 
             var cParam = comp.SourceModule.GlobalNamespace.GetTypeMember("C").GetMethod("M").Parameters.Skip(1).Single();
@@ -6938,6 +6968,46 @@ End Structure
 Imports System.Runtime.CompilerServices
 Public Class C
     Public Shared Sub M(i As Integer, <InterpolatedStringHandlerArgument(CStr(Nothing))> c As CustomHandler)
+    End Sub
+End Class
+<InterpolatedStringHandler>
+Public Structure CustomHandler
+End Structure
+";
+
+            var vbComp = CreateVisualBasicCompilation(new[] { vbCode, InterpolatedStringHandlerAttributesVB });
+            vbComp.VerifyDiagnostics();
+
+            var comp = CreateCompilation(@"C.M(1, $"""");", references: new[] { vbComp.EmitToImageReference() });
+            comp.VerifyEmitDiagnostics(
+                // (1,8): error CS8949: The InterpolatedStringHandlerArgumentAttribute applied to parameter 'CustomHandler' is malformed and cannot be interpreted. Construct an instance of 'CustomHandler' manually.
+                // C.M(1, $"");
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerArgumentAttributeMalformed, @"$""""").WithArguments("CustomHandler", "CustomHandler").WithLocation(1, 8),
+                // (1,8): error CS1729: 'CustomHandler' does not contain a constructor that takes 2 arguments
+                // C.M(1, $"");
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""""").WithArguments("CustomHandler", "2").WithLocation(1, 8),
+                // (1,8): error CS1729: 'CustomHandler' does not contain a constructor that takes 3 arguments
+                // C.M(1, $"");
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"$""""").WithArguments("CustomHandler", "3").WithLocation(1, 8)
+            );
+
+            var customHandler = comp.GetTypeByMetadataName("CustomHandler");
+            Assert.True(customHandler.IsInterpolatedStringHandlerType);
+
+            var cParam = comp.GetTypeByMetadataName("C").GetMethod("M").Parameters.Skip(1).Single();
+            AssertEx.Equal("System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute",
+                           cParam.GetAttributes().Single().AttributeClass.ToTestDisplayString());
+            Assert.Empty(cParam.InterpolatedStringHandlerArgumentIndexes);
+            Assert.True(cParam.HasInterpolatedStringHandlerArgumentError);
+        }
+
+        [Fact]
+        public void InterpolatedStringHandlerArgumentAttributeError_NullConstant_FromMetadata_04()
+        {
+            var vbCode = @"
+Imports System.Runtime.CompilerServices
+Public Class C
+    Public Shared Sub M(i As Integer, <InterpolatedStringHandlerArgument(DirectCast(Nothing, String()))> c As CustomHandler)
     End Sub
 End Class
 <InterpolatedStringHandler>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -6871,7 +6871,10 @@ class C
             comp.VerifyDiagnostics(
                 // (4,8): error CS8949: The InterpolatedStringHandlerArgumentAttribute applied to parameter 'CustomHandler' is malformed and cannot be interpreted. Construct an instance of 'CustomHandler' manually.
                 // C.M(1, $"");
-                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerArgumentAttributeMalformed, @"$""""").WithArguments("CustomHandler", "CustomHandler").WithLocation(4, 8)
+                Diagnostic(ErrorCode.ERR_InterpolatedStringHandlerArgumentAttributeMalformed, @"$""""").WithArguments("CustomHandler", "CustomHandler").WithLocation(4, 8),
+                // (8,34): error CS8943: null is not a valid parameter name. To get access to the receiver of an instance method, use the empty string as the parameter name.
+                //     public static void M(int i, [InterpolatedStringHandlerArgumentAttribute((string[])null)] CustomHandler c) {}
+                Diagnostic(ErrorCode.ERR_NullInvalidInterpolatedStringHandlerArgumentName, "InterpolatedStringHandlerArgumentAttribute((string[])null)").WithLocation(8, 34)
             );
 
             var cParam = comp.SourceModule.GlobalNamespace.GetTypeMember("C").GetMethod("M").Parameters.Skip(1).Single();

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1940,13 +1940,6 @@ namespace Microsoft.CodeAnalysis
                 return false;
             }
 
-            // II.23.3 says that the length must be a int32 if not null. There can't be negative lengths,
-            // so if it's greater than int.MaxValue then we cannot interpret this array.
-            if (length > int.MaxValue)
-            {
-                throw new BadImageFormatException();
-            }
-
             return true;
         }
 

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1932,7 +1932,7 @@ namespace Microsoft.CodeAnalysis
 
         private static bool ValidateMetadataArrayLength(uint length)
         {
-            // Null arrays are represented in metadata by a length of 0xFFFF_FFFF. See ECMA 335 II.23.2.
+            // Null arrays are represented in metadata by a length of 0xFFFF_FFFF. See ECMA 335 II.23.3.
             const uint NullArray = 0xFFFF_FFFF;
 
             if (length == NullArray)
@@ -1940,7 +1940,7 @@ namespace Microsoft.CodeAnalysis
                 return false;
             }
 
-            // II.23.2 says that the length must be a int32 if not null. There can't be negative lengths,
+            // II.23.3 says that the length must be a int32 if not null. There can't be negative lengths,
             // so if it's greater than int.MaxValue then we cannot interpret this array.
             if (length > int.MaxValue)
             {

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1905,7 +1905,7 @@ namespace Microsoft.CodeAnalysis
             {
                 uint arrayLen = sig.ReadUInt32();
 
-                if (!ValidateMetadataArrayLength(arrayLen))
+                if (IsArrayNull(arrayLen))
                 {
                     value = default;
                     return false;
@@ -1930,17 +1930,17 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
-        private static bool ValidateMetadataArrayLength(uint length)
+        private static bool IsArrayNull(uint length)
         {
             // Null arrays are represented in metadata by a length of 0xFFFF_FFFF. See ECMA 335 II.23.3.
             const uint NullArray = 0xFFFF_FFFF;
 
             if (length == NullArray)
             {
-                return false;
+                return true;
             }
 
-            return true;
+            return false;
         }
 
         internal static bool CrackBoolAndStringArrayInAttributeValue(out BoolAndStringArrayData value, ref BlobReader sig)
@@ -2058,7 +2058,7 @@ namespace Microsoft.CodeAnalysis
             {
                 uint arrayLen = sig.ReadUInt32();
 
-                if (!ValidateMetadataArrayLength(arrayLen))
+                if (IsArrayNull(arrayLen))
                 {
                     value = default;
                     return false;
@@ -2087,7 +2087,7 @@ namespace Microsoft.CodeAnalysis
             {
                 uint arrayLen = sig.ReadUInt32();
 
-                if (!ValidateMetadataArrayLength(arrayLen))
+                if (IsArrayNull(arrayLen))
                 {
                     value = default;
                     return false;

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1209,6 +1209,7 @@ namespace Microsoft.CodeAnalysis
             }
             else if (TryExtractStringArrayValueFromAttribute(targetAttribute.Handle, out var paramNames))
             {
+                Debug.Assert(!paramNames.IsDefault);
                 return (paramNames.NullToEmpty(), true);
             }
 
@@ -1903,18 +1904,21 @@ namespace Microsoft.CodeAnalysis
             if (sig.RemainingBytes >= 4)
             {
                 uint arrayLen = sig.ReadUInt32();
-                var stringArray = new string?[arrayLen];
-                for (int i = 0; i < arrayLen; i++)
+                if (sig.RemainingBytes >= arrayLen)
                 {
-                    if (!CrackStringInAttributeValue(out stringArray[i], ref sig))
+                    var stringArray = new string?[arrayLen];
+                    for (int i = 0; i < arrayLen; i++)
                     {
-                        value = stringArray.AsImmutableOrNull();
-                        return false;
+                        if (!CrackStringInAttributeValue(out stringArray[i], ref sig))
+                        {
+                            value = stringArray.AsImmutableOrNull();
+                            return false;
+                        }
                     }
-                }
 
-                value = stringArray.AsImmutableOrNull();
-                return true;
+                    value = stringArray.AsImmutableOrNull();
+                    return true;
+                }
             }
 
             value = default;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58598. Fixes https://github.com/dotnet/roslyn/issues/58025. Interpolated string handlers were presuming there would never be a null array in source, and we had a general bug with our string array cracking code that assumed arrays from metadata would also never be null.
