### PR TITLE
🐇 Avoid allocations for .globalconfig parsing when possible

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis
             foreach (var section in _globalConfig.NamedSections)
             {
                 var escapedSectionName = TryUnescapeSectionName(section.Name, out var sectionName);
-                if (escapedSectionName && normalizedPath.Equals(sectionName, Section.NameComparer))
+                if (escapedSectionName && sectionName.Equals(normalizedPath.AsSpan(), Section.NameComparer))
                 {
                     sectionKey.Add(section);
                 }


### PR DESCRIPTION
Eliminates ~94% of allocations under `GetOptionsForSourcePath` based on [AB#1458595](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1458595).

🚧 Still needs tests