### PR TITLE
Handle null coalescing assign-to-self scenarios

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseParameterNullChecking/CSharpUseParameterNullCheckingDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseParameterNullChecking/CSharpUseParameterNullCheckingDiagnosticAnalyzer.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking
 
             foreach (var statement in block.Statements)
             {
-                var parameter = TryGetParameterNullCheckedByStatement(statement, out var location);
+                var parameter = TryGetParameterNullCheckedByStatement(statement, out var diagnosticLocation);
                 if (ParameterCanUseNullChecking(parameter)
                     && parameter.DeclaringSyntaxReferences.FirstOrDefault() is SyntaxReference reference
                     && reference.SyntaxTree.Equals(statement.SyntaxTree)
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking
                 {
                     context.ReportDiagnostic(DiagnosticHelper.Create(
                         Descriptor,
-                        location ?? statement.GetLocation(),
+                        diagnosticLocation ?? statement.GetLocation(),
                         option.Notification.Severity,
                         additionalLocations: new[] { parameterSyntax.GetLocation() },
                         properties: null));

--- a/src/Analyzers/CSharp/Analyzers/UseParameterNullChecking/CSharpUseParameterNullCheckingDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseParameterNullChecking/CSharpUseParameterNullCheckingDiagnosticAnalyzer.cs
@@ -183,7 +183,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking
                     // if (param is null) { throw new ArgumentNullException(nameof(param)); }
                     // if (object.ReferenceEquals(param, null)) { throw new ArgumentNullException(nameof(param)); }
                     case IfStatementSyntax ifStatement:
-
                         ExpressionSyntax left, right;
                         switch (ifStatement)
                         {

--- a/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking
                         editor.ReplaceNode(nullCoalescing, parameterReferenceSyntax.WithAppendedTrailingTrivia(SyntaxFactory.ElasticMarker));
                         break;
                     case IfStatementSyntax:
-                    case ExpressionStatementSyntax { Expression: BinaryExpressionSyntax(SyntaxKind.CoalesceExpression) }:
+                    case ExpressionStatementSyntax { Expression: AssignmentExpressionSyntax { Right: BinaryExpressionSyntax(SyntaxKind.CoalesceExpression) } }:
                         editor.RemoveNode(node);
                         break;
                     default:

--- a/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
@@ -54,15 +55,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking
                 var node = diagnostic.Location.FindNode(getInnermostNodeForTie: true, cancellationToken: cancellationToken);
                 switch (node)
                 {
-                    case IfStatementSyntax ifStatement:
-                        editor.RemoveNode(ifStatement);
-                        break;
-                    case ExpressionStatementSyntax expressionStatement:
+                    case ExpressionSyntax { Parent: BinaryExpressionSyntax(SyntaxKind.CoalesceExpression) nullCoalescing }:
                         // this.item = item ?? throw new ArgumentNullException(nameof(item));
-                        var assignment = (AssignmentExpressionSyntax)expressionStatement.Expression;
-                        var nullCoalescing = (BinaryExpressionSyntax)assignment.Right;
                         var parameterReferenceSyntax = nullCoalescing.Left;
                         editor.ReplaceNode(nullCoalescing, parameterReferenceSyntax.WithAppendedTrailingTrivia(SyntaxFactory.ElasticMarker));
+                        break;
+                    case IfStatementSyntax:
+                    case ExpressionStatementSyntax { Expression: BinaryExpressionSyntax(SyntaxKind.CoalesceExpression) }:
+                        editor.RemoveNode(node);
                         break;
                     default:
                         throw ExceptionUtilities.UnexpectedValue(node);

--- a/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
@@ -192,7 +192,7 @@ class C
     private readonly string s;
     public C(string s)
     {
-        [|this.s = s ?? throw new ArgumentNullException(nameof(s));|]
+        this.s = s ?? [|throw new ArgumentNullException(nameof(s))|];
     }
 }",
                 FixedCode = @"
@@ -204,6 +204,34 @@ class C
     public C(string s!!)
     {
         this.s = s;
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullCoalescingThrow_AssignSameVariable()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"
+using System;
+
+class C
+{
+    public void M(string s)
+    {
+        [|s = s ?? throw new ArgumentNullException(nameof(s));|]
+    }
+}",
+                FixedCode = @"
+using System;
+
+class C
+{
+    public void M(string s!!)
+    {
     }
 }",
                 LanguageVersion = LanguageVersionExtensions.CSharpNext


### PR DESCRIPTION
Related to #36024

After running fix-all in Roslyn I noticed a few warnings in scenarios like the following:

```cs
void M(string s)
{
    s = s ?? throw new ArgumentNullException(nameof(s));
}
```

We fixed this by turning it into `s = s;` which is a warning (variable assigned to itself). Instead, what we should do is delete the entire statement in this case.
