### PR TITLE
Correctly handle additional inputs to user-defined conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -569,6 +569,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ImplicitTupleLiteral:
                 case ConversionKind.StackAllocToPointerType:
                 case ConversionKind.StackAllocToSpanType:
+                case ConversionKind.InterpolatedStringHandler:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -569,7 +569,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ImplicitTupleLiteral:
                 case ConversionKind.StackAllocToPointerType:
                 case ConversionKind.StackAllocToSpanType:
-                case ConversionKind.InterpolatedStringHandler:
                     return true;
                 default:
                     return false;
@@ -629,10 +628,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // 
             // We extend the definition of standard implicit conversions to include
             // all of the implicit conversions that are allowed based on an expression,
-            // with the exception of the switch expression conversion.
+            // with the exception of the switch expression conversion and the interpolated
+            // string builder conversion.
 
             Conversion conversion = ClassifyImplicitBuiltInConversionFromExpression(sourceExpression, source, destination, ref useSiteInfo);
-            if (conversion.Exists)
+            if (conversion.Exists && !conversion.IsInterpolatedStringHandler)
             {
                 Debug.Assert(IsStandardImplicitConversionFromExpression(conversion.Kind));
                 return conversion;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -605,6 +605,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ImplicitEnumeration:
                 case ConversionKind.StackAllocToPointerType:
                 case ConversionKind.StackAllocToSpanType:
+                case ConversionKind.InterpolatedStringHandler:
 
                 // Not "standard".
                 case ConversionKind.ImplicitUserDefined:
@@ -634,6 +635,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.Boxing:
                 case ConversionKind.ImplicitConstant:
                 case ConversionKind.ImplicitPointerToVoid:
+                case ConversionKind.ImplicitPointer:
 
                 // Added to spec in Roslyn timeframe.
                 case ConversionKind.NullLiteral:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -635,7 +635,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.Boxing:
                 case ConversionKind.ImplicitConstant:
                 case ConversionKind.ImplicitPointerToVoid:
-                case ConversionKind.ImplicitPointer:
 
                 // Added to spec in Roslyn timeframe.
                 case ConversionKind.NullLiteral:
@@ -648,6 +647,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // Added for C# 7.1
                 case ConversionKind.DefaultLiteral:
+
+                // Added for C# 9
+                case ConversionKind.ImplicitPointer:
                     return true;
 
                 default:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -607,6 +607,98 @@ ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: delegate*<Syst
 ");
         }
 
