### PR TITLE
Insert casts to ensure that runtime types (And values) are not impacted when converting switch to expression

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
@@ -185,6 +185,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
             private ExpressionSyntax CastIfChangeInRuntimeRepresentation(ExpressionSyntax node)
             {
+                // If the existing return/assign had an conversion involved that changed the runtime representation of
+                // the type (or value), then insert that same cast explicitly in the final result.  This is needed as
+                // switch statements do not use best-common-type, but switch expressions can use it.  We don't want the
+                // original conversion to be lost because a new best-common-type conversion is added.
                 var typeInfo = _semanticModel.GetTypeInfo(node, _cancellationToken);
                 if (typeInfo.ConvertedType is not null &&
                     typeInfo.Type is not null &&
@@ -253,8 +257,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
             private SwitchStatementSyntax AddCastIfNecessary(SwitchStatementSyntax node)
             {
-                // If the swith statement expression is being implicitly converted then we need to explicitly cast the expression
-                // before rewriting as a switch expression
+                // If the switch statement expression is being implicitly converted then we need to explicitly cast the
+                // expression before rewriting as a switch expression
                 var expressionType = _semanticModel.GetSymbolInfo(node.Expression).Symbol.GetSymbolType();
                 var expressionConvertedType = _semanticModel.GetTypeInfo(node.Expression).ConvertedType;
 

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.Rewriter.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
@@ -22,12 +20,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
     {
         private sealed class Rewriter : CSharpSyntaxVisitor<ExpressionSyntax>
         {
+            private readonly SemanticModel _semanticModel;
             private readonly bool _isAllThrowStatements;
+            private readonly CancellationToken _cancellationToken;
 
-            private ExpressionSyntax _assignmentTargetOpt;
+            private ExpressionSyntax? _assignmentTargetOpt;
 
-            private Rewriter(bool isAllThrowStatements)
-                => _isAllThrowStatements = isAllThrowStatements;
+            private Rewriter(SemanticModel semanticModel, bool isAllThrowStatements, CancellationToken cancellationToken)
+            {
+                _semanticModel = semanticModel;
+                _isAllThrowStatements = isAllThrowStatements;
+                _cancellationToken = cancellationToken;
+            }
 
             public static StatementSyntax Rewrite(
                 SwitchStatementSyntax switchStatement,
@@ -35,7 +39,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                 ITypeSymbol declaratorToRemoveTypeOpt,
                 SyntaxKind nodeToGenerate,
                 bool shouldMoveNextStatementToSwitchExpression,
-                bool generateDeclaration)
+                bool generateDeclaration,
+                CancellationToken cancellationToken)
             {
                 if (switchStatement.ContainsDirectives)
                 {
@@ -43,10 +48,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                     return switchStatement;
                 }
 
-                var rewriter = new Rewriter(isAllThrowStatements: nodeToGenerate == SyntaxKind.ThrowStatement);
+                var rewriter = new Rewriter(model, isAllThrowStatements: nodeToGenerate == SyntaxKind.ThrowStatement, cancellationToken);
 
                 // Rewrite the switch statement as a switch expression.
-                var switchExpression = rewriter.RewriteSwitchStatement(switchStatement, model,
+                var switchExpression = rewriter.RewriteSwitchStatement(
+                    switchStatement, topLevel: true,
                     allowMoveNextStatementToSwitchExpression: shouldMoveNextStatementToSwitchExpression);
 
                 // Generate the final statement to wrap the switch expression, e.g. a "return" or an assignment.
@@ -85,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
             private ExpressionStatementSyntax GenerateAssignment(ExpressionSyntax switchExpression, SyntaxKind assignmentKind, SyntaxTriviaList leadingTrivia)
             {
-                Debug.Assert(_assignmentTargetOpt != null);
+                Contract.ThrowIfNull(_assignmentTargetOpt);
 
                 return ExpressionStatement(
                     AssignmentExpression(assignmentKind,
@@ -96,12 +102,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
             private StatementSyntax GenerateVariableDeclaration(ExpressionSyntax switchExpression, ITypeSymbol declaratorToRemoveTypeOpt)
             {
-                Debug.Assert(_assignmentTargetOpt is IdentifierNameSyntax);
+                Contract.ThrowIfFalse(_assignmentTargetOpt is IdentifierNameSyntax);
 
                 // There is a probability that we cannot use var if the declaration type is a reference type or nullable type.
                 // In these cases, we generate the explicit type for now and decide later whether or not to use var.
                 var cannotUseVar = declaratorToRemoveTypeOpt != null && (declaratorToRemoveTypeOpt.IsReferenceType || declaratorToRemoveTypeOpt.IsNullable());
-                var type = cannotUseVar ? declaratorToRemoveTypeOpt.GenerateTypeSyntax() : IdentifierName("var");
+                var type = cannotUseVar ? declaratorToRemoveTypeOpt!.GenerateTypeSyntax() : IdentifierName("var");
 
                 return LocalDeclarationStatement(
                     VariableDeclaration(
@@ -121,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                     expression: RewriteStatements(node.Statements));
             }
 
-            private static PatternSyntax GetPattern(SyntaxList<SwitchLabelSyntax> switchLabels, out WhenClauseSyntax whenClauseOpt)
+            private static PatternSyntax GetPattern(SyntaxList<SwitchLabelSyntax> switchLabels, out WhenClauseSyntax? whenClauseOpt)
             {
                 if (switchLabels.Count == 1)
                     return GetPattern(switchLabels[0], out whenClauseOpt);
@@ -149,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                 return totalPattern;
             }
 
-            private static PatternSyntax GetPattern(SwitchLabelSyntax switchLabel, out WhenClauseSyntax whenClauseOpt)
+            private static PatternSyntax GetPattern(SwitchLabelSyntax switchLabel, out WhenClauseSyntax? whenClauseOpt)
             {
                 switch (switchLabel.Kind())
                 {
@@ -174,22 +180,41 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
             public override ExpressionSyntax VisitAssignmentExpression(AssignmentExpressionSyntax node)
             {
                 _assignmentTargetOpt ??= node.Left;
-                return node.Right;
+                return CastIfChangeInRuntimeRepresentation(node.Right);
+            }
+
+            private ExpressionSyntax CastIfChangeInRuntimeRepresentation(ExpressionSyntax node)
+            {
+                var typeInfo = _semanticModel.GetTypeInfo(node, _cancellationToken);
+                if (typeInfo.ConvertedType is not null &&
+                    typeInfo.Type is not null &&
+                    !Equals(typeInfo.ConvertedType, typeInfo.Type))
+                {
+                    var conversion = _semanticModel.Compilation.ClassifyConversion(typeInfo.Type, typeInfo.ConvertedType);
+                    if (!conversion.IsIdentityOrImplicitReference())
+                        return node.Cast(typeInfo.ConvertedType);
+                }
+
+                return node;
             }
 
             private ExpressionSyntax RewriteStatements(SyntaxList<StatementSyntax> statements)
             {
                 Debug.Assert(statements.Count is 1 or 2);
                 Debug.Assert(!statements[0].IsKind(SyntaxKind.BreakStatement));
-                return Visit(statements[0]);
+                var result = Visit(statements[0]);
+                Contract.ThrowIfNull(result);
+                return result;
             }
 
             public override ExpressionSyntax VisitSwitchStatement(SwitchStatementSyntax node)
-                => RewriteSwitchStatement(node, null);
+                => RewriteSwitchStatement(node, topLevel: false);
 
-            private ExpressionSyntax RewriteSwitchStatement(SwitchStatementSyntax node, SemanticModel model, bool allowMoveNextStatementToSwitchExpression = true)
+            private ExpressionSyntax RewriteSwitchStatement(
+                SwitchStatementSyntax node,
+                bool topLevel,
+                bool allowMoveNextStatementToSwitchExpression = true)
             {
-
                 var switchArms = node.Sections
                     // The default label must come last in the switch expression.
                     .OrderBy(section => section.Labels.Any(label => IsDefaultSwitchLabel(label)))
@@ -204,14 +229,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                     var nextStatement = node.GetNextStatement();
                     if (nextStatement.IsKind(SyntaxKind.ThrowStatement, SyntaxKind.ReturnStatement))
                     {
+                        var armExpression = Visit(nextStatement);
+                        Contract.ThrowIfNull(armExpression);
+
                         switchArms.Add(
                             (tokensForLeadingTrivia: new[] { nextStatement.GetFirstToken() },
                              tokensForTrailingTrivia: new[] { nextStatement.GetLastToken() },
-                             SwitchExpressionArm(DiscardPattern(), Visit(nextStatement))));
+                             SwitchExpressionArm(DiscardPattern(), armExpression)));
                     }
                 }
                 // add explicit cast if necessary 
-                var switchStatement = AddCastIfNecessary(model, node);
+                var switchStatement = topLevel ? AddCastIfNecessary(node) : node;
 
                 return SwitchExpression(
                     switchStatement.Expression.Parenthesize(),
@@ -223,12 +251,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                     Token(SyntaxKind.CloseBraceToken));
             }
 
-            private static SwitchStatementSyntax AddCastIfNecessary(SemanticModel model, SwitchStatementSyntax node)
+            private SwitchStatementSyntax AddCastIfNecessary(SwitchStatementSyntax node)
             {
                 // If the swith statement expression is being implicitly converted then we need to explicitly cast the expression
                 // before rewriting as a switch expression
-                var expressionType = model.GetSymbolInfo(node.Expression).Symbol.GetSymbolType();
-                var expressionConvertedType = model.GetTypeInfo(node.Expression).ConvertedType;
+                var expressionType = _semanticModel.GetSymbolInfo(node.Expression).Symbol.GetSymbolType();
+                var expressionConvertedType = _semanticModel.GetTypeInfo(node.Expression).ConvertedType;
 
                 if (expressionConvertedType != null &&
                     !SymbolEqualityComparer.Default.Equals(expressionConvertedType, expressionType))
@@ -244,20 +272,24 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
             public override ExpressionSyntax VisitReturnStatement(ReturnStatementSyntax node)
             {
-                Debug.Assert(node.Expression != null);
-                return node.Expression;
+                Contract.ThrowIfNull(node.Expression);
+                return CastIfChangeInRuntimeRepresentation(node.Expression);
             }
 
             public override ExpressionSyntax VisitThrowStatement(ThrowStatementSyntax node)
             {
-                Debug.Assert(node.Expression != null);
+                Contract.ThrowIfNull(node.Expression);
                 // If this is an all-throw switch statement, we return the expression rather than
                 // creating a throw expression so we can wrap the switch expression inside a throw expression.
                 return _isAllThrowStatements ? node.Expression : ThrowExpression(node.Expression);
             }
 
             public override ExpressionSyntax VisitExpressionStatement(ExpressionStatementSyntax node)
-                => Visit(node.Expression);
+            {
+                var result = Visit(node.Expression);
+                Contract.ThrowIfNull(result);
+                return result;
+            }
 
             public override ExpressionSyntax DefaultVisit(SyntaxNode node)
                 => throw ExceptionUtilities.UnexpectedValue(node.Kind());

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -75,8 +75,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                 spans.Add(switchLocation.SourceSpan);
 
                 var properties = diagnostic.Properties;
-                var nodeToGenerate = (SyntaxKind)int.Parse(properties[Constants.NodeToGenerateKey]);
-                var shouldRemoveNextStatement = bool.Parse(properties[Constants.ShouldRemoveNextStatementKey]);
+                var nodeToGenerate = (SyntaxKind)int.Parse(properties[Constants.NodeToGenerateKey]!);
+                var shouldRemoveNextStatement = bool.Parse(properties[Constants.ShouldRemoveNextStatementKey]!);
 
                 var declaratorToRemoveLocation = diagnostic.AdditionalLocations.ElementAtOrDefault(1);
                 var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Composition;
@@ -22,6 +20,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 {
@@ -79,39 +78,40 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                 var nodeToGenerate = (SyntaxKind)int.Parse(properties[Constants.NodeToGenerateKey]);
                 var shouldRemoveNextStatement = bool.Parse(properties[Constants.ShouldRemoveNextStatementKey]);
 
-                var declaratorToRemoveLocationOpt = diagnostic.AdditionalLocations.ElementAtOrDefault(1);
-                var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var declaratorToRemoveLocation = diagnostic.AdditionalLocations.ElementAtOrDefault(1);
+                var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-                SyntaxNode declaratorToRemoveNodeOpt = null;
-                ITypeSymbol declaratorToRemoveTypeOpt = null;
+                SyntaxNode? declaratorToRemoveNode = null;
+                ITypeSymbol? declaratorToRemoveType = null;
 
-                if (declaratorToRemoveLocationOpt != null)
+                if (declaratorToRemoveLocation != null)
                 {
-                    declaratorToRemoveNodeOpt = declaratorToRemoveLocationOpt.FindNode(cancellationToken);
-                    declaratorToRemoveTypeOpt = semanticModel.GetDeclaredSymbol(declaratorToRemoveNodeOpt, cancellationToken).GetSymbolType();
+                    declaratorToRemoveNode = declaratorToRemoveLocation.FindNode(cancellationToken);
+                    declaratorToRemoveType = semanticModel.GetDeclaredSymbol(declaratorToRemoveNode, cancellationToken).GetSymbolType();
                 }
 
                 var switchStatement = (SwitchStatementSyntax)switchLocation.FindNode(getInnermostNodeForTie: true, cancellationToken);
 
                 var switchExpression = Rewriter.Rewrite(
-                   switchStatement, semanticModel, declaratorToRemoveTypeOpt, nodeToGenerate,
+                   switchStatement, semanticModel, declaratorToRemoveType, nodeToGenerate,
                    shouldMoveNextStatementToSwitchExpression: shouldRemoveNextStatement,
-                   generateDeclaration: declaratorToRemoveLocationOpt is not null,
+                   generateDeclaration: declaratorToRemoveLocation is not null,
                    cancellationToken);
 
                 editor.ReplaceNode(switchStatement, switchExpression.WithAdditionalAnnotations(Formatter.Annotation));
 
-                if (declaratorToRemoveLocationOpt is not null)
+                if (declaratorToRemoveLocation is not null)
                 {
-                    editor.RemoveNode(declaratorToRemoveLocationOpt.FindNode(cancellationToken));
+                    editor.RemoveNode(declaratorToRemoveLocation.FindNode(cancellationToken));
                 }
 
                 if (shouldRemoveNextStatement)
                 {
                     // Already morphed into the top-level switch expression.
-                    SyntaxNode nextStatement = switchStatement.GetNextStatement();
+                    var nextStatement = switchStatement.GetNextStatement();
+                    Contract.ThrowIfNull(nextStatement);
                     Debug.Assert(nextStatement.IsKind(SyntaxKind.ThrowStatement, SyntaxKind.ReturnStatement));
-                    editor.RemoveNode(nextStatement.IsParentKind(SyntaxKind.GlobalStatement) ? nextStatement.Parent : nextStatement);
+                    editor.RemoveNode(nextStatement.IsParentKind(SyntaxKind.GlobalStatement) ? nextStatement.GetRequiredParent() : nextStatement);
                 }
             }
         }

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -21,7 +21,6 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
@@ -97,7 +96,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                 var switchExpression = Rewriter.Rewrite(
                    switchStatement, semanticModel, declaratorToRemoveTypeOpt, nodeToGenerate,
                    shouldMoveNextStatementToSwitchExpression: shouldRemoveNextStatement,
-                   generateDeclaration: declaratorToRemoveLocationOpt is object);
+                   generateDeclaration: declaratorToRemoveLocationOpt is not null,
+                   cancellationToken);
 
                 editor.ReplaceNode(switchStatement, switchExpression.WithAdditionalAnnotations(Formatter.Annotation));
 

--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
                 editor.ReplaceNode(switchStatement, switchExpression.WithAdditionalAnnotations(Formatter.Annotation));
 
-                if (declaratorToRemoveLocationOpt is object)
+                if (declaratorToRemoveLocationOpt is not null)
                 {
                     editor.RemoveNode(declaratorToRemoveLocationOpt.FindNode(cancellationToken));
                 }

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -2208,6 +2208,48 @@ class Program
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
         [WorkItem(58636, "https://github.com/dotnet/roslyn/issues/58636")]
+        public async Task TestRuntimeTypeConversion_Assignment2()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"class Program
+{
+    void M(string s)
+    {
+        object result;
+
+        [|switch|] (s)
+        {
+        case ""a"":
+            result = 1234;
+            break;
+        case ""b"":
+            result = 3.14;
+            break;
+        case ""c"":
+            result = true;
+            break;
+        default:
+            throw new System.Exception();
+        }
+    }
+}",
+@"class Program
+{
+    void M(string s)
+    {
+        object result = s switch
+        {
+            ""a"" => 1234,
+            ""b"" => 3.14,
+            ""c"" => true,
+            _ => throw new System.Exception(),
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
+        [WorkItem(58636, "https://github.com/dotnet/roslyn/issues/58636")]
         public async Task TestRuntimeTypeConversion_Return1()
         {
             await VerifyCS.VerifyCodeFixAsync(
@@ -2234,6 +2276,43 @@ class Program
         {
             ""a"" => 1234,
             ""b"" => (object)3.14,
+            _ => throw new System.Exception(),
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
+        [WorkItem(58636, "https://github.com/dotnet/roslyn/issues/58636")]
+        public async Task TestRuntimeTypeConversion_Return2()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"class Program
+{
+    object M(string s)
+    {
+        [|switch|] (s)
+        {
+        case ""a"":
+            return 1234;
+        case ""b"":
+            return 3.14;
+        case ""c"":
+            return true;
+        default:
+            throw new System.Exception();
+        }
+    }
+}",
+@"class Program
+{
+    object M(string s)
+    {
+        return s switch
+        {
+            ""a"" => 1234,
+            ""b"" => 3.14,
+            ""c"" => true,
             _ => throw new System.Exception(),
         };
     }

--- a/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionTests.cs
@@ -2167,5 +2167,77 @@ class Program
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
+        [WorkItem(58636, "https://github.com/dotnet/roslyn/issues/58636")]
+        public async Task TestRuntimeTypeConversion_Assignment1()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"class Program
+{
+    void M(string s)
+    {
+        object result;
+
+        [|switch|] (s)
+        {
+        case ""a"":
+            result = 1234;
+            break;
+        case ""b"":
+            result = 3.14;
+            break;
+        default:
+            throw new System.Exception();
+        }
+    }
+}",
+@"class Program
+{
+    void M(string s)
+    {
+        object result = s switch
+        {
+            ""a"" => 1234,
+            ""b"" => (object)3.14,
+            _ => throw new System.Exception(),
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertSwitchStatementToExpression)]
+        [WorkItem(58636, "https://github.com/dotnet/roslyn/issues/58636")]
+        public async Task TestRuntimeTypeConversion_Return1()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"class Program
+{
+    object M(string s)
+    {
+        [|switch|] (s)
+        {
+        case ""a"":
+            return 1234;
+        case ""b"":
+            return 3.14;
+        default:
+            throw new System.Exception();
+        }
+    }
+}",
+@"class Program
+{
+    object M(string s)
+    {
+        return s switch
+        {
+            ""a"" => 1234,
+            ""b"" => (object)3.14,
+            _ => throw new System.Exception(),
+        };
+    }
+}");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58636
