### PR TITLE
Remove places where the compiler is swallowing exceptions

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -11722,7 +11722,13 @@ System.NotImplementedException: 28
    at TestAnalyzer.get_SupportedDiagnostics()
    at Microsoft.CodeAnalysis.Diagnostics.AnalyzerManager.AnalyzerExecutionContext.<>c__DisplayClass20_0.<ComputeDiagnosticDescriptors>b__0(Object _)
    at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows_NoLock[TArg](DiagnosticAnalyzer analyzer, Action`1 analyze, TArg argument, Nullable`1 info)
------", outputWithoutPaths);
+-----
+Analyzer 'TestAnalyzer' threw the following exception:
+'System.NotImplementedException: 28
+   at TestAnalyzer.get_SupportedDiagnostics()
+   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.CreateDisablingMessage(DiagnosticAnalyzer analyzer, String analyzerName)
+-----
+'.", outputWithoutPaths);
 
             Assert.Equal(0, result.ExitCode);
         }

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageAttributeCompilerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageAttributeCompilerTests.cs
@@ -154,13 +154,16 @@ public class C2
         public async Task AnalyzerExceptionFromSupportedDiagnosticsCall()
         {
             var exception = new Exception();
+            const string AnalyzerName = "Microsoft.CodeAnalysis.UnitTests.Diagnostics.SuppressMessageAttributeTests+ThrowExceptionFromSupportedDiagnostics";
 
             var diagnostic = Diagnostic("AD0001", null)
                 .WithArguments(
-                    "Microsoft.CodeAnalysis.UnitTests.Diagnostics.SuppressMessageAttributeTests+ThrowExceptionFromSupportedDiagnostics",
+                    AnalyzerName,
                     "System.Exception",
                     exception.Message,
-                    (IFormattable)$@"{new LazyToString(() => exception.ToString().Substring(0, exception.ToString().IndexOf("---")))}-----")
+                    (IFormattable)$@"{new LazyToString(() =>
+                        exception.ToString().Substring(0, exception.ToString().IndexOf("---")) + "-----" + Environment.NewLine + Environment.NewLine +
+                        string.Format(CodeAnalysisResources.CompilerAnalyzerThrowsDescription, AnalyzerName, exception.ToString() + Environment.NewLine + "-----" + Environment.NewLine))}")
                 .WithLocation(1, 1);
 
             await VerifyCSharpAsync("public class C { }",

--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -75,19 +75,7 @@ namespace Microsoft.CodeAnalysis
         /// <returns></returns>
         public IOperation? GetOperation(SyntaxNode node, CancellationToken cancellationToken = default(CancellationToken))
         {
-            try
-            {
-                return GetOperationCore(node, cancellationToken);
-            }
-#pragma warning disable CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete; tracked by https://github.com/dotnet/roslyn/issues/58375
-            catch (Exception e) when (FatalError.ReportIfNonFatalAndCatchUnlessCanceled(e, cancellationToken))
-#pragma warning restore CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete
-            {
-                // Log a Non-fatal-watson and then ignore the crash in the attempt of getting operation
-                Debug.Assert(false, "\n" + e.ToString());
-            }
-
-            return null;
+            return GetOperationCore(node, cancellationToken);
         }
 
         protected abstract IOperation? GetOperationCore(SyntaxNode node, CancellationToken cancellationToken);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2697,12 +2697,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     return GetOperationsToAnalyze(operationBlocksToAnalyze);
                 }
-#pragma warning disable CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete; tracked by https://github.com/dotnet/roslyn/issues/58375
-                catch (Exception ex) when (ex is InsufficientExecutionStackException || FatalError.ReportIfNonFatalAndCatchUnlessCanceled(ex, cancellationToken))
-#pragma warning restore CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete
+                catch (Exception ex) when (ex is InsufficientExecutionStackException)
                 {
-                    // the exception filter will short-circuit if `ex` is `InsufficientExecutionStackException` (from OperationWalker)
-                    // and no non-fatal-watson will be logged as a result.
                     var diagnostic = AnalyzerExecutor.CreateDriverExceptionDiagnostic(ex);
                     var analyzer = this.Analyzers[0];
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1657,9 +1657,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     diagnosticIds = diagnosticIds.Add(diagnostic.Id);
                 }
             }
