### PR TITLE
Fix flaky compiler server test

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/BuildServerController.cs
@@ -151,14 +151,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             return controller.RunServer(pipeName, compilerServerHost, clientConnectionHost, listener, keepAlive, cancellationToken);
         }
 
-        internal int RunShutdown(string pipeName, CancellationToken cancellationToken = default) =>
-            RunShutdownAsync(pipeName, waitForProcess: true, cancellationToken).GetAwaiter().GetResult();
+        internal int RunShutdown(string pipeName, int? timeoutOverride = null, CancellationToken cancellationToken = default) =>
+            RunShutdownAsync(pipeName, waitForProcess: true, timeoutOverride, cancellationToken).GetAwaiter().GetResult();
 
-        internal async Task<int> RunShutdownAsync(string pipeName, bool waitForProcess, CancellationToken cancellationToken = default)
+        internal async Task<int> RunShutdownAsync(string pipeName, bool waitForProcess, int? timeoutOverride, CancellationToken cancellationToken = default)
         {
             var success = await BuildServerConnection.RunServerShutdownRequestAsync(
                 pipeName,
-                timeoutOverride: null,
+                timeoutOverride,
                 waitForProcess: waitForProcess,
                 _logger,
                 cancellationToken).ConfigureAwait(false);

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             private Task<int> RunShutdownAsync(string pipeName, bool waitForProcess = true, CancellationToken cancellationToken = default(CancellationToken))
             {
                 var appSettings = new NameValueCollection();
-                return new BuildServerController(appSettings, Logger).RunShutdownAsync(pipeName, waitForProcess, cancellationToken);
+                return new BuildServerController(appSettings, Logger).RunShutdownAsync(pipeName, waitForProcess, Timeout.Infinite, cancellationToken);
             }
 
             [Fact]


### PR DESCRIPTION
The test failure logs have the following exception:

```
Keep alive timeout is: -1 milliseconds.
Attempt to open named pipe '02ebce08-7'
Attempt to connect named pipe '02ebce08-7'
Error Error: 'TimeoutException' 'The operation has timed out.' occurred during 'Connecting to server timed out after 1000 ms'
Stack trace:
   at System.IO.Pipes.NamedPipeClientStream.ConnectInternal(Int32 timeout, CancellationToken cancellationToken, Int32 startTime)
   at System.IO.Pipes.NamedPipeClientStream.<>c__DisplayClass20_0.<ConnectAsync>b__0()
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__271_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at Microsoft.CodeAnalysis.CommandLine.BuildServerConnection.TryConnectToServerAsync(String pipeName, Int32 timeoutMs, ICompilerServerLogger logger, CancellationToken cancellationToken) in /_/src/Compilers/Shared/BuildServerConnection.cs:line 376
```

That error reveals that the test is using the one second timeout value
for connecting to the server. That is our standard production value but
in test code we need to use `Timeout.Infinite`. The reason is that test
machines can be under load and that can delay the amount of time it
takes for the test to run and can lead to it exceeding the timeout
value.

Fixed the timeout.

closes #57837