### PR TITLE
[EE] Handle ArrayExpansion for 1D array with non-zero lower bounds

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ArrayExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ArrayExpansion.cs
@@ -105,7 +105,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         {
             if (_divisors == null)
             {
-                return new[] { index };
+                // _divisors is null if dimension is 1, but
+                // _lowerBounds need not necessarily be so.
+                Debug.Assert(_lowerBounds == null || _lowerBounds.Count == 1);
+                int lowerBound = _lowerBounds != null && _lowerBounds.Count == 1 ? _lowerBounds[0] : 0;
+                return new[] { lowerBound + index };
             }
 
             var n = _divisors.Count;


### PR DESCRIPTION
Issue:
- Evaluating + expanding `Array myArray = Array.CreateInstance(typeof(int), new int[1] { 12 }, new int[1] { 1 });` while debugging crashes Visual Studio.
- This is because Roslyn ends up passing an invalid index to VIL which throws an `IndexOutOfRangeException` and is expected. Roslyn should instead request the correct index.
- Tracked by DevDiv Bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1456359

Changes:
1. ArrayExpansion:
- Lower bounds correction wasn't being done for 1D arrays, so add it.
- This can't really be tested in C#/VB since non-zero lower bounds 1D array can't be expressed in C#/VB (Array.CreateInstance with 1D params can't be cast to a 1D array - see Remarks here: https://docs.microsoft.com/en-us/dotnet/api/system.array.createinstance#system-array-createinstance(system-type-system-int32()-system-int32()) )
- Corner case, will add tests on debugger side.