### PR TITLE
Move reading HideAdvancedMembers option up

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
@@ -6503,7 +6504,7 @@ class Program
         [WorkItem(1266354, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1266354")]
         public async Task TestAddUsingsEditorBrowsableAdvancedDifferentProjectOptionOff(TestHost testHost)
         {
-            const string InitialWorkspace = @"
+            var initialWorkspace = @"
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""lib"" CommonReferences=""true"">
         <Document FilePath=""lib.vb"">
@@ -6529,8 +6530,8 @@ class Program
     </Project>
 </Workspace>";
 
-            await TestMissingAsync(InitialWorkspace, new TestParameters(
-                options: Option(CompletionOptions.Metadata.HideAdvancedMembers, true),
+            await TestMissingAsync(initialWorkspace, new TestParameters(
+                codeActionOptions: CodeActionOptions.Default with { HideAdvancedMembers = true },
                 testHost: testHost));
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -467,7 +467,8 @@ class Class
                     var diagnostics = await diagnosticService.GetDiagnosticsForSpanAsync(document, span);
                     Assert.Equal(2, diagnostics.Where(d => d.Id == "CS0219").Count());
 
-                    var allFixes = (await fixService.GetFixesAsync(document, span, cancellationToken: CancellationToken.None))
+                    var options = CodeActionOptions.Default;
+                    var allFixes = (await fixService.GetFixesAsync(document, span, options, CancellationToken.None))
                         .SelectMany(fixCollection => fixCollection.Fixes);
 
                     var cs0219Fixes = allFixes.Where(fix => fix.PrimaryDiagnostic.Id == "CS0219").ToArray();

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImports;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -561,6 +562,8 @@ namespace A
         {
             using var workspace = TestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf);
 
+            var options = CodeActionOptions.Default;
+
             var solution = workspace.CurrentSolution
                 .WithOptions(workspace.Options
                     .WithChangedOption(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp, systemUsingsFirst)
@@ -586,7 +589,7 @@ namespace A
             var enabledDiagnostics = codeCleanupService.GetAllDiagnostics();
 
             var newDoc = await codeCleanupService.CleanupAsync(
-                document, enabledDiagnostics, new ProgressTracker(), CancellationToken.None);
+                document, enabledDiagnostics, new ProgressTracker(), options, CancellationToken.None);
 
             var actual = await newDoc.GetTextAsync();
 

--- a/src/EditorFeatures/CSharpTest/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/FullyQualify/FullyQualifyTests.cs
@@ -1618,7 +1618,7 @@ class Program
         [WorkItem(54544, "https://github.com/dotnet/roslyn/issues/54544")]
         public async Task TestAddUsingsEditorBrowsableAdvancedDifferentProjectOptionOff()
         {
-            const string InitialWorkspace = @"
+            var initialWorkspace = @"
 <Workspace>
     <Project Language=""Visual Basic"" AssemblyName=""lib"" CommonReferences=""true"">
         <Document FilePath=""lib.vb"">
@@ -1644,8 +1644,8 @@ class Program
     </Project>
 </Workspace>";
 
-            await TestMissingAsync(InitialWorkspace, new TestParameters(
-                options: Option(CompletionOptions.Metadata.HideAdvancedMembers, true)));
+            await TestMissingAsync(initialWorkspace, new TestParameters(
+                codeActionOptions: CodeActionOptions.Default with { HideAdvancedMembers = true }));
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
@@ -168,12 +168,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 var workspace = document.Project.Solution.Workspace;
                 var supportsFeatureService = workspace.Services.GetRequiredService<ITextBufferSupportsFeatureService>();
 
+                var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: false);
+
                 var fixesTask = GetCodeFixesAsync(
                     state, supportsFeatureService, requestedActionCategories, workspace, document, range,
-                    addOperationScope, priority, isBlocking: false, cancellationToken);
+                    addOperationScope, priority, options, cancellationToken);
                 var refactoringsTask = GetRefactoringsAsync(
                     state, supportsFeatureService, requestedActionCategories, GlobalOptions, workspace, document, selection,
-                    addOperationScope, priority, isBlocking: false, cancellationToken);
+                    addOperationScope, priority, options, cancellationToken);
 
                 await Task.WhenAll(fixesTask, refactoringsTask).ConfigureAwait(false);
 

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (document == null)
                     return null;
 
-                var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: true);
+                var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: false);
 
                 using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var linkedToken = linkedTokenSource.Token;

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -177,15 +177,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     Func<string, IDisposable?> addOperationScope =
                         description => operationContext?.AddScope(allowCancellation: true, string.Format(EditorFeaturesResources.Gathering_Suggestions_0, description));
 
+                    var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: true);
+
                     // We convert the code fixes and refactorings to UnifiedSuggestedActionSets instead of
                     // SuggestedActionSets so that we can share logic between local Roslyn and LSP.
                     var fixesTask = GetCodeFixesAsync(
                         state, supportsFeatureService, requestedActionCategories, workspace, document, range,
                         addOperationScope, CodeActionRequestPriority.None,
-                        isBlocking: true, cancellationToken);
+                        options, cancellationToken);
+
                     var refactoringsTask = GetRefactoringsAsync(
                         state, supportsFeatureService, requestedActionCategories, GlobalOptions, workspace, document, selection,
-                        addOperationScope, CodeActionRequestPriority.None, isBlocking: true, cancellationToken);
+                        addOperationScope, CodeActionRequestPriority.None, options, cancellationToken);
 
                     Task.WhenAll(fixesTask, refactoringsTask).WaitAndGetResult(cancellationToken);
 
@@ -263,7 +266,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 SnapshotSpan range,
                 Func<string, IDisposable?> addOperationScope,
                 CodeActionRequestPriority priority,
-                bool isBlocking,
+                CodeActionOptions options,
                 CancellationToken cancellationToken)
             {
                 if (state.Target.Owner._codeFixService == null ||
@@ -275,7 +278,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
                     workspace, state.Target.Owner._codeFixService, document, range.Span.ToTextSpan(),
-                    priority, isBlocking, addOperationScope, cancellationToken).AsTask();
+                    priority, options, addOperationScope, cancellationToken).AsTask();
             }
 
             private static string GetFixCategory(DiagnosticSeverity severity)
@@ -303,7 +306,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 TextSpan? selection,
                 Func<string, IDisposable?> addOperationScope,
                 CodeActionRequestPriority priority,
-                bool isBlocking,
+                CodeActionOptions options,
                 CancellationToken cancellationToken)
             {
                 if (!selection.HasValue)
@@ -332,7 +335,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 var filterOutsideSelection = !requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring);
 
                 return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(
-                    workspace, state.Target.Owner._codeRefactoringService, document, selection.Value, priority, isBlocking,
+                    workspace, state.Target.Owner._codeRefactoringService, document, selection.Value, priority, options,
                     addOperationScope, filterOutsideSelection, cancellationToken);
             }
 
