### PR TITLE
Fix CompilerDiagnostic not being Equal to itself.

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
@@ -106,7 +106,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 public override bool Equals(object? obj)
                 {
-                    return _original.Equals(obj);
+                    if (obj instanceof CompilerDiagnostic cd) {
+                        return _original.Equals(cd._original);
+                    } else {
+                        return _original.Equals(obj);
+                    }
                 }
 
                 public override int GetHashCode()
@@ -116,7 +120,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 public override bool Equals(Diagnostic? obj)
                 {
-                    return _original.Equals(obj);
+                    if (obj instanceof CompilerDiagnostic cd) {
+                        return _original.Equals(cd._original);
+                    } else {
+                        return _original.Equals(obj);
+                    }
                 }
 
                 internal override Diagnostic WithLocation(Location location)


### PR DESCRIPTION
This fixes the fact that `a.Equals(a)` returns false.