### PR TITLE
Fix empty strings in ThrowHelper

### DIFF
--- a/src/Dependencies/Collections/Internal/ThrowHelper.cs
+++ b/src/Dependencies/Collections/Internal/ThrowHelper.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                     return "destinationArray";
                 default:
                     Debug.Fail("The enum value is not defined, please check the ExceptionArgument Enum.");
-                    return "";
+                    return string.Empty;
             }
         }
 
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Collections.Internal
                     return SR.InvalidOperation_IComparerFailed;
                 default:
                     Debug.Fail("The enum value is not defined, please check the ExceptionResource Enum.");
-                    return "";
+                    return string.Empty;
             }
         }
     }


### PR DESCRIPTION
Replacing empty strings with string.Empty

I ran into this as msbuild relies on Microsoft.CodeAnalysis.Collections and the stylecop analyzer highlighted this problem when we turned on the rule [SA1122](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1122.md).

The associated msbuild PR is https://github.com/dotnet/msbuild/pull/7239