### PR TITLE
Avoid setting MICROSOFT_DIASYMREADER_NATIVE_ env variables in tests

### DIFF
--- a/src/Compilers/Test/Core/ModuleInitializer.cs
+++ b/src/Compilers/Test/Core/ModuleInitializer.cs
@@ -17,10 +17,6 @@ namespace Roslyn.Test.Utilities
         {
             Trace.Listeners.Clear();
             Trace.Listeners.Add(new ThrowingTraceListener());
-
-            // Make sure we load DSRN from the directory containing the unit tests and not from a runtime directory on .NET 5+.
-            Environment.SetEnvironmentVariable("MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH", Path.GetDirectoryName(typeof(ModuleInitializer).Assembly.Location));
-            Environment.SetEnvironmentVariable("MICROSOFT_DIASYMREADER_NATIVE_USE_ALT_LOAD_PATH_ONLY", "1");
         }
     }
 }


### PR DESCRIPTION
Closes #57526 (avoid setting MICROSOFT_DIASYMREADER_NATIVE_* env variables in tests)

![image](https://user-images.githubusercontent.com/12466233/149208011-44744345-3938-4f30-a740-c767a9cf379e.png)
