### PR TITLE
Set the default value of Combine With Indicator Margin to false

### DIFF
--- a/src/EditorFeatures/Core/Shared/Options/FeatureOnOffOptions.cs
+++ b/src/EditorFeatures/Core/Shared/Options/FeatureOnOffOptions.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
             new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowInheritanceMargin"));
 
         public static readonly Option2<bool> InheritanceMarginCombinedWithIndicatorMargin = new(
-            FeatureName, "InheritanceMarginCombinedWithIndicatorMargin", defaultValue: true,
+            FeatureName, "InheritanceMarginCombinedWithIndicatorMargin", defaultValue: false,
             new RoamingProfileStorageLocation("TextEditor.InheritanceMarginCombinedWithIndicatorMargin"));
 
         public static readonly Option2<bool> AutomaticallyCompleteStatementOnSemicolon = new(


### PR DESCRIPTION
Fixes [AB#1450426](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1450426)
There is no good way to handle overlapping glyphs in the editor margin.
So breakpoint could overlap with inheritance margin glyph, so there is no way to set/clear the breakpoint at this time.

This behavior is known so before inheritance margin is enabled I added an option, which can move the inheritance margin glyph to our own margin.

However, many users don't know this option and feel depressed when seeing the overlapping problem.

So this PR set the default value to false in 17.1.
In the future release, also we want to find a better way to let the user could discover this option when click inheritance margin.
