### PR TITLE
[LSP] Fix semantic tokens overlap bug

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
@@ -187,7 +188,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 // Therefore, we set both optional parameters to false.
                 var spans = await ClassifierHelper.GetClassifiedSpansAsync(
                     document, textSpan, cancellationToken, removeAdditiveSpans: false, fillInClassifiedSpanGaps: false).ConfigureAwait(false);
-                classifiedSpans.AddRange(spans);
+
+                // The spans returned to us may include some empty spans, which we don't care about.
+                var nonEmptySpans = spans.Where(s => !s.TextSpan.IsEmpty);
+                classifiedSpans.AddRange(nonEmptySpans);
             }
             else
             {

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -358,6 +358,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
             // 3. Token length
             var tokenLength = originalTextSpan.Length;
+            Contract.ThrowIfFalse(tokenLength > 0);
 
             // We currently only have one modifier (static). The logic below will need to change in the future if other
             // modifiers are added in the future.

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
@@ -252,9 +252,9 @@ class C
                 {
                     // Line | Char | Len | Token type                                                                         | Modifier
                        0,     0,     5,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Keyword],                0, // 'using'
-                       0,     6,     6,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Variable],               0, // 'System'
+                       0,     6,     6,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.NamespaceName],         0, // 'System'
                        0,     6,     1,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Operator],               0, // '.'
-                       0,     1,     4,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Variable],               0, // 'Text'
+                       0,     1,     4,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.NamespaceName],         0, // 'Text'
                        0,     4,     1,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Operator],               0, // '.'
                        0,     1,     18,   SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.NamespaceName],         0, // 'RegularExpressions'
                        0,     18,    1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // ';'
@@ -270,7 +270,7 @@ class C
                        0,     4,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.LocalName],             0, // 'x'
                        0,     2,     1,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Operator],               0, // '='
                        0,     2,     3,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Keyword],                0, // 'new'
-                       0,     4,     5,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Variable],               0, // 'Regex'
+                       0,     4,     5,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.ClassName],             0, // 'Regex'
                        0,     5,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // '('
                        0,     1,     8,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.String],                 0, // '"(abc)*"'
                        0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.RegexGrouping],         0, // '('

--- a/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
@@ -198,10 +198,18 @@ namespace Microsoft.CodeAnalysis.Classification
                 // Take the semantic part if it's just 'text'.  We want to keep it if
                 // the semantic classifier actually produced an interesting result 
                 // (as opposed to it just being a 'gap' classification).
-                var part = replacementIndex >= 0 && !IsClassifiedAsText(semanticParts[replacementIndex])
-                    ? semanticParts[replacementIndex]
-                    : syntaxPartAndSpan;
-                finalParts.Add(part);
+                if (replacementIndex >= 0 && !IsClassifiedAsText(semanticParts[replacementIndex]))
+                {
+                    finalParts.Add(semanticParts[replacementIndex]);
+                }
+                // We might already have a semantic part for the given TextSpan, in
+                // which case we don't want to add the syntactic part unless it's a
+                // modifier.
+                else if (finalParts.Count == 0 || !finalParts[^1].TextSpan.Equals(syntaxPartAndSpan.TextSpan) ||
+                    ClassificationTypeNames.AdditiveTypeNames.Contains(syntaxPartAndSpan.ClassificationType))
+                {
+                    finalParts.Add(syntaxPartAndSpan);
+                }
 
                 if (replacementIndex >= 0)
                 {

--- a/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
@@ -203,9 +203,10 @@ namespace Microsoft.CodeAnalysis.Classification
                     finalParts.Add(semanticParts[replacementIndex]);
                 }
                 // We might already have a semantic part for the given TextSpan, in
-                // which case we don't want to add the syntactic part unless it's a
-                // modifier.
-                else if (finalParts.Count == 0 || !finalParts[^1].TextSpan.Equals(syntaxPartAndSpan.TextSpan) ||
+                // which case we don't want to add the syntactic part unless it's an
+                // additive type name (e.g. `static`).
+                else if (finalParts.Count == 0 ||
+                    !finalParts[^1].TextSpan.Equals(syntaxPartAndSpan.TextSpan) ||
                     ClassificationTypeNames.AdditiveTypeNames.Contains(syntaxPartAndSpan.ClassificationType))
                 {
                     finalParts.Add(syntaxPartAndSpan);


### PR DESCRIPTION
I inadvertently introduced a bug in https://github.com/dotnet/roslyn/pull/58238, in which we sometimes return both semantic and syntactic classifications for the same TextSpan. In reality, if there is a semantic classification, it should override the syntactic classification for any matching TextSpan unless the syntactic classification is a modifier (e.g. `static`).

This bug introduced was caught via an assert failure in Razor and is currently breaking semantic tokens on their end.

The existing LSP semantic tokens tests were previously partially incorrect. They have been updated this PR and now have the correct expected results, which should help catch this problem in the future.