### PR TITLE
Filter cancellation exceptions in generator driver

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -1527,17 +1527,13 @@ class C { }
                 Assert.IsType<InvalidOperationException>(e.InnerException);
             }
 
-            CancellationTokenSource cts = new CancellationTokenSource();
-            cts.Cancel();
-
             // cancellation is not wrapped, and is bubbled up
-            Assert.Throws<OperationCanceledException>(() => timeoutFunc(30, cts.Token));
-            Assert.Throws<OperationCanceledException>(() => userTimeoutFunc(30, cts.Token));
+            Assert.Throws<OperationCanceledException>(() => timeoutFunc(30, new CancellationToken(true)));
+            Assert.Throws<OperationCanceledException>(() => userTimeoutFunc(30, new CancellationToken(true)));
 
             // unless it wasn't *our* cancellation token, in which case it still gets wrapped
-            cts = new CancellationTokenSource();
-            Assert.Throws<OperationCanceledException>(() => otherTimeoutFunc(30, cts.Token));
-            Assert.Throws<UserFunctionException>(() => userOtherTimeoutFunc(30,  cts.Token));
+            Assert.Throws<OperationCanceledException>(() => otherTimeoutFunc(30, CancellationToken.None));
+            Assert.Throws<UserFunctionException>(() => userOtherTimeoutFunc(30, CancellationToken.None));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -1527,13 +1527,17 @@ class C { }
                 Assert.IsType<InvalidOperationException>(e.InnerException);
             }
 
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
             // cancellation is not wrapped, and is bubbled up
-            Assert.Throws<OperationCanceledException>(() => timeoutFunc(30, new CancellationToken(true)));
-            Assert.Throws<OperationCanceledException>(() => userTimeoutFunc(30, new CancellationToken(true)));
+            Assert.Throws<OperationCanceledException>(() => timeoutFunc(30, cts.Token));
+            Assert.Throws<OperationCanceledException>(() => userTimeoutFunc(30, cts.Token));
 
             // unless it wasn't *our* cancellation token, in which case it still gets wrapped
-            Assert.Throws<OperationCanceledException>(() => otherTimeoutFunc(30, CancellationToken.None));
-            Assert.Throws<UserFunctionException>(() => userOtherTimeoutFunc(30, CancellationToken.None));
+            Assert.True(cts.TryReset());
+            Assert.Throws<OperationCanceledException>(() => otherTimeoutFunc(30, cts.Token));
+            Assert.Throws<UserFunctionException>(() => userOtherTimeoutFunc(30,  cts.Token));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -1535,7 +1535,7 @@ class C { }
             Assert.Throws<OperationCanceledException>(() => userTimeoutFunc(30, cts.Token));
 
             // unless it wasn't *our* cancellation token, in which case it still gets wrapped
-            Assert.True(cts.TryReset());
+            cts = new CancellationTokenSource();
             Assert.Throws<OperationCanceledException>(() => otherTimeoutFunc(30, cts.Token));
             Assert.Throws<UserFunctionException>(() => userOtherTimeoutFunc(30,  cts.Token));
         }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -1990,7 +1990,6 @@ class C
             driver = driver.RunGenerators(compilation, CancellationToken.None);
             var results = driver.GetRunResult();
 
-
             Assert.Single(results.Results);
             Assert.IsType<OperationCanceledException>(results.Results[0].Exception);
             Assert.Equal("Simulated cancellation from external source", results.Results[0].Exception.Message);

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -1992,7 +1992,7 @@ class C
 
             Assert.Single(results.Results);
             Assert.IsType<OperationCanceledException>(results.Results[0].Exception);
-            Assert.Equal("Simulated cancellation from external source", results.Results[0].Exception.Message);
+            Assert.Equal("Simulated cancellation from external source", results.Results[0].Exception!.Message);
         }
 
         private class TestReceiverBase<T>

--- a/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
@@ -36,6 +36,6 @@ namespace Roslyn.Utilities
         /// <param name="cancellationToken">Checked to see if the provided token was cancelled.</param>
         /// <returns><see langword="true"/> if the exception was an <see cref="OperationCanceledException" /> and the token was canceled.</returns>
         internal static bool IsCurrentOperationBeingCancelled(Exception exception, CancellationToken cancellationToken)
-            => exception is OperationCanceledException oce && oce.CancellationToken == cancellationToken;
+            => exception is OperationCanceledException oce && cancellationToken.IsCancellationRequested;
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
@@ -29,7 +29,7 @@ namespace Roslyn.Utilities
             get { return new InvalidOperationException("This program location is thought to be unreachable."); }
         }
 
