### PR TITLE
Run debug builds for pull requests instead of full pairwise testing

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -15,21 +15,20 @@ pr:
 - demos/*
 
 jobs:
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - job: VS_Integration_Debug_32
-    pool:
-      name: $(poolName)
-      demands: ImageOverride -equals $(queueName)
-    timeoutInMinutes: 135
-    variables:
-      - name: XUNIT_LOGS
-        value: $(Build.SourcesDirectory)\artifacts\log\Debug
-    steps:
-      - template: eng/pipelines/test-integration-job.yml
-        parameters:
-          configuration: Debug
-          oop64bit: false
-          lspEditor: false
+- job: VS_Integration_Debug_32
+  pool:
+    name: $(poolName)
+    demands: ImageOverride -equals $(queueName)
+  timeoutInMinutes: 135
+  variables:
+    - name: XUNIT_LOGS
+      value: $(Build.SourcesDirectory)\artifacts\log\Debug
+  steps:
+    - template: eng/pipelines/test-integration-job.yml
+      parameters:
+        configuration: Debug
+        oop64bit: false
+        lspEditor: false
 
 - job: VS_Integration_Debug_64
   pool:
@@ -46,20 +45,21 @@ jobs:
         oop64bit: true
         lspEditor: false
 
-- job: VS_Integration_Release_32
-  pool:
-    name: $(poolName)
-    demands: ImageOverride -equals $(queueName)
-  timeoutInMinutes: 135
-  variables:
-    - name: XUNIT_LOGS
-      value: $(Build.SourcesDirectory)\artifacts\log\Release
-  steps:
-    - template: eng/pipelines/test-integration-job.yml
-      parameters:
-        configuration: Release
-        oop64bit: false
-        lspEditor: false
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - job: VS_Integration_Release_32
+    pool:
+      name: $(poolName)
+      demands: ImageOverride -equals $(queueName)
+    timeoutInMinutes: 135
+    variables:
+      - name: XUNIT_LOGS
+        value: $(Build.SourcesDirectory)\artifacts\log\Release
+    steps:
+      - template: eng/pipelines/test-integration-job.yml
+        parameters:
+          configuration: Release
+          oop64bit: false
+          lspEditor: false
 
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - job: VS_Integration_Release_64


### PR DESCRIPTION
Large numbers of validation checks are disabled for the release builds, so the most accurate information for pull request success comes from debug runs. If we only keep two builds for pull requests, it seems like both should be debug builds.