+        [Fact, WorkItem(57994, "https://github.com/dotnet/roslyn/issues/57994")]
+        public void UserDefinedConversion_04()
+        {
+            var comp = CreateCompilationWithFunctionPointers(@"
+unsafe readonly struct S
+{
+    public static implicit operator delegate*<void*, void>(S _) => null;
+    void M()
+    {
+        // S -> delegate*<void*, void> -> delegate*<int*, void>
+        /*<bind>*/delegate*<int*, void> _ = new S()/*</bind>*/;
+    }
+}");
+
+            var verifier = CompileAndVerifyFunctionPointers(comp);
+            verifier.VerifyIL("S.M", @"
+{
+  // Code size       16 (0x10)
+  .maxstack  1
+  .locals init (delegate*<int*, void> V_0, //_
+                S V_1)
+  IL_0000:  ldloca.s   V_1
+  IL_0002:  initobj    ""S""
+  IL_0008:  ldloc.1
+  IL_0009:  call       ""delegate*<void*, void> S.op_Implicit(S)""
+  IL_000e:  stloc.0
+  IL_000f:  ret
+}
+");
+
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(comp, @"
+IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null) (Syntax: 'delegate*<i ... _ = new S()')
+  Declarators:
+      IVariableDeclaratorOperation (Symbol: delegate*<System.Int32*, System.Void> _) (OperationKind.VariableDeclarator, Type: null) (Syntax: '_ = new S()')
+        Initializer:
+          IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= new S()')
+            IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: delegate*<System.Int32*, System.Void>, IsImplicit) (Syntax: 'new S()')
+              Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+              Operand:
+                IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: delegate*<System.Void*, System.Void> S.op_Implicit(S _)) (OperationKind.Conversion, Type: delegate*<System.Void*, System.Void>, IsImplicit) (Syntax: 'new S()')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: delegate*<System.Void*, System.Void> S.op_Implicit(S _))
+                  Operand:
+                    IObjectCreationOperation (Constructor: S..ctor()) (OperationKind.ObjectCreation, Type: S) (Syntax: 'new S()')
+                      Arguments(0)
+                      Initializer:
+                        null
+  Initializer:
+    null
+");
+        }
+
+        [Fact, WorkItem(57994, "https://github.com/dotnet/roslyn/issues/57994")]
+        public void UserDefinedConversion_05()
+        {
+            var comp = CreateCompilationWithFunctionPointers(@"
+unsafe readonly struct S
+{
+    public static explicit operator delegate*<void*, void>(S _) => null;
+    void M()
+    {
+        // S -> delegate*<void*, void> -> delegate*<int*, void>
+        /*<bind>*/delegate*<int*, void> _ = new S()/*</bind>*/;
+    }
+}");
+
+            comp.VerifyDiagnostics(
+                // (8,45): error CS0266: Cannot implicitly convert type 'S' to 'delegate*<int*, void>'. An explicit conversion exists (are you missing a cast?)
+                //         /*<bind>*/delegate*<int*, void> _ = new S()/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "new S()").WithArguments("S", "delegate*<int*, void>").WithLocation(8, 45)
+            );
+
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(comp, @"
+IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null, IsInvalid) (Syntax: 'delegate*<i ... _ = new S()')
+  Declarators:
+      IVariableDeclaratorOperation (Symbol: delegate*<System.Int32*, System.Void> _) (OperationKind.VariableDeclarator, Type: null, IsInvalid) (Syntax: '_ = new S()')
+        Initializer:
+          IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null, IsInvalid) (Syntax: '= new S()')
+            IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: delegate*<System.Int32*, System.Void>, IsInvalid, IsImplicit) (Syntax: 'new S()')
+              Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+              Operand:
+                IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: delegate*<System.Void*, System.Void> S.op_Explicit(S _)) (OperationKind.Conversion, Type: delegate*<System.Void*, System.Void>, IsInvalid, IsImplicit) (Syntax: 'new S()')
+                  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: delegate*<System.Void*, System.Void> S.op_Explicit(S _))
+                  Operand:
+                    IObjectCreationOperation (Constructor: S..ctor()) (OperationKind.ObjectCreation, Type: S, IsInvalid) (Syntax: 'new S()')
+                      Arguments(0)
+                      Initializer:
+                        null
+  Initializer:
+    null
+");
+        }
+
         [Fact]
         public void FunctionPointerToFunctionPointerValid_ReferenceVarianceAndIdentity()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -3978,6 +3978,62 @@ namespace System.Runtime.CompilerServices
             );
         }
 