-         /// <summary>
+        /// <summary>
         /// Determine if an exception was an <see cref="OperationCanceledException"/>, and that the provided token caused the cancellation.
         /// </summary>
         /// <param name="exception">The exception to test.</param>

--- a/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace Roslyn.Utilities
 {
@@ -27,5 +28,26 @@ namespace Roslyn.Utilities
         {
             get { return new InvalidOperationException("This program location is thought to be unreachable."); }
         }
+
+        /// <summary>
+        /// Determine if an exception was not an <see cref="OperationCanceledException"/>, and optionally check that the provided token was cancelled.
+        /// </summary>
+        /// <remarks>
+        /// Used in exception filters to determine if the exception should be handled or not.
+        /// </remarks>
+        /// <param name="exception">The exception to test.</param>
+        /// <param name="cancellationToken">Optional. Checked to see if the cancellation was caused by the provided token and considered not cancelled if not.</param>
+        /// <returns><see langword="true"/> if the exception should be handled by the caller, or <see langword="false"/> if the exception was caused by cancellation.</returns>
+        internal static bool IsNotCancelled(Exception exception, CancellationToken? cancellationToken = null)
+            => !IsCurrentOperationBeingCancelled(exception, cancellationToken ?? new CancellationToken(true));
+
+         /// <summary>
+        /// Determine if an exception was an <see cref="OperationCanceledException"/>, and that the token was cancelled.
+        /// </summary>
+        /// <param name="exception">The exception to test.</param>
+        /// <param name="cancellationToken">Checked to see if the provided token was cancelled.</param>
+        /// <returns><see langword="true"/> if the exception was an <see cref="OperationCanceledException" /> and the token was canceled.</returns>
+        internal static bool IsCurrentOperationBeingCancelled(Exception exception, CancellationToken cancellationToken)
+            => exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
@@ -36,6 +36,6 @@ namespace Roslyn.Utilities
         /// <param name="cancellationToken">Checked to see if the provided token was cancelled.</param>
         /// <returns><see langword="true"/> if the exception was an <see cref="OperationCanceledException" /> and the token was canceled.</returns>
         internal static bool IsCurrentOperationBeingCancelled(Exception exception, CancellationToken cancellationToken)
-            => exception is OperationCanceledException oce && cancellationToken.IsCancellationRequested;
+            => exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ExceptionUtilities.cs
@@ -29,25 +29,13 @@ namespace Roslyn.Utilities
             get { return new InvalidOperationException("This program location is thought to be unreachable."); }
         }
 
-        /// <summary>
-        /// Determine if an exception was not an <see cref="OperationCanceledException"/>, and optionally check that the provided token was cancelled.
-        /// </summary>
-        /// <remarks>
-        /// Used in exception filters to determine if the exception should be handled or not.
-        /// </remarks>
-        /// <param name="exception">The exception to test.</param>
-        /// <param name="cancellationToken">Optional. Checked to see if the cancellation was caused by the provided token and considered not cancelled if not.</param>
-        /// <returns><see langword="true"/> if the exception should be handled by the caller, or <see langword="false"/> if the exception was caused by cancellation.</returns>
-        internal static bool IsNotCancelled(Exception exception, CancellationToken? cancellationToken = null)
-            => !IsCurrentOperationBeingCancelled(exception, cancellationToken ?? new CancellationToken(true));
-
          /// <summary>
-        /// Determine if an exception was an <see cref="OperationCanceledException"/>, and that the token was cancelled.
+        /// Determine if an exception was an <see cref="OperationCanceledException"/>, and that the provided token caused the cancellation.
         /// </summary>
         /// <param name="exception">The exception to test.</param>
         /// <param name="cancellationToken">Checked to see if the provided token was cancelled.</param>
         /// <returns><see langword="true"/> if the exception was an <see cref="OperationCanceledException" /> and the token was canceled.</returns>
         internal static bool IsCurrentOperationBeingCancelled(Exception exception, CancellationToken cancellationToken)
-            => exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
+            => exception is OperationCanceledException oce && oce.CancellationToken == cancellationToken;
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
+using Roslyn.Utilities;
 
 #if NET20
 // Some APIs referenced by documentation comments are not available on .NET Framework 2.0.
@@ -91,9 +92,6 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
 #endif
 
-        private static bool IsCurrentOperationBeingCancelled(Exception exception, CancellationToken cancellationToken)
-            => exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
-
         /// <summary>
         /// Use in an exception filter to report an error without catching the exception.
         /// The error is reported by calling <see cref="Handler"/>.
