### PR TITLE
Ide analyzer options

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnreachableCode/CSharpRemoveUnreachableCodeDiagnosticAnalyzer.cs
@@ -40,11 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnreachableCode
 
         private void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
         {
-#if CODE_STYLE
-            var fadeCode = true;
-#else
-            var fadeCode = context.GetOption(Fading.FadingOptions.FadeOutUnreachableCode, LanguageNames.CSharp);
-#endif
+            var fadeCode = context.GetIdeOptions().FadeOutUnreachableCode;
             var semanticModel = context.SemanticModel;
             var cancellationToken = context.CancellationToken;
 

--- a/src/Analyzers/Core/Analyzers/Helpers/AnalyzerHelper.cs
+++ b/src/Analyzers/Core/Analyzers/Helpers/AnalyzerHelper.cs
@@ -13,8 +13,49 @@ using TOption = Microsoft.CodeAnalysis.Options.IOption;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
+    internal readonly record struct IdeAnalyzerOptions(
+        bool FadeOutUnusedImports,
+        bool FadeOutUnreachableCode,
+        bool ReportInvalidPlaceholdersInStringDotFormatCalls,
+        bool ReportInvalidRegexPatterns)
+    {
+        public static readonly IdeAnalyzerOptions CodeStyleDefault = new(
+            FadeOutUnusedImports: false,
+            FadeOutUnreachableCode: false,
+            ReportInvalidPlaceholdersInStringDotFormatCalls: true,
+            ReportInvalidRegexPatterns: true);
+    }
+
     internal static partial class AnalyzerHelper
     {
+        public static IdeAnalyzerOptions GetIdeOptions(this SyntaxTreeAnalysisContext context)
+#if CODE_STYLE
+            => IdeAnalyzerOptions.CodeStyleDefault;
+#else
+            => (context.Options is WorkspaceAnalyzerOptions workspaceOptions) ? workspaceOptions.GetIdeOptions(context.Tree.Options.Language) : IdeAnalyzerOptions.CodeStyleDefault;
+#endif
+
+        public static IdeAnalyzerOptions GetIdeOptions(this OperationAnalysisContext context)
+#if CODE_STYLE
+            => IdeAnalyzerOptions.CodeStyleDefault;
+#else
+            => (context.Options is WorkspaceAnalyzerOptions workspaceOptions) ? workspaceOptions.GetIdeOptions(context.Operation.Language) : IdeAnalyzerOptions.CodeStyleDefault;
+#endif
+
+        public static IdeAnalyzerOptions GetIdeOptions(this SyntaxNodeAnalysisContext context)
+#if CODE_STYLE
+            => IdeAnalyzerOptions.CodeStyleDefault;
+#else
+            => (context.Options is WorkspaceAnalyzerOptions workspaceOptions) ? workspaceOptions.GetIdeOptions(context.Node.Language) : IdeAnalyzerOptions.CodeStyleDefault;
+#endif
+
+        public static IdeAnalyzerOptions GetIdeOptions(this SemanticModelAnalysisContext context)
+#if CODE_STYLE
+            => IdeAnalyzerOptions.CodeStyleDefault;
+#else
+            => (context.Options is WorkspaceAnalyzerOptions workspaceOptions) ? workspaceOptions.GetIdeOptions(context.SemanticModel.Language) : IdeAnalyzerOptions.CodeStyleDefault;
+#endif
+
         public static T GetOption<T>(this SemanticModelAnalysisContext context, Option2<T> option)
         {
             var analyzerOptions = context.Options;

--- a/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
                 // for us appropriately.
                 unnecessaryImports = MergeImports(unnecessaryImports);
 
-                var fadeOut = ShouldFade(context.Options, tree, language, cancellationToken);
+                var fadeOut = context.GetIdeOptions().FadeOutUnusedImports;
 
                 DiagnosticDescriptor descriptor;
                 if (GeneratedCodeUtilities.IsGeneratedCode(tree, IsRegularCommentOrDocComment, cancellationToken))
@@ -163,15 +163,6 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
                 {
                     context.ReportDiagnostic(diagnostic);
                 }
-            }
-
-            static bool ShouldFade(AnalyzerOptions options, SyntaxTree tree, string language, CancellationToken cancellationToken)
-            {
-#if CODE_STYLE
-                return true;
-#else
-                return options.GetOption(Fading.FadingOptions.FadeOutUnusedImports, language, tree, cancellationToken);
-#endif
             }
         }
 

--- a/src/Analyzers/Core/Analyzers/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/ValidateFormatString/AbstractValidateFormatStringDiagnosticAnalyzer.cs
@@ -96,10 +96,7 @@ namespace Microsoft.CodeAnalysis.ValidateFormatString
                 return;
             }
 
