### PR TITLE
Remove implicit conversion from string to `ReadOnlySpan<T>` from test source for `ReadOnlySpan<T>`.

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
@@ -14,11 +14,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
     public class CodeGenReadOnlySpanConstructionTest : CSharpTestBase
     {
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void EmptyOrNullStringConv()
         {
-            var comp = CreateCompilationWithMscorlibAndSpan(@"
+            var comp = CreateCompilation(@"
 using System;
 
 class Test
@@ -37,7 +37,7 @@ class Test
     }
 }
 
-", TestOptions.ReleaseExe);
+", targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
 
             CompileAndVerify(comp, expectedOutput: "TrueTrue", verify: Verification.Passes).VerifyIL("Test.Main", @"
 {
@@ -46,10 +46,10 @@ class Test
   .locals init (System.ReadOnlySpan<char> V_0, //s1
                 System.ReadOnlySpan<char> V_1) //s2
   IL_0000:  ldstr      """"
-  IL_0005:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
+  IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
   IL_000b:  ldstr      """"
-  IL_0010:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
+  IL_0010:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_0015:  stloc.1
   IL_0016:  ldloca.s   V_0
   IL_0018:  call       ""int System.ReadOnlySpan<char>.Length.get""
@@ -58,10 +58,10 @@ class Test
   IL_0024:  ceq
   IL_0026:  call       ""void System.Console.Write(bool)""
   IL_002b:  ldnull
-  IL_002c:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
+  IL_002c:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_0031:  stloc.0
   IL_0032:  ldnull
-  IL_0033:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
+  IL_0033:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_0038:  stloc.1
   IL_0039:  ldloca.s   V_0
   IL_003b:  call       ""int System.ReadOnlySpan<char>.Length.get""
@@ -492,11 +492,11 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         [WorkItem(23358, "https://github.com/dotnet/roslyn/issues/23358")]
         public void ConvInMethodCall()
         {
-            var comp = CreateCompilationWithMscorlibAndSpan(@"
+            var comp = CreateCompilation(@"
 using System;
 
 class Test
@@ -513,14 +513,14 @@ class Test
     }
 }
 
-", TestOptions.ReleaseExe);
+", targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
 
             CompileAndVerify(comp, expectedOutput: "P10", verify: Verification.Fails).VerifyIL("Test.Main", @"
 {
   // Code size       28 (0x1c)
   .maxstack  3
   IL_0000:  ldstr      ""QWERTYUIOP""
-  IL_0005:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
+  IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  ldsflda    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=10 <PrivateImplementationDetails>.C848E1013F9F04A9D63FA43CE7FD4AF035152C7C669A4A404B67107CEE5F2E4E""
   IL_000f:  ldc.i4.s   10
   IL_0011:  newobj     ""System.ReadOnlySpan<byte>..ctor(void*, int)""

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/ForeachTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/ForeachTest.cs
@@ -477,10 +477,10 @@ class Test
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(CoreClrOnly))]
         public void TestReadOnlySpanString()
         {
-            var comp = CreateCompilationWithMscorlibAndSpan(@"
+            var comp = CreateCompilation(@"
 using System;
 
 class Test
@@ -495,7 +495,7 @@ class Test
     }
 }
 
-", TestOptions.ReleaseExe);
+", targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseExe);
 
             CompileAndVerify(comp, expectedOutput: "hello", verify: Verification.Passes).VerifyIL("Test.Main", @"
 {
@@ -504,7 +504,7 @@ class Test
   .locals init (System.ReadOnlySpan<char> V_0,
                 int V_1)
   IL_0000:  ldstr      ""hello""
-  IL_0005:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
+  IL_0005:  call       ""System.ReadOnlySpan<char> string.op_Implicit(string)""
   IL_000a:  stloc.0
   IL_000b:  ldc.i4.0
   IL_000c:  stloc.1

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -2224,8 +2224,6 @@ namespace System
             }
 
             public static implicit operator ReadOnlySpan<T>(T[] array) => array == null ? default : new ReadOnlySpan<T>(array);
-
-            public static implicit operator ReadOnlySpan<T>(string stringValue) => string.IsNullOrEmpty(stringValue) ? default : new ReadOnlySpan<T>((T[])(object)stringValue.ToCharArray());
         }
 
         public readonly ref struct SpanLike<T>


### PR DESCRIPTION
There is no such operator in real type. Instead `string` type declares an implicit conversion to ```ReadOnlySpan<char>```.