@@ -439,6 +442,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             private async Task<string?> TryGetRefactoringSuggestedActionCategoryAsync(
                 Document document,
                 TextSpan? selection,
+                CodeActionOptions options,
                 CancellationToken cancellationToken)
             {
                 using var state = _state.TryAddReference();
@@ -457,7 +461,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     state.Target.SubjectBuffer.SupportsRefactorings())
                 {
                     if (await state.Target.Owner._codeRefactoringService.HasRefactoringsAsync(
-                            document, selection.Value, cancellationToken).ConfigureAwait(false))
+                            document, selection.Value, options, cancellationToken).ConfigureAwait(false))
                     {
                         return PredefinedSuggestedActionCategoryNames.Refactoring;
                     }
@@ -610,6 +614,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (document == null)
                     return null;
 
+                var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: true);
+
                 using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var linkedToken = linkedTokenSource.Token;
 
@@ -621,7 +627,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (selection != null)
                 {
                     refactoringTask = Task.Run(
-                        () => TryGetRefactoringSuggestedActionCategoryAsync(document, selection, linkedToken), linkedToken);
+                        () => TryGetRefactoringSuggestedActionCategoryAsync(document, selection, options, linkedToken), linkedToken);
                 }
 
                 // If we happen to get the result of the error task before the refactoring task,

--- a/src/EditorFeatures/Core/Implementation/AddImports/AbstractAddImportsPasteCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/AddImports/AbstractAddImportsPasteCommandHandler.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.AddMissingImports;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -114,6 +115,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AddImports
                 return;
             }
 
+            var options = new AddMissingImportsOptions(
+                HideAdvancedMembers: document.Project.Solution.Options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language));
+
             using var _ = executionContext.OperationContext.AddScope(allowCancellation: true, DialogText);
             var cancellationToken = executionContext.OperationContext.UserCancellationToken;
 
@@ -123,7 +127,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AddImports
 
             var addMissingImportsService = document.GetRequiredLanguageService<IAddMissingImportsFeatureService>();
 #pragma warning disable VSTHRD102 // Implement internal logic asynchronously
-            var updatedDocument = _threadingContext.JoinableTaskFactory.Run(() => addMissingImportsService.AddMissingImportsAsync(document, textSpan, cancellationToken));
+            var updatedDocument = _threadingContext.JoinableTaskFactory.Run(() => addMissingImportsService.AddMissingImportsAsync(document, textSpan, options, cancellationToken));
 #pragma warning restore VSTHRD102 // Implement internal logic asynchronously
             if (updatedDocument is null)
             {

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.SymbolSearch;
 
 namespace Microsoft.CodeAnalysis.CodeActions
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
             return new(
                 IsBlocking: isBlocking,
                 SearchReferenceAssemblies: options.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, language),
-                HideAdvancedMembers: options.GetOption(CodeAnalysis.Completion.CompletionOptions.Metadata.HideAdvancedMembers, language));
+                HideAdvancedMembers: options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, language));
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsFactory.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.SymbolSearch;
+
+namespace Microsoft.CodeAnalysis.CodeActions
+{
+    internal static class CodeActionOptionsFactory
+    {
+        internal static CodeActionOptions GetCodeActionOptions(Project project, bool isBlocking)
+        {
+            var options = project.Solution.Options;
+            var language = project.Language;
+
+            return new(
+                IsBlocking: isBlocking,
+                SearchReferenceAssemblies: options.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, language),
+                HideAdvancedMembers: options.GetOption(CodeAnalysis.Completion.CompletionOptions.Metadata.HideAdvancedMembers, language));
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
@@ -220,14 +220,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
         {
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var textSpan = ProtocolConversions.RangeToTextSpan(selection, text);
+            var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: false);
 
             var codeFixes = await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
                 document.Project.Solution.Workspace, codeFixService, document, textSpan,
                 CodeActionRequestPriority.None,
-                isBlocking: false, addOperationScope: _ => null, cancellationToken).ConfigureAwait(false);
+                options, addOperationScope: _ => null, cancellationToken).ConfigureAwait(false);
 
             var codeRefactorings = await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(
-                document.Project.Solution.Workspace, codeRefactoringService, document, textSpan, CodeActionRequestPriority.None, isBlocking: false,
+                document.Project.Solution.Workspace, codeRefactoringService, document, textSpan, CodeActionRequestPriority.None, options,
                 addOperationScope: _ => null, filterOutsideSelection: false, cancellationToken).ConfigureAwait(false);
 
             var actionSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(codeFixes, codeRefactorings, textSpan, currentActionCount: 0);

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
 
             public TestParameters WithWorkspaceKind(string workspaceKind)