-            var option = context.GetOption(
-                    ValidateFormatStringOption.ReportInvalidPlaceholdersInStringDotFormatCalls,
-                    context.SemanticModel.Language);
-            if (option == false)
+            if (!context.GetIdeOptions().ReportInvalidPlaceholdersInStringDotFormatCalls)
             {
                 return;
             }

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingNuGetTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingNuGetTests.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.AddImport;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.SymbolSearch;
@@ -35,9 +36,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
 
         protected override void InitializeWorkspace(TestWorkspace workspace, TestParameters parameters)
         {
-            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
-                .WithChangedOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, LanguageNames.CSharp, true)
-                .WithChangedOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, LanguageNames.CSharp, true)));
+            workspace.GlobalOptions.SetGlobalOption(new OptionKey(SymbolSearchOptionsStorage.SearchNuGetPackages, LanguageNames.CSharp), true);
+            workspace.GlobalOptions.SetGlobalOption(new OptionKey(SymbolSearchOptionsStorage.SearchReferenceAssemblies, LanguageNames.CSharp), true);
         }
 
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsStorage.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsStorage.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
     {
         internal static CodeActionOptions GetCodeActionOptions(this IGlobalOptionService globalOptions, string language, bool isBlocking)
             => new(
-                IsBlocking: isBlocking,
-                SearchReferenceAssemblies: globalOptions.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, language),
-                HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsStorage.HideAdvancedMembers, language));
+                SearchOptions: globalOptions.GetSymbolSearchOptions(language),
+                HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsStorage.HideAdvancedMembers, language),
+                IsBlocking: isBlocking);
     }
 }

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchOptionsStorage.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchOptionsStorage.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.SymbolSearch
+{
+    internal static class SymbolSearchOptionsStorage
+    {
+        internal static SymbolSearchOptions GetSymbolSearchOptions(this IGlobalOptionService globalOptions, string language)
+            => new(
+                SearchReferenceAssemblies: globalOptions.GetOption(SearchReferenceAssemblies, language),
+                SearchNuGetPackages: globalOptions.GetOption(SearchNuGetPackages, language));
+
+        private const string FeatureName = "SymbolSearchOptions";
+
+        public static PerLanguageOption2<bool> SearchReferenceAssemblies =
+            new(FeatureName, "SuggestForTypesInReferenceAssemblies", SymbolSearchOptions.Default.SearchReferenceAssemblies,
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInReferenceAssemblies"));
+
+        public static PerLanguageOption2<bool> SearchNuGetPackages =
+            new(FeatureName, "SuggestForTypesInNuGetPackages", SymbolSearchOptions.Default.SearchNuGetPackages,
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInNuGetPackages"));
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Packaging
 Imports Microsoft.CodeAnalysis.Shared.Utilities
 Imports Microsoft.CodeAnalysis.SymbolSearch
@@ -25,9 +26,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
             ImmutableArray.Create(New PackageSource(PackageSourceHelper.NugetOrgSourceName, "http://nuget.org"))
 
         Protected Overrides Sub InitializeWorkspace(workspace As TestWorkspace, parameters As TestParameters)
-            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.
-                WithChangedOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, LanguageNames.VisualBasic, True).
-                WithChangedOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, LanguageNames.VisualBasic, True)))
+            workspace.GlobalOptions.SetGlobalOption(New OptionKey(SymbolSearchOptionsStorage.SearchNuGetPackages, LanguageNames.VisualBasic), True)
+            workspace.GlobalOptions.SetGlobalOption(New OptionKey(SymbolSearchOptionsStorage.SearchReferenceAssemblies, LanguageNames.VisualBasic), True)
         End Sub
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -60,21 +60,19 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             var solution = document.Project.Solution;
 
-            var searchNuGetPackages = solution.Options.GetOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, document.Project.Language);
-
             var placement = await AddImportPlacementOptions.FromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
 
             var options = new AddImportOptions(
-                context.Options.SearchReferenceAssemblies,
+                context.Options.SearchOptions,
                 context.Options.HideAdvancedMembers,
                 placement);
 
-            var symbolSearchService = options.SearchReferenceAssemblies || searchNuGetPackages
+            var symbolSearchService = options.SearchOptions.SearchReferenceAssemblies
                 ? _symbolSearchService ?? solution.Workspace.Services.GetService<ISymbolSearchService>()
                 : null;
 
             var installerService = GetPackageInstallerService(document);