+        [Fact, WorkItem(58346, "https://github.com/dotnet/roslyn/issues/58346")]
+        public void UserDefinedConversion_AsFromTypeOfConversion()
+        {
+            var code = @"
+struct S
+{
+    public static implicit operator S(CustomHandler c) => default;
+
+    static void M()
+    {
+        /*<bind>*/S s = $"""";/*<bind>*/
+    }
+}
+";
+
+            var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false);
+
+            var comp = CreateCompilation(new[] { code, handler });
+            comp.VerifyDiagnostics(
+                // (8,25): error CS0266: Cannot implicitly convert type 'string' to 'S'. An explicit conversion exists (are you missing a cast?)
+                //         S /*<bind>*/s = $""/*<bind>*/;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, @"$""""").WithArguments("string", "S").WithLocation(8, 25)
+            );
+
+            VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(comp, @"
+IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDeclarationGroup, Type: null, IsInvalid) (Syntax: 'S s = $"""";')
+  IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null, IsInvalid) (Syntax: 'S s = $""""')
+    Declarators:
+        IVariableDeclaratorOperation (Symbol: S s) (OperationKind.VariableDeclarator, Type: null, IsInvalid) (Syntax: 's = $""""')
+          Initializer:
+            IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null, IsInvalid) (Syntax: '= $""""')
+              IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: S S.op_Implicit(CustomHandler c)) (OperationKind.Conversion, Type: S, IsInvalid, IsImplicit) (Syntax: '$""""')
+                Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: S S.op_Implicit(CustomHandler c))
+                Operand:
+                  IInterpolatedStringHandlerCreationOperation (HandlerAppendCallsReturnBool: False, HandlerCreationHasSuccessParameter: False) (OperationKind.InterpolatedStringHandlerCreation, Type: CustomHandler, IsInvalid, IsImplicit) (Syntax: '$""""')
+                    Creation:
+                      IObjectCreationOperation (Constructor: CustomHandler..ctor(System.Int32 literalLength, System.Int32 formattedCount)) (OperationKind.ObjectCreation, Type: CustomHandler, IsInvalid, IsImplicit) (Syntax: '$""""')
+                        Arguments(2):
+                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: literalLength) (OperationKind.Argument, Type: null, IsInvalid, IsImplicit) (Syntax: '$""""')
+                              ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0, IsInvalid, IsImplicit) (Syntax: '$""""')
+                              InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                              OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: formattedCount) (OperationKind.Argument, Type: null, IsInvalid, IsImplicit) (Syntax: '$""""')
+                              ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0, IsInvalid, IsImplicit) (Syntax: '$""""')
+                              InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                              OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                        Initializer:
+                          null
+                    Content:
+                      IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String, Constant: """", IsInvalid) (Syntax: '$""""')
+                        Parts(0)
+    Initializer:
+      null
+");
+        }
+
         [Theory]
         [InlineData(@"$""Text{1}""")]
         [InlineData(@"$""Text"" + $""{1}""")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -3979,7 +3979,7 @@ namespace System.Runtime.CompilerServices
         }
 
         [Fact, WorkItem(58346, "https://github.com/dotnet/roslyn/issues/58346")]
-        public void UserDefinedConversion_AsFromTypeOfConversion()
+        public void UserDefinedConversion_AsFromTypeOfConversion_01()
         {
             var code = @"
 struct S
@@ -3997,9 +3997,9 @@ struct S
 
             var comp = CreateCompilation(new[] { code, handler });
             comp.VerifyDiagnostics(
-                // (8,25): error CS0266: Cannot implicitly convert type 'string' to 'S'. An explicit conversion exists (are you missing a cast?)
-                //         S /*<bind>*/s = $""/*<bind>*/;
-                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, @"$""""").WithArguments("string", "S").WithLocation(8, 25)
+                // (8,25): error CS0029: Cannot implicitly convert type 'string' to 'S'
+                //         /*<bind>*/S s = $"";/*<bind>*/
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"$""""").WithArguments("string", "S").WithLocation(8, 25)
             );
 
             VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(comp, @"
@@ -4009,25 +4009,103 @@ IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDecla
         IVariableDeclaratorOperation (Symbol: S s) (OperationKind.VariableDeclarator, Type: null, IsInvalid) (Syntax: 's = $""""')
           Initializer:
             IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null, IsInvalid) (Syntax: '= $""""')
