### PR TITLE
Avoid unnecessary array creation

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1288,7 +1288,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             if (hasBody)
                             {
-                                boundStatements = boundStatements.Concat(ImmutableArray.Create(loweredBodyOpt));
+                                boundStatements = boundStatements.Concat(loweredBodyOpt);
                             }
 
                             var factory = new SyntheticBoundNodeFactory(methodSymbol, syntax, compilationState, diagsForCurrentMethod);

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.vb
@@ -235,7 +235,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return RewriteReceiverArgumentsAndGenerateAccessorCall(node.Syntax,
                                   setMethod,
                                   setNode.ReceiverOpt,
-                                  setNode.Arguments.Concat(ImmutableArray.Create(node.Right)),
+                                  setNode.Arguments.Concat(node.Right),
                                   node.ConstantValueOpt,
                                   isLValue:=False,
                                   suppressObjectClone:=False,


### PR DESCRIPTION
Our ImmutableArrayExtensions includes a Concat method which delegates directly to [`ImmutableArray<T>.Add(T)`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutablearray-1.add?view=net-6.0#system-collections-immutable-immutablearray-1-add(-0)). Using this, we can avoid allocating a single-element array in this code path.

https://github.com/dotnet/roslyn/blob/19fd5558723a790326865cecf551c8facf4e7790/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs#L691-L694