-            var packageSources = searchNuGetPackages && symbolSearchService != null && installerService?.IsEnabled(document.Project.Id) == true
+            var packageSources = options.SearchOptions.SearchNuGetPackages && symbolSearchService != null && installerService?.IsEnabled(document.Project.Id) == true
                 ? installerService.TryGetPackageSources()
                 : ImmutableArray<PackageSource>.Empty;
 

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CodeGeneration;
-using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SymbolSearch;
@@ -20,15 +16,15 @@ namespace Microsoft.CodeAnalysis.AddImport
     {
         private const int MaxResults = 5;
 
-        private readonly IPackageInstallerService _packageInstallerService;
-        private readonly ISymbolSearchService _symbolSearchService;
+        private readonly IPackageInstallerService? _packageInstallerService;
+        private readonly ISymbolSearchService? _symbolSearchService;
 
         /// <summary>
         /// Values for these parameters can be provided (during testing) for mocking purposes.
         /// </summary> 
         protected AbstractAddImportCodeFixProvider(
-            IPackageInstallerService packageInstallerService = null,
-            ISymbolSearchService symbolSearchService = null)
+            IPackageInstallerService? packageInstallerService = null,
+            ISymbolSearchService? symbolSearchService = null)
         {
             _packageInstallerService = packageInstallerService;
             _symbolSearchService = symbolSearchService;
@@ -42,7 +38,7 @@ namespace Microsoft.CodeAnalysis.AddImport
         private protected override CodeActionRequestPriority ComputeRequestPriority()
             => CodeActionRequestPriority.High;
 
-        public sealed override FixAllProvider GetFixAllProvider()
+        public sealed override FixAllProvider? GetFixAllProvider()
         {
             // Currently Fix All is not supported for this provider
             // https://github.com/dotnet/roslyn/issues/34457
@@ -56,28 +52,34 @@ namespace Microsoft.CodeAnalysis.AddImport
             var cancellationToken = context.CancellationToken;
             var diagnostics = context.Diagnostics;
 
-            var addImportService = document.GetLanguageService<IAddImportFeatureService>();
+            var addImportService = document.GetRequiredLanguageService<IAddImportFeatureService>();
+            var services = document.Project.Solution.Workspace.Services;
 
-            var solution = document.Project.Solution;
+            var searchOptions = context.Options.SearchOptions;
 
-            var placement = await AddImportPlacementOptions.FromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+            var symbolSearchService = _symbolSearchService ?? services.GetRequiredService<ISymbolSearchService>();
 
-            var options = new AddImportOptions(
-                context.Options.SearchOptions,
-                context.Options.HideAdvancedMembers,
-                placement);
+            var installerService = searchOptions.SearchNuGetPackages ?
+                _packageInstallerService ?? services.GetService<IPackageInstallerService>() : null;
 
-            var symbolSearchService = options.SearchOptions.SearchReferenceAssemblies
-                ? _symbolSearchService ?? solution.Workspace.Services.GetService<ISymbolSearchService>()
-                : null;
-
-            var installerService = GetPackageInstallerService(document);
-            var packageSources = options.SearchOptions.SearchNuGetPackages && symbolSearchService != null && installerService?.IsEnabled(document.Project.Id) == true
+            var packageSources = installerService?.IsEnabled(document.Project.Id) == true
                 ? installerService.TryGetPackageSources()
                 : ImmutableArray<PackageSource>.Empty;
 
+            if (packageSources.IsEmpty)
+            {
+                searchOptions = searchOptions with { SearchNuGetPackages = false };
+            }
+
+            var placement = await AddImportPlacementOptions.FromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+
+            var addImportOptions = new AddImportOptions(
+                searchOptions,
+                context.Options.HideAdvancedMembers,
+                placement);
+
             var fixesForDiagnostic = await addImportService.GetFixesForDiagnosticsAsync(
-                document, span, diagnostics, MaxResults, symbolSearchService, options, packageSources, cancellationToken).ConfigureAwait(false);
+                document, span, diagnostics, MaxResults, symbolSearchService, addImportOptions, packageSources, cancellationToken).ConfigureAwait(false);
 
             foreach (var (diagnostic, fixes) in fixesForDiagnostic)
             {
@@ -86,8 +88,5 @@ namespace Microsoft.CodeAnalysis.AddImport
                 context.RegisterFixes(codeActions, diagnostic);
             }
         }
-
-        private IPackageInstallerService GetPackageInstallerService(Document document)
-            => _packageInstallerService ?? document.Project.Solution.Workspace.Services.GetService<IPackageInstallerService>();
     }
 }

