### PR TITLE
Allow patch releases of the SDK to be used

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "6.0.100",
     "allowPrerelease": true,
-    "rollForward": "disable"
+    "rollForward": "latestPatch"
   },
   "tools": {
     "dotnet": "6.0.100",


### PR DESCRIPTION
According to the documentation [here](https://docs.microsoft.com/dotnet/core/tools/global-json) setting `rollForward` to `latestPatch` should allow newer SDKs to be used _only_ if the patch digits of the SDK have changed.

So under these values any `6.0.1xx` SDK is valid but `6.0.200` would not be.
