### PR TITLE
Steps to investigate CI flakiness with async-streams tests

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -130,10 +130,13 @@ class C
             comp.VerifyEmitDiagnostics(expected);
         }
 
-        private CSharpCompilation CreateCompilationWithAsyncIterator(CSharpTestSource source, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null)
-            // Instrumented to investigate CI failure: https://github.com/dotnet/roslyn/issues/34207
-            => CreateCompilationWithTasksExtensions(new[] { (CSharpTestSource)source.GetSyntaxTrees(parseOptions, "source"), CSharpTestBase.Parse(AsyncStreamsTypes, filename: "AsyncStreamsTypes", parseOptions) },
+        // Instrumentation to investigate CI failure: https://github.com/dotnet/roslyn/issues/34207
+        private CSharpCompilation CreateCompilationWithAsyncIterator(string source, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null)
+            => CreateCompilationWithTasksExtensions(new[] { (CSharpTestSource)CSharpTestBase.Parse(source, filename: "source", parseOptions), CSharpTestBase.Parse(AsyncStreamsTypes, filename: "AsyncStreamsTypes", parseOptions) },
                 options: options, parseOptions: parseOptions);
+
+        private CSharpCompilation CreateCompilationWithAsyncIterator(CSharpTestSource source, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null)
+            => CreateCompilationWithTasksExtensions(new[] { source, AsyncStreamsTypes }, options: options, parseOptions: parseOptions);
 
         [Fact]
         [WorkItem(38961, "https://github.com/dotnet/roslyn/issues/38961")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -130,7 +131,9 @@ class C
         }
 
         private CSharpCompilation CreateCompilationWithAsyncIterator(CSharpTestSource source, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null)
-            => CreateCompilationWithTasksExtensions(new[] { source, AsyncStreamsTypes }, options: options, parseOptions: parseOptions);
+            // Instrumented to investigate CI failure: https://github.com/dotnet/roslyn/issues/34207
+            => CreateCompilationWithTasksExtensions(new[] { (CSharpTestSource)source.GetSyntaxTrees(parseOptions, "source"), CSharpTestBase.Parse(AsyncStreamsTypes, filename: "AsyncStreamsTypes", parseOptions) },
+                options: options, parseOptions: parseOptions);
 
         [Fact]
         [WorkItem(38961, "https://github.com/dotnet/roslyn/issues/38961")]

--- a/src/Compilers/Test/Core/Compilation/IRuntimeEnvironment.cs
+++ b/src/Compilers/Test/Core/Compilation/IRuntimeEnvironment.cs
@@ -242,6 +242,7 @@ namespace Roslyn.Test.Utilities
             var assembly = default(ImmutableArray<byte>);
             var pdbStream = (emitOptions.DebugInformationFormat != DebugInformationFormat.Embedded) ? new MemoryStream() : null;
 
+            // Note: don't forget to name the source inputs to get them embedded for debugging
             var embeddedTexts = compilation.SyntaxTrees
                 .Select(t => (filePath: t.FilePath, text: t.GetText()))
                 .Where(t => t.text.CanBeEmbedded && !string.IsNullOrEmpty(t.filePath))

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -522,6 +522,9 @@ namespace System.Threading.Tasks.Sources
         internal static readonly Action<object> s_sentinel = CompletionSentinel;
         private static void CompletionSentinel(object _) // named method to aid debugging
         {
+            // Instrumented with FailFast to investigate CI failure:
+            // https://github.com/dotnet/roslyn/issues/34207
+            System.Environment.FailFast(""The sentinel delegate should never be invoked."");
             Debug.Fail(""The sentinel delegate should never be invoked."");
             throw new InvalidOperationException();
         }

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -269,20 +269,38 @@ namespace System.Runtime.CompilerServices
 
 namespace System.Threading.Tasks.Sources
 {
+    // From https://github.com/dotnet/runtime/blob/f580068aa93fb3c6d5fbc7e33f6cd7d52fa86b24/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
     using System.Diagnostics;
     using System.Runtime.ExceptionServices;
     using System.Runtime.InteropServices;
 
+    /// <summary>Provides the core logic for implementing a manual-reset <see cref=""IValueTaskSource""/> or <see cref=""IValueTaskSource{TResult}""/>.</summary>
+    /// <typeparam name=""TResult""></typeparam>
     [StructLayout(LayoutKind.Auto)]
     public struct ManualResetValueTaskSourceCore<TResult>
     {
+        /// <summary>
+        /// The callback to invoke when the operation completes if <see cref=""OnCompleted""/> was called before the operation completed,
+        /// or <see cref=""ManualResetValueTaskSourceCoreShared.s_sentinel""/> if the operation completed before a callback was supplied,
+        /// or null if a callback hasn't yet been provided and the operation hasn't yet completed.
+        /// </summary>
         private Action<object> _continuation;
+        /// <summary>State to pass to <see cref=""_continuation""/>.</summary>
         private object _continuationState;
+        /// <summary><see cref=""ExecutionContext""/> to flow to the callback, or null if no flowing is required.</summary>
         private ExecutionContext _executionContext;
+        /// <summary>
+        /// A ""captured"" <see cref=""SynchronizationContext""/> or <see cref=""TaskScheduler""/> with which to invoke the callback,
+        /// or null if no special context is required.
+        /// </summary>
         private object _capturedContext;
+        /// <summary>Whether the current operation has completed.</summary>
         private bool _completed;
+        /// <summary>The result with which the operation succeeded, or the default value if it hasn't yet completed or failed.</summary>
         private TResult _result;
+        /// <summary>The exception with which the operation failed, or null if it hasn't yet completed or completed successfully.</summary>
         private ExceptionDispatchInfo _error;
+        /// <summary>The current version of this value, used to help prevent misuse.</summary>
         private short _version;
 
         /// <summary>Gets or sets whether to force continuations to run asynchronously.</summary>
@@ -303,42 +321,56 @@ namespace System.Threading.Tasks.Sources
             _continuationState = null;
         }
 
+        /// <summary>Completes with a successful result.</summary>
+        /// <param name=""result"">The result.</param>
         public void SetResult(TResult result)
         {
             _result = result;
             SignalCompletion();
         }
 
+        /// <summary>Complets with an error.</summary>
+        /// <param name=""error""></param>
         public void SetException(Exception error)
         {
             _error = ExceptionDispatchInfo.Capture(error);
             SignalCompletion();
         }
 
+        /// <summary>Gets the operation version.</summary>
         public short Version => _version;
 
+        /// <summary>Gets the status of the operation.</summary>
+        /// <param name=""token"">Opaque value that was provided to the <see cref=""ValueTask""/>'s constructor.</param>
         public ValueTaskSourceStatus GetStatus(short token)
         {
             ValidateToken(token);
             return
-                !_completed ? ValueTaskSourceStatus.Pending :
+                _continuation == null || !_completed ? ValueTaskSourceStatus.Pending :
                 _error == null ? ValueTaskSourceStatus.Succeeded :
                 _error.SourceException is OperationCanceledException ? ValueTaskSourceStatus.Canceled :
                 ValueTaskSourceStatus.Faulted;
         }
 
+        /// <summary>Gets the result of the operation.</summary>
+        /// <param name=""token"">Opaque value that was provided to the <see cref=""ValueTask""/>'s constructor.</param>
         public TResult GetResult(short token)
         {
             ValidateToken(token);
             if (!_completed)
             {
-                ManualResetValueTaskSourceCoreShared.ThrowInvalidOperationException();
+                throw new InvalidOperationException();
             }
 
             _error?.Throw();
             return _result;
         }
 
+        /// <summary>Schedules the continuation action for this operation.</summary>
+        /// <param name=""continuation"">The continuation to invoke when the operation has completed.</param>
+        /// <param name=""state"">The state object to pass to <paramref name=""continuation""/> when it's invoked.</param>
+        /// <param name=""token"">Opaque value that was provided to the <see cref=""ValueTask""/>'s constructor.</param>
+        /// <param name=""flags"">The flags describing the behavior of the continuation.</param>
         public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
         {
             if (continuation == null)
@@ -389,7 +421,7 @@ namespace System.Threading.Tasks.Sources
                 // Operation already completed, so we need to queue the supplied callback.
                 if (!ReferenceEquals(oldContinuation, ManualResetValueTaskSourceCoreShared.s_sentinel))
                 {
-                    ManualResetValueTaskSourceCoreShared.ThrowInvalidOperationException();
+                    throw new InvalidOperationException();
                 }
 
                 switch (_capturedContext)
@@ -413,19 +445,22 @@ namespace System.Threading.Tasks.Sources
             }
         }
 
+        /// <summary>Ensures that the specified token matches the current version.</summary>
+        /// <param name=""token"">The token supplied by <see cref=""ValueTask""/>.</param>
         private void ValidateToken(short token)
         {
             if (token != _version)
             {
-                ManualResetValueTaskSourceCoreShared.ThrowInvalidOperationException();
+                throw new InvalidOperationException();
             }
         }
 
+        /// <summary>Signals that the operation has completed.  Invoked after the result or error has been set.</summary>
         private void SignalCompletion()
         {
             if (_completed)
             {
-                ManualResetValueTaskSourceCoreShared.ThrowInvalidOperationException();
+                throw new InvalidOperationException();
             }
             _completed = true;
 
@@ -445,8 +480,15 @@ namespace System.Threading.Tasks.Sources
             }
         }
 