-              IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: S S.op_Implicit(CustomHandler c)) (OperationKind.Conversion, Type: S, IsInvalid, IsImplicit) (Syntax: '$""""')
+              IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: S, IsInvalid, IsImplicit) (Syntax: '$""""')
+                Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                Operand:
+                  IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String, Constant: """", IsInvalid) (Syntax: '$""""')
+                    Parts(0)
+    Initializer:
+      null
+");
+        }
+
+        [Fact, WorkItem(58346, "https://github.com/dotnet/roslyn/issues/58346")]
+        public void UserDefinedConversion_AsFromTypeOfConversion_02()
+        {
+            var code = @"
+struct S
+{
+    public static implicit operator S(CustomHandler c) => default;
+
+    static void M()
+    {
+        /*<bind>*/S s = (S)$"""";/*<bind>*/
+    }
+}
+";
+
+            var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false);
+
+            var comp = CreateCompilation(new[] { code, handler });
+            comp.VerifyDiagnostics(
+                // (8,25): error CS0030: Cannot convert type 'string' to 'S'
+                //         /*<bind>*/S s = (S)$"";/*<bind>*/
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, @"(S)$""""").WithArguments("string", "S").WithLocation(8, 25)
+            );
+
+            VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(comp, @"
+IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDeclarationGroup, Type: null, IsInvalid) (Syntax: 'S s = (S)$"""";')
+  IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null, IsInvalid) (Syntax: 'S s = (S)$""""')
+    Declarators:
+        IVariableDeclaratorOperation (Symbol: S s) (OperationKind.VariableDeclarator, Type: null, IsInvalid) (Syntax: 's = (S)$""""')
+          Initializer:
+            IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null, IsInvalid) (Syntax: '= (S)$""""')
+              IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: S, IsInvalid) (Syntax: '(S)$""""')
+                Conversion: CommonConversion (Exists: False, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+                Operand:
+                  IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String, Constant: """", IsInvalid) (Syntax: '$""""')
+                    Parts(0)
+    Initializer:
+      null
+");
+        }
+
+        [Fact, WorkItem(58346, "https://github.com/dotnet/roslyn/issues/58346")]
+        public void UserDefinedConversion_AsFromTypeOfConversion_03()
+        {
+            var code = @"
+struct S
+{
+    public static implicit operator S(CustomHandler c) => default;
+
+    static void M()
+    {
+        /*<bind>*/S s = (CustomHandler)$"""";/*<bind>*/
+    }
+}
+";
+
+            var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false);
+
+            var comp = CreateCompilation(new[] { code, handler });
+            comp.VerifyDiagnostics();
+
+            VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(comp, @"
+IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDeclarationGroup, Type: null) (Syntax: 'S s = (Cust ... andler)$"""";')
+  IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null) (Syntax: 'S s = (CustomHandler)$""""')
+    Declarators:
+        IVariableDeclaratorOperation (Symbol: S s) (OperationKind.VariableDeclarator, Type: null) (Syntax: 's = (CustomHandler)$""""')
+          Initializer:
+            IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= (CustomHandler)$""""')
+              IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: S S.op_Implicit(CustomHandler c)) (OperationKind.Conversion, Type: S, IsImplicit) (Syntax: '(CustomHandler)$""""')
                 Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: S S.op_Implicit(CustomHandler c))
                 Operand:
-                  IInterpolatedStringHandlerCreationOperation (HandlerAppendCallsReturnBool: False, HandlerCreationHasSuccessParameter: False) (OperationKind.InterpolatedStringHandlerCreation, Type: CustomHandler, IsInvalid, IsImplicit) (Syntax: '$""""')
+                  IInterpolatedStringHandlerCreationOperation (HandlerAppendCallsReturnBool: False, HandlerCreationHasSuccessParameter: False) (OperationKind.InterpolatedStringHandlerCreation, Type: CustomHandler) (Syntax: '(CustomHandler)$""""')
                     Creation:
-                      IObjectCreationOperation (Constructor: CustomHandler..ctor(System.Int32 literalLength, System.Int32 formattedCount)) (OperationKind.ObjectCreation, Type: CustomHandler, IsInvalid, IsImplicit) (Syntax: '$""""')
+                      IObjectCreationOperation (Constructor: CustomHandler..ctor(System.Int32 literalLength, System.Int32 formattedCount)) (OperationKind.ObjectCreation, Type: CustomHandler, IsImplicit) (Syntax: '$""""')
                         Arguments(2):
-                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: literalLength) (OperationKind.Argument, Type: null, IsInvalid, IsImplicit) (Syntax: '$""""')
-                              ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0, IsInvalid, IsImplicit) (Syntax: '$""""')
+                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: literalLength) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: '$""""')
+                              ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0, IsImplicit) (Syntax: '$""""')
                               InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                               OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