-                => new(parseOptions, compilationOptions, options, codeActionOptions,  fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+                => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
         }
 
 #pragma warning disable IDE0052 // Remove unread private members (unused when CODE_STYLE is set)

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
     {
         public struct TestParameters
         {
+            internal readonly CodeActionOptions codeActionOptions;
             internal readonly OptionsCollection options;
             internal readonly TestHost testHost;
             internal readonly string workspaceKind;
@@ -63,6 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 ParseOptions parseOptions = null,
                 CompilationOptions compilationOptions = null,
                 OptionsCollection options = null,
+                CodeActionOptions? codeActionOptions = null,
                 object fixProviderData = null,
                 int index = 0,
                 CodeActionPriority? priority = null,
@@ -75,6 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 this.parseOptions = parseOptions;
                 this.compilationOptions = compilationOptions;
                 this.options = options;
+                this.codeActionOptions = codeActionOptions ?? CodeActionOptions.Default;
                 this.fixProviderData = fixProviderData;
                 this.index = index;
                 this.priority = priority;
@@ -86,28 +89,31 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             }
 
             public TestParameters WithParseOptions(ParseOptions parseOptions)
-                => new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+                => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
 
             public TestParameters WithCompilationOptions(CompilationOptions compilationOptions)
-                => new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+                => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
 
             internal TestParameters WithOptions(OptionsCollection options)
-                => new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+                => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+
+            internal TestParameters WithCodeActionOptions(CodeActionOptions codeActionOptions)
+                => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
 
             public TestParameters WithFixProviderData(object fixProviderData)
-                => new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+                => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
 
             public TestParameters WithIndex(int index)
-                => new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+                => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
 
             public TestParameters WithRetainNonFixableDiagnostics(bool retainNonFixableDiagnostics)
-                => new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+                => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
 
             public TestParameters WithIncludeDiagnosticsOutsideSelection(bool includeDiagnosticsOutsideSelection)
-                => new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+                => new(parseOptions, compilationOptions, options, codeActionOptions, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
 
             public TestParameters WithWorkspaceKind(string workspaceKind)
-                => new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
+                => new(parseOptions, compilationOptions, options, codeActionOptions,  fixProviderData, index, priority, retainNonFixableDiagnostics, includeDiagnosticsOutsideSelection, title, testHost, workspaceKind);
         }
 
 #pragma warning disable IDE0052 // Remove unread private members (unused when CODE_STYLE is set)
@@ -379,7 +385,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         {
             return TestInRegularAndScript1Async(
                 initialMarkup, expectedMarkup, index,
-                new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, title: title, testHost: testHost));
+                new TestParameters(parseOptions, compilationOptions, options, CodeActionOptions.Default, fixProviderData, index, priority, title: title, testHost: testHost));
         }
 
         internal Task TestInRegularAndScript1Async(
@@ -419,7 +425,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             return TestAsync(
                 initialMarkup,
                 expectedMarkup,
-                new TestParameters(parseOptions, compilationOptions, options, fixProviderData, index, priority, testHost: testHost));
+                new TestParameters(parseOptions, compilationOptions, options, CodeActionOptions.Default, fixProviderData, index, priority, testHost: testHost));
         }
 
         private async Task TestAsync(

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -69,7 +69,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             var span = documentsWithSelections.Single().SelectedSpans.Single();
             var actions = ArrayBuilder<(CodeAction, TextSpan?)>.GetInstance();
             var document = workspace.CurrentSolution.GetDocument(documentsWithSelections.Single().Id);
-            var context = new CodeRefactoringContext(document, span, (a, t) => actions.Add((a, t)), isBlocking: false, CancellationToken.None);
+            var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: false);
+            var context = new CodeRefactoringContext(document, span, (a, t) => actions.Add((a, t)), options, CancellationToken.None);
             await provider.ComputeRefactoringsAsync(context);
 
             var result = actions.Count > 0 ? new CodeRefactoring(provider, actions.ToImmutable()) : null;

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var ids = new HashSet<string>(fixer.FixableDiagnosticIds);
             var dxs = diagnostics.Where(d => ids.Contains(d.Id)).ToList();
             var (resultDiagnostics, codeActions, actionToInvoke) = await GetDiagnosticAndFixesAsync(
-                dxs, fixer, testDriver, document, span, annotation, parameters.index);
+                dxs, fixer, testDriver, document, span, parameters.codeActionOptions, annotation, parameters.index);
 
             // If we are also testing non-fixable diagnostics,
             // then the result diagnostics need to include all diagnostics,

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractSuppressionDiagnosticTest.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var wrapperCodeFixer = new WrapperCodeFixProvider(fixer, filteredDiagnostics.Select(d => d.Id));
             return await GetDiagnosticAndFixesAsync(
                 filteredDiagnostics, wrapperCodeFixer, testDriver, document,
-                span, annotation, parameters.index);
+                span, CodeActionOptions.Default, annotation, parameters.index);
         }
     }
 }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUnncessarySuppressionDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUnncessarySuppressionDiagnosticTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
             return await GetDiagnosticAndFixesAsync(
                 diagnostics, CodeFixProvider, testDriver, document,
-                span, annotation, parameters.index);
+                span, CodeActionOptions.Default, annotation, parameters.index);
         }
     }
 }

--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -87,7 +87,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager, analyzerReference);
 
             // Verify that we do not crash when computing fixes.
-            _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), cancellationToken: CancellationToken.None);
+            var options = CodeActionOptions.Default;
+
+            _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
 
             // Verify that code fix is invoked with both the diagnostics in the context,
             // i.e. duplicate diagnostics are not silently discarded by the CodeFixService.
@@ -113,7 +115,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager, analyzerReference);
 
             // Verify registered configuration code actions do not have duplicates.
-            var fixCollections = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), cancellationToken: CancellationToken.None);
+            var options = CodeActionOptions.Default;
+            var fixCollections = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
             var codeActions = fixCollections.SelectMany(c => c.Fixes.Select(f => f.Action)).ToImmutableArray();
             Assert.Equal(7, codeActions.Length);
             var uniqueTitles = new HashSet<string>();
@@ -143,16 +146,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             using var workspace = tuple.workspace;
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager, analyzerReference);
 
+            var options = CodeActionOptions.Default;
+
             // Verify only analyzerWithFix is executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Normal'.
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                priority: CodeActionRequestPriority.Normal, isBlocking: false,
+                priority: CodeActionRequestPriority.Normal, options,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(analyzerWithFix.ReceivedCallback);
             Assert.False(analyzerWithoutFix.ReceivedCallback);
 
             // Verify both analyzerWithFix and analyzerWithoutFix are executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Lowest'.
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                priority: CodeActionRequestPriority.Lowest, isBlocking: false,
+                priority: CodeActionRequestPriority.Lowest, options,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(analyzerWithFix.ReceivedCallback);
             Assert.True(analyzerWithoutFix.ReceivedCallback);
@@ -180,8 +185,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager, analyzerReference);
 
             // Verify both analyzers are executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Normal'.
+            var options = CodeActionOptions.Default;
+
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                priority: CodeActionRequestPriority.Normal, isBlocking: false,
+                priority: CodeActionRequestPriority.Normal, options,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(documentDiagnosticAnalyzer.ReceivedCallback);
         }
@@ -265,7 +272,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var reference = new MockAnalyzerReference(codefix, ImmutableArray.Create(diagnosticAnalyzer));
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
             document = project.Documents.Single();
-            var fixes = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), cancellationToken: CancellationToken.None);
+            var options = CodeActionOptions.Default;
+            var fixes = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
 
             if (exception)
             {
@@ -679,7 +687,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
 
             var document = project.Documents.Single();
-            return await fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), cancellationToken: CancellationToken.None);
+            var options = CodeActionOptions.Default;
+
+            return await fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
         }
 
         private sealed class NuGetCodeFixProvider : AbstractNuGetOrVsixCodeFixProvider

--- a/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
+++ b/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
@@ -43,7 +43,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
             var reference = new StubAnalyzerReference();
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
             var document = project.Documents.Single();
-            var refactorings = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), CancellationToken.None);
+            var options = CodeActionOptions.Default;
+            var refactorings = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
 
             var stubRefactoringAction = refactorings.Single(refactoring => refactoring.CodeActions.FirstOrDefault().action?.Title == nameof(StubRefactoring));
             Assert.True(stubRefactoringAction is object);
@@ -66,7 +67,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
             var project = workspace.CurrentSolution.Projects.Single();
             var document = project.Documents.Single();
             var extensionManager = (EditorLayerExtensionManager.ExtensionManager)document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
-            var result = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), CancellationToken.None);
+            var options = CodeActionOptions.Default;
+            var result = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(codeRefactoring));
             Assert.False(extensionManager.IsIgnored(codeRefactoring));
 

--- a/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
+++ b/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
@@ -52,6 +52,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences({analyzerReference}))
 
                 Dim project = workspace.CurrentSolution.Projects(0)
+                Dim options = CodeActionOptionsFactory.GetCodeActionOptions(project, isBlocking:=False)
 
                 Assert.IsType(Of MockDiagnosticUpdateSourceRegistrationService)(workspace.GetService(Of IDiagnosticUpdateSourceRegistrationService)())
                 Dim diagnosticService = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
