### PR TITLE
Add test for nullable value type

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
@@ -1553,6 +1553,33 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullableValueType()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+class C
+{
+    static void M(int? value)
+    {
+        [|if (value == null)
+            throw new ArgumentNullException(nameof(value));|]
+    }
+}
+",
+                FixedCode = @"using System;
+class C
+{
+    static void M(int? value!!)
+    {
+    }
+}
+",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
         public async Task TestPartialMethod()
         {
             var partialDeclaration = @"


### PR DESCRIPTION
Related to #36024

Just didn't have coverage for this scenario and I wanted to record the behavior. The fixed code results in a warning for null-checking a nullable parameter, but I think this is a good thing.