+        /// <summary>
+        /// Invokes the continuation with the appropriate captured context / scheduler.
+        /// This assumes that if <see cref=""_executionContext""/> is not null we're already
+        /// running within that <see cref=""ExecutionContext""/>.
+        /// </summary>
         private void InvokeContinuation()
         {
+            Debug.Assert(_continuation != null);
+
             switch (_capturedContext)
             {
                 case null:
@@ -477,13 +519,11 @@ namespace System.Threading.Tasks.Sources
 
     internal static class ManualResetValueTaskSourceCoreShared // separated out of generic to avoid unnecessary duplication
     {
-        internal static void ThrowInvalidOperationException() => throw new InvalidOperationException();
-
         internal static readonly Action<object> s_sentinel = CompletionSentinel;
         private static void CompletionSentinel(object _) // named method to aid debugging
         {
             Debug.Fail(""The sentinel delegate should never be invoked."");
-            ThrowInvalidOperationException();
+            throw new InvalidOperationException();
         }
     }
 }


### PR DESCRIPTION
From discussion with Stephen, those steps should help:
1. update the ManualResetValueTaskSourceCore code
2. try to get a crash dump (including embedded symbols and sources)

Relates to https://github.com/dotnet/roslyn/issues/34207
Relates to https://github.com/dotnet/roslyn/issues/58196
Relates to https://github.com/dotnet/roslyn/issues/47156
Relates to https://github.com/dotnet/roslyn/issues/40927