@@ -73,9 +74,12 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 Assert.Equal(1, diagnostics.Count())
 
                 ' Verify available codefix with a global fixer
-                Dim fixes = Await codefixService.GetFixesAsync(document,
+                Dim fixes = Await codefixService.GetFixesAsync(
+                    document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                    cancellationToken:=CancellationToken.None)
+                    options,
+                    CancellationToken.None)
+
                 Assert.Equal(0, fixes.Count())
 
                 ' Verify available codefix with a global fixer + a project fixer
@@ -86,17 +90,22 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 Dim projectAnalyzerReferences = ImmutableArray.Create(Of AnalyzerReference)(projectAnalyzerReference)
                 project = project.WithAnalyzerReferences(projectAnalyzerReferences)
                 document = project.Documents.Single()
-                fixes = Await codefixService.GetFixesAsync(document,
-                                                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                                                     cancellationToken:=CancellationToken.None)
+                fixes = Await codefixService.GetFixesAsync(
+                    document,
+                    (Await document.GetSyntaxRootAsync()).FullSpan,
+                    options,
+                    CancellationToken.None)
                 Assert.Equal(1, fixes.Count())
 
                 ' Remove a project analyzer
                 project = project.RemoveAnalyzerReference(projectAnalyzerReference)
                 document = project.Documents.Single()
-                fixes = Await codefixService.GetFixesAsync(document,
-                                                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                                                     cancellationToken:=CancellationToken.None)
+                fixes = Await codefixService.GetFixesAsync(
+                    document,
+                    (Await document.GetSyntaxRootAsync()).FullSpan,
+                    options,
+                    CancellationToken.None)
+
                 Assert.Equal(0, fixes.Count())
             End Using
         End Function
@@ -120,6 +129,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences({analyzerReference}))
 
                 Dim project = workspace.CurrentSolution.Projects(0)
+                Dim options = CodeActionOptionsFactory.GetCodeActionOptions(project, isBlocking:=False)
 
                 Assert.IsType(Of MockDiagnosticUpdateSourceRegistrationService)(workspace.GetService(Of IDiagnosticUpdateSourceRegistrationService)())
                 Dim diagnosticService = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
@@ -141,9 +151,12 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 Assert.Equal(1, diagnostics.Count())
 
                 ' Verify no codefix with a global fixer
-                Dim fixes = Await codefixService.GetFixesAsync(document,
-                                                         (Await document.GetSyntaxRootAsync()).FullSpan,
-                                                         cancellationToken:=CancellationToken.None)
+                Dim fixes = Await codefixService.GetFixesAsync(
+                    document,
+                    (Await document.GetSyntaxRootAsync()).FullSpan,
+                    options,
+                    CancellationToken.None)
+
                 Assert.Equal(0, fixes.Count())
 
                 ' Verify no codefix with a global fixer + a project fixer
@@ -154,9 +167,12 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 Dim projectAnalyzerReferences = ImmutableArray.Create(Of AnalyzerReference)(projectAnalyzerReference)
                 project = project.WithAnalyzerReferences(projectAnalyzerReferences)
                 document = project.Documents.Single()
-                fixes = Await codefixService.GetFixesAsync(document,
-                                                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                                                     cancellationToken:=CancellationToken.None)
+                fixes = Await codefixService.GetFixesAsync(
+                    document,
+                    (Await document.GetSyntaxRootAsync()).FullSpan,
+                    options,
+                    CancellationToken.None)
+
                 Assert.Equal(0, fixes.Count())
             End Using
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Formatting/CodeCleanUpTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/CodeCleanUpTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeCleanup
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Diagnostics.VisualBasic
@@ -328,6 +329,8 @@ End Class
                                                                              Optional systemImportsFirst As Boolean = True,
                                                                              Optional separateImportsGroups As Boolean = False) As Task
             Using workspace = TestWorkspace.CreateVisualBasic(code, composition:=EditorTestCompositions.EditorFeaturesWpf)
+                Dim options = CodeActionOptions.Default
+
                 Dim solution = workspace.CurrentSolution _
                     .WithOptions(workspace.Options _
                     .WithChangedOption(GenerationOptions.PlaceSystemNamespaceFirst,
@@ -355,10 +358,12 @@ End Class
 
                 Dim enabledDiagnostics = codeCleanupService.GetAllDiagnostics()
 
-                Dim newDoc = Await codeCleanupService.CleanupAsync(document,
-                                                               enabledDiagnostics,
-                                                               New ProgressTracker,
-                                                               CancellationToken.None)
+                Dim newDoc = Await codeCleanupService.CleanupAsync(
+                    document,
+                    enabledDiagnostics,
+                    New ProgressTracker,
+                    options,
+                    CancellationToken.None)
 
                 Dim actual = Await newDoc.GetTextAsync()
 

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SymbolSearch;
@@ -57,12 +58,14 @@ namespace Microsoft.CodeAnalysis.AddImport
             var addImportService = document.GetLanguageService<IAddImportFeatureService>();
 
             var solution = document.Project.Solution;
-            var options = solution.Options;
 
-            var searchReferenceAssemblies = options.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, document.Project.Language);
-            var searchNuGetPackages = options.GetOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, document.Project.Language);
+            var searchNuGetPackages = solution.Options.GetOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, document.Project.Language);
 
-            var symbolSearchService = searchReferenceAssemblies || searchNuGetPackages
+            var options = new AddImportOptions(
+                SearchReferenceAssemblies: solution.Options.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, document.Project.Language),
+                HideAdvancedMembers: solution.Options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language));
+
+            var symbolSearchService = options.SearchReferenceAssemblies || searchNuGetPackages
                 ? _symbolSearchService ?? solution.Workspace.Services.GetService<ISymbolSearchService>()
                 : null;
 
@@ -72,7 +75,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 : ImmutableArray<PackageSource>.Empty;
 
             var fixesForDiagnostic = await addImportService.GetFixesForDiagnosticsAsync(
-                document, span, diagnostics, MaxResults, symbolSearchService, searchReferenceAssemblies, packageSources, cancellationToken).ConfigureAwait(false);
+                document, span, diagnostics, MaxResults, symbolSearchService, options, packageSources, cancellationToken).ConfigureAwait(false);
 
             foreach (var (diagnostic, fixes) in fixesForDiagnostic)
             {

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -62,8 +62,8 @@ namespace Microsoft.CodeAnalysis.AddImport
             var searchNuGetPackages = solution.Options.GetOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, document.Project.Language);
 
             var options = new AddImportOptions(
-                SearchReferenceAssemblies: solution.Options.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, document.Project.Language),
-                HideAdvancedMembers: solution.Options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language));
+                context.Options.SearchReferenceAssemblies,
+                context.Options.HideAdvancedMembers);
 
             var symbolSearchService = options.SearchReferenceAssemblies || searchNuGetPackages
                 ? _symbolSearchService ?? solution.Workspace.Services.GetService<ISymbolSearchService>()

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         public async Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
             Document document, TextSpan span, string diagnosticId, int maxResults,
             bool allowInHiddenRegions,