--- a/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/IAddImportFeatureService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 {
     [DataContract]
     internal readonly record struct AddImportOptions(
-        [property: DataMember(Order = 0)] bool SearchReferenceAssemblies,
+        [property: DataMember(Order = 0)] SymbolSearchOptions SearchOptions,
         [property: DataMember(Order = 1)] bool HideAdvancedMembers,
         [property: DataMember(Order = 2)] AddImportPlacementOptions Placement);
 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 _options = options;
                 _packageSources = packageSources;
 
-                if (options.SearchReferenceAssemblies || packageSources.Length > 0)
+                if (options.SearchOptions.SearchReferenceAssemblies || packageSources.Length > 0)
                 {
                     Contract.ThrowIfNull(symbolSearchService);
                 }

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -62,12 +62,6 @@ namespace Microsoft.CodeAnalysis.AddImport
                 _symbolSearchService = symbolSearchService;
                 _options = options;
                 _packageSources = packageSources;
-
-                if (options.SearchOptions.SearchReferenceAssemblies || packageSources.Length > 0)
-                {
-                    Contract.ThrowIfNull(symbolSearchService);
-                }
-
                 _syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
 
                 _namespacesInScope = GetNamespacesInScope(cancellationToken);

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder_PackageAssemblySearch.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 ArrayBuilder<Reference> allReferences, TSimpleNameSyntax nameNode,
                 string name, int arity, bool isAttributeSearch, CancellationToken cancellationToken)
             {
-                if (_options.SearchReferenceAssemblies)
+                if (_options.SearchOptions.SearchReferenceAssemblies)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     await FindReferenceAssemblyTypeReferencesAsync(

--- a/src/Features/Core/Portable/AddPackage/AbstractAddPackageCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddPackage/AbstractAddPackageCodeFixProvider.cs
@@ -49,16 +49,10 @@ namespace Microsoft.CodeAnalysis.AddPackage
             var symbolSearchService = _symbolSearchService ?? workspaceServices.GetService<ISymbolSearchService>();
             var installerService = _packageInstallerService ?? workspaceServices.GetService<IPackageInstallerService>();
 
-            var language = document.Project.Language;
-
-            var options = document.Project.Solution.Options;
-            var searchNugetPackages = options.GetOption(
-                SymbolSearchOptions.SuggestForTypesInNuGetPackages, language);
-
             var codeActions = ArrayBuilder<CodeAction>.GetInstance();
             if (symbolSearchService != null &&
                 installerService != null &&
-                searchNugetPackages &&
+                context.Options.SearchOptions.SearchNuGetPackages &&
                 installerService.IsEnabled(document.Project.Id))
             {
                 var packageSources = PackageSourceHelper.GetPackageSources(installerService.TryGetPackageSources());

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             var packageSources = ImmutableArray<PackageSource>.Empty;
 
             var addImportOptions = new AddImportOptions(
-                SearchReferenceAssemblies: true,
+                SearchOptions: new(SearchReferenceAssemblies: true, SearchNuGetPackages: false),
                 HideAdvancedMembers: options.HideAdvancedMembers,
                 Placement: options.Placement);
 

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal static partial class AnalyzerHelper
     {
-
         // These are the error codes of the compiler warnings. 
         // Keep the ids the same so that de-duplication against compiler errors
         // works in the error list (after a build).

--- a/src/Features/Core/Portable/Diagnostics/WorkspaceAnalyzerOptions.cs
+++ b/src/Features/Core/Portable/Diagnostics/WorkspaceAnalyzerOptions.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -20,11 +21,26 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         private readonly Solution _solution;
 
+        // IDE options for each encountered language
+        private ImmutableDictionary<string, IdeAnalyzerOptions> _ideOptionsCache;
+
         public WorkspaceAnalyzerOptions(AnalyzerOptions options, Solution solution)
             : base(options.AdditionalFiles, options.AnalyzerConfigOptionsProvider)
         {
             _solution = solution;
+            _ideOptionsCache = ImmutableDictionary<string, IdeAnalyzerOptions>.Empty;
         }
+
+        public IdeAnalyzerOptions GetIdeOptions(string language)
+            => ImmutableInterlocked.GetOrAdd(
+                ref _ideOptionsCache,
+                language,
+                static (language, solution) => new IdeAnalyzerOptions(
+                    FadeOutUnusedImports: solution.Options.GetOption(Fading.FadingOptions.Metadata.FadeOutUnusedImports, language),
+                    FadeOutUnreachableCode: solution.Options.GetOption(Fading.FadingOptions.Metadata.FadeOutUnusedImports, language),
+                    ReportInvalidPlaceholdersInStringDotFormatCalls: solution.Options.GetOption(ValidateFormatString.ValidateFormatStringOption.ReportInvalidPlaceholdersInStringDotFormatCalls, language),
+                    ReportInvalidRegexPatterns: solution.Options.GetOption(Features.EmbeddedLanguages.RegularExpressions.LanguageServices.RegularExpressionsOptions.ReportInvalidRegexPatterns, language)),
+                _solution);
 
         public HostWorkspaceServices Services => _solution.Workspace.Services;
 
@@ -60,9 +76,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public override int GetHashCode()
-        {
-            return Hash.Combine(_solution.Workspace,
-                Hash.Combine(_solution.WorkspaceVersion, base.GetHashCode()));
-        }
+            => Hash.Combine(_solution.Workspace,
+               Hash.Combine(_solution.WorkspaceVersion, base.GetHashCode()));
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/WorkspaceAnalyzerOptions.cs
+++ b/src/Features/Core/Portable/Diagnostics/WorkspaceAnalyzerOptions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 language,
                 static (language, solution) => new IdeAnalyzerOptions(
                     FadeOutUnusedImports: solution.Options.GetOption(Fading.FadingOptions.Metadata.FadeOutUnusedImports, language),
-                    FadeOutUnreachableCode: solution.Options.GetOption(Fading.FadingOptions.Metadata.FadeOutUnusedImports, language),
+                    FadeOutUnreachableCode: solution.Options.GetOption(Fading.FadingOptions.Metadata.FadeOutUnreachableCode, language),
                     ReportInvalidPlaceholdersInStringDotFormatCalls: solution.Options.GetOption(ValidateFormatString.ValidateFormatStringOption.ReportInvalidPlaceholdersInStringDotFormatCalls, language),
                     ReportInvalidRegexPatterns: solution.Options.GetOption(Features.EmbeddedLanguages.RegularExpressions.LanguageServices.RegularExpressionsOptions.ReportInvalidRegexPatterns, language)),
                 _solution);

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexDiagnosticAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
         protected AbstractRegexDiagnosticAnalyzer(EmbeddedLanguageInfo info)
             : base(DiagnosticId,
                    EnforceOnBuildValues.Regex,
-                   RegularExpressionsOptions.ReportInvalidRegexPatterns,
+                   option: null,
                    new LocalizableResourceString(nameof(FeaturesResources.Invalid_regex_pattern), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
                    new LocalizableResourceString(nameof(FeaturesResources.Regex_issue_0), FeaturesResources.ResourceManager, typeof(FeaturesResources)))
         {
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
             var syntaxTree = semanticModel.SyntaxTree;
             var cancellationToken = context.CancellationToken;
 
-            var option = context.GetOption(RegularExpressionsOptions.ReportInvalidRegexPatterns, syntaxTree.Options.Language);
+            var option = context.GetIdeOptions().ReportInvalidRegexPatterns;
             if (!option)
                 return;
 

--- a/src/Features/Core/Portable/Fading/FadingOptions.cs
+++ b/src/Features/Core/Portable/Fading/FadingOptions.cs
@@ -14,27 +14,27 @@ namespace Microsoft.CodeAnalysis.Fading
     internal sealed class FadingOptions
     {
         [ExportSolutionOptionProvider, Shared]
-        internal sealed class Provider : IOptionProvider
+        internal sealed class Metadata : IOptionProvider
         {
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public Provider()
+            public Metadata()
             {
             }
 
             ImmutableArray<IOption> IOptionProvider.Options { get; } = ImmutableArray.Create<IOption>(
                 FadeOutUnusedImports,
                 FadeOutUnreachableCode);
+
+            private const string FeatureName = "FadingOptions";
+
+            public static readonly PerLanguageOption2<bool> FadeOutUnusedImports = new(
+                FeatureName, "FadeOutUnusedImports", defaultValue: true,
+                storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.FadeOutUnusedImports"));
+
+            public static readonly PerLanguageOption2<bool> FadeOutUnreachableCode = new(
+                FeatureName, "FadeOutUnreachableCode", defaultValue: true,
+                storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.FadeOutUnreachableCode"));
         }
-
-        private const string FeatureName = "FadingOptions";
-
-        public static readonly PerLanguageOption2<bool> FadeOutUnusedImports = new(
-            FeatureName, "FadeOutUnusedImports", defaultValue: true,
-            storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.FadeOutUnusedImports"));
-
-        public static readonly PerLanguageOption2<bool> FadeOutUnreachableCode = new(
-            FeatureName, "FadeOutUnreachableCode", defaultValue: true,
-            storageLocation: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.FadeOutUnreachableCode"));
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -66,8 +66,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
             BindToOption(PlaceSystemNamespaceFirst, GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp);
             BindToOption(SeparateImportGroups, GenerationOptions.SeparateImportDirectiveGroups, LanguageNames.CSharp);
-            BindToOption(SuggestForTypesInReferenceAssemblies, SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, LanguageNames.CSharp);
-            BindToOption(SuggestForTypesInNuGetPackages, SymbolSearchOptions.SuggestForTypesInNuGetPackages, LanguageNames.CSharp);
+            BindToOption(SuggestForTypesInReferenceAssemblies, SymbolSearchOptionsStorage.SearchReferenceAssemblies, LanguageNames.CSharp);
+            BindToOption(SuggestForTypesInNuGetPackages, SymbolSearchOptionsStorage.SearchNuGetPackages, LanguageNames.CSharp);
             BindToOption(AddUsingsOnPaste, FeatureOnOffOptions.AddImportsOnPaste, LanguageNames.CSharp, () =>
             {
                 // This option used to be backed by an experimentation flag but is no longer.
@@ -84,8 +84,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Show_outlining_for_comments_and_preprocessor_regions, BlockStructureOptions.Metadata.ShowOutliningForCommentsAndPreprocessorRegions, LanguageNames.CSharp);
             BindToOption(Collapse_regions_when_collapsing_to_definitions, BlockStructureOptions.Metadata.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.CSharp);
 
-            BindToOption(Fade_out_unused_usings, FadingOptions.FadeOutUnusedImports, LanguageNames.CSharp);
-            BindToOption(Fade_out_unreachable_code, FadingOptions.FadeOutUnreachableCode, LanguageNames.CSharp);
+            BindToOption(Fade_out_unused_usings, FadingOptions.Metadata.FadeOutUnusedImports, LanguageNames.CSharp);
+            BindToOption(Fade_out_unreachable_code, FadingOptions.Metadata.FadeOutUnreachableCode, LanguageNames.CSharp);
 
             BindToOption(Show_guides_for_declaration_level_constructs, BlockStructureOptions.Metadata.ShowBlockStructureGuidesForDeclarationLevelConstructs, LanguageNames.CSharp);
             BindToOption(Show_guides_for_code_level_constructs, BlockStructureOptions.Metadata.ShowBlockStructureGuidesForCodeLevelConstructs, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.Fading.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.Fading.cs
@@ -10,14 +10,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
     {
         public int Fading_FadeOutUnreachableCode
         {
-            get { return GetBooleanOption(FadingOptions.FadeOutUnreachableCode); }
-            set { SetBooleanOption(FadingOptions.FadeOutUnreachableCode, value); }
+            get { return GetBooleanOption(FadingOptions.Metadata.FadeOutUnreachableCode); }
+            set { SetBooleanOption(FadingOptions.Metadata.FadeOutUnreachableCode, value); }
         }
 
         public int Fading_FadeOutUnusedImports
         {
-            get { return GetBooleanOption(FadingOptions.FadeOutUnusedImports); }
-            set { SetBooleanOption(FadingOptions.FadeOutUnusedImports, value); }
+            get { return GetBooleanOption(FadingOptions.Metadata.FadeOutUnusedImports); }
+            set { SetBooleanOption(FadingOptions.Metadata.FadeOutUnusedImports, value); }
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.SymbolSearch.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.SymbolSearch.cs
@@ -10,14 +10,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
     {
         public int AddImport_SuggestForTypesInReferenceAssemblies
         {
-            get { return GetBooleanOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies); }
-            set { SetBooleanOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, value); }
+            get { return GetBooleanOption(SymbolSearchOptionsStorage.SearchReferenceAssemblies); }
+            set { SetBooleanOption(SymbolSearchOptionsStorage.SearchReferenceAssemblies, value); }
         }
 
         public int AddImport_SuggestForTypesInNuGetPackages
         {
-            get { return GetBooleanOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages); }
-            set { SetBooleanOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, value); }
+            get { return GetBooleanOption(SymbolSearchOptionsStorage.SearchNuGetPackages); }
+            set { SetBooleanOption(SymbolSearchOptionsStorage.SearchNuGetPackages, value); }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -105,12 +105,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             [Import(AllowDefault = true)] Lazy<IVsPackageInstaller2>? packageInstaller,
             [Import(AllowDefault = true)] Lazy<IVsPackageUninstaller>? packageUninstaller,
             [Import(AllowDefault = true)] Lazy<IVsPackageSourceProvider>? packageSourceProvider)
-            : base(threadingContext,
-                   workspace,
-                   globalOptions,
-                   SymbolSearchGlobalOptions.Enabled,
-                   SymbolSearchOptions.SuggestForTypesInReferenceAssemblies,
-                   SymbolSearchOptions.SuggestForTypesInNuGetPackages)
+            : base(globalOptions,
+                  listenerProvider,
+                  threadingContext,
+                  featureEnabledOption: SymbolSearchGlobalOptions.Enabled,
+                  perLanguageOptions: ImmutableArray.Create(SymbolSearchOptionsStorage.SearchReferenceAssemblies, SymbolSearchOptionsStorage.SearchNuGetPackages))
         {
             _operationExecutor = operationExecutor;
             _workspace = workspace;

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -108,6 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             : base(globalOptions,
                   listenerProvider,
                   threadingContext,
+                  workspace,
                   featureEnabledOption: SymbolSearchGlobalOptions.Enabled,
                   perLanguageOptions: ImmutableArray.Create(SymbolSearchOptionsStorage.SearchReferenceAssemblies, SymbolSearchOptionsStorage.SearchNuGetPackages))
         {

--- a/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
@@ -29,6 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
     {
         private readonly List<string> _registeredLanguageNames = new();
 
+        private readonly Workspace _workspace;
         private readonly IAsynchronousOperationListener _asyncListener;
         private readonly IGlobalOptionService _globalOptions;
 
@@ -46,10 +47,12 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
             IThreadingContext threadingContext,
+            Workspace workspace,
             Option2<bool> featureEnabledOption,
             ImmutableArray<PerLanguageOption2<bool>> perLanguageOptions)
             : base(threadingContext)
         {
+            _workspace = workspace;
             _asyncListener = listenerProvider.GetListener(FeatureAttribute.Workspace);
             _globalOptions = globalOptions;
             _featureEnabledOption = featureEnabledOption;
@@ -75,7 +78,8 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             if (_registeredLanguageNames.Count == 1)
             {
                 // Register to hear about option changing.
-                _globalOptions.OptionChanged += OnOptionChanged;
+                var optionsService = _workspace.Services.GetRequiredService<IOptionService>();
+                optionsService.OptionChanged += OnOptionChanged;
             }
 
             // Kick things off.

--- a/src/VisualStudio/Core/Def/SymbolSearch/SymbolSearchGlobalOptions.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/SymbolSearchGlobalOptions.cs
@@ -2,27 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Options.Providers;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
 {
-    [ExportGlobalOptionProvider, Shared]
-    internal sealed class SymbolSearchGlobalOptions : IOptionProvider
+    internal sealed class SymbolSearchGlobalOptions
     {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public SymbolSearchGlobalOptions()
-        {
-        }
-
-        ImmutableArray<IOption> IOptionProvider.Options => ImmutableArray.Create<IOption>(
-            Enabled);
-
         private const string LocalRegistryPath = @"Roslyn\Features\SymbolSearch\";
         private const string FeatureName = "SymbolSearchOptions";
 

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SymbolSearch;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Settings;
@@ -53,11 +54,15 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public VisualStudioSymbolSearchService(
             IThreadingContext threadingContext,
+            IAsynchronousOperationListenerProvider listenerProvider,
             VisualStudioWorkspaceImpl workspace,
             IGlobalOptionService globalOptions,
             VSShell.SVsServiceProvider serviceProvider)
-            : base(threadingContext, workspace, globalOptions, SymbolSearchGlobalOptions.Enabled,
-                  SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, SymbolSearchOptions.SuggestForTypesInNuGetPackages)
+            : base(globalOptions,
+                   listenerProvider,
+                   threadingContext,
+                   featureEnabledOption: SymbolSearchGlobalOptions.Enabled,
+                   perLanguageOptions: ImmutableArray.Create(SymbolSearchOptionsStorage.SearchReferenceAssemblies, SymbolSearchOptionsStorage.SearchNuGetPackages))
         {
             _workspace = workspace;
             _installerService = workspace.Services.GetService<IPackageInstallerService>();

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -61,6 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             : base(globalOptions,
                    listenerProvider,
                    threadingContext,
+                   workspace,
                    featureEnabledOption: SymbolSearchGlobalOptions.Enabled,
                    perLanguageOptions: ImmutableArray.Create(SymbolSearchOptionsStorage.SearchReferenceAssemblies, SymbolSearchOptionsStorage.SearchNuGetPackages))
         {

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -64,8 +64,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             ' Import directives
             BindToOption(PlaceSystemNamespaceFirst, GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.VisualBasic)
             BindToOption(SeparateImportGroups, GenerationOptions.SeparateImportDirectiveGroups, LanguageNames.VisualBasic)
-            BindToOption(SuggestForTypesInReferenceAssemblies, SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, LanguageNames.VisualBasic)
-            BindToOption(SuggestForTypesInNuGetPackages, SymbolSearchOptions.SuggestForTypesInNuGetPackages, LanguageNames.VisualBasic)
+            BindToOption(SuggestForTypesInReferenceAssemblies, SymbolSearchOptionsStorage.SearchReferenceAssemblies, LanguageNames.VisualBasic)
+            BindToOption(SuggestForTypesInNuGetPackages, SymbolSearchOptionsStorage.SearchNuGetPackages, LanguageNames.VisualBasic)
             BindToOption(AddMissingImportsOnPaste, FeatureOnOffOptions.AddImportsOnPaste, LanguageNames.VisualBasic,
                          Function()
                              ' This option used to be backed by an experimentation flag but Is no longer.
@@ -94,7 +94,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(Collapse_regions_when_collapsing_to_definitions, BlockStructureOptions.Metadata.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.VisualBasic)
 
             ' Fading
-            BindToOption(Fade_out_unused_imports, FadingOptions.FadeOutUnusedImports, LanguageNames.VisualBasic)
+            BindToOption(Fade_out_unused_imports, FadingOptions.Metadata.FadeOutUnusedImports, LanguageNames.VisualBasic)
 
             ' Block structure guides
             BindToOption(Show_guides_for_declaration_level_constructs, BlockStructureOptions.Metadata.ShowBlockStructureGuidesForDeclarationLevelConstructs, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.Fading.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.Fading.vb
@@ -8,19 +8,19 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
     Partial Public Class AutomationObject
         Public Property Fading_FadeOutUnreachableCode As Boolean
             Get
-                Return GetBooleanOption(FadingOptions.FadeOutUnreachableCode)
+                Return GetBooleanOption(FadingOptions.Metadata.FadeOutUnreachableCode)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(FadingOptions.FadeOutUnreachableCode, value)
+                SetBooleanOption(FadingOptions.Metadata.FadeOutUnreachableCode, value)
             End Set
         End Property
 
         Public Property Fading_FadeOutUnusedImports As Boolean
             Get
-                Return GetBooleanOption(FadingOptions.FadeOutUnusedImports)
+                Return GetBooleanOption(FadingOptions.Metadata.FadeOutUnusedImports)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(FadingOptions.FadeOutUnusedImports, value)
+                SetBooleanOption(FadingOptions.Metadata.FadeOutUnusedImports, value)
             End Set
         End Property
     End Class

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.SymbolSearch.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.SymbolSearch.vb
@@ -8,19 +8,19 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
     Partial Public Class AutomationObject
         Public Property Option_SuggestImportsForTypesInReferenceAssemblies As Boolean
             Get
-                Return GetBooleanOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies)
+                Return GetBooleanOption(SymbolSearchOptionsStorage.SearchReferenceAssemblies)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, value)
+                SetBooleanOption(SymbolSearchOptionsStorage.SearchReferenceAssemblies, value)
             End Set
         End Property
 
         Public Property Option_SuggestImportsForTypesInNuGetPackages As Boolean
             Get
-                Return GetBooleanOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages)
+                Return GetBooleanOption(SymbolSearchOptionsStorage.SearchNuGetPackages)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, value)
+                SetBooleanOption(SymbolSearchOptionsStorage.SearchNuGetPackages, value)
             End Set
         End Property
     End Class

--- a/src/Workspaces/Core/Portable/CodeActions/CodeActionOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeActionOptions.cs
@@ -2,19 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
+using Microsoft.CodeAnalysis.SymbolSearch;
+
 namespace Microsoft.CodeAnalysis.CodeActions
 {
     /// <summary>
     /// Options available to code fixes that are supplied by the IDE (i.e. not stored in editorconfig).
     /// </summary>
+    [DataContract]
     internal readonly record struct CodeActionOptions(
-        bool IsBlocking,
-        bool SearchReferenceAssemblies,
-        bool HideAdvancedMembers)
+        [property: DataMember(Order = 0)] SymbolSearchOptions SearchOptions,
+        [property: DataMember(Order = 1)] bool HideAdvancedMembers = false,
+        [property: DataMember(Order = 2)] bool IsBlocking = false)
     {
-        public static readonly CodeActionOptions Default = new(
-            IsBlocking: false,
-            SearchReferenceAssemblies: true,
-            HideAdvancedMembers: false);
+        public CodeActionOptions()
+            : this(SearchOptions: SymbolSearchOptions.Default)
+        {
+        }
+
+        public static readonly CodeActionOptions Default = new();
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/SymbolSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/SymbolSearchOptions.cs
@@ -2,36 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Options.Providers;
+using System.Runtime.Serialization;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
 {
-    [ExportSolutionOptionProvider, Shared]
-    internal sealed class SymbolSearchOptions : IOptionProvider
+    [DataContract]
+    internal readonly record struct SymbolSearchOptions(
+        [property: DataMember(Order = 0)] bool SearchReferenceAssemblies = true,
+        [property: DataMember(Order = 1)] bool SearchNuGetPackages = true)
     {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public SymbolSearchOptions()
+            : this(SearchReferenceAssemblies: true)
         {
         }
 
-        public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
-            SuggestForTypesInReferenceAssemblies,
-            SuggestForTypesInNuGetPackages);
-
-        private const string FeatureName = "SymbolSearchOptions";
-
-        public static PerLanguageOption2<bool> SuggestForTypesInReferenceAssemblies =
-            new(FeatureName, "SuggestForTypesInReferenceAssemblies", defaultValue: true,
-                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInReferenceAssemblies"));
-
-        public static PerLanguageOption2<bool> SuggestForTypesInNuGetPackages =
-            new(FeatureName, "SuggestForTypesInNuGetPackages", defaultValue: true,
-                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInNuGetPackages"));
+        public static readonly SymbolSearchOptions Default = new();
     }
 }


### PR DESCRIPTION
Moves options that are not defined in editorconfig but used in analyzers to `IdeOptions` accessible from `WorkspaceAnalyzerOptions`.

Makes `SymbolSearchOptions` global.

Depends on https://github.com/dotnet/roslyn/pull/58747