### PR TITLE
Update CSharpUseTupleSwapCodeFixProvider for top-level statements

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UseTupleSwap/CSharpUseTupleSwapCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseTupleSwap/CSharpUseTupleSwapCodeFixProvider.cs
@@ -58,10 +58,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UseTupleSwap
         private static void FixOne(
             SyntaxEditor editor, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
-            var localDeclarationStatement = (LocalDeclarationStatementSyntax)diagnostic.AdditionalLocations[0].FindNode(cancellationToken);
+            var localDeclarationStatement = (LocalDeclarationStatementSyntax)diagnostic.AdditionalLocations[0].FindNode(getInnermostNodeForTie: true, cancellationToken);
             // `expr_a = expr_b`;
-            var firstAssignmentStatement = (ExpressionStatementSyntax)diagnostic.AdditionalLocations[1].FindNode(cancellationToken);
-            var secondAssignmentStatment = (ExpressionStatementSyntax)diagnostic.AdditionalLocations[2].FindNode(cancellationToken);
+            var firstAssignmentStatement = (ExpressionStatementSyntax)diagnostic.AdditionalLocations[1].FindNode(getInnermostNodeForTie: true, cancellationToken);
+            var secondAssignmentStatment = (ExpressionStatementSyntax)diagnostic.AdditionalLocations[2].FindNode(getInnermostNodeForTie: true, cancellationToken);
 
             editor.RemoveNode(firstAssignmentStatement);
             editor.RemoveNode(secondAssignmentStatment);

--- a/src/Analyzers/CSharp/Tests/UseTupleSwap/UseTupleSwapTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseTupleSwap/UseTupleSwapTests.cs
@@ -8,6 +8,8 @@ using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseTupleSwap;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseTupleSwap
@@ -440,6 +442,32 @@ class C
             {
                 TestCode = code,
                 FixedCode = code,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseLocalFunction)]
+        [WorkItem(58759, "https://github.com/dotnet/roslyn/issues/58759")]
+        public async Task TestTopLevelStatements()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+                LanguageVersion = LanguageVersion.CSharp9,
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
+[|var|] temp = args[0];
+args[0] = args[1];
+args[1] = temp;
+",
+                    },
+                    OutputKind = OutputKind.ConsoleApplication,
+                },
+                FixedCode = @"
+(args[1], args[0]) = (args[0], args[1]);
+",
             }.RunAsync();
         }
     }


### PR DESCRIPTION
Fixes #58759