@@ -143,7 +141,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         [DebuggerHidden]
         public static bool ReportAndPropagateUnlessCanceled(Exception exception, CancellationToken contextCancellationToken, ErrorSeverity severity = ErrorSeverity.Uncategorized)
         {
-            if (IsCurrentOperationBeingCancelled(exception, contextCancellationToken))
+            if (ExceptionUtilities.IsCurrentOperationBeingCancelled(exception, contextCancellationToken))
             {
                 return false;
             }
@@ -258,7 +256,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 #endif
             static bool ReportAndCatchUnlessCanceled(Exception exception, CancellationToken contextCancellationToken, ErrorSeverity severity = ErrorSeverity.Uncategorized)
         {
-            if (IsCurrentOperationBeingCancelled(exception, contextCancellationToken))
+            if (ExceptionUtilities.IsCurrentOperationBeingCancelled(exception, contextCancellationToken))
             {
                 return false;
             }
@@ -290,7 +288,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         [Obsolete("This is only to support places the compiler is catching and swallowing exceptions on the command line; do not use in new code.")]
         public static bool ReportIfNonFatalAndCatchUnlessCanceled(Exception exception, CancellationToken contextCancellationToken, ErrorSeverity severity = ErrorSeverity.Uncategorized)
         {
-            if (IsCurrentOperationBeingCancelled(exception, contextCancellationToken))
+            if (ExceptionUtilities.IsCurrentOperationBeingCancelled(exception, contextCancellationToken))
             {
                 return false;
             }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         generator.Initialize(pipelineContext);
                     }
-                    catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e, cancellationToken))
+                    catch (Exception e) when (!ExceptionUtilities.IsCurrentOperationBeingCancelled(e, cancellationToken))
                     {
                         ex = e;
                     }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -193,9 +192,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         generator.Initialize(pipelineContext);
                     }
-#pragma warning disable CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete; tracked by https://github.com/dotnet/roslyn/issues/58375
-                    catch (Exception e) when (FatalError.ReportIfNonFatalAndCatchUnlessCanceled(e, cancellationToken))
-#pragma warning restore CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete
+                    catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e, cancellationToken))
                     {
                         ex = e;
                     }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         generator.Initialize(pipelineContext);
                     }
-                    catch (Exception e) when (!ExceptionUtilities.IsCurrentOperationBeingCancelled(e, cancellationToken))
+                    catch (Exception e)
                     {
                         ex = e;
                     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/PostInitOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/PostInitOutputNode.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class PostInitOutputNode : IIncrementalGeneratorOutputNode
     {
-        private readonly Action<IncrementalGeneratorPostInitializationContext> _callback;
+        private readonly Action<IncrementalGeneratorPostInitializationContext, CancellationToken> _callback;
 
-        public PostInitOutputNode(Action<IncrementalGeneratorPostInitializationContext> callback)
+        public PostInitOutputNode(Action<IncrementalGeneratorPostInitializationContext, CancellationToken> callback)
         {
             _callback = callback;
         }
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis
 
         public void AppendOutputs(IncrementalExecutionContext context, CancellationToken cancellationToken)
         {
-            _callback(new IncrementalGeneratorPostInitializationContext(context.Sources, cancellationToken));
+            _callback(new IncrementalGeneratorPostInitializationContext(context.Sources, cancellationToken), cancellationToken);
         }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -17,13 +17,13 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly IIncrementalGeneratorNode<TInput> _source;
 
-        private readonly Action<SourceProductionContext, TInput> _action;
+        private readonly Action<SourceProductionContext, TInput, CancellationToken> _action;
 
         private readonly IncrementalGeneratorOutputKind _outputKind;
 
         private readonly string _sourceExtension;
 
-        public SourceOutputNode(IIncrementalGeneratorNode<TInput> source, Action<SourceProductionContext, TInput> action, IncrementalGeneratorOutputKind outputKind, string sourceExtension)
+        public SourceOutputNode(IIncrementalGeneratorNode<TInput> source, Action<SourceProductionContext, TInput, CancellationToken>action, IncrementalGeneratorOutputKind outputKind, string sourceExtension)
         {
             _source = source;
             _action = action;
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis
                     try
                     {
                         var stopwatch = SharedStopwatch.StartNew();
-                        _action(context, entry.Item);
+                        _action(context, entry.Item, cancellationToken);
                         var sourcesAndDiagnostics = (sourcesBuilder.ToImmutable(), diagnostics.ToReadOnly());
                         nodeTable.AddEntry(sourcesAndDiagnostics, EntryState.Added, stopwatch.Elapsed, inputs, EntryState.Added);
                     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SourceOutputNode.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
 
         private readonly string _sourceExtension;
 
-        public SourceOutputNode(IIncrementalGeneratorNode<TInput> source, Action<SourceProductionContext, TInput, CancellationToken>action, IncrementalGeneratorOutputKind outputKind, string sourceExtension)
+        public SourceOutputNode(IIncrementalGeneratorNode<TInput> source, Action<SourceProductionContext, TInput, CancellationToken> action, IncrementalGeneratorOutputKind outputKind, string sourceExtension)
         {
             _source = source;
             _action = action;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis
                             lastElapsedTime = stopwatch.Elapsed;
                         }
                     }
-                    catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e, cancellationToken))
+                    catch (Exception e) when (!ExceptionUtilities.IsCurrentOperationBeingCancelled(e, cancellationToken))
                     {
                         throw new UserFunctionException(e);
                     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxReceiverInputNode.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis
                             lastElapsedTime = stopwatch.Elapsed;
                         }
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e, cancellationToken))
                     {
                         throw new UserFunctionException(e);
                     }

