### PR TITLE
Don't crash when default namespace isn't a valid name

### DIFF
--- a/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
+++ b/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Test.Utilities;
 using Xunit;
 using VerifyCS = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.CSharpCodeFixVerifier<
     Microsoft.CodeAnalysis.CSharp.Analyzers.MatchFolderAndNamespace.CSharpMatchFolderAndNamespaceDiagnosticAnalyzer,
@@ -885,6 +886,71 @@ $@"namespace Test.Root.Namespace.A.B.C
             fixedProject2.Sources.Add((Path.Combine(folder1, "P.cs"), project2FixedSource));
 
             await testState.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(58372, "https://github.com/dotnet/roslyn/issues/58372")]
+        public async Task InvalidProjectName_ChangeNamespace()
+        {
+            var defaultNamespace = "Invalid-Namespace";
+            var editorConfig = @$"
+is_global=true
+build_property.ProjectDir = {Directory}
+build_property.RootNamespace = {defaultNamespace}
+";
+
+            var folder = CreateFolderPath(new[] { "B", "C" });
+            var code =
+@"
+namespace [|A.B|]
+{    
+    class Class1
+    {
+    }
+}";
+
+            // The project name is invalid so the default namespace is not prepended
+            var fixedCode =
+@$"namespace B.C
+{{
+    class Class1
+    {{
+    }}
+}}";
+
+            await RunTestAsync(
+                "Class1.cs",
+                fileContents: code,
+                fixedCode: fixedCode,
+                directory: folder,
+                editorConfig: editorConfig,
+                defaultNamespace: defaultNamespace);
+        }
+
+        [Fact]
+        public async Task InvalidProjectName_DocumentAtRoot_ChangeNamespace()
+        {
+            var defaultNamespace = "Invalid-Namespace";
+            var editorConfig = @$"
+is_global=true
+build_property.ProjectDir = {Directory}
+build_property.RootNamespace = {defaultNamespace}
+";
+
+            var folder = CreateFolderPath();
+
+            var code =
+$@"namespace Test.Code
+{{
+    class C {{ }}
+}}";
+
+            await RunTestAsync(
+                "Class1.cs",
+                fileContents: code,
+                directory: folder,
+                editorConfig: editorConfig,
+                defaultNamespace: defaultNamespace);
         }
     }
 }

--- a/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
+++ b/src/Analyzers/CSharp/Tests/MatchFolderAndNamespace/CSharpMatchFolderAndNamespaceTests.cs
@@ -952,5 +952,30 @@ $@"namespace Test.Code
                 editorConfig: editorConfig,
                 defaultNamespace: defaultNamespace);
         }
+
+        [Fact]
+        public async Task InvalidRootNamespace_DocumentAtRoot_ChangeNamespace()
+        {
+            var editorConfig = @$"
+is_global=true
+build_property.ProjectDir = {Directory}
+build_property.RootNamespace = Test.Code # not an editorconfig comment even though it looks like one
+";
+
+            var folder = CreateFolderPath();
+
+            var code =
+$@"namespace Test.Code
+{{
+    class C {{ }}
+}}";
+
+            await RunTestAsync(
+                "Class1.cs",
+                fileContents: code,
+                directory: folder,
+                editorConfig: editorConfig,
+                defaultNamespace: "Invalid-Namespace");
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PathMetadataUtilities.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PathMetadataUtilities.cs
@@ -27,6 +27,14 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         {
             var parts = folders.SelectMany(folder => folder.Split(NamespaceSeparatorArray)).SelectAsArray(syntaxFacts.EscapeIdentifier);
 
+            // The root namespace can come directly from the project file name and/or
+            // editor config file, so if its not valid we don't want to use it.
+            if (rootNamespace is not null &&
+                !rootNamespace.Split(NamespaceSeparatorArray).All(syntaxFacts.IsValidIdentifier))
+            {
+                rootNamespace = null;
+            }
+
             if (parts.IsDefaultOrEmpty)
             {
                 return rootNamespace;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PathMetadataUtilities.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PathMetadataUtilities.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             // The root namespace can come directly from the project file name and/or
             // editor config file, so if its not valid we don't want to use it.
-            if (rootNamespace is not null &&
+            if (rootNamespace is { Length: > 0 } &&
                 !rootNamespace.Split(NamespaceSeparatorArray).All(syntaxFacts.IsValidIdentifier))
             {
                 rootNamespace = null;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58372