### PR TITLE
VS 2022 editor colors

### DIFF
--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2022.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2022.xml
@@ -533,15 +533,15 @@
   <Theme Name="DarkExperimental" GUID="{575628dd-e4dc-452b-bf6a-6b50d63837d6}">
     <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
       <Color Name="class name">
-        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+        <Foreground Type="CT_RAW" Source="FF57D2DA" />
       </Color>
       <Color Name="constant name" />
       <Color Name="delegate name">
-        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+        <Foreground Type="CT_RAW" Source="FF57D2DA" />
       </Color>
       <Color Name="enum member name" />
       <Color Name="enum name">
-        <Foreground Type="CT_RAW" Source="FFA4CD6C" />
+        <Foreground Type="CT_RAW" Source="FFCFE6AF" />
       </Color>
       <Color Name="event name" />
       <Color Name="extension method name">
@@ -549,23 +549,23 @@
       </Color>
       <Color Name="field name" />
       <Color Name="inline diagnostics - compiler warning">
-        <Background Type="CT_RAW" Source="FFA4CD6C" />
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Background Type="CT_RAW" Source="FF6CCB5F" />
+        <Foreground Type="CT_RAW" Source="FF1A1A1A" />
       </Color>
       <Color Name="inline diagnostics - Edit and Continue">
-        <Background Type="CT_RAW" Source="FFD696C0" />
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Background Type="CT_RAW" Source="FFA79CF1" />
+        <Foreground Type="CT_RAW" Source="FF1A1A1A" />
       </Color>
       <Color Name="inline diagnostics - syntax error">
         <Background Type="CT_RAW" Source="FFFF99A4" />
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FF1A1A1A" />
       </Color>
       <Color Name="inline hints">
-        <Background Type="CT_RAW" Source="FF6BA02B" />
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Background Type="CT_RAW" Source="FF424242" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
       <Color Name="interface name">
-        <Foreground Type="CT_RAW" Source="FFA4CD6C" />
+        <Foreground Type="CT_RAW" Source="FFCFE6AF" />
       </Color>
       <Color Name="keyword - control">
         <Foreground Type="CT_RAW" Source="FFD696C0" />
@@ -578,7 +578,7 @@
         <Foreground Type="CT_RAW" Source="FFEDDEA6" />
       </Color>
       <Color Name="module name">
-        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+        <Foreground Type="CT_RAW" Source="FF57D2DA" />
       </Color>
       <Color Name="namespace name" />
       <Color Name="operator - overloaded">
@@ -588,15 +588,15 @@
         <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="preprocessor text">
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
       <Color Name="property name" />
       <Color Name="punctuation">
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
       <Color Name="record name" />
       <Color Name="regex - alternation">
-        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+        <Foreground Type="CT_RAW" Source="FF57D2DA" />
       </Color>
       <Color Name="regex - anchor">
         <Foreground Type="CT_RAW" Source="FFD696C0" />
@@ -605,10 +605,10 @@
         <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="regex - comment">
-        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+        <Foreground Type="CT_RAW" Source="FF4CA64C" />
       </Color>
       <Color Name="regex - grouping">
-        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+        <Foreground Type="CT_RAW" Source="FF57D2DA" />
       </Color>
       <Color Name="regex - other escape">
         <Foreground Type="CT_RAW" Source="FFEDDEA6" />
@@ -632,56 +632,56 @@
         <Foreground Type="CT_RAW" Source="FFA4CD6C" />
       </Color>
       <Color Name="xml doc comment - attribute name">
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
       <Color Name="xml doc comment - attribute quotes">
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
       <Color Name="xml doc comment - attribute value">
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
       <Color Name="xml doc comment - cdata section">
         <Foreground Type="CT_RAW" Source="FFEDDEA6" />
       </Color>
       <Color Name="xml doc comment - comment">
-        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+        <Foreground Type="CT_RAW" Source="FF4CA64C" />
       </Color>
       <Color Name="xml doc comment - delimiter">
-        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+        <Foreground Type="CT_RAW" Source="FF4CA64C" />
       </Color>
       <Color Name="xml doc comment - entity reference">
-        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+        <Foreground Type="CT_RAW" Source="FF4CA64C" />
       </Color>
       <Color Name="xml doc comment - name">
-        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+        <Foreground Type="CT_RAW" Source="FF4CA64C" />
       </Color>
       <Color Name="xml doc comment - processing instruction">
-        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+        <Foreground Type="CT_RAW" Source="FF4CA64C" />
       </Color>
       <Color Name="xml doc comment - text">
-        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+        <Foreground Type="CT_RAW" Source="FF4CA64C" />
       </Color>
       <Color Name="xml literal - attribute name">
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
       <Color Name="xml literal - attribute quotes">
         <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="xml literal - attribute value">
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
       <Color Name="xml literal - cdata section">
         <Foreground Type="CT_RAW" Source="FFEDDEA6" />
       </Color>
       <Color Name="xml literal - comment">
-        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+        <Foreground Type="CT_RAW" Source="FF4CA64C" />
       </Color>
       <Color Name="xml literal - delimiter">
-        <Foreground Type="CT_RAW" Source="FFA4CD6C" />
+        <Foreground Type="CT_RAW" Source="FFCFE6AF" />
       </Color>
       <Color Name="xml literal - embedded expression">
-        <Background Type="CT_RAW" Source="FFD6D6D6" />
-        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+        <Background Type="CT_RAW" Source="FF1A1A1A" />
+        <Foreground Type="CT_RAW" Source="FF4CA64C" />
       </Color>
       <Color Name="xml literal - entity reference">
         <Foreground Type="CT_RAW" Source="FF83BEEB" />
@@ -690,10 +690,10 @@
         <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="xml literal - processing instruction">
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
       <Color Name="xml literal - text">
-        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FFCCCCCC" />
       </Color>
     </Category>
   </Theme>

--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2022.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2022.xml
@@ -530,6 +530,181 @@
       </Color>
     </Category>
   </Theme>