--- a/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     return userFunction(input, token);
                 }
-                catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e, token))
+                catch (Exception e) when (!ExceptionUtilities.IsCurrentOperationBeingCancelled(e, token))
                 {
                     throw new UserFunctionException(e);
                 }
@@ -42,30 +42,30 @@ namespace Microsoft.CodeAnalysis
             return (input, token) => userFunction.WrapUserFunction()(input, token).ToImmutableArray();
         }
 
-        internal static Action<TInput> WrapUserAction<TInput>(this Action<TInput> userAction)
+        internal static Action<TInput, CancellationToken> WrapUserAction<TInput>(this Action<TInput> userAction)
         {
-            return input =>
+            return (input, token) =>
             {
                 try
                 {
                     userAction(input);
                 }
-                catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e))
+                catch (Exception e) when (!ExceptionUtilities.IsCurrentOperationBeingCancelled(e, token))
                 {
                     throw new UserFunctionException(e);
                 }
             };
         }
 
-        internal static Action<TInput1, TInput2> WrapUserAction<TInput1, TInput2>(this Action<TInput1, TInput2> userAction)
+        internal static Action<TInput1, TInput2, CancellationToken> WrapUserAction<TInput1, TInput2>(this Action<TInput1, TInput2> userAction)
         {
-            return (input1, input2) =>
+            return (input1, input2, token) =>
             {
                 try
                 {
                     userAction(input1, input2);
                 }
-                catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e))
+                catch (Exception e) when (!ExceptionUtilities.IsCurrentOperationBeingCancelled(e, token))
                 {
                     throw new UserFunctionException(e);
                 }

--- a/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/UserFunction.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
-using Microsoft.CodeAnalysis.ErrorReporting;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -30,9 +30,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     return userFunction(input, token);
                 }
-#pragma warning disable CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete; tracked by https://github.com/dotnet/roslyn/issues/58375
-                catch (Exception e) when (FatalError.ReportIfNonFatalAndCatchUnlessCanceled(e, token))
-#pragma warning restore CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete
+                catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e, token))
                 {
                     throw new UserFunctionException(e);
                 }
@@ -52,9 +50,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     userAction(input);
                 }
-#pragma warning disable CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete; tracked by https://github.com/dotnet/roslyn/issues/58375
-                catch (Exception e) when (FatalError.ReportIfNonFatalAndCatchUnlessCanceled(e))
-#pragma warning restore CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete
+                catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e))
                 {
                     throw new UserFunctionException(e);
                 }
@@ -69,9 +65,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     userAction(input1, input2);
                 }
-#pragma warning disable CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete; tracked by https://github.com/dotnet/roslyn/issues/58375
-                catch (Exception e) when (FatalError.ReportIfNonFatalAndCatchUnlessCanceled(e))
-#pragma warning restore CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete
+                catch (Exception e) when (ExceptionUtilities.IsNotCancelled(e))
                 {
                     throw new UserFunctionException(e);
                 }


### PR DESCRIPTION
Previously we were using the fatal error handler to do filtering which has been obsoleted via https://github.com/dotnet/roslyn/pull/58094. 

Also fixes https://github.com/dotnet/roslyn/issues/58290 by adding a missing filter to the syntax receiver shim.