-                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: formattedCount) (OperationKind.Argument, Type: null, IsInvalid, IsImplicit) (Syntax: '$""""')
-                              ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0, IsInvalid, IsImplicit) (Syntax: '$""""')
+                            IArgumentOperation (ArgumentKind.Explicit, Matching Parameter: formattedCount) (OperationKind.Argument, Type: null, IsImplicit) (Syntax: '$""""')
+                              ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0, IsImplicit) (Syntax: '$""""')
                               InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                               OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
                         Initializer:
                           null
                     Content:
-                      IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String, Constant: """", IsInvalid) (Syntax: '$""""')
+                      IInterpolatedStringOperation (OperationKind.InterpolatedString, Type: System.String, Constant: """") (Syntax: '$""""')
                         Parts(0)
     Initializer:
       null

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -3988,7 +3988,7 @@ struct S
 
     static void M()
     {
-        /*<bind>*/S s = $"""";/*<bind>*/
+        /*<bind>*/S s = $"""";/*</bind>*/
     }
 }
 ";
@@ -4029,7 +4029,7 @@ struct S
 
     static void M()
     {
-        /*<bind>*/S s = (S)$"""";/*<bind>*/
+        /*<bind>*/S s = (S)$"""";/*</bind>*/
     }
 }
 ";
@@ -4064,7 +4064,7 @@ IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDecla
         public void UserDefinedConversion_AsFromTypeOfConversion_03()
         {
             var code = @"
-/*<bind>*/S s = (CustomHandler)$"""";/*<bind>*/
+/*<bind>*/S s = (CustomHandler)$"""";/*</bind>*/
 
 struct S
 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -4064,13 +4064,14 @@ IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDecla
         public void UserDefinedConversion_AsFromTypeOfConversion_03()
         {
             var code = @"
+/*<bind>*/S s = (CustomHandler)$"""";/*<bind>*/
+
 struct S
 {
-    public static implicit operator S(CustomHandler c) => default;
-
-    static void M()
+    public static implicit operator S(CustomHandler c) 
     {
-        /*<bind>*/S s = (CustomHandler)$"""";/*<bind>*/
+        System.Console.WriteLine(""In handler"");
+        return default;
     }
 }
 ";
@@ -4078,7 +4079,7 @@ struct S
             var handler = GetInterpolatedStringCustomHandlerType("CustomHandler", "struct", useBoolReturns: false);
 
             var comp = CreateCompilation(new[] { code, handler });
-            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "In handler").VerifyDiagnostics();
 
             VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(comp, @"
 IVariableDeclarationGroupOperation (1 declarations) (OperationKind.VariableDeclarationGroup, Type: null) (Syntax: 'S s = (Cust ... andler)$"""";')

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -1397,6 +1397,12 @@ namespace System.Runtime.CompilerServices
                 string exprFullText = node.ToFullString();
                 exprFullText = exprFullText.Trim();
 
+                // Account for comments being added as leading trivia for this node.
+                while (exprFullText.StartsWith("//"))
+                {
+                    exprFullText = exprFullText[exprFullText.IndexOf('\n')..].Trim();
+                }
+
                 if (exprFullText.StartsWith(StartString, StringComparison.Ordinal))
                 {
                     if (exprFullText.Contains(EndString))


### PR DESCRIPTION
Function pointers and interpolated strings (crazy coincidence) aren't being correctly handled when they are involved in a user-defined conversion. This updates that codepath to expect those conversion kinds and correctly handle their presence (accepted for pointers, like the other implicit pointer conversions, and disallowed for strings, like the other conversions-from-expression kinds).

Fixes https://github.com/dotnet/roslyn/issues/58346. Fixes https://github.com/dotnet/roslyn/issues/57994.