+  <Theme Name="DarkExperimental" GUID="{575628dd-e4dc-452b-bf6a-6b50d63837d6}">
+    <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="class name">
+        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+      </Color>
+      <Color Name="constant name" >
+      </Color>
+      <Color Name="delegate name">
+        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+      </Color>
+      <Color Name="enum member name" >
+      </Color>
+      <Color Name="enum name">
+        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+      </Color>
+      <Color Name="event name" >
+      </Color>
+      <Color Name="extension method name">
+        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+      </Color>
+      <Color Name="field name" >
+      </Color>
+      <Color Name="inline diagnostics - compiler warning">
+        <Background Type="CT_RAW" Source="FFA0D8A0" />
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="inline diagnostics - Edit and Continue">
+        <Background Type="CT_RAW" Source="FFECA5D1" />
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="inline diagnostics - syntax error">
+        <Background Type="CT_RAW" Source="FFEDACB1" />
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="inline hints">
+        <Background Type="CT_RAW" Source="FF6BA02B" />
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="interface name">
+        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+      </Color>
+      <Color Name="keyword - control">
+        <Foreground Type="CT_RAW" Source="FFECA5D1" />
+      </Color>
+      <Color Name="label name" >
+      </Color>
+      <Color Name="local name">
+        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+      </Color>
+      <Color Name="method name">
+        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+      </Color>
+      <Color Name="module name">
+        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+      </Color>
+      <Color Name="namespace name" >
+      </Color>
+      <Color Name="operator - overloaded">
+        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+      </Color>
+      <Color Name="parameter name">
+        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+      </Color>
+      <Color Name="preprocessor text">
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="property name" >
+      </Color>
+      <Color Name="punctuation">
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="record name" >
+      </Color>
+      <Color Name="regex - alternation">
+        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+      </Color>
+      <Color Name="regex - anchor">
+        <Foreground Type="CT_RAW" Source="FFECA5D1" />
+      </Color>
+      <Color Name="regex - character class">
+        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+      </Color>
+      <Color Name="regex - comment">
+        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+      </Color>
+      <Color Name="regex - grouping">
+        <Foreground Type="CT_RAW" Source="FF92D1D1" />
+      </Color>
+      <Color Name="regex - other escape">
+        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+      </Color>
+      <Color Name="regex - quantifier">
+        <Foreground Type="CT_RAW" Source="FFECA5D1" />
+      </Color>
+      <Color Name="regex - self escaped character">
+        <Foreground Type="CT_RAW" Source="FFEFC4AD" />
+      </Color>
+      <Color Name="regex - text">
+        <Foreground Type="CT_RAW" Source="FFEFC4AD" />
+      </Color>
+      <Color Name="string - verbatim">
+        <Foreground Type="CT_RAW" Source="FFEFC4AD" />
+      </Color>
+      <Color Name="struct name">
+        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+      </Color>
+      <Color Name="type parameter name">
+        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+      </Color>
+      <Color Name="xml doc comment - attribute name">
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="xml doc comment - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="xml doc comment - attribute value">
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="xml doc comment - cdata section">
+        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+      </Color>
+      <Color Name="xml doc comment - comment">
+        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+      </Color>
+      <Color Name="xml doc comment - delimiter">
+        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+      </Color>
+      <Color Name="xml doc comment - entity reference">
+        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+      </Color>
+      <Color Name="xml doc comment - name">
+        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+      </Color>
+      <Color Name="xml doc comment - processing instruction">
+        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+      </Color>
+      <Color Name="xml doc comment - text">
+        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+      </Color>
+      <Color Name="xml literal - attribute name">
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="xml literal - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+      </Color>
+      <Color Name="xml literal - attribute value">
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="xml literal - cdata section">
+        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+      </Color>
+      <Color Name="xml literal - comment">
+        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+      </Color>
+      <Color Name="xml literal - delimiter">
+        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+      </Color>
+      <Color Name="xml literal - embedded expression">
+        <Background Type="CT_RAW" Source="FFD6D6D6" />
+        <Foreground Type="CT_RAW" Source="FF6BA02B" />
+      </Color>
+      <Color Name="xml literal - entity reference">
+        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+      </Color>
+      <Color Name="xml literal - name">
+        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+      </Color>
+      <Color Name="xml literal - processing instruction">
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+      <Color Name="xml literal - text">
+        <Foreground Type="CT_RAW" Source="FFD6D6D6" />
+      </Color>
+    </Category>
+  </Theme>
   <Theme Name="HighContrast" GUID="{a5c004b4-2d4b-494e-bf01-45fc492522c7}">
     <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
       <Color Name="class name">

--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2022.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2022.xml
@@ -535,33 +535,29 @@
       <Color Name="class name">
         <Foreground Type="CT_RAW" Source="FF92D1D1" />
       </Color>
-      <Color Name="constant name" >
-      </Color>
+      <Color Name="constant name" />
       <Color Name="delegate name">
         <Foreground Type="CT_RAW" Source="FF92D1D1" />
       </Color>
-      <Color Name="enum member name" >
-      </Color>
+      <Color Name="enum member name" />
       <Color Name="enum name">
-        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+        <Foreground Type="CT_RAW" Source="FFA4CD6C" />
       </Color>
-      <Color Name="event name" >
-      </Color>
+      <Color Name="event name" />
       <Color Name="extension method name">
-        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+        <Foreground Type="CT_RAW" Source="FFEDDEA6" />
       </Color>
-      <Color Name="field name" >
-      </Color>
+      <Color Name="field name" />
       <Color Name="inline diagnostics - compiler warning">
-        <Background Type="CT_RAW" Source="FFA0D8A0" />
+        <Background Type="CT_RAW" Source="FFA4CD6C" />
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
       </Color>
       <Color Name="inline diagnostics - Edit and Continue">
-        <Background Type="CT_RAW" Source="FFECA5D1" />
+        <Background Type="CT_RAW" Source="FFD696C0" />
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
       </Color>
       <Color Name="inline diagnostics - syntax error">
-        <Background Type="CT_RAW" Source="FFEDACB1" />
+        <Background Type="CT_RAW" Source="FFFF99A4" />
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
       </Color>
       <Color Name="inline hints">
@@ -569,48 +565,44 @@
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
       </Color>
       <Color Name="interface name">
-        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+        <Foreground Type="CT_RAW" Source="FFA4CD6C" />
       </Color>
       <Color Name="keyword - control">
-        <Foreground Type="CT_RAW" Source="FFECA5D1" />
+        <Foreground Type="CT_RAW" Source="FFD696C0" />
       </Color>
-      <Color Name="label name" >
-      </Color>
+      <Color Name="label name" />
       <Color Name="local name">
-        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+        <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="method name">
-        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+        <Foreground Type="CT_RAW" Source="FFEDDEA6" />
       </Color>
       <Color Name="module name">
         <Foreground Type="CT_RAW" Source="FF92D1D1" />
       </Color>
-      <Color Name="namespace name" >
-      </Color>
+      <Color Name="namespace name" />
       <Color Name="operator - overloaded">
-        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+        <Foreground Type="CT_RAW" Source="FFEDDEA6" />
       </Color>
       <Color Name="parameter name">
-        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+        <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="preprocessor text">
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
       </Color>
-      <Color Name="property name" >
-      </Color>
+      <Color Name="property name" />
       <Color Name="punctuation">
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
       </Color>
-      <Color Name="record name" >
-      </Color>
+      <Color Name="record name" />
       <Color Name="regex - alternation">
         <Foreground Type="CT_RAW" Source="FF92D1D1" />
       </Color>
       <Color Name="regex - anchor">
-        <Foreground Type="CT_RAW" Source="FFECA5D1" />
+        <Foreground Type="CT_RAW" Source="FFD696C0" />
       </Color>
       <Color Name="regex - character class">
-        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+        <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="regex - comment">
         <Foreground Type="CT_RAW" Source="FF6BA02B" />
@@ -619,25 +611,25 @@
         <Foreground Type="CT_RAW" Source="FF92D1D1" />
       </Color>
       <Color Name="regex - other escape">
-        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+        <Foreground Type="CT_RAW" Source="FFEDDEA6" />
       </Color>
       <Color Name="regex - quantifier">
-        <Foreground Type="CT_RAW" Source="FFECA5D1" />
+        <Foreground Type="CT_RAW" Source="FFD696C0" />
       </Color>
       <Color Name="regex - self escaped character">
-        <Foreground Type="CT_RAW" Source="FFEFC4AD" />
+        <Foreground Type="CT_RAW" Source="FFF4BEAA" />
       </Color>
       <Color Name="regex - text">
-        <Foreground Type="CT_RAW" Source="FFEFC4AD" />
+        <Foreground Type="CT_RAW" Source="FFF4BEAA" />
       </Color>
       <Color Name="string - verbatim">
-        <Foreground Type="CT_RAW" Source="FFEFC4AD" />
+        <Foreground Type="CT_RAW" Source="FFF4BEAA" />
       </Color>
       <Color Name="struct name">
-        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+        <Foreground Type="CT_RAW" Source="FFA4CD6C" />
       </Color>
       <Color Name="type parameter name">
-        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+        <Foreground Type="CT_RAW" Source="FFA4CD6C" />
       </Color>
       <Color Name="xml doc comment - attribute name">
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
@@ -649,7 +641,7 @@
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
       </Color>
       <Color Name="xml doc comment - cdata section">
-        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+        <Foreground Type="CT_RAW" Source="FFEDDEA6" />
       </Color>
       <Color Name="xml doc comment - comment">
         <Foreground Type="CT_RAW" Source="FF6BA02B" />
@@ -673,29 +665,29 @@
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
       </Color>
       <Color Name="xml literal - attribute quotes">
-        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+        <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="xml literal - attribute value">
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />
       </Color>
       <Color Name="xml literal - cdata section">
-        <Foreground Type="CT_RAW" Source="FFE0CFA2" />
+        <Foreground Type="CT_RAW" Source="FFEDDEA6" />
       </Color>
       <Color Name="xml literal - comment">
         <Foreground Type="CT_RAW" Source="FF6BA02B" />
       </Color>
       <Color Name="xml literal - delimiter">