-            ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
+            ISymbolSearchService symbolSearchService, AddImportOptions options,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
         {
             var client = await RemoteHostClient.TryGetClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 var result = await client.TryInvokeAsync<IRemoteMissingImportDiscoveryService, ImmutableArray<AddImportFixData>>(
                     document.Project.Solution,
                     (service, solutionInfo, callbackId, cancellationToken) =>
-                        service.GetFixesAsync(solutionInfo, callbackId, document.Id, span, diagnosticId, maxResults, allowInHiddenRegions, searchReferenceAssemblies, packageSources, cancellationToken),
+                        service.GetFixesAsync(solutionInfo, callbackId, document.Id, span, diagnosticId, maxResults, allowInHiddenRegions, options, packageSources, cancellationToken),
                     callbackTarget: symbolSearchService,
                     cancellationToken).ConfigureAwait(false);
 
@@ -75,14 +75,14 @@ namespace Microsoft.CodeAnalysis.AddImport
             return await GetFixesInCurrentProcessAsync(
                 document, span, diagnosticId, maxResults,
                 allowInHiddenRegions,
-                symbolSearchService, searchReferenceAssemblies,
+                symbolSearchService, options,
                 packageSources, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<ImmutableArray<AddImportFixData>> GetFixesInCurrentProcessAsync(
             Document document, TextSpan span, string diagnosticId, int maxResults,
             bool allowInHiddenRegions,
-            ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
+            ISymbolSearchService symbolSearchService, AddImportOptions options,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
         {
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                             var allSymbolReferences = await FindResultsAsync(
                                 document, semanticModel, diagnosticId, node, maxResults, symbolSearchService,
-                                searchReferenceAssemblies, packageSources, cancellationToken).ConfigureAwait(false);
+                                options, packageSources, cancellationToken).ConfigureAwait(false);
 
                             // Nothing found at all. No need to proceed.
                             foreach (var reference in allSymbolReferences)
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
         private async Task<ImmutableArray<Reference>> FindResultsAsync(
             Document document, SemanticModel semanticModel, string diagnosticId, SyntaxNode node, int maxResults, ISymbolSearchService symbolSearchService,
-            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
+            AddImportOptions options, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
         {
             // Caches so we don't produce the same data multiple times while searching 
             // all over the solution.
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             var finder = new SymbolReferenceFinder(
                 this, document, semanticModel, diagnosticId, node, symbolSearchService,
-                searchReferenceAssemblies, packageSources, cancellationToken);
+                options, packageSources, cancellationToken);
 
             // Look for exact matches first:
             var exactReferences = await FindResultsAsync(projectToAssembly, referenceToCompilation, project, maxResults, finder, exact: true, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
         public async Task<ImmutableArray<(Diagnostic Diagnostic, ImmutableArray<AddImportFixData> Fixes)>> GetFixesForDiagnosticsAsync(
             Document document, TextSpan span, ImmutableArray<Diagnostic> diagnostics, int maxResultsPerDiagnostic,
-            ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
+            ISymbolSearchService symbolSearchService, AddImportOptions options,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
         {
             // We might have multiple different diagnostics covering the same span.  Have to
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 var fixes = await GetFixesAsync(
                     document, span, diagnostic.Id, maxResultsPerDiagnostic,
                     allowInHiddenRegions,
-                    symbolSearchService, searchReferenceAssemblies,
+                    symbolSearchService, options,
                     packageSources, cancellationToken).ConfigureAwait(false);
 
                 fixesForDiagnosticBuilder.Add((diagnostic, fixes));
@@ -517,7 +517,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
         public async Task<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(
             Document document, TextSpan span, ImmutableArray<string> diagnosticIds,
-            ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
+            ISymbolSearchService symbolSearchService, AddImportOptions options,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
         {
             var client = await RemoteHostClient.TryGetClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
@@ -526,7 +526,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 var result = await client.TryInvokeAsync<IRemoteMissingImportDiscoveryService, ImmutableArray<AddImportFixData>>(
                     document.Project.Solution,
                     (service, solutionInfo, callbackId, cancellationToken) =>
-                        service.GetUniqueFixesAsync(solutionInfo, callbackId, document.Id, span, diagnosticIds, searchReferenceAssemblies, packageSources, cancellationToken),
+                        service.GetUniqueFixesAsync(solutionInfo, callbackId, document.Id, span, diagnosticIds, options, packageSources, cancellationToken),
                     callbackTarget: symbolSearchService,
                     cancellationToken).ConfigureAwait(false);
 
@@ -535,7 +535,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             return await GetUniqueFixesAsyncInCurrentProcessAsync(
                 document, span, diagnosticIds,
-                symbolSearchService, searchReferenceAssemblies,
+                symbolSearchService, options,
                 packageSources, cancellationToken).ConfigureAwait(false);
         }
 
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             TextSpan span,
             ImmutableArray<string> diagnosticIds,
             ISymbolSearchService symbolSearchService,
-            bool searchReferenceAssemblies,
+            AddImportOptions options,
             ImmutableArray<PackageSource> packageSources,
             CancellationToken cancellationToken)
         {
@@ -561,7 +561,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 .GroupBy(diagnostic => diagnostic.Location.SourceSpan)
                 .Select(diagnosticsForSourceSpan => GetFixesForDiagnosticsAsync(
                         document, diagnosticsForSourceSpan.Key, diagnosticsForSourceSpan.AsImmutable(),
-                        maxResultsPerDiagnostic: 2, symbolSearchService, searchReferenceAssemblies, packageSources, cancellationToken));
+                        maxResultsPerDiagnostic: 2, symbolSearchService, options, packageSources, cancellationToken));
 
             using var _ = ArrayBuilder<AddImportFixData>.GetInstance(out var fixes);
             foreach (var getFixesForDiagnosticsTask in getFixesForDiagnosticsTasks)

--- a/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -13,6 +14,11 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.AddImport
 {
+    [DataContract]
+    internal readonly record struct AddImportOptions(
+        [property: DataMember(Order = 0)] bool SearchReferenceAssemblies,
+        [property: DataMember(Order = 1)] bool HideAdvancedMembers);
+
     internal interface IAddImportFeatureService : ILanguageService
     {
         /// <summary>
@@ -22,7 +28,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
             Document document, TextSpan span, string diagnosticId, int maxResults,
             bool allowInHiddenRegions,
-            ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
+            ISymbolSearchService symbolSearchService, AddImportOptions options,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
 
         /// <summary>
@@ -31,7 +37,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         /// </summary>
         Task<ImmutableArray<(Diagnostic Diagnostic, ImmutableArray<AddImportFixData> Fixes)>> GetFixesForDiagnosticsAsync(
             Document document, TextSpan span, ImmutableArray<Diagnostic> diagnostics, int maxResultsPerDiagnostic,
-            ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
+            ISymbolSearchService symbolSearchService, AddImportOptions options,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
 
         /// <summary>
@@ -44,12 +50,12 @@ namespace Microsoft.CodeAnalysis.AddImport
 
         /// <summary>
         /// Gets data for how to fix a particular <see cref="Diagnostic" /> id within the specified Document.
-        /// Similar to <see cref="GetFixesAsync(Document, TextSpan, string, int, bool, ISymbolSearchService, bool, ImmutableArray{PackageSource}, CancellationToken)"/> 
+        /// Similar to <see cref="GetFixesAsync(Document, TextSpan, string, int, bool, ISymbolSearchService, AddImportOptions, ImmutableArray{PackageSource}, CancellationToken)"/> 
         /// except it only returns fix data when there is a single using fix for a given span
         /// </summary>
         Task<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(
             Document document, TextSpan span, ImmutableArray<string> diagnosticIds,
-            ISymbolSearchService symbolSearchService, bool searchReferenceAssemblies,
+            ISymbolSearchService symbolSearchService, AddImportOptions options,
             ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteMissingImportDiscoveryService.cs
@@ -25,9 +25,10 @@ namespace Microsoft.CodeAnalysis.AddImport
 
         ValueTask<ImmutableArray<AddImportFixData>> GetFixesAsync(
             PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId documentId, TextSpan span, string diagnosticId, int maxResults,
-            bool allowInHiddenRegions, bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
+            bool allowInHiddenRegions, AddImportOptions options, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
+
         ValueTask<ImmutableArray<AddImportFixData>> GetUniqueFixesAsync(
             PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId id, TextSpan span, ImmutableArray<string> diagnosticIds,
-            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
+            AddImportOptions options, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -39,15 +39,17 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             private readonly SyntaxNode _node;
             private readonly ISymbolSearchService _symbolSearchService;
-            private readonly bool _searchReferenceAssemblies;
+            private readonly AddImportOptions _options;
             private readonly ImmutableArray<PackageSource> _packageSources;
 
             public SymbolReferenceFinder(
                 AbstractAddImportFeatureService<TSimpleNameSyntax> owner,
-                Document document, SemanticModel semanticModel,
-                string diagnosticId, SyntaxNode node,
+                Document document,
+                SemanticModel semanticModel,
+                string diagnosticId,
+                SyntaxNode node,
                 ISymbolSearchService symbolSearchService,
-                bool searchReferenceAssemblies,
+                AddImportOptions options,
                 ImmutableArray<PackageSource> packageSources,
                 CancellationToken cancellationToken)
             {
@@ -58,10 +60,10 @@ namespace Microsoft.CodeAnalysis.AddImport
                 _node = node;
 
                 _symbolSearchService = symbolSearchService;
-                _searchReferenceAssemblies = searchReferenceAssemblies;
+                _options = options;
                 _packageSources = packageSources;
 
-                if (_searchReferenceAssemblies || packageSources.Length > 0)
+                if (options.SearchReferenceAssemblies || packageSources.Length > 0)
                 {
                     Contract.ThrowIfNull(symbolSearchService);
                 }
@@ -217,14 +219,13 @@ namespace Microsoft.CodeAnalysis.AddImport
 
                 var typeSymbols = OfType<ITypeSymbol>(symbols);
 
-                var hideAdvancedMembers = _document.Project.Solution.Options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, _document.Project.Language);
                 var editorBrowserInfo = new EditorBrowsableInfo(_semanticModel.Compilation);
 
                 // Only keep symbols which are accessible from the current location and that are allowed by the current
                 // editor browsable rules.
                 var accessibleTypeSymbols = typeSymbols.WhereAsArray(
                     s => ArityAccessibilityAndAttributeContextAreCorrect(s.Symbol, arity, inAttributeContext, hasIncompleteParentMember, looksGeneric) &&
-                         s.Symbol.IsEditorBrowsable(hideAdvancedMembers, _semanticModel.Compilation, editorBrowserInfo));
+                         s.Symbol.IsEditorBrowsable(_options.HideAdvancedMembers, _semanticModel.Compilation, editorBrowserInfo));
 
                 // These types may be contained within namespaces, or they may be nested 
                 // inside generic types.  Record these namespaces/types if it would be 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 ArrayBuilder<Reference> allReferences, TSimpleNameSyntax nameNode,
                 string name, int arity, bool isAttributeSearch, CancellationToken cancellationToken)
             {
-                if (_searchReferenceAssemblies)
+                if (_options.SearchReferenceAssemblies)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     await FindReferenceAssemblyTypeReferencesAsync(

--- a/src/Features/Core/Portable/CodeCleanup/ICodeCleanupService.cs
+++ b/src/Features/Core/Portable/CodeCleanup/ICodeCleanupService.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 
@@ -11,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
 {
     internal interface ICodeCleanupService : ILanguageService
     {
-        Task<Document> CleanupAsync(Document document, EnabledDiagnosticOptions enabledDiagnostics, IProgressTracker progressTracker, CancellationToken cancellationToken);
+        Task<Document> CleanupAsync(Document document, EnabledDiagnosticOptions enabledDiagnostics, IProgressTracker progressTracker, CodeActionOptions options, CancellationToken cancellationToken);
         EnabledDiagnosticOptions GetAllDiagnostics();
     }
 }

--- a/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
@@ -15,19 +15,16 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 {
     internal interface ICodeFixService
     {
-        Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, bool isBlocking, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
-        Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CancellationToken cancellationToken);
-        Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, IProgressTracker progressTracker, CancellationToken cancellationToken);
+        Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptions options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
+        Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CodeActionOptions options, CancellationToken cancellationToken);
+        Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, IProgressTracker progressTracker, CodeActionOptions options, CancellationToken cancellationToken);
         CodeFixProvider? GetSuppressionFixer(string language, IEnumerable<string> diagnosticIds);
         Task<FirstDiagnosticResult> GetMostSevereFixableDiagnosticAsync(Document document, TextSpan range, CancellationToken cancellationToken);
     }
 
     internal static class ICodeFixServiceExtensions
     {
-        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, CancellationToken cancellationToken)
-            => service.GetFixesAsync(document, range, isBlocking: false, cancellationToken);
-
-        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, bool isBlocking, CancellationToken cancellationToken)
-            => service.GetFixesAsync(document, range, CodeActionRequestPriority.None, isBlocking, addOperationScope: _ => null, cancellationToken);
+        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, CodeActionOptions options, CancellationToken cancellationToken)
+            => service.GetFixesAsync(document, range, CodeActionRequestPriority.None, options, addOperationScope: _ => null, cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
@@ -28,9 +29,9 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
         protected abstract ImmutableArray<string> FixableDiagnosticIds { get; }
 
         /// <inheritdoc/>
-        public async Task<Document> AddMissingImportsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
+        public async Task<Document> AddMissingImportsAsync(Document document, TextSpan textSpan, AddMissingImportsOptions options, CancellationToken cancellationToken)
         {
-            var analysisResult = await AnalyzeAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
+            var analysisResult = await AnalyzeAsync(document, textSpan, options, cancellationToken).ConfigureAwait(false);
             return await AddMissingImportsAsync(document, analysisResult, cancellationToken).ConfigureAwait(false);
         }
 
@@ -48,7 +49,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
         }
 
         /// <inheritdoc/>
-        public async Task<AddMissingImportsAnalysisResult> AnalyzeAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
+        public async Task<AddMissingImportsAnalysisResult> AnalyzeAsync(Document document, TextSpan textSpan, AddMissingImportsOptions options, CancellationToken cancellationToken)
         {
             // Get the diagnostics that indicate a missing import.
             var addImportFeatureService = document.GetRequiredLanguageService<IAddImportFeatureService>();
@@ -59,9 +60,13 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             // Since we are not currently considering NuGet packages, pass an empty array
             var packageSources = ImmutableArray<PackageSource>.Empty;
 
+            var addImportOptions = new AddImportOptions(
+                SearchReferenceAssemblies: true,
+                HideAdvancedMembers: options.HideAdvancedMembers);
+
             var unambiguousFixes = await addImportFeatureService.GetUniqueFixesAsync(
                 document, textSpan, FixableDiagnosticIds, symbolSearchService,
-                searchReferenceAssemblies: true, packageSources, cancellationToken).ConfigureAwait(false);
+                addImportOptions, packageSources, cancellationToken).ConfigureAwait(false);
 
             // We do not want to add project or framework references without the user's input, so filter those out.
             var usableFixes = unambiguousFixes.WhereAsArray(fixData => DoesNotAddReference(fixData, document.Project.Id));

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
@@ -37,8 +37,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             // Check pasted text span for missing imports
             var addMissingImportsService = document.GetLanguageService<IAddMissingImportsFeatureService>();
 
-            var options = new AddMissingImportsOptions(
-                HideAdvancedMembers: document.Project.Solution.Options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language));
+            var options = new AddMissingImportsOptions(context.Options.HideAdvancedMembers);
 
             var analysis = await addMissingImportsService.AnalyzeAsync(document, textSpan, options, cancellationToken).ConfigureAwait(false);
             if (!analysis.CanAddMissingImports)

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
@@ -8,6 +8,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.PasteTracking;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -36,7 +37,10 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             // Check pasted text span for missing imports
             var addMissingImportsService = document.GetLanguageService<IAddMissingImportsFeatureService>();
 
-            var analysis = await addMissingImportsService.AnalyzeAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
+            var options = new AddMissingImportsOptions(
+                HideAdvancedMembers: document.Project.Solution.Options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language));
+
+            var analysis = await addMissingImportsService.AnalyzeAsync(document, textSpan, options, cancellationToken).ConfigureAwait(false);
             if (!analysis.CanAddMissingImports)
             {
                 return;

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/IAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/IAddMissingImportsFeatureService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -9,6 +10,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.AddMissingImports
 {
+    [DataContract]
+    internal readonly record struct AddMissingImportsOptions(
+        [property: DataMember(Order = 0)] bool HideAdvancedMembers);
+
     internal interface IAddMissingImportsFeatureService : ILanguageService
     {
         /// <summary>
@@ -17,15 +22,15 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
         /// if there are ambiguous imports, no known resolutions to import, or if no imports that would be provided
         /// would be added without adding a reference for the project. 
         /// </summary>
-        Task<Document> AddMissingImportsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+        Task<Document> AddMissingImportsAsync(Document document, TextSpan textSpan, AddMissingImportsOptions options, CancellationToken cancellationToken);
 
         /// <summary>
         /// Analyzes the document inside the texstpan to determine if imports can be added.
         /// </summary>
-        Task<AddMissingImportsAnalysisResult> AnalyzeAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+        Task<AddMissingImportsAnalysisResult> AnalyzeAsync(Document document, TextSpan textSpan, AddMissingImportsOptions options, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Performs the same action as <see cref="AddMissingImportsAsync(Document, TextSpan, CancellationToken)"/> but
+        /// Performs the same action as <see cref="AddMissingImportsAsync(Document, TextSpan, AddMissingImportsOptions, CancellationToken)"/> but
         /// with a predetermined analysis of the input instead of recalculating it
         /// </summary>
         Task<Document> AddMissingImportsAsync(Document document, AddMissingImportsAnalysisResult analysisResult, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
@@ -13,17 +13,14 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 {
     internal interface ICodeRefactoringService
     {
-        Task<bool> HasRefactoringsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+        Task<bool> HasRefactoringsAsync(Document document, TextSpan textSpan, CodeActionOptions options, CancellationToken cancellationToken);
 
-        Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, bool isBlocking, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
+        Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptions options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
     }
 
     internal static class ICodeRefactoringServiceExtensions
     {
-        public static Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(this ICodeRefactoringService service, Document document, TextSpan state, CancellationToken cancellationToken)
-            => service.GetRefactoringsAsync(document, state, isBlocking: false, cancellationToken);
-
-        public static Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(this ICodeRefactoringService service, Document document, TextSpan state, bool isBlocking, CancellationToken cancellationToken)
-            => service.GetRefactoringsAsync(document, state, CodeActionRequestPriority.None, isBlocking, addOperationScope: _ => null, cancellationToken);
+        public static Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(this ICodeRefactoringService service, Document document, TextSpan state, CodeActionOptions options, CancellationToken cancellationToken)
+            => service.GetRefactoringsAsync(document, state, CodeActionRequestPriority.None, options, addOperationScope: _ => null, cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
                     return;
                 }
 
-                var hideAdvancedMembers = document.Project.Solution.Options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language);
+                var hideAdvancedMembers = context.Options.HideAdvancedMembers;
                 var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
                 var matchingTypes = await GetMatchingTypesAsync(document, semanticModel, node, hideAdvancedMembers, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -63,9 +63,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
                     return;
                 }
 
+                var hideAdvancedMembers = document.Project.Solution.Options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language);
                 var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-                var matchingTypes = await GetMatchingTypesAsync(document, semanticModel, node, cancellationToken).ConfigureAwait(false);
+                var matchingTypes = await GetMatchingTypesAsync(document, semanticModel, node, hideAdvancedMembers, cancellationToken).ConfigureAwait(false);
                 var matchingNamespaces = await GetMatchingNamespacesAsync(project, semanticModel, node, cancellationToken).ConfigureAwait(false);
 
                 if (matchingTypes.IsEmpty && matchingNamespaces.IsEmpty)
@@ -147,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
         }
 
         private async Task<ImmutableArray<SymbolResult>> GetMatchingTypesAsync(
-            Document document, SemanticModel semanticModel, SyntaxNode node, CancellationToken cancellationToken)
+            Document document, SemanticModel semanticModel, SyntaxNode node, bool hideAdvancedMembers, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -171,8 +172,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
                 symbols = symbols.Concat(attributeSymbols);
             }
 
-            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var hideAdvancedMembers = options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers);
             var editorBrowserInfo = new EditorBrowsableInfo(semanticModel.Compilation);
 
             var validSymbols = symbols

--- a/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/Core/Portable/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             Document document,
             TextSpan selection,
             CodeActionRequestPriority priority,
-            bool isBlocking,
+            CodeActionOptions options,
             Func<string, IDisposable?> addOperationScope,
             CancellationToken cancellationToken)
         {
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 document,
                 selection,
                 priority,
-                isBlocking,
+                options,
                 addOperationScope,
                 cancellationToken), cancellationToken).ConfigureAwait(false);
 
@@ -388,7 +388,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             Document document,
             TextSpan selection,
             CodeActionRequestPriority priority,
-            bool isBlocking,
+            CodeActionOptions options,
             Func<string, IDisposable?> addOperationScope,
             bool filterOutsideSelection,
             CancellationToken cancellationToken)
@@ -399,7 +399,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             // the UI thread.
             var refactorings = await Task.Run(
                 () => codeRefactoringService.GetRefactoringsAsync(
-                    document, selection, priority, isBlocking, addOperationScope,
+                    document, selection, priority, options, addOperationScope,
                     cancellationToken), cancellationToken).ConfigureAwait(false);
 
             var filteredRefactorings = FilterOnAnyThread(refactorings, selection, filterOutsideSelection);

--- a/src/Workspaces/Core/Portable/CodeActions/CodeActionOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeActionOptions.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.CodeActions
+{
+    /// <summary>
+    /// Options available to code fixes that are supplied by the IDE (i.e. not stored in editorconfig).
+    /// </summary>
+    internal readonly record struct CodeActionOptions(
+        bool IsBlocking,
+        bool SearchReferenceAssemblies,
+        bool HideAdvancedMembers)
+    {
+        public static readonly CodeActionOptions Default = new(
+            IsBlocking: false,
+            SearchReferenceAssemblies: true,
+            HideAdvancedMembers: false);
+
+    }
+}

--- a/src/Workspaces/Core/Portable/CodeActions/CodeActionOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeActionOptions.cs
@@ -16,6 +16,5 @@ namespace Microsoft.CodeAnalysis.CodeActions
             IsBlocking: false,
             SearchReferenceAssemblies: true,
             HideAdvancedMembers: false);
-
     }
 }

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -45,8 +45,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
 
-        private readonly bool _isBlocking;
-        bool ITypeScriptCodeFixContext.IsBlocking => _isBlocking;
+        internal readonly CodeActionOptions Options;
+        bool ITypeScriptCodeFixContext.IsBlocking => Options.IsBlocking;
 
         /// <summary>
         /// Creates a code fix context to be passed into <see cref="CodeFixProvider.RegisterCodeFixesAsync(CodeFixContext)"/> method.
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                    span,
                    VerifyDiagnosticsArgument(diagnostics, span),
                    registerCodeFix ?? throw new ArgumentNullException(nameof(registerCodeFix)),
-                   isBlocking: false,
+                   CodeActionOptions.Default,
                    cancellationToken)
         {
         }
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                    (diagnostic ?? throw new ArgumentNullException(nameof(diagnostic))).Location.SourceSpan,
                    ImmutableArray.Create(diagnostic),
                    registerCodeFix ?? throw new ArgumentNullException(nameof(registerCodeFix)),
