### PR TITLE
Fix null reference in SyntaxInputNode

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis
                 if (state == EntryState.Removed)
                 {
                     // mark both syntax *and* transform nodes removed
-                    if(_filterTable.TryRemoveEntries(TimeSpan.Zero, noInputStepsStepInfo, out ImmutableArray<SyntaxNode> removedNodes))
+                    if (_filterTable.TryRemoveEntries(TimeSpan.Zero, noInputStepsStepInfo, out ImmutableArray<SyntaxNode> removedNodes))
                     {
                         for (int i = 0; i < removedNodes.Length; i++)
                         {

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxInputNode.cs
@@ -74,13 +74,13 @@ namespace Microsoft.CodeAnalysis
                 if (state == EntryState.Removed)
                 {
                     // mark both syntax *and* transform nodes removed
-                    _filterTable.TryRemoveEntries(TimeSpan.Zero, noInputStepsStepInfo, out ImmutableArray<SyntaxNode> removedNodes);
-
-                    for (int i = 0; i < removedNodes.Length; i++)
+                    if(_filterTable.TryRemoveEntries(TimeSpan.Zero, noInputStepsStepInfo, out ImmutableArray<SyntaxNode> removedNodes))
                     {
-                        _transformTable.TryRemoveEntries(TimeSpan.Zero, noInputStepsStepInfo);
+                        for (int i = 0; i < removedNodes.Length; i++)
+                        {
+                            _transformTable.TryRemoveEntries(TimeSpan.Zero, noInputStepsStepInfo);
+                        }
                     }
-
                 }
                 else
                 {


### PR DESCRIPTION
Ensure we don't try and remove transform table entries if filter table failed.

Fixes https://github.com/dotnet/roslyn/issues/58647