-        <Foreground Type="CT_RAW" Source="FFA0D8A0" />
+        <Foreground Type="CT_RAW" Source="FFA4CD6C" />
       </Color>
       <Color Name="xml literal - embedded expression">
         <Background Type="CT_RAW" Source="FFD6D6D6" />
         <Foreground Type="CT_RAW" Source="FF6BA02B" />
       </Color>
       <Color Name="xml literal - entity reference">
-        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+        <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="xml literal - name">
-        <Foreground Type="CT_RAW" Source="FFA9D3F2" />
+        <Foreground Type="CT_RAW" Source="FF83BEEB" />
       </Color>
       <Color Name="xml literal - processing instruction">
         <Foreground Type="CT_RAW" Source="FFD6D6D6" />

--- a/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2022.xml
+++ b/src/VisualStudio/Core/Def/ColorSchemes/VisualStudio2022.xml
@@ -5,886 +5,873 @@
         inherit their color from the their parent classification (For instance Type
         and Member name classifications inherit from Identifier).
     -->
-    <Theme Name="Light" GUID="{de3dbbcd-f642-433c-8353-8f1df4370aba}">
-        <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
-            <Color Name="preprocessor text">
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="punctuation">
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="string - verbatim">
-                <Foreground Type="CT_RAW" Source="FF800000" />
-            </Color>
-            <Color Name="keyword - control">
-                <Foreground Type="CT_RAW" Source="FF8F08C4" />
-            </Color>
-            <Color Name="operator - overloaded">
-                <Foreground Type="CT_RAW" Source="FF74531F" />
-            </Color>
-            <Color Name="class name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="delegate name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="enum name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="interface name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="module name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="struct name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="type parameter name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="field name">
-            </Color>
-            <Color Name="enum member name">
-            </Color>
-            <Color Name="constant name">
-            </Color>
-            <Color Name="local name">
-                <Foreground Type="CT_RAW" Source="FF1F377F" />
-            </Color>
-            <Color Name="parameter name">
-                <Foreground Type="CT_RAW" Source="FF1F377F" />
-            </Color>
-            <Color Name="method name">
-                <Foreground Type="CT_RAW" Source="FF74531F" />
-            </Color>
-            <Color Name="extension method name">
-                <Foreground Type="CT_RAW" Source="FF74531F" />
-            </Color>
-            <Color Name="property name">
-            </Color>
-            <Color Name="event name">
-            </Color>
-            <Color Name="namespace name">
-            </Color>
-            <Color Name="label name">
-            </Color>
-            <Color Name="record name">
-            </Color>
-            <Color Name="inline hints">
-                <Background Type="CT_RAW" Source="FFE6E6FA" />
-                <Foreground Type="CT_RAW" Source="FF686868" />
-            </Color>
-            <Color Name="inline diagnostics - syntax error">
-                <!--Background default matches syntax error-->
-                <Background Type="CT_RAW" Source="FFFC3E36" />
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="inline diagnostics - compiler warning">
-                <!--Background default matches compiler warning-->
-                <Background Type="CT_RAW" Source="FF95BD7D" />
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="inline diagnostics - Edit and Continue">
-                <!--Background default matches edit and continue-->
-                <Background Type="CT_RAW" Source="FF800080" />
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="xml doc comment - attribute name">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - attribute quotes">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - attribute value">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - cdata section">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - comment">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - delimiter">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - entity reference">
-                <Foreground Type="CT_RAW" Source="FF008000" />
-            </Color>
-            <Color Name="xml doc comment - name">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - processing instruction">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - text">
-                <Foreground Type="CT_RAW" Source="FF008000" />
-            </Color>
-            <Color Name="regex - comment">
-                <Foreground Type="CT_RAW" Source="FF008000" />
-            </Color>
-            <Color Name="regex - character class">
-                <Foreground Type="CT_RAW" Source="FF0073FF" />
-            </Color>
-            <Color Name="regex - anchor">
-                <Foreground Type="CT_RAW" Source="FFFF00C1" />
-            </Color>
-            <Color Name="regex - quantifier">
-                <Foreground Type="CT_RAW" Source="FFFF00C1" />
-            </Color>
-            <Color Name="regex - grouping">
-                <Foreground Type="CT_RAW" Source="FF05C3BA" />
-            </Color>
-            <Color Name="regex - alternation">
-                <Foreground Type="CT_RAW" Source="FF05C3BA" />
-            </Color>
-            <Color Name="regex - text">
-                <Foreground Type="CT_RAW" Source="FF800000" />
-            </Color>
-            <Color Name="regex - self escaped character">
-                <Foreground Type="CT_RAW" Source="FF800000" />
-            </Color>
-            <Color Name="regex - other escape">
-                <Foreground Type="CT_RAW" Source="FF9E5B71" />
-            </Color>
-            <Color Name="xml literal - attribute name">
-                <Foreground Type="CT_RAW" Source="FFB96464" />
-            </Color>
-            <Color Name="xml literal - attribute quotes">
-                <Foreground Type="CT_RAW" Source="FF555555" />
-            </Color>
-            <Color Name="xml literal - attribute value">
-                <Foreground Type="CT_RAW" Source="FF6464B9" />
-            </Color>
-            <Color Name="xml literal - cdata section">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml literal - comment">
-                <Foreground Type="CT_RAW" Source="FF629755" />
-            </Color>
-            <Color Name="xml literal - delimiter">
-                <Foreground Type="CT_RAW" Source="FF6464B9" />
-            </Color>
-            <Color Name="xml literal - embedded expression">
-                <Background Type="CT_RAW" Source="FFFFFEBF" />
-                <Foreground Type="CT_RAW" Source="FF555555" />
-            </Color>
-            <Color Name="xml literal - entity reference">
-                <Foreground Type="CT_RAW" Source="FFB96464" />
-            </Color>
-            <Color Name="xml literal - name">
-                <Foreground Type="CT_RAW" Source="FF844646" />
-            </Color>
-            <Color Name="xml literal - processing instruction">
-                <Foreground Type="CT_RAW" Source="FFC0C0C0" />
-            </Color>
-            <Color Name="xml literal - text">
-                <Foreground Type="CT_RAW" Source="FF555555" />
-            </Color>
-        </Category>
-    </Theme>
-    <Theme Name="Blue" GUID="{a4d6a176-b948-4b29-8c66-53c97a1ed7d0}">
-        <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
-            <Color Name="preprocessor text">
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="punctuation">
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="string - verbatim">
-                <Foreground Type="CT_RAW" Source="FF800000" />
-            </Color>
-            <Color Name="keyword - control">
-                <Foreground Type="CT_RAW" Source="FF8F08C4" />
-            </Color>
-            <Color Name="operator - overloaded">
-                <Foreground Type="CT_RAW" Source="FF74531F" />
-            </Color>
-            <Color Name="class name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="delegate name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="enum name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="interface name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="module name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="struct name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="type parameter name">
-                <Foreground Type="CT_RAW" Source="FF2B91AF" />
-            </Color>
-            <Color Name="field name">
-            </Color>
-            <Color Name="enum member name">
-            </Color>
-            <Color Name="constant name">
-            </Color>
-            <Color Name="local name">
-                <Foreground Type="CT_RAW" Source="FF1F377F" />
-            </Color>
-            <Color Name="parameter name">
-                <Foreground Type="CT_RAW" Source="FF1F377F" />
-            </Color>
-            <Color Name="method name">
-                <Foreground Type="CT_RAW" Source="FF74531F" />
-            </Color>
-            <Color Name="extension method name">
-                <Foreground Type="CT_RAW" Source="FF74531F" />
-            </Color>
-            <Color Name="property name">
-            </Color>
-            <Color Name="event name">
-            </Color>
-            <Color Name="namespace name">
-            </Color>
-            <Color Name="label name">
-            </Color>
-            <Color Name="record name">
-            </Color>
-            <Color Name="inline hints">
-                <Background Type="CT_RAW" Source="FFE6E6FA" />
-                <Foreground Type="CT_RAW" Source="FF686868" />
-            </Color>
-            <Color Name="inline diagnostics - syntax error">
-                <!--Background default matches syntax error-->
-                <Background Type="CT_RAW" Source="FFFC3E36" />
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="inline diagnostics - compiler warning">
-                <!--Background default matches compiler warning-->
-                <Background Type="CT_RAW" Source="FF95BD7D" />
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="inline diagnostics - Edit and Continue">
-                <!--Background default matches edit and continue-->
-                <Background Type="CT_RAW" Source="FF800080" />
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="xml doc comment - attribute name">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - attribute quotes">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - attribute value">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - cdata section">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - comment">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - delimiter">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - entity reference">
-                <Foreground Type="CT_RAW" Source="FF008000" />
-            </Color>
-            <Color Name="xml doc comment - name">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - processing instruction">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml doc comment - text">
-                <Foreground Type="CT_RAW" Source="FF008000" />
-            </Color>
-            <Color Name="regex - comment">
-                <Foreground Type="CT_RAW" Source="FF008000" />
-            </Color>
-            <Color Name="regex - character class">
-                <Foreground Type="CT_RAW" Source="FF0073FF" />
-            </Color>
-            <Color Name="regex - anchor">
-                <Foreground Type="CT_RAW" Source="FFFF00C1" />
-            </Color>
-            <Color Name="regex - quantifier">
-                <Foreground Type="CT_RAW" Source="FFFF00C1" />
-            </Color>
-            <Color Name="regex - grouping">
-                <Foreground Type="CT_RAW" Source="FF05C3BA" />
-            </Color>
-            <Color Name="regex - alternation">
-                <Foreground Type="CT_RAW" Source="FF05C3BA" />
-            </Color>
-            <Color Name="regex - text">
-                <Foreground Type="CT_RAW" Source="FF800000" />
-            </Color>
-            <Color Name="regex - self escaped character">
-                <Foreground Type="CT_RAW" Source="FF800000" />
-            </Color>
-            <Color Name="regex - other escape">
-                <Foreground Type="CT_RAW" Source="FF9E5B71" />
-            </Color>
-            <Color Name="xml literal - attribute name">
-                <Foreground Type="CT_RAW" Source="FFB96464" />
-            </Color>
-            <Color Name="xml literal - attribute quotes">
-                <Foreground Type="CT_RAW" Source="FF555555" />
-            </Color>
-            <Color Name="xml literal - attribute value">
-                <Foreground Type="CT_RAW" Source="FF6464B9" />
-            </Color>
-            <Color Name="xml literal - cdata section">
-                <Foreground Type="CT_RAW" Source="FF808080" />
-            </Color>
-            <Color Name="xml literal - comment">
-                <Foreground Type="CT_RAW" Source="FF629755" />
-            </Color>
-            <Color Name="xml literal - delimiter">
-                <Foreground Type="CT_RAW" Source="FF6464B9" />
-            </Color>
-            <Color Name="xml literal - embedded expression">
-                <Background Type="CT_RAW" Source="FFFFFEBF" />
-                <Foreground Type="CT_RAW" Source="FF555555" />
-            </Color>
-            <Color Name="xml literal - entity reference">
-                <Foreground Type="CT_RAW" Source="FFB96464" />
-            </Color>
-            <Color Name="xml literal - name">
-                <Foreground Type="CT_RAW" Source="FF844646" />
-            </Color>
-            <Color Name="xml literal - processing instruction">
-                <Foreground Type="CT_RAW" Source="FFC0C0C0" />
-            </Color>
-            <Color Name="xml literal - text">
-                <Foreground Type="CT_RAW" Source="FF555555" />
-            </Color>
-        </Category>
-    </Theme>
-    <Theme Name="AdditionalContrast" GUID="{ce94d289-8481-498b-8ca9-9b6191a315b9}">
-        <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
-            <Color Name="preprocessor text">
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="punctuation">
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="string - verbatim">
-                <Foreground Type="CT_RAW" Source="FF800000" />
-            </Color>
-            <Color Name="keyword - control">
-                <Foreground Type="CT_RAW" Source="FF8F08C4" />
-            </Color>
-            <Color Name="operator - overloaded">
-                <Foreground Type="CT_RAW" Source="FF74531F" />
-            </Color>
-            <Color Name="class name">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="delegate name">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="enum name">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="interface name">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="module name">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="struct name">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="type parameter name">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="field name">
-            </Color>
-            <Color Name="enum member name">
-            </Color>
-            <Color Name="constant name">
-            </Color>
-            <Color Name="local name">
-                <Foreground Type="CT_RAW" Source="FF1F377F" />
-            </Color>
-            <Color Name="parameter name">
-                <Foreground Type="CT_RAW" Source="FF1F377F" />
-            </Color>
-            <Color Name="method name">
-                <Foreground Type="CT_RAW" Source="FF74531F" />
-            </Color>
-            <Color Name="extension method name">
-                <Foreground Type="CT_RAW" Source="FF74531F" />
-            </Color>
-            <Color Name="property name">
-            </Color>
-            <Color Name="event name">
-            </Color>
-            <Color Name="namespace name">
-            </Color>
-            <Color Name="label name">
-            </Color>
-            <Color Name="record name">
-            </Color>
-            <Color Name="inline hints">
-                <Background Type="CT_RAW" Source="FFE6E6FA" />
-                <Foreground Type="CT_RAW" Source="FF504848" />
-            </Color>
-            <Color Name="inline diagnostics - syntax error">
-                <!--Background default matches syntax error-->
-                <Background Type="CT_RAW" Source="FFFC3E36" />
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="inline diagnostics - compiler warning">
-                <!--Background default matches compiler warning-->
-                <Background Type="CT_RAW" Source="FF95BD7D" />
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="inline diagnostics - Edit and Continue">
-                <!--Background default matches edit and continue-->
-                <Background Type="CT_RAW" Source="FF800080" />
-                <Foreground Type="CT_RAW" Source="FF000000" />
-            </Color>
-            <Color Name="xml doc comment - attribute name">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml doc comment - attribute quotes">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml doc comment - attribute value">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml doc comment - cdata section">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml doc comment - comment">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml doc comment - delimiter">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml doc comment - entity reference">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="xml doc comment - name">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml doc comment - processing instruction">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml doc comment - text">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="regex - comment">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="regex - character class">
-                <Foreground Type="CT_RAW" Source="FF043BB3" />
-            </Color>
-            <Color Name="regex - anchor">
-                <Foreground Type="CT_RAW" Source="FF83146C" />
-            </Color>
-            <Color Name="regex - quantifier">
-                <Foreground Type="CT_RAW" Source="FF83146C" />
-            </Color>
-            <Color Name="regex - grouping">
-                <Foreground Type="CT_RAW" Source="FF204F4B" />
-            </Color>
-            <Color Name="regex - alternation">
-                <Foreground Type="CT_RAW" Source="FF204F4B" />
-            </Color>
-            <Color Name="regex - text">
-                <Foreground Type="CT_RAW" Source="FF800000" />
-            </Color>
-            <Color Name="regex - self escaped character">
-                <Foreground Type="CT_RAW" Source="FF800000" />
-            </Color>
-            <Color Name="regex - other escape">
-                <Foreground Type="CT_RAW" Source="FF72324E" />
-            </Color>
-            <Color Name="xml literal - attribute name">
-                <Foreground Type="CT_RAW" Source="FF863434" />
-            </Color>
-            <Color Name="xml literal - attribute quotes">
-                <Foreground Type="CT_RAW" Source="FF3F3F3F" />
-            </Color>
-            <Color Name="xml literal - attribute value">
-                <Foreground Type="CT_RAW" Source="FF5245A9" />
-            </Color>
-            <Color Name="xml literal - cdata section">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml literal - comment">
-                <Foreground Type="CT_RAW" Source="FF066555" />
-            </Color>
-            <Color Name="xml literal - delimiter">
-                <Foreground Type="CT_RAW" Source="FF5245A9" />
-            </Color>
-            <Color Name="xml literal - embedded expression">
-                <Background Type="CT_RAW" Source="FFEDE0D1" />
-                <Foreground Type="CT_RAW" Source="FF3F3F3F" />
-            </Color>
-            <Color Name="xml literal - entity reference">
-                <Foreground Type="CT_RAW" Source="FF863434" />
-            </Color>
-            <Color Name="xml literal - name">
-                <Foreground Type="CT_RAW" Source="FF863434" />
-            </Color>
-            <Color Name="xml literal - processing instruction">
-                <Foreground Type="CT_RAW" Source="FF5B5B5B" />
-            </Color>
-            <Color Name="xml literal - text">
-                <Foreground Type="CT_RAW" Source="FF3F3F3F" />
-            </Color>
-       </Category>
-    </Theme>
-    <Theme Name="Dark" GUID="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
-        <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
-            <Color Name="preprocessor text">
-                <Foreground Type="CT_RAW" Source="FFDCDCDC" />
-            </Color>
-            <Color Name="punctuation">
-                <Foreground Type="CT_RAW" Source="FFDCDCDC" />
-            </Color>
-            <Color Name="string - verbatim">
-                <Foreground Type="CT_RAW" Source="FFD69D85" />
-            </Color>
-            <Color Name="keyword - control">
-                <Foreground Type="CT_RAW" Source="FFD8A0DF" />
-            </Color>
-            <Color Name="operator - overloaded">
-                <Foreground Type="CT_RAW" Source="FFDCDCAA" />
-            </Color>
-            <Color Name="class name">
-                <Foreground Type="CT_RAW" Source="FF4EC9B0" />
-            </Color>
-            <Color Name="delegate name">
-                <Foreground Type="CT_RAW" Source="FF4EC9B0" />
-            </Color>
-            <Color Name="enum name">
-                <Foreground Type="CT_RAW" Source="FFB8D7A3" />
-            </Color>
-            <Color Name="interface name">
-                <Foreground Type="CT_RAW" Source="FFB8D7A3" />
-            </Color>
-            <Color Name="module name">
-                <Foreground Type="CT_RAW" Source="FF4EC9B0" />
-            </Color>
-            <Color Name="struct name">
-                <Foreground Type="CT_RAW" Source="FF86C691" />
-            </Color>
-            <Color Name="type parameter name">
-                <Foreground Type="CT_RAW" Source="FFB8D7A3" />
-            </Color>
-            <Color Name="field name">
-            </Color>
-            <Color Name="enum member name">
-            </Color>
-            <Color Name="constant name">
-            </Color>
-            <Color Name="local name">
-                <Foreground Type="CT_RAW" Source="FF9CDCFE" />
-            </Color>
-            <Color Name="parameter name">
-                <Foreground Type="CT_RAW" Source="FF9CDCFE" />
-            </Color>
-            <Color Name="method name">
-                <Foreground Type="CT_RAW" Source="FFDCDCAA" />
-            </Color>
-            <Color Name="extension method name">
-                <Foreground Type="CT_RAW" Source="FFDCDCAA" />
-            </Color>
-            <Color Name="property name">
-            </Color>
-            <Color Name="event name">
-            </Color>
-            <Color Name="namespace name">
-            </Color>
-            <Color Name="label name">
-            </Color>
-            <Color Name="record name">
-            </Color>
-            <Color Name="inline hints">
-                <Background Type="CT_RAW" Source="FF3E3E3E" />
-                <Foreground Type="CT_RAW" Source="FFA9A8A7" />
-            </Color>
-            <Color Name="inline diagnostics - syntax error">
-                <!--Background default matches syntax error-->
-                <Background Type="CT_RAW" Source="FFFC3E36" />
-                <Foreground Type="CT_RAW" Source="FFDCDCDC" />
-            </Color>
-            <Color Name="inline diagnostics - compiler warning">
-                <!--Background default matches compiler warning-->
-                <Background Type="CT_RAW" Source="FF95BD7D" />
-                <Foreground Type="CT_RAW" Source="FFDCDCDC" />
-            </Color>
-            <Color Name="inline diagnostics - Edit and Continue">
-                <!--Background default matches edit and continue-->
-                <Background Type="CT_RAW" Source="FF800080" />
-                <Foreground Type="CT_RAW" Source="FFDCDCDC" />
-            </Color>
-            <Color Name="xml doc comment - attribute name">
-                <Foreground Type="CT_RAW" Source="FFC8C8C8" />
-            </Color>
-            <Color Name="xml doc comment - attribute quotes">
-                <Foreground Type="CT_RAW" Source="FFC8C8C8" />
-            </Color>
-            <Color Name="xml doc comment - attribute value">
-                <Foreground Type="CT_RAW" Source="FFC8C8C8" />
-            </Color>
-            <Color Name="xml doc comment - cdata section">
-                <Foreground Type="CT_RAW" Source="FFE9D585" />
-            </Color>
-            <Color Name="xml doc comment - comment">
-                <Foreground Type="CT_RAW" Source="FF608B4E" />
-            </Color>
-            <Color Name="xml doc comment - delimiter">
-                <Foreground Type="CT_RAW" Source="FF608B4E" />
-            </Color>
-            <Color Name="xml doc comment - entity reference">
-                <Foreground Type="CT_RAW" Source="FF608B4E" />
-            </Color>
-            <Color Name="xml doc comment - name">
-                <Foreground Type="CT_RAW" Source="FF608B4E" />
-            </Color>
-            <Color Name="xml doc comment - processing instruction">
-                <Foreground Type="CT_RAW" Source="FF608B4E" />
-            </Color>
-            <Color Name="xml doc comment - text">
-                <Foreground Type="CT_RAW" Source="FF608B4E" />
-            </Color>
-            <Color Name="regex - comment">
-                <Foreground Type="CT_RAW" Source="FF57A64A" />
-            </Color>
-            <Color Name="regex - character class">
-                <Foreground Type="CT_RAW" Source="FF2EABFE" />
-            </Color>
-            <Color Name="regex - anchor">
-                <Foreground Type="CT_RAW" Source="FFF979AE" />
-            </Color>
-            <Color Name="regex - quantifier">
-                <Foreground Type="CT_RAW" Source="FFF979AE" />
-            </Color>
-            <Color Name="regex - grouping">
-                <Foreground Type="CT_RAW" Source="FF05C3BA" />
-            </Color>
-            <Color Name="regex - alternation">
-                <Foreground Type="CT_RAW" Source="FF05C3BA" />
-            </Color>
-            <Color Name="regex - text">
-                <Foreground Type="CT_RAW" Source="FFD69D85" />
-            </Color>
-            <Color Name="regex - self escaped character">
-                <Foreground Type="CT_RAW" Source="FFD69D85" />
-            </Color>
-            <Color Name="regex - other escape">
-                <Foreground Type="CT_RAW" Source="FFFFD68F" />
-            </Color>
-            <Color Name="xml literal - attribute name">
-                <Foreground Type="CT_RAW" Source="FFC8C8C8" />
-            </Color>
-            <Color Name="xml literal - attribute quotes">
-                <Foreground Type="CT_RAW" Source="FF92CAF4" />
-            </Color>
-            <Color Name="xml literal - attribute value">
-                <Foreground Type="CT_RAW" Source="FFC8C8C8" />
-            </Color>
-            <Color Name="xml literal - cdata section">
-                <Foreground Type="CT_RAW" Source="FFE9D585" />
-            </Color>
-            <Color Name="xml literal - comment">
-                <Foreground Type="CT_RAW" Source="FF608B4E" />
-            </Color>
-            <Color Name="xml literal - delimiter">
-                <Foreground Type="CT_RAW" Source="FF89BB82" />
-            </Color>
-            <Color Name="xml literal - embedded expression">
-                <Background Type="CT_RAW" Source="FFEDE0D1" />
-                <Foreground Type="CT_RAW" Source="FF717171" />
-            </Color>
-            <Color Name="xml literal - entity reference">
-                <Foreground Type="CT_RAW" Source="FF92CAF4" />
-            </Color>
-            <Color Name="xml literal - name">
-                <Foreground Type="CT_RAW" Source="FF569CD6" />
-            </Color>
-            <Color Name="xml literal - processing instruction">
-                <Foreground Type="CT_RAW" Source="FFAEAEAE" />
-            </Color>
-            <Color Name="xml literal - text">
-                <Foreground Type="CT_RAW" Source="FFC8C8C8" />
-            </Color>
-        </Category>
-    </Theme>
-    <!-- IMPORTANT: The HighContrast Theme settings should be the same across Scheme files. -->
-    <Theme Name="HighContrast" GUID="{a5c004b4-2d4b-494e-bf01-45fc492522c7}">
-        <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
-            <Color Name="preprocessor text">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="punctuation">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="string - verbatim">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="keyword - control">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="operator - overloaded">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="class name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="delegate name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="enum name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="interface name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="module name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="struct name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="type parameter name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="field name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="enum member name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="constant name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="local name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="parameter name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="method name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="extension method name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="property name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="event name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="namespace name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="label name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="record name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="inline parameter name hints">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - attribute name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - attribute quotes">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - attribute value">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - cdata section">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - comment">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - delimiter">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - entity reference">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - processing instruction">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml doc comment - text">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="regex - comment">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="regex - character class">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="regex - anchor">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="regex - quantifier">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="regex - grouping">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="regex - alternation">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="regex - text">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="regex - self escaped character">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="regex - other escape">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - attribute name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - attribute quotes">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - attribute value">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - cdata section">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - comment">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - delimiter">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - embedded expression">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - entity reference">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - name">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - processing instruction">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-            <Color Name="xml literal - text">
-                <Foreground Type="CT_SYSCOLOR" Source="00000008" />
-            </Color>
-        </Category>
-    </Theme>
+  <Theme Name="AdditionalContrast" GUID="{ce94d289-8481-498b-8ca9-9b6191a315b9}">
+    <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="class name">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="constant name" >
+      </Color>
+      <Color Name="delegate name">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="enum member name" >
+      </Color>
+      <Color Name="enum name">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="event name" >
+      </Color>
+      <Color Name="extension method name">
+        <Foreground Type="CT_RAW" Source="FF74531F" />
+      </Color>
+      <Color Name="field name" >
+      </Color>
+      <Color Name="inline diagnostics - compiler warning">
+        <Background Type="CT_RAW" Source="FF95BD7D" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="inline diagnostics - Edit and Continue">
+        <Background Type="CT_RAW" Source="FF800080" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="inline diagnostics - syntax error">
+        <Background Type="CT_RAW" Source="FFFC3E36" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="inline hints">
+        <Background Type="CT_RAW" Source="FFE6E6FA" />
+        <Foreground Type="CT_RAW" Source="FF504848" />
+      </Color>
+      <Color Name="interface name">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="keyword - control">
+        <Foreground Type="CT_RAW" Source="FF8F08C4" />
+      </Color>
+      <Color Name="label name" >
+      </Color>
+      <Color Name="local name">
+        <Foreground Type="CT_RAW" Source="FF1F377F" />
+      </Color>
+      <Color Name="method name">
+        <Foreground Type="CT_RAW" Source="FF74531F" />
+      </Color>
+      <Color Name="module name">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="namespace name" >
+      </Color>
+      <Color Name="operator - overloaded">
+        <Foreground Type="CT_RAW" Source="FF74531F" />
+      </Color>
+      <Color Name="parameter name">
+        <Foreground Type="CT_RAW" Source="FF1F377F" />
+      </Color>
+      <Color Name="preprocessor text">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="property name" >
+      </Color>
+      <Color Name="punctuation">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="record name" >
+      </Color>
+      <Color Name="regex - alternation">
+        <Foreground Type="CT_RAW" Source="FF204F4B" />
+      </Color>
+      <Color Name="regex - anchor">
+        <Foreground Type="CT_RAW" Source="FF83146C" />
+      </Color>
+      <Color Name="regex - character class">
+        <Foreground Type="CT_RAW" Source="FF043BB3" />
+      </Color>
+      <Color Name="regex - comment">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="regex - grouping">
+        <Foreground Type="CT_RAW" Source="FF204F4B" />
+      </Color>
+      <Color Name="regex - other escape">
+        <Foreground Type="CT_RAW" Source="FF72324E" />
+      </Color>
+      <Color Name="regex - quantifier">
+        <Foreground Type="CT_RAW" Source="FF83146C" />
+      </Color>
+      <Color Name="regex - self escaped character">
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="regex - text">
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="string - verbatim">
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="struct name">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="type parameter name">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="xml doc comment - attribute name">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml doc comment - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml doc comment - attribute value">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml doc comment - cdata section">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml doc comment - comment">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml doc comment - delimiter">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml doc comment - entity reference">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="xml doc comment - name">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml doc comment - processing instruction">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml doc comment - text">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="xml literal - attribute name">
+        <Foreground Type="CT_RAW" Source="FF863434" />
+      </Color>
+      <Color Name="xml literal - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FF3F3F3F" />
+      </Color>
+      <Color Name="xml literal - attribute value">
+        <Foreground Type="CT_RAW" Source="FF5245A9" />
+      </Color>
+      <Color Name="xml literal - cdata section">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml literal - comment">
+        <Foreground Type="CT_RAW" Source="FF066555" />
+      </Color>
+      <Color Name="xml literal - delimiter">
+        <Foreground Type="CT_RAW" Source="FF5245A9" />
+      </Color>
+      <Color Name="xml literal - embedded expression">
+        <Background Type="CT_RAW" Source="FFEDE0D1" />
+        <Foreground Type="CT_RAW" Source="FF3F3F3F" />
+      </Color>
+      <Color Name="xml literal - entity reference">
+        <Foreground Type="CT_RAW" Source="FF863434" />
+      </Color>
+      <Color Name="xml literal - name">
+        <Foreground Type="CT_RAW" Source="FF863434" />
+      </Color>
+      <Color Name="xml literal - processing instruction">
+        <Foreground Type="CT_RAW" Source="FF5B5B5B" />
+      </Color>
+      <Color Name="xml literal - text">
+        <Foreground Type="CT_RAW" Source="FF3F3F3F" />
+      </Color>
+    </Category>
+  </Theme>
+  <Theme Name="Blue" GUID="{a4d6a176-b948-4b29-8c66-53c97a1ed7d0}">
+    <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="class name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="constant name" >
+      </Color>
+      <Color Name="delegate name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="enum member name" >
+      </Color>
+      <Color Name="enum name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="event name" >
+      </Color>
+      <Color Name="extension method name">
+        <Foreground Type="CT_RAW" Source="FF74531F" />
+      </Color>
+      <Color Name="field name" >
+      </Color>
+      <Color Name="inline diagnostics - compiler warning">
+        <Background Type="CT_RAW" Source="FF95BD7D" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="inline diagnostics - Edit and Continue">
+        <Background Type="CT_RAW" Source="FF800080" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="inline diagnostics - syntax error">
+        <Background Type="CT_RAW" Source="FFFC3E36" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="inline hints">
+        <Background Type="CT_RAW" Source="FFE6E6FA" />
+        <Foreground Type="CT_RAW" Source="FF686868" />
+      </Color>
+      <Color Name="interface name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="keyword - control">
+        <Foreground Type="CT_RAW" Source="FF8F08C4" />
+      </Color>
+      <Color Name="label name" >
+      </Color>
+      <Color Name="local name">
+        <Foreground Type="CT_RAW" Source="FF1F377F" />
+      </Color>
+      <Color Name="method name">
+        <Foreground Type="CT_RAW" Source="FF74531F" />
+      </Color>
+      <Color Name="module name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="namespace name" >
+      </Color>
+      <Color Name="operator - overloaded">
+        <Foreground Type="CT_RAW" Source="FF74531F" />
+      </Color>
+      <Color Name="parameter name">
+        <Foreground Type="CT_RAW" Source="FF1F377F" />
+      </Color>
+      <Color Name="preprocessor text">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="property name" >
+      </Color>
+      <Color Name="punctuation">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="record name" >
+      </Color>
+      <Color Name="regex - alternation">
+        <Foreground Type="CT_RAW" Source="FF05C3BA" />
+      </Color>
+      <Color Name="regex - anchor">
+        <Foreground Type="CT_RAW" Source="FFFF00C1" />
+      </Color>
+      <Color Name="regex - character class">
+        <Foreground Type="CT_RAW" Source="FF0073FF" />
+      </Color>
+      <Color Name="regex - comment">
+        <Foreground Type="CT_RAW" Source="FF008000" />
+      </Color>
+      <Color Name="regex - grouping">
+        <Foreground Type="CT_RAW" Source="FF05C3BA" />
+      </Color>
+      <Color Name="regex - other escape">
+        <Foreground Type="CT_RAW" Source="FF9E5B71" />
+      </Color>
+      <Color Name="regex - quantifier">
+        <Foreground Type="CT_RAW" Source="FFFF00C1" />
+      </Color>
+      <Color Name="regex - self escaped character">
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="regex - text">
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="string - verbatim">
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="struct name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="type parameter name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="xml doc comment - attribute name">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - attribute value">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - cdata section">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - comment">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - delimiter">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - entity reference">
+        <Foreground Type="CT_RAW" Source="FF008000" />
+      </Color>
+      <Color Name="xml doc comment - name">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - processing instruction">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - text">
+        <Foreground Type="CT_RAW" Source="FF008000" />
+      </Color>
+      <Color Name="xml literal - attribute name">
+        <Foreground Type="CT_RAW" Source="FFB96464" />
+      </Color>
+      <Color Name="xml literal - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="xml literal - attribute value">
+        <Foreground Type="CT_RAW" Source="FF6464B9" />
+      </Color>
+      <Color Name="xml literal - cdata section">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml literal - comment">
+        <Foreground Type="CT_RAW" Source="FF629755" />
+      </Color>
+      <Color Name="xml literal - delimiter">
+        <Foreground Type="CT_RAW" Source="FF6464B9" />
+      </Color>
+      <Color Name="xml literal - embedded expression">
+        <Background Type="CT_RAW" Source="FFFFFEBF" />
+        <Foreground Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="xml literal - entity reference">
+        <Foreground Type="CT_RAW" Source="FFB96464" />
+      </Color>
+      <Color Name="xml literal - name">
+        <Foreground Type="CT_RAW" Source="FF844646" />
+      </Color>
+      <Color Name="xml literal - processing instruction">
+        <Foreground Type="CT_RAW" Source="FFC0C0C0" />
+      </Color>
+      <Color Name="xml literal - text">
+        <Foreground Type="CT_RAW" Source="FF555555" />
+      </Color>
+    </Category>
+  </Theme>
+  <Theme Name="Dark" GUID="{1ded0138-47ce-435e-84ef-9ec1f439b749}">
+    <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="class name">
+        <Foreground Type="CT_RAW" Source="FF4EC9B0" />
+      </Color>
+      <Color Name="constant name" >
+      </Color>
+      <Color Name="delegate name">
+        <Foreground Type="CT_RAW" Source="FF4EC9B0" />
+      </Color>
+      <Color Name="enum member name" >
+      </Color>
+      <Color Name="enum name">
+        <Foreground Type="CT_RAW" Source="FFB8D7A3" />
+      </Color>
+      <Color Name="event name" >
+      </Color>
+      <Color Name="extension method name">
+        <Foreground Type="CT_RAW" Source="FFDCDCAA" />
+      </Color>
+      <Color Name="field name" >
+      </Color>
+      <Color Name="inline diagnostics - compiler warning">
+        <Background Type="CT_RAW" Source="FF95BD7D" />
+        <Foreground Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="inline diagnostics - Edit and Continue">
+        <Background Type="CT_RAW" Source="FF800080" />
+        <Foreground Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="inline diagnostics - syntax error">
+        <Background Type="CT_RAW" Source="FFFC3E36" />
+        <Foreground Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="inline hints">
+        <Background Type="CT_RAW" Source="FF3E3E3E" />
+        <Foreground Type="CT_RAW" Source="FFA9A8A7" />
+      </Color>
+      <Color Name="interface name">
+        <Foreground Type="CT_RAW" Source="FFB8D7A3" />
+      </Color>
+      <Color Name="keyword - control">
+        <Foreground Type="CT_RAW" Source="FFD8A0DF" />
+      </Color>
+      <Color Name="label name" >
+      </Color>
+      <Color Name="local name">
+        <Foreground Type="CT_RAW" Source="FF9CDCFE" />
+      </Color>
+      <Color Name="method name">
+        <Foreground Type="CT_RAW" Source="FFDCDCAA" />
+      </Color>
+      <Color Name="module name">
+        <Foreground Type="CT_RAW" Source="FF4EC9B0" />
+      </Color>
+      <Color Name="namespace name" >
+      </Color>
+      <Color Name="operator - overloaded">
+        <Foreground Type="CT_RAW" Source="FFDCDCAA" />
+      </Color>
+      <Color Name="parameter name">
+        <Foreground Type="CT_RAW" Source="FF9CDCFE" />
+      </Color>
+      <Color Name="preprocessor text">
+        <Foreground Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="property name" >
+      </Color>
+      <Color Name="punctuation">
+        <Foreground Type="CT_RAW" Source="FFDCDCDC" />
+      </Color>
+      <Color Name="record name" >
+      </Color>
+      <Color Name="regex - alternation">
+        <Foreground Type="CT_RAW" Source="FF05C3BA" />
+      </Color>
+      <Color Name="regex - anchor">
+        <Foreground Type="CT_RAW" Source="FFF979AE" />
+      </Color>
+      <Color Name="regex - character class">
+        <Foreground Type="CT_RAW" Source="FF2EABFE" />
+      </Color>
+      <Color Name="regex - comment">
+        <Foreground Type="CT_RAW" Source="FF57A64A" />
+      </Color>
+      <Color Name="regex - grouping">
+        <Foreground Type="CT_RAW" Source="FF05C3BA" />
+      </Color>
+      <Color Name="regex - other escape">
+        <Foreground Type="CT_RAW" Source="FFFFD68F" />
+      </Color>
+      <Color Name="regex - quantifier">
+        <Foreground Type="CT_RAW" Source="FFF979AE" />
+      </Color>
+      <Color Name="regex - self escaped character">
+        <Foreground Type="CT_RAW" Source="FFD69D85" />
+      </Color>
+      <Color Name="regex - text">
+        <Foreground Type="CT_RAW" Source="FFD69D85" />
+      </Color>
+      <Color Name="string - verbatim">
+        <Foreground Type="CT_RAW" Source="FFD69D85" />
+      </Color>
+      <Color Name="struct name">
+        <Foreground Type="CT_RAW" Source="FF86C691" />
+      </Color>
+      <Color Name="type parameter name">
+        <Foreground Type="CT_RAW" Source="FFB8D7A3" />
+      </Color>
+      <Color Name="xml doc comment - attribute name">
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml doc comment - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml doc comment - attribute value">
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml doc comment - cdata section">
+        <Foreground Type="CT_RAW" Source="FFE9D585" />
+      </Color>
+      <Color Name="xml doc comment - comment">
+        <Foreground Type="CT_RAW" Source="FF608B4E" />
+      </Color>
+      <Color Name="xml doc comment - delimiter">
+        <Foreground Type="CT_RAW" Source="FF608B4E" />
+      </Color>
+      <Color Name="xml doc comment - entity reference">
+        <Foreground Type="CT_RAW" Source="FF608B4E" />
+      </Color>
+      <Color Name="xml doc comment - name">
+        <Foreground Type="CT_RAW" Source="FF608B4E" />
+      </Color>
+      <Color Name="xml doc comment - processing instruction">
+        <Foreground Type="CT_RAW" Source="FF608B4E" />
+      </Color>
+      <Color Name="xml doc comment - text">
+        <Foreground Type="CT_RAW" Source="FF608B4E" />
+      </Color>
+      <Color Name="xml literal - attribute name">
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml literal - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FF92CAF4" />
+      </Color>
+      <Color Name="xml literal - attribute value">
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+      <Color Name="xml literal - cdata section">
+        <Foreground Type="CT_RAW" Source="FFE9D585" />
+      </Color>
+      <Color Name="xml literal - comment">
+        <Foreground Type="CT_RAW" Source="FF608B4E" />
+      </Color>
+      <Color Name="xml literal - delimiter">
+        <Foreground Type="CT_RAW" Source="FF89BB82" />
+      </Color>
+      <Color Name="xml literal - embedded expression">
+        <Background Type="CT_RAW" Source="FFEDE0D1" />
+        <Foreground Type="CT_RAW" Source="FF717171" />
+      </Color>
+      <Color Name="xml literal - entity reference">
+        <Foreground Type="CT_RAW" Source="FF92CAF4" />
+      </Color>
+      <Color Name="xml literal - name">
+        <Foreground Type="CT_RAW" Source="FF569CD6" />
+      </Color>
+      <Color Name="xml literal - processing instruction">
+        <Foreground Type="CT_RAW" Source="FFAEAEAE" />
+      </Color>
+      <Color Name="xml literal - text">
+        <Foreground Type="CT_RAW" Source="FFC8C8C8" />
+      </Color>
+    </Category>
+  </Theme>
+  <Theme Name="HighContrast" GUID="{a5c004b4-2d4b-494e-bf01-45fc492522c7}">
+    <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="class name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="constant name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="delegate name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="enum member name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="enum name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="event name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="extension method name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="field name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="inline parameter name hints">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="interface name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="keyword - control">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="label name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="local name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="method name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="module name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="namespace name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="operator - overloaded">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="parameter name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="preprocessor text">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="property name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="punctuation">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="record name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="regex - alternation">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="regex - anchor">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="regex - character class">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="regex - comment">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="regex - grouping">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="regex - other escape">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="regex - quantifier">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="regex - self escaped character">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="regex - text">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="string - verbatim">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="struct name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="type parameter name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - attribute name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - attribute quotes">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - attribute value">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - cdata section">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - comment">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - delimiter">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - entity reference">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - processing instruction">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml doc comment - text">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - attribute name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - attribute quotes">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - attribute value">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - cdata section">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - comment">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - delimiter">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - embedded expression">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - entity reference">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - name">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - processing instruction">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+      <Color Name="xml literal - text">
+        <Foreground Type="CT_SYSCOLOR" Source="00000008" />
+      </Color>
+    </Category>
+  </Theme>
+  <Theme Name="Light" GUID="{de3dbbcd-f642-433c-8353-8f1df4370aba}">
+    <Category Name="Roslyn Text Editor MEF Items" GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}">
+      <Color Name="class name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="constant name" >
+      </Color>
+      <Color Name="delegate name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="enum member name" >
+      </Color>
+      <Color Name="enum name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="event name" >
+      </Color>
+      <Color Name="extension method name">
+        <Foreground Type="CT_RAW" Source="FF74531F" />
+      </Color>
+      <Color Name="field name" >
+      </Color>
+      <Color Name="inline diagnostics - compiler warning">
+        <Background Type="CT_RAW" Source="FF95BD7D" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="inline diagnostics - Edit and Continue">
+        <Background Type="CT_RAW" Source="FF800080" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="inline diagnostics - syntax error">
+        <Background Type="CT_RAW" Source="FFFC3E36" />
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="inline hints">
+        <Background Type="CT_RAW" Source="FFE6E6FA" />
+        <Foreground Type="CT_RAW" Source="FF686868" />
+      </Color>
+      <Color Name="interface name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="keyword - control">
+        <Foreground Type="CT_RAW" Source="FF8F08C4" />
+      </Color>
+      <Color Name="label name" >
+      </Color>
+      <Color Name="local name">
+        <Foreground Type="CT_RAW" Source="FF1F377F" />
+      </Color>
+      <Color Name="method name">
+        <Foreground Type="CT_RAW" Source="FF74531F" />
+      </Color>
+      <Color Name="module name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="namespace name" >
+      </Color>
+      <Color Name="operator - overloaded">
+        <Foreground Type="CT_RAW" Source="FF74531F" />
+      </Color>
+      <Color Name="parameter name">
+        <Foreground Type="CT_RAW" Source="FF1F377F" />
+      </Color>
+      <Color Name="preprocessor text">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="property name" >
+      </Color>
+      <Color Name="punctuation">
+        <Foreground Type="CT_RAW" Source="FF000000" />
+      </Color>
+      <Color Name="record name" >
+      </Color>
+      <Color Name="regex - alternation">
+        <Foreground Type="CT_RAW" Source="FF05C3BA" />
+      </Color>
+      <Color Name="regex - anchor">
+        <Foreground Type="CT_RAW" Source="FFFF00C1" />
+      </Color>
+      <Color Name="regex - character class">
+        <Foreground Type="CT_RAW" Source="FF0073FF" />
+      </Color>
+      <Color Name="regex - comment">
+        <Foreground Type="CT_RAW" Source="FF008000" />
+      </Color>
+      <Color Name="regex - grouping">
+        <Foreground Type="CT_RAW" Source="FF05C3BA" />
+      </Color>
+      <Color Name="regex - other escape">
+        <Foreground Type="CT_RAW" Source="FF9E5B71" />
+      </Color>
+      <Color Name="regex - quantifier">
+        <Foreground Type="CT_RAW" Source="FFFF00C1" />
+      </Color>
+      <Color Name="regex - self escaped character">
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="regex - text">
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="string - verbatim">
+        <Foreground Type="CT_RAW" Source="FF800000" />
+      </Color>
+      <Color Name="struct name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="type parameter name">
+        <Foreground Type="CT_RAW" Source="FF2B91AF" />
+      </Color>
+      <Color Name="xml doc comment - attribute name">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - attribute value">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - cdata section">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - comment">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - delimiter">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - entity reference">
+        <Foreground Type="CT_RAW" Source="FF008000" />
+      </Color>
+      <Color Name="xml doc comment - name">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - processing instruction">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml doc comment - text">
+        <Foreground Type="CT_RAW" Source="FF008000" />
+      </Color>
+      <Color Name="xml literal - attribute name">
+        <Foreground Type="CT_RAW" Source="FFB96464" />
+      </Color>
+      <Color Name="xml literal - attribute quotes">
+        <Foreground Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="xml literal - attribute value">
+        <Foreground Type="CT_RAW" Source="FF6464B9" />
+      </Color>
+      <Color Name="xml literal - cdata section">
+        <Foreground Type="CT_RAW" Source="FF808080" />
+      </Color>
+      <Color Name="xml literal - comment">
+        <Foreground Type="CT_RAW" Source="FF629755" />
+      </Color>
+      <Color Name="xml literal - delimiter">
+        <Foreground Type="CT_RAW" Source="FF6464B9" />
+      </Color>
+      <Color Name="xml literal - embedded expression">
+        <Background Type="CT_RAW" Source="FFFFFEBF" />
+        <Foreground Type="CT_RAW" Source="FF555555" />
+      </Color>
+      <Color Name="xml literal - entity reference">
+        <Foreground Type="CT_RAW" Source="FFB96464" />
+      </Color>
+      <Color Name="xml literal - name">
+        <Foreground Type="CT_RAW" Source="FF844646" />
+      </Color>
+      <Color Name="xml literal - processing instruction">
+        <Foreground Type="CT_RAW" Source="FFC0C0C0" />
+      </Color>
+      <Color Name="xml literal - text">
+        <Foreground Type="CT_RAW" Source="FF555555" />
+      </Color>
+    </Category>
+  </Theme>
 </Themes>


### PR DESCRIPTION
## Changes
- Resorted tokens and matched indentation with shell theme for cleaner diff later. Future theme updates will follow the same sort order (theme > category > token name).
- Add `DarkExperimental` theme entry to match current shell theme structure. Adding this new entry also fixes this bug: [FeedbackTicket 1453126: VS 2022 Color Theme - Use System Settings option works incorrectly](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1453126/)
- Snapped the `DarkExperimental` portion editor colors to Fluent + Win11 color palette.

## ⚠️ Notes:
- We're not changing Blue, Light, High Contrast, etc. themes at this moment. The scope is to update the dark theme.
- In this iteration, the color assignment is similar to original 2019 version. I only snapped them to a close match in the Fluent + Win11 palette. In the VS 2022 new dark theme, Shell colors are also from the same palette.
- To see the color updates with all the context, you'll need:
  - This branch in roslyn repo
  - Changes in EditorColors.xml in VS repo (PR link TBD)
  - Latest VS2022 build from main branch, switch to "Dark" theme.

## Screenshots
TBD