### PR TITLE
ensure globalconfig files are lowercase

### DIFF
--- a/src/CodeStyle/Tools/Program.cs
+++ b/src/CodeStyle/Tools/Program.cs
@@ -70,7 +70,7 @@ namespace CodeStyleConfigFileGenerator
             {
                 CreateGlobalconfig(
                     configDir,
-                    $"AnalysisLevelStyle_{analysisMode}.editorconfig",
+                    $"AnalysisLevelStyle_{analysisMode}.editorconfig".ToLowerInvariant(),
                     (AnalysisMode)analysisMode!,
                     allRulesById);
             }


### PR DESCRIPTION
fixes https://github.com/dotnet/roslyn/issues/58948

I made this same change in https://github.com/dotnet/roslyn-analyzers/pull/5600 for roslyn-analyzers but forgot to make the subsequent change to code style