-                   isBlocking: false,
+                   CodeActionOptions.Default,
                    cancellationToken)
         {
         }
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             TextSpan span,
             ImmutableArray<Diagnostic> diagnostics,
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
-            bool isBlocking,
+            CodeActionOptions options,
             CancellationToken cancellationToken)
         {
             Debug.Assert(diagnostics.Any(d => d.Location.SourceSpan == span));
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             _span = span;
             _diagnostics = diagnostics;
             _registerCodeFix = registerCodeFix;
-            _isBlocking = isBlocking;
+            Options = options;
             _cancellationToken = cancellationToken;
         }
 

--- a/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
     /// <summary>
     /// Context for code refactorings provided by a <see cref="CodeRefactoringProvider"/>.
     /// </summary>
-    public struct CodeRefactoringContext : ITypeScriptCodeRefactoringContext
+    public readonly struct CodeRefactoringContext : ITypeScriptCodeRefactoringContext
     {
         /// <summary>
         /// Document corresponding to the <see cref="CodeRefactoringContext.Span"/> to refactor.
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         /// </summary>
         public CancellationToken CancellationToken { get; }
 
-        private readonly bool _isBlocking;
-        bool ITypeScriptCodeRefactoringContext.IsBlocking => _isBlocking;
+        internal readonly CodeActionOptions Options;
+        bool ITypeScriptCodeRefactoringContext.IsBlocking => Options.IsBlocking;
 
         private readonly Action<CodeAction, TextSpan?> _registerRefactoring;
 
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             TextSpan span,
             Action<CodeAction> registerRefactoring,
             CancellationToken cancellationToken)