-#pragma warning disable CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete; tracked by https://github.com/dotnet/roslyn/issues/58375
-            catch (Exception e) when (FatalError.ReportIfNonFatalAndCatchUnlessCanceled(e))
-#pragma warning restore CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete
+            catch (Exception)
             {
                 // Intentionally empty
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1629,7 +1629,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var analyzerName = analyzer.ToString();
             var title = CodeAnalysisResources.CompilerAnalyzerFailure;
             var messageFormat = CodeAnalysisResources.CompilerAnalyzerThrows;
-            var contextInformation = string.Join(Environment.NewLine, CreateDiagnosticDescription(info, e), CreateDisablingMessage(analyzer)).Trim();
+            var contextInformation = string.Join(Environment.NewLine, CreateDiagnosticDescription(info, e), CreateDisablingMessage(analyzer, analyzerName)).Trim();
             var messageArguments = new[] { analyzerName, e.GetType().ToString(), e.Message, contextInformation };
             var description = string.Format(CodeAnalysisResources.CompilerAnalyzerThrowsDescription, analyzerName, CreateDiagnosticDescription(info, e));
             var descriptor = GetAnalyzerExceptionDiagnosticDescriptor(AnalyzerExceptionDiagnosticId, title, description, messageFormat);
@@ -1647,19 +1647,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 string.Format(CodeAnalysisResources.ExceptionContext, info?.GetContext()), e.CreateDiagnosticDescription());
         }
 
-        private static string CreateDisablingMessage(DiagnosticAnalyzer analyzer)
+        private static string CreateDisablingMessage(DiagnosticAnalyzer analyzer, string analyzerName)
         {
             var diagnosticIds = ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
             try
             {
                 foreach (var diagnostic in analyzer.SupportedDiagnostics)
                 {
-                    diagnosticIds = diagnosticIds.Add(diagnostic.Id);
+                    // If a null diagnostic is returned, we would have already reported that to the user earlier; we can just skip this.
+                    if (diagnostic != null)
+                    {
+                        diagnosticIds = diagnosticIds.Add(diagnostic.Id);
+                    }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // Intentionally empty
+                return string.Format(CodeAnalysisResources.CompilerAnalyzerThrowsDescription, analyzerName, ex.CreateDiagnosticDescription());
             }
 
             if (diagnosticIds.IsEmpty)

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraph.cs
@@ -178,21 +178,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 throw new ArgumentException(CodeAnalysisResources.OperationHasNullSemanticModel, argumentNameForException);
             }
 
-            try
-            {
-                ControlFlowGraph controlFlowGraph = ControlFlowGraphBuilder.Create(operation);
-                Debug.Assert(controlFlowGraph.OriginalOperation == operation);
-                return controlFlowGraph;
-            }
-#pragma warning disable CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete; tracked by https://github.com/dotnet/roslyn/issues/58375
-            catch (Exception e) when (FatalError.ReportIfNonFatalAndCatchUnlessCanceled(e, cancellationToken))
-#pragma warning restore CS0618 // ReportIfNonFatalAndCatchUnlessCanceled is obsolete
-            {
-                // Log a Non-fatal-watson and then ignore the crash in the attempt of getting flow graph.
-                Debug.Assert(false, "\n" + e.ToString());
-            }
-
-            return null;
+            ControlFlowGraph controlFlowGraph = ControlFlowGraphBuilder.Create(operation);
+            Debug.Assert(controlFlowGraph.OriginalOperation == operation);
+            return controlFlowGraph;
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Def/Implementation/Watson/FaultReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/FaultReporter.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         public static void InitializeFatalErrorHandlers()
         {
             FatalError.Handler = static (exception, severity, forceDump) => ReportFault(exception, ConvertSeverity(severity), forceDump);
-            FatalError.HandlerIsNonFatal = true;
             FatalError.CopyHandlerTo(typeof(Compilation).Assembly);
         }
 


### PR DESCRIPTION
There are a few places where compiler APIs are swallowing internal exceptions and returning null from APIs as a way to march on; this removes those places, and then removes our ReportAndCatch* APIs from the compiler layer entirely. We currently have no (cross platform) way of implementing those in a way that would allow for non-fatal error reporting.

Closes #58375