### PR TITLE
Reduce Stack Trace Explorer automatic open behavior scope

### DIFF
--- a/src/Features/Core/Portable/StackTraceExplorer/IgnoredFrame.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/IgnoredFrame.cs
@@ -13,8 +13,6 @@ namespace Microsoft.CodeAnalysis.StackTraceExplorer
             _originalText = originalText;
         }
 
-        public override bool IsStackFrame => false;
-
         public override string ToString()
         {
             return _originalText;

--- a/src/Features/Core/Portable/StackTraceExplorer/ParsedFrame.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/ParsedFrame.cs
@@ -9,7 +9,5 @@ namespace Microsoft.CodeAnalysis.StackTraceExplorer
         public ParsedFrame()
         {
         }
-
-        public abstract bool IsStackFrame { get; }
     }
 }

--- a/src/Features/Core/Portable/StackTraceExplorer/ParsedStackFrame.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/ParsedStackFrame.cs
@@ -32,8 +32,6 @@ namespace Microsoft.CodeAnalysis.StackTraceExplorer
 
         public StackFrameCompilationUnit Root => Tree.Root;
 
-        public override bool IsStackFrame => true;
-
         public override string ToString()
         {
             return Tree.Text.CreateString();

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerCommandHandler.cs
@@ -6,6 +6,7 @@ using System;
 using System.ComponentModel.Design;
 using System.IO.Packaging;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.StackTraceExplorer;
 using Microsoft.VisualStudio.LanguageServices.Setup;
@@ -63,6 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.StackTraceExplorer
                     await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
                     var windowFrame = (IVsWindowFrame)window.Frame;
                     ErrorHandler.ThrowOnFailure(windowFrame.Show());
+                    Logger.Log(FunctionId.StackTraceToolWindow_ShowOnActivated, logLevel: LogLevel.Information);
                 }
             });
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -537,5 +537,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         Inline_Hints_DoubleClick = 530,
         NavigateToExternalSources = 531,
+
+        StackTraceToolWindow_ShowOnActivated = 540,
     }
 }


### PR DESCRIPTION
Fix so that the stack trace explorer only automatically activates on focus if the clipboard has "at" trivia in the frame.