### PR TITLE
Update VisualStudioCacheVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -119,7 +119,7 @@
     <MicrosoftServiceHubFrameworkVersion>3.1.4</MicrosoftServiceHubFrameworkVersion>
     <MicrosoftSourceLinkToolsVersion>1.1.1-beta-21566-01</MicrosoftSourceLinkToolsVersion>
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
-    <MicrosoftVisualStudioCacheVersion>17.0.13-alpha</MicrosoftVisualStudioCacheVersion>
+    <MicrosoftVisualStudioCacheVersion>17.0.42</MicrosoftVisualStudioCacheVersion>
     <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.8.27812-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.8.27812-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>
     <MicrosoftVisualStudioComponentModelHostVersion>$(VisualStudioEditorNewPackagesVersion)</MicrosoftVisualStudioComponentModelHostVersion>


### PR DESCRIPTION
Fix https://dnceng.visualstudio.com/internal/_componentGovernance/dotnet-roslyn/alert/4930757?typeId=6262992
VisualStudioCache package is referenecing some Azure package, which cause the alert.

I have tested on my local machine, after updating the package version the System.Text.Encodings.Web 4.6.0 won't be restored.