### PR TITLE
Handle synthesized delegates without refKinds

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// The arity is appended via `N suffix in MetadataName calculation since the delegate is generic.
         /// </summary>
         /// <remarks>
-        /// Logic here should match <see cref="TryParseSynthesizedDelegateName" /> below.
+        /// Logic here should match <see cref="TryParseSynthesizedDelegateName" />.
         /// </remarks>
         internal static string MakeSynthesizedDelegateName(RefKindVector byRefs, bool returnsVoid, int generation)
         {
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Parses the name of a synthesized delegate out into the things it represents.
         /// </summary>
         /// <remarks>
-        /// Logic here should match <see cref="MakeSynthesizedDelegateName" /> below.
+        /// Logic here should match <see cref="MakeSynthesizedDelegateName" />.
         /// </remarks>
         internal static bool TryParseSynthesizedDelegateName(string name, out RefKindVector byRefs, out bool returnsVoid, out int generation, out int parameterCount)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -359,6 +359,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Produces name of the synthesized delegate symbol that encodes the parameter byref-ness and return type of the delegate.
         /// The arity is appended via `N suffix in MetadataName calculation since the delegate is generic.
         /// </summary>
+        /// <remarks>
+        /// Logic here should match <see cref="TryParseSynthesizedDelegateName" /> below.
+        /// </remarks>
         internal static string MakeSynthesizedDelegateName(RefKindVector byRefs, bool returnsVoid, int generation)
         {
             var pooledBuilder = PooledStringBuilder.GetInstance();
@@ -375,6 +378,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return pooledBuilder.ToStringAndFree();
         }
 
+        /// <summary>
+        /// Parses the name of a synthesized delegate out into the things it represents.
+        /// </summary>
+        /// <remarks>
+        /// Logic here should match <see cref="MakeSynthesizedDelegateName" /> below.
+        /// </remarks>
         internal static bool TryParseSynthesizedDelegateName(string name, out RefKindVector byRefs, out bool returnsVoid, out int generation, out int parameterCount)
         {
             byRefs = default;
@@ -397,7 +406,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var nameEndIndex = name.LastIndexOf('}');
             if (nameEndIndex < 0)
             {
-                nameEndIndex = DelegateNamePrefixLength;
+                nameEndIndex = DelegateNamePrefixLength - 1;
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs
@@ -392,8 +392,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             parameterCount = arity - (returnsVoid ? 0 : 1);
 
-            // If there are more than 16 type parameters then the synthesized delegate doesn't ref kinds encoded
-            // (and therefore no braces) so we use the end of the prefix instead.
+            // If there are no ref kinds encoded
+            // (and therefore no braces), use the end of the prefix instead.
             var nameEndIndex = name.LastIndexOf('}');
             if (nameEndIndex < 0)
             {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -1621,6 +1621,61 @@ class C
                 Diagnostic(ErrorCode.ERR_EncUpdateFailedDelegateTypeChanged).WithLocation(1, 1));
         }
 
+        [Fact]
+        public void Lambda_SynthesizedDeletage_06()
+        {
+            var source0 = MarkedSource(
+@"class C
+{
+    void F()
+    {
+        var x = <N:0>(int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10, int p11, int p12, int p13, int p14, int p15, int p16, int p17) => 1</N:0>;
+    }
+}");
+            var source1 = MarkedSource(
+@"class C
+{
+    void F()
+    {
+        var x = <N:0>(int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10, int p11, int p12, int p13, int p14, int p15, int p16, int p17) => 1</N:0>;
+
+        System.Console.WriteLine(1);
+    }
+}");
+
+            var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            var v0 = CompileAndVerify(compilation0, verify: Verification.Skipped);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+            var reader0 = md0.MetadataReader;
+
+            var method0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var method1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "<>F`18", "C", "<>c");
+            CheckNames(reader0, reader0.GetMethodDefNames(), ".ctor", "Invoke", "F", ".ctor", ".cctor", ".ctor", "<F>b__0_0");
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Update, method0, method1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            // Verify delta metadata contains expected rows.
+            using var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+            var readers = new[] { reader0, reader1 };
+
+            EncValidation.VerifyModuleMvid(1, reader0, reader1);
+
+            CheckNames(readers, reader1.GetTypeDefNames());
+            CheckNames(readers, reader1.GetMethodDefNames(), "F", "<F>b__0_0");
+
+            diff1.VerifySynthesizedMembers(
+                "C.<>c: {<>9__0_0, <F>b__0_0}",
+                "C: {<>c}");
+        }
+
         [WorkItem(962219, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/962219")]
         [Fact]
         public void PartialMethod()

--- a/src/Compilers/CSharp/Test/Emit/Emit/GeneratedNamesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/GeneratedNamesTests.cs
@@ -12,6 +12,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
         [Theory]
         [InlineData("<>A", true, 0, 0)]
         [InlineData("<>A{00010000}`8", true, 0, 8)]
+        [InlineData("<>A{00010000}#2`8", true, 2, 8)]
+        [InlineData("<>A{00010000,00000000}`16", true, 0, 16)]
+        [InlineData("<>A{00010000,00000000}#4`16", true, 4, 16)]
         [InlineData("<>A`5", true, 0, 5)]
         [InlineData("<>A`18", true, 0, 18)]
         [InlineData("<>F`1", false, 0, 0)]
@@ -21,7 +24,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
         public void TryParseSynthesizedDelegateName_Success(string name, bool returnsVoid, int generation, int parameterCount)
         {
             Assert.True(GeneratedNames.TryParseSynthesizedDelegateName(name, out var actualByRefs, out var actualReturnsVoid, out var actualGeneration, out var actualParameterCount));
-
 
             Assert.Equal(returnsVoid, actualReturnsVoid);
             Assert.Equal(generation, actualGeneration);
@@ -40,6 +42,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
         [InlineData("<>ABCDEF")]
         [InlineData("<>A{Z}")]
         [InlineData("<>A#F")]
+        [InlineData("<>A{}")]
+        [InlineData("<>A{,}")]
+        [InlineData("<>A#")]
+        [InlineData("<>A{0,}")]
+        [InlineData("<>A{,1}")]
         public void TryParseSynthesizedDelegateName_Failure(string name)
         {
             Assert.False(GeneratedNames.TryParseSynthesizedDelegateName(name, out _, out _, out _, out _));

--- a/src/Compilers/CSharp/Test/Emit/Emit/GeneratedNamesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/GeneratedNamesTests.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
+{
+    public class GeneratedNamesTests
+    {
+        [Theory]
+        [InlineData("<>A", true, 0, 0)]
+        [InlineData("<>A{00010000}`8", true, 0, 8)]
+        [InlineData("<>A`5", true, 0, 5)]
+        [InlineData("<>A`18", true, 0, 18)]
+        [InlineData("<>F`1", false, 0, 0)]
+        [InlineData("<>F`6", false, 0, 5)]
+        [InlineData("<>F`19", false, 0, 18)]
+        [InlineData("<>F#3`19", false, 3, 18)]
+        public void TryParseSynthesizedDelegateName_Success(string name, bool returnsVoid, int generation, int parameterCount)
+        {
+            Assert.True(GeneratedNames.TryParseSynthesizedDelegateName(name, out var actualByRefs, out var actualReturnsVoid, out var actualGeneration, out var actualParameterCount));
+
+
+            Assert.Equal(returnsVoid, actualReturnsVoid);
+            Assert.Equal(generation, actualGeneration);
+            Assert.Equal(parameterCount, actualParameterCount);
+
+
+            // We need to strip arity in order to validate round-tripping
+            name = MetadataHelpers.InferTypeArityAndUnmangleMetadataName(name, out _);
+            Assert.Equal(name, GeneratedNames.MakeSynthesizedDelegateName(actualByRefs, actualReturnsVoid, actualGeneration));
+        }
+
+        [Theory]
+        [InlineData("<>D")]
+        [InlineData("<>A{")]
+        [InlineData("<>A00}")]
+        [InlineData("<>ABCDEF")]
+        [InlineData("<>A{Z}")]
+        [InlineData("<>A#F")]
+        public void TryParseSynthesizedDelegateName_Failure(string name)
+        {
+            Assert.False(GeneratedNames.TryParseSynthesizedDelegateName(name, out _, out _, out _, out _));
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58782

I made an incorrect assumption when adding support for synthesized delegates.