### PR TITLE
Call InitializeTelemetrySession on background thread (#58399)

### DIFF
--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -157,16 +157,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
 
             _workspace = this.ComponentModel.GetService<VisualStudioWorkspace>();
 
-            // Fetch the session synchronously on the UI thread; if this doesn't happen before we try using this on
-            // the background thread then we will experience hangs like we see in this bug:
-            // https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=190808 or
-            // https://devdiv.visualstudio.com/DevDiv/_workitems?id=296981&_a=edit
-            var telemetryService = (VisualStudioWorkspaceTelemetryService)_workspace.Services.GetRequiredService<IWorkspaceTelemetryService>();
-            telemetryService.InitializeTelemetrySession(TelemetryService.DefaultSession);
-
-            Logger.Log(FunctionId.Run_Environment,
-                KeyValueLogMessage.Create(m => m["Version"] = FileVersionInfo.GetVersionInfo(typeof(VisualStudioWorkspace).Assembly.Location).FileVersion));
-
             InitializeColors();
 
             // load some services that have to be loaded in UI thread


### PR DESCRIPTION
Port #58399 from main.

Fixes [AB#1449211](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1449211).

InitializeTelemetrySession accessed options which triggered assembly load that caused deadlock.

As per [AB#296981](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/296981), the `TelemetryService.DefaultSession` property must be accessed on UI thread but the rest of Roslyn telemetry service initialization can be run on background thread. 

The change moves telemetry initialization to VisualStudioWorkspaceImpl, so that it does not depend on RoslynPackage being loaded.