-            : this(document, span, (action, textSpan) => registerRefactoring(action), isBlocking: false, cancellationToken)
+            : this(document, span, (action, textSpan) => registerRefactoring(action), CodeActionOptions.Default, cancellationToken)
         { }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             Document document,
             TextSpan span,
             Action<CodeAction, TextSpan?> registerRefactoring,
-            bool isBlocking,
+            CodeActionOptions options,
             CancellationToken cancellationToken)
         {
             // NOTE/TODO: Don't make this overload public & obsolete the `Action<CodeAction> registerRefactoring`
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             Document = document ?? throw new ArgumentNullException(nameof(document));
             Span = span;
             _registerRefactoring = registerRefactoring ?? throw new ArgumentNullException(nameof(registerRefactoring));
-            _isBlocking = isBlocking;
+            Options = options;
             CancellationToken = cancellationToken;
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Remote
             string diagnosticId,
             int maxResults,
             bool allowInHiddenRegions,
-            bool searchReferenceAssemblies,
+            AddImportOptions options,
             ImmutableArray<PackageSource> packageSources,
             CancellationToken cancellationToken)
         {
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var result = await service.GetFixesAsync(
                     document, span, diagnosticId, maxResults,
                     allowInHiddenRegions,
-                    symbolSearchService, searchReferenceAssemblies,
+                    symbolSearchService, options,
                     packageSources, cancellationToken).ConfigureAwait(false);
 
                 return result;
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Remote
             DocumentId documentId,
             TextSpan span,
             ImmutableArray<string> diagnosticIds,
-            bool searchReferenceAssemblies,
+            AddImportOptions options,
             ImmutableArray<PackageSource> packageSources,
             CancellationToken cancellationToken)
         {
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var result = await service.GetUniqueFixesAsync(
                     document, span, diagnosticIds,
-                    symbolSearchService, searchReferenceAssemblies,
+                    symbolSearchService, options,
                     packageSources, cancellationToken).ConfigureAwait(false);
 
                 return result;


### PR DESCRIPTION
The goal is to flow all completion options to all services that need them explicitly and remove them from solution snapshot.

Contributes to https://github.com/dotnet/roslyn/issues/58717