### PR TITLE
 Force the spill sequence rewriter to spill the receiver for interpolated string handlers

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1611,6 +1611,10 @@
     <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
     <Field Name="SideEffects" Type="ImmutableArray&lt;BoundExpression&gt;"/>
     <Field Name="Value" Type="BoundExpression"/>
+
+    <!-- Force the SpillSequenceSpiller to treat this sequence as if it should be spilled, regardless of whether it contains any
+         nested BoundSpillSequence nodes. -->
+    <Field Name="ForceSpill" Type="bool"/>
   </Node>
 
   <!-- 

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -731,4 +731,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Update(operatorKind, operand, methodOpt, constrainedToTypeOpt, operandPlaceholder, operandConversion, resultPlaceholder, resultConversion, resultKind, this.OriginalUserDefinedOperatorsOpt, type);
         }
     }
+
+    internal partial class BoundSequence
+    {
+        public BoundSequence(
+            SyntaxNode syntax,
+            ImmutableArray<LocalSymbol> locals,
+            ImmutableArray<BoundExpression> sideEffects,
+            BoundExpression value,
+            TypeSymbol type,
+            bool hasErrors = false)
+            : this(syntax, locals, sideEffects, value, forceSpill: false, type, hasErrors)
+        {
+        }
+    }
 }

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.DiaSymReader;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeGen
@@ -745,6 +746,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                                     rewrittenSideeffects.ToImmutableAndFree() :
                                     sideeffects,
                                 value,
+                                node.ForceSpill,
                                 node.Type);
         }
 
@@ -899,6 +901,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 BoundExpression rewritten = sequence.Update(sequence.Locals,
                                         sequence.SideEffects,
                                         node.Update(sequence.Value, node.Right, node.IsRef, node.Type),
+                                        sequence.ForceSpill,
                                         sequence.Type);
 
                 rewritten = (BoundExpression)Visit(rewritten);

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ClosureConversion.cs
@@ -1108,7 +1108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var newValue = (BoundExpression)this.Visit(node.Value);
             var newType = this.VisitType(node.Type);
 
-            return node.Update(newLocals.ToImmutableAndFree(), prologue.ToImmutableAndFree(), newValue, newType);
+            return node.Update(newLocals.ToImmutableAndFree(), prologue.ToImmutableAndFree(), newValue, node.ForceSpill, newType);
         }
 
         public override BoundNode VisitBlock(BoundBlock node)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -1103,9 +1103,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            private void Fail(BoundNode node)
+            public override BoundNode? VisitSequence(BoundSequence node)
             {
-                Debug.Assert(false, $"Bound nodes of kind {node.Kind} should not survive past local rewriting");
+                if (node.ForceSpill)
+                {
+                    Fail(node, extraContent: $" with {nameof(BoundSequence)}.{nameof(node.ForceSpill)} true");
+                }
+
+                return null;
+            }
+
+            private void Fail(BoundNode node, string extraContent = "")
+            {
+                Debug.Assert(false, $"Bound nodes of kind {node.Kind}{extraContent} should not survive past local rewriting");
             }
         }
 #endif

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -265,6 +265,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 isRef,
                                 type,
                                 used),
+                            sequence.ForceSpill,
                             type);
                     }
                     goto default;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -486,7 +486,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     Debug.Assert(visitedReceiver != null && requiresInstanceReceiver);
                                     local = _factory.StoreToTemp(visitedReceiver, out var store, refKind: visitedReceiver.GetRefKind());
                                     temps.Add(local.LocalSymbol);
-                                    visitedReceiver = _factory.Sequence(ImmutableArray<LocalSymbol>.Empty, ImmutableArray.Create<BoundExpression>(store), local);
+                                    visitedReceiver = _factory.Sequence(ImmutableArray<LocalSymbol>.Empty, ImmutableArray.Create<BoundExpression>(store), local, forceSpill: true);
                                     receiverAssignedToTemp = true;
                                     break;
 

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var newSideEffects = VisitList<BoundExpression>(node.SideEffects);
             var newValue = (BoundExpression)this.Visit(node.Value);
             var newType = this.VisitType(node.Type);
-            return node.Update(newLocals, newSideEffects, newValue, newType);
+            return node.Update(newLocals, newSideEffects, newValue, node.ForceSpill, newType);
         }
 
         public override BoundNode VisitForStatement(BoundForStatement node)

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -1222,14 +1222,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var sideEffects = VisitExpressionList(ref builder, node.SideEffects, forceSpill: valueBuilder != null, sideEffectsOnly: true);
 
-            if (builder == null && valueBuilder == null)
+            if (builder == null && valueBuilder == null && !node.ForceSpill)
             {
-                return node.Update(node.Locals, sideEffects, value, node.Type);
+                return node.Update(node.Locals, sideEffects, value, node.ForceSpill, node.Type);
             }
 
             if (builder == null)
             {
-                builder = new BoundSpillSequenceBuilder(valueBuilder.Syntax);
+                builder = new BoundSpillSequenceBuilder(valueBuilder?.Syntax ?? node.Syntax);
             }
 
             PromoteAndAddLocals(builder, node.Locals);

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -919,20 +919,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Sequence(locals, builder.ToImmutableAndFree(), lastExpression);
         }
 
-        public BoundSequence Sequence(BoundExpression[] sideEffects, BoundExpression result, TypeSymbol? type = null)
+        public BoundSequence Sequence(BoundExpression[] sideEffects, BoundExpression result, TypeSymbol? type = null, bool forceSpill = false)
         {
             Debug.Assert(result.Type is { });
             var resultType = type ?? result.Type;
-            return new BoundSequence(Syntax, ImmutableArray<LocalSymbol>.Empty, sideEffects.AsImmutableOrNull(), result, resultType) { WasCompilerGenerated = true };
+            return new BoundSequence(Syntax, ImmutableArray<LocalSymbol>.Empty, sideEffects.AsImmutableOrNull(), result, forceSpill, resultType) { WasCompilerGenerated = true };
         }
 
-        public BoundExpression Sequence(ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundExpression> sideEffects, BoundExpression result)
+        public BoundExpression Sequence(ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundExpression> sideEffects, BoundExpression result, bool forceSpill = false)
         {
             Debug.Assert(result.Type is { });
             return
                 locals.IsDefaultOrEmpty && sideEffects.IsDefaultOrEmpty
                 ? result
-                : new BoundSequence(Syntax, locals, sideEffects, result, result.Type) { WasCompilerGenerated = true };
+                : new BoundSequence(Syntax, locals, sideEffects, result, forceSpill, result.Type) { WasCompilerGenerated = true };
         }
 
         public BoundSpillSequence SpillSequence(ImmutableArray<LocalSymbol> locals, ImmutableArray<BoundStatement> sideEffects, BoundExpression result)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -9699,7 +9699,7 @@ StructLogger#2:
         }
 
         [Fact, WorkItem(58514, "https://github.com/dotnet/roslyn/issues/58514")]
-        public void StructReceiver_Rvalue_ObjectCreationArgument()
+        public void StructArgument_Rvalue_ObjectCreationArgument()
         {
             var code = @"
 using System;


### PR DESCRIPTION
The SpillSequenceSpiller has an assumption that, unless a BoundSequence contains an await, it will not affect any BoundSpillSequence nodes. This isn't true for interpolated strings, as the receiver could be a sequence that spills the receiver to a temp later used by the handler constructor. We therefore now mark such BoundSequences as needing to be spilled, and in such cases the SpillSequenceSpiller will treat the sequence as if it needs to be spilled, regardless of whether it contained an `await` or not.

Fixes #58514.