### PR TITLE
Use record param docs as property summary docs

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.DocumentationCommentWalker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.DocumentationCommentWalker.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 DocumentationCommentWalker walker = new DocumentationCommentWalker(compilation, BindingDiagnosticBag.Discarded, symbol, writer, includeElementNodes, documentedParameters: null, documentedTypeParameters: null);
 
                 // Before: <param name="NAME">CONTENT</param>
-                // After: <summary>CONTENT</param>
+                // After: <summary>CONTENT</summary>
                 foreach (var paramElement in paramElements)
                 {
                     // '///<param': '<' owns the '///' trivia
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var endGreaterThanToken = paramElement.EndTag.GreaterThanToken;
                     walker.VisitToken(paramElement.EndTag.GreaterThanToken);
 
-                    // The '</summary>' node doesn't own the following new line. Instead, it is directly followed by an 'XmlTextLiteralNewLineToken'.
+                    // The '>' token doesn't own the following new line. Instead, it is directly followed by an 'XmlTextLiteralNewLineToken'.
                     if (endGreaterThanToken.GetNextToken() is SyntaxToken newLineToken && newLineToken.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
                     {
                         walker.VisitToken(newLineToken);

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.DocumentationCommentWalker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.DocumentationCommentWalker.cs
@@ -5,8 +5,10 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -23,12 +25,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Walks a DocumentationCommentTriviaSyntax, binding the semantically meaningful parts 
         /// to produce diagnostics and to replace source crefs with documentation comment IDs.
         /// </summary>
+        [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
         private class DocumentationCommentWalker : CSharpSyntaxWalker
         {
             private readonly CSharpCompilation _compilation;
             private readonly BindingDiagnosticBag _diagnostics;
             private readonly Symbol _memberSymbol;
-            private readonly TextWriter _writer;
+            private readonly StringWriter _writer;
             private readonly ArrayBuilder<CSharpSyntaxNode> _includeElementNodes;
 
             private HashSet<ParameterSymbol> _documentedParameters;
@@ -38,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CSharpCompilation compilation,
                 BindingDiagnosticBag diagnostics,
                 Symbol memberSymbol,
-                TextWriter writer,
+                StringWriter writer,
                 ArrayBuilder<CSharpSyntaxNode> includeElementNodes,
                 HashSet<ParameterSymbol> documentedParameters,
                 HashSet<TypeParameterSymbol> documentedTypeParameters)
@@ -52,6 +55,56 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 _documentedParameters = documentedParameters;
                 _documentedTypeParameters = documentedTypeParameters;
+            }
+
+            /// <summary>
+            /// Writes the matching 'param' tags on a primary constructor as 'summary' tags for a synthesized record property.
+            /// </summary>
+            /// <remarks>
+            /// Still has all of the comment punctuation (///, /**, etc). associated with the 'param' tag.
+            /// </remarks>
+            public static void GetSubstitutedText(
+                CSharpCompilation compilation,
+                SynthesizedRecordPropertySymbol symbol,
+                ArrayBuilder<XmlElementSyntax> paramElements,
+                ArrayBuilder<CSharpSyntaxNode> includeElementNodes,
+                StringBuilder builder)
+            {
+                StringWriter writer = new StringWriter(builder, CultureInfo.InvariantCulture);
+                DocumentationCommentWalker walker = new DocumentationCommentWalker(compilation, BindingDiagnosticBag.Discarded, symbol, writer, includeElementNodes, documentedParameters: null, documentedTypeParameters: null);
+
+                // Before: <param name="NAME">CONTENT</param>
+                // After: <summary>CONTENT</param>
+                foreach (var paramElement in paramElements)
+                {
+                    // '///<param': '<' owns the '///' trivia
+                    // '/// <param': ' ' token preceding '<' owns '///' trivia
+                    var startLessThanToken = paramElement.StartTag.LessThanToken;
+                    if (!startLessThanToken.LeadingTrivia.Any(SyntaxKind.DocumentationCommentExteriorTrivia))
+                    {
+                        walker.VisitToken(startLessThanToken.GetPreviousToken());
+                    }
+                    walker.VisitToken(startLessThanToken);
+                    writer.Write("summary");
+                    walker.VisitToken(paramElement.StartTag.GreaterThanToken);
+
+                    foreach (var item in paramElement.Content)
+                    {
+                        walker.Visit(item);
+                    }
+
+                    walker.VisitToken(paramElement.EndTag.LessThanSlashToken);
+                    writer.Write("summary");
+
+                    var endGreaterThanToken = paramElement.EndTag.GreaterThanToken;
+                    walker.VisitToken(paramElement.EndTag.GreaterThanToken);
+
+                    // The '</summary>' node doesn't own the following new line. Instead, it is directly followed by an 'XmlTextLiteralNewLineToken'.
+                    if (endGreaterThanToken.GetNextToken() is SyntaxToken newLineToken && newLineToken.IsKind(SyntaxKind.XmlTextLiteralNewLineToken))
+                    {
+                        walker.VisitToken(newLineToken);
+                    }
+                }
             }
 
             /// <summary>
@@ -165,6 +218,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 base.VisitToken(token);
+            }
+
+            private string GetDebuggerDisplay()
+            {
+                return _writer.GetStringBuilder().ToString();
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -235,6 +236,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+#nullable enable
+
         /// <summary>
         /// Compile documentation comments on the symbol and write them to the stream if one is provided.
         /// </summary>
@@ -279,9 +282,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            DocumentationMode maxDocumentationMode;
-            ImmutableArray<DocumentationCommentTriviaSyntax> docCommentNodes;
-            if (!TryGetDocumentationCommentNodes(symbol, out maxDocumentationMode, out docCommentNodes))
+            // synthesized record property: emit the matching param doc on containing type as the summary doc of the property.
+            var symbolForDocComments = symbol is SynthesizedRecordPropertySymbol ? symbol.ContainingType : symbol;
+            if (!TryGetDocumentationCommentNodes(symbolForDocComments, out var maxDocumentationMode, out var docCommentNodes))
             {
                 // If the XML in any of the doc comments is invalid, skip all further processing (for this symbol) and 
                 // just write a comment saying that info was lost for this symbol.
@@ -351,7 +354,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // NOTE: we are expanding include elements AFTER formatting the comment, since the included text is pure
                 // XML, not XML mixed with documentation comment trivia (e.g. ///).  If we expanded them before formatting,
                 // the formatting engine would have trouble determining what prefix to remove from each line.
-                TextWriter expanderWriter = shouldSkipPartialDefinitionComments ? null : _writer; // Don't actually write partial method definition parts.
+                TextWriter? expanderWriter = shouldSkipPartialDefinitionComments ? null : _writer; // Don't actually write partial method definition parts.
                 IncludeElementExpander.ProcessIncludes(withUnprocessedIncludes, symbol, includeElementNodes,
                     _compilation, ref documentedParameters, ref documentedTypeParameters, ref _includedFileCache, expanderWriter, _diagnostics, _cancellationToken);
             }
@@ -375,7 +378,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (!documentedParameters.Contains(parameter))
                         {
                             Location location = parameter.Locations[0];
-                            Debug.Assert(location.SourceTree.ReportDocumentationCommentDiagnostics()); //Should be the same tree as for the symbol.
+                            Debug.Assert(location.SourceTree!.ReportDocumentationCommentDiagnostics()); //Should be the same tree as for the symbol.
 
                             // NOTE: parameter name, since the parameter would be displayed as just its type.
                             _diagnostics.Add(ErrorCode.WRN_MissingParamTag, location, parameter.Name, symbol);
@@ -390,7 +393,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (!documentedTypeParameters.Contains(typeParameter))
                         {
                             Location location = typeParameter.Locations[0];
-                            Debug.Assert(location.SourceTree.ReportDocumentationCommentDiagnostics()); //Should be the same tree as for the symbol.
+                            Debug.Assert(location.SourceTree!.ReportDocumentationCommentDiagnostics()); //Should be the same tree as for the symbol.
 
                             _diagnostics.Add(ErrorCode.WRN_MissingTypeParamTag, location, typeParameter, symbol);
                         }
@@ -403,9 +406,72 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return symbol.IsImplicitlyDeclared ||
                 symbol.IsAccessor() ||
-                symbol is SynthesizedSimpleProgramEntryPointSymbol ||
-                symbol is SynthesizedRecordPropertySymbol;
+                symbol is SynthesizedSimpleProgramEntryPointSymbol;
         }
+
+        private bool TryProcessRecordPropertyDocumentation(
+            SynthesizedRecordPropertySymbol recordPropertySymbol,
+            ImmutableArray<DocumentationCommentTriviaSyntax> docCommentNodes,
+            [NotNullWhen(true)] out string? withUnprocessedIncludes,
+            out ImmutableArray<CSharpSyntaxNode> includeElementNodes)
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            if (getMatchingParamTags() is not { } paramTags)
+            {
+                withUnprocessedIncludes = null;
+                includeElementNodes = default;
+                return false;
+            }
+
+            Debug.Assert(paramTags.Count > 0);
+
+            BeginTemporaryString();
+            WriteLine("<member name=\"{0}\">", recordPropertySymbol.GetDocumentationCommentId());
+            Indent();
+            var substitutedTextBuilder = PooledStringBuilder.GetInstance();
+            var includeElementNodesBuilder = _processIncludes ? ArrayBuilder<CSharpSyntaxNode>.GetInstance() : null;
+            DocumentationCommentWalker.GetSubstitutedText(_compilation, recordPropertySymbol, paramTags, includeElementNodesBuilder, substitutedTextBuilder.Builder);
+            string substitutedText = substitutedTextBuilder.ToStringAndFree();
+            string formattedXml = FormatComment(substitutedText);
+            Write(formattedXml);
+            Unindent();
+            WriteLine("</member>");
+
+            withUnprocessedIncludes = GetAndEndTemporaryString();
+            includeElementNodes = includeElementNodesBuilder?.ToImmutableAndFree() ?? default;
+
+            paramTags.Free();
+            return true;
+
+            ArrayBuilder<XmlElementSyntax>? getMatchingParamTags()
+            {
+                ArrayBuilder<XmlElementSyntax>? result = null;
+                foreach (var trivia in docCommentNodes)
+                {
+                    foreach (var contentItem in trivia.Content)
+                    {
+                        if (contentItem is XmlElementSyntax elementSyntax)
+                        {
+                            foreach (var attribute in elementSyntax.StartTag.Attributes)
+                            {
+                                if (attribute is XmlNameAttributeSyntax nameAttribute
+                                    && nameAttribute.GetElementKind() == XmlNameAttributeElementKind.Parameter
+                                    && string.Equals(nameAttribute.Identifier.Identifier.ValueText, recordPropertySymbol.Name, StringComparison.Ordinal))
+                                {
+                                    result ??= ArrayBuilder<XmlElementSyntax>.GetInstance();
+                                    result.Add(elementSyntax);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                return result;
+            }
+        }
+
+#nullable disable
 
         /// <summary>
         /// Loop over the DocumentationCommentTriviaSyntaxes.  Gather
@@ -439,6 +505,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Saw an XmlException while parsing one of the DocumentationCommentTriviaSyntax nodes.
             haveParseError = false;
+
+            if (symbol is SynthesizedRecordPropertySymbol recordProperty)
+            {
+                return TryProcessRecordPropertyDocumentation(recordProperty, docCommentNodes, out withUnprocessedIncludes, out includeElementNodes);
+            }
 
             // We're doing substitution and formatting per-trivia, rather than per-symbol,
             // because a single symbol can have both single-line and multi-line style
@@ -706,7 +777,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(numLines > 0);
                 }
 
-                Debug.Assert(TrimmedStringStartsWith(lines[0], "/**"));
                 WriteFormattedMultiLineComment(lines, numLines);
             }
 
@@ -897,7 +967,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     trimmed = TrimEndOfMultiLineComment(trimmed);
                 }
-                WriteLine(trimmed.Substring(SyntaxFacts.IsWhitespace(trimmed[3]) ? 4 : 3));
+                WriteLine(trimmed.Substring(
+                    trimmed.StartsWith("/** ") ? 4 :
+                    trimmed.StartsWith("/**") ? 3 :
+                    trimmed.StartsWith("* ") ? 2 :
+                    trimmed.StartsWith("*") ? 1 :
+                    0));
             }
 
             for (int i = 1; i < numLines; i++)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -3227,6 +3227,110 @@ namespace System.Runtime.CompilerServices
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
             Assert.Equal(SymbolKind.Property, model.GetSymbolInfo(cref).Symbol!.Kind);
+
+            var property = comp.GetMember("C.I1");
+            AssertEx.Equal(
+@"<member name=""P:C.I1"">
+    <summary>Description for <see cref=""P:C.I1""/></summary>
+</member>
+", property.GetDocumentationCommentXml());
+        }
+
+        [Fact]
+        public void XmlDoc_Cref_OtherMember()
+        {
+            var src = @"
+/// <summary>Summary</summary>
+/// <param name=""I1"">Description for <see cref=""I2""/></param>
+public record struct C(int I1, int I2)
+{
+    /// <summary>Summary</summary>
+    /// <param name=""x"">Description for <see cref=""x""/></param>
+    public void M(int x) { }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Ignored</summary>
+    public static class IsExternalInit
+    {
+    }
+}
+";
+
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularWithDocumentationComments);
+            comp.VerifyDiagnostics(
+                // (4,36): warning CS1573: Parameter 'I2' has no matching param tag in the XML comment for 'C.C(int, int)' (but other parameters do)
+                // public record struct C(int I1, int I2)
+                Diagnostic(ErrorCode.WRN_MissingParamTag, "I2").WithArguments("I2", "C.C(int, int)").WithLocation(4, 36),
+                // (7,52): warning CS1574: XML comment has cref attribute 'x' that could not be resolved
+                //     /// <param name="x">Description for <see cref="x"/></param>
+                Diagnostic(ErrorCode.WRN_BadXMLRef, "x").WithArguments("x").WithLocation(7, 52)
+                );
+
+            var tree = comp.SyntaxTrees.Single();
+            var docComments = tree.GetCompilationUnitRoot().DescendantTrivia().Select(trivia => trivia.GetStructure()).OfType<DocumentationCommentTriviaSyntax>();
+            var cref = docComments.First().DescendantNodes().OfType<XmlCrefAttributeSyntax>().First().Cref;
+            Assert.Equal("I2", cref.ToString());
+
+            var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            Assert.Equal(SymbolKind.Property, model.GetSymbolInfo(cref).Symbol!.Kind);
+
+            var property = comp.GetMember("C.I1");
+            AssertEx.Equal(
+@"<member name=""P:C.I1"">
+    <summary>Description for <see cref=""P:C.I2""/></summary>
+</member>
+", property.GetDocumentationCommentXml());
+        }
+
+        [Fact]
+        public void XmlDoc_SeeAlso_InsideParamTag()
+        {
+            var src = @"
+/// <summary>Summary</summary>
+/// <param name=""I1"">Description for <seealso cref=""I2""/>something like I2</seealso></param>
+public record struct C(int I1, int I2)
+{
+    /// <summary>Summary</summary>
+    /// <param name=""x"">Description for <see cref=""x""/></param>
+    public void M(int x) { }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Ignored</summary>
+    public static class IsExternalInit
+    {
+    }
+}
+";
+
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularWithDocumentationComments);
+            comp.VerifyDiagnostics(
+                // (3,77): warning CS1570: XML comment has badly formed XML -- 'End tag 'seealso' does not match the start tag 'param'.'
+                // /// <param name="I1">Description for <seealso cref="I2"/>something like I2</seealso></param>
+                Diagnostic(ErrorCode.WRN_XMLParseError, "seealso").WithArguments("seealso", "param").WithLocation(3, 77),
+                // (3,85): warning CS1570: XML comment has badly formed XML -- 'End tag was not expected at this location.'
+                // /// <param name="I1">Description for <seealso cref="I2"/>something like I2</seealso></param>
+                Diagnostic(ErrorCode.WRN_XMLParseError, "<").WithLocation(3, 85),
+                // (7,52): warning CS1574: XML comment has cref attribute 'x' that could not be resolved
+                //     /// <param name="x">Description for <see cref="x"/></param>
+                Diagnostic(ErrorCode.WRN_BadXMLRef, "x").WithArguments("x").WithLocation(7, 52)
+                );
+
+            var tree = comp.SyntaxTrees.Single();
+            var docComments = tree.GetCompilationUnitRoot().DescendantTrivia().Select(trivia => trivia.GetStructure()).OfType<DocumentationCommentTriviaSyntax>();
+            var cref = docComments.First().DescendantNodes().OfType<XmlCrefAttributeSyntax>().First().Cref;
+            Assert.Equal("I2", cref.ToString());
+
+            var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
+            Assert.Equal(SymbolKind.Property, model.GetSymbolInfo(cref).Symbol!.Kind);
+
+            var property = comp.GetMember("C.I1");
+            AssertEx.Equal(
+@"<!-- Badly formed XML comment ignored for member ""P:C.I1"" -->
+", property.GetDocumentationCommentXml());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -3184,7 +3184,11 @@ namespace System.Runtime.CompilerServices
             Assert.Equal("", constructor.GetParameters()[0].GetDocumentationCommentXml());
 
             var property = cMember.GetMembers("I1").Single();
-            Assert.Equal("", property.GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:C.I1"">
+    <summary>Description for I1</summary>
+</member>
+", property.GetDocumentationCommentXml());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordTests.cs
@@ -28314,7 +28314,11 @@ namespace System.Runtime.CompilerServices
             Assert.Equal("", constructor.GetParameters()[0].GetDocumentationCommentXml());
 
             var property = cMember.GetMembers("I1").Single();
-            Assert.Equal("", property.GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:C.I1"">
+    <summary>Description for I1</summary>
+</member>
+", property.GetDocumentationCommentXml());
         }
 
         [Fact, WorkItem(53912, "https://github.com/dotnet/roslyn/issues/53912")]
@@ -28345,7 +28349,8 @@ namespace NamespaceA
 
             var actual = GetDocumentationCommentText(comp);
             // the cref becomes `P:...`
-            var expected = (@"<?xml version=""1.0""?>
+            var expected =
+@"<?xml version=""1.0""?>
 <doc>
     <assembly>
         <name>Test</name>
@@ -28367,6 +28372,11 @@ namespace NamespaceA
             A property
             </param>
         </member>
+        <member name=""P:NamespaceA.LinkDestinationRecord.Prop1"">
+            <summary>
+            A property
+            </summary>
+        </member>
         <member name=""T:NamespaceA.LinkingClass"">
             <summary>
             Simple class.
@@ -28376,7 +28386,7 @@ namespace NamespaceA
             <inheritdoc cref=""P:NamespaceA.LinkDestinationRecord.Prop1"" />
         </member>
     </members>
-</doc>");
+</doc>";
             Assert.Equal(expected, actual);
         }
 
@@ -28418,7 +28428,11 @@ namespace System.Runtime.CompilerServices
             Assert.Equal("", constructor.GetParameters()[0].GetDocumentationCommentXml());
 
             var property = cMember.GetMembers("I1").Single();
-            Assert.Equal("", property.GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:C.I1"">
+    <summary>Description for I1</summary>
+</member>
+", property.GetDocumentationCommentXml());
         }
 
         [Fact]
@@ -28706,7 +28720,11 @@ namespace System.Runtime.CompilerServices
 ", cConstructor.GetDocumentationCommentXml());
 
             Assert.Equal("", cConstructor.GetParameters()[0].GetDocumentationCommentXml());
-            Assert.Equal("", c.GetMembers("I1").Single().GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:C.I1"">
+    <summary>Description for I1</summary>
+</member>
+", c.GetMembers("I1").Single().GetDocumentationCommentXml());
         }
 
         [Fact]
@@ -28749,7 +28767,11 @@ namespace System.Runtime.CompilerServices
 ", dConstructor.GetDocumentationCommentXml());
 
             Assert.Equal("", dConstructor.GetParameters()[0].GetDocumentationCommentXml());
-            Assert.Equal("", d.GetMembers("I1").Single().GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:D.I1"">
+    <summary>Description for I1</summary>
+</member>
+", d.GetMembers("I1").Single().GetDocumentationCommentXml());
         }
 
         [Fact]
@@ -28793,7 +28815,11 @@ namespace System.Runtime.CompilerServices
             var eConstructor = e.GetMembers(".ctor").OfType<SynthesizedRecordConstructor>().Single();
             Assert.Equal("", eConstructor.GetDocumentationCommentXml());
             Assert.Equal("", eConstructor.GetParameters()[0].GetDocumentationCommentXml());
-            Assert.Equal("", e.GetMembers("I1").Single().GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:E.I1"">
+    <summary>Description for I1</summary>
+</member>
+", e.GetMembers("I1").Single().GetDocumentationCommentXml());
         }
 
         [Fact]
@@ -28837,7 +28863,11 @@ namespace System.Runtime.CompilerServices
             var eConstructor = e.GetMembers(".ctor").OfType<SynthesizedRecordConstructor>().Single();
             Assert.Equal("", eConstructor.GetDocumentationCommentXml());
             Assert.Equal("", eConstructor.GetParameters()[0].GetDocumentationCommentXml());
-            Assert.Equal("", e.GetMembers("I1").Single().GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:E.I1"">
+    <summary>Description for I1</summary>
+</member>
+", e.GetMembers("I1").Single().GetDocumentationCommentXml());
         }
 
         [Fact]
@@ -28885,7 +28915,11 @@ namespace System.Runtime.CompilerServices
             Assert.Equal(1, cConstructor.DeclaringSyntaxReferences.Count());
             Assert.Equal("", cConstructor.GetDocumentationCommentXml());
             Assert.Equal("", cConstructor.GetParameters()[0].GetDocumentationCommentXml());
-            Assert.Equal("", c.GetMembers("I1").Single().GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:C.I1"">
+    <summary>Description for I1</summary>
+</member>
+", c.GetMembers("I1").Single().GetDocumentationCommentXml());
         }
 
         [Fact]
@@ -28932,7 +28966,11 @@ namespace System.Runtime.CompilerServices
 ", dConstructor.GetDocumentationCommentXml());
 
             Assert.Equal("", dConstructor.GetParameters()[0].GetDocumentationCommentXml());
-            Assert.Equal("", d.GetMembers("I1").Single().GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:D.I1"">
+    <summary>Description for I1</summary>
+</member>
+", d.GetMembers("I1").Single().GetDocumentationCommentXml());
         }
 
         [Fact]
@@ -28986,7 +29024,12 @@ namespace System.Runtime.CompilerServices
 </member>
 ", eConstructor.GetDocumentationCommentXml());
             Assert.Equal("", eConstructor.GetParameters()[0].GetDocumentationCommentXml());
-            Assert.Equal("", e.GetMembers("I1").Single().GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:E.I1"">
+    <summary>Description1 for I1</summary>
+    <summary>Description2 for I1</summary>
+</member>
+", e.GetMembers("I1").Single().GetDocumentationCommentXml());
         }
 
         [Fact]
@@ -29088,7 +29131,11 @@ namespace System.Runtime.CompilerServices
 </member>
 ", eConstructor.GetDocumentationCommentXml());
             Assert.Equal("", eConstructor.GetParameters()[0].GetDocumentationCommentXml());
-            Assert.Equal("", e.GetMembers("I1").Single().GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:E.I1"">
+    <summary>Description1 for I1</summary>
+</member>
+", e.GetMembers("I1").Single().GetDocumentationCommentXml());
         }
 
         [Fact]
@@ -29135,7 +29182,11 @@ namespace System.Runtime.CompilerServices
             Assert.Equal("", constructor.GetParameters()[0].GetDocumentationCommentXml());
 
             var property = cMember.GetMembers("I1").Single();
-            Assert.Equal("", property.GetDocumentationCommentXml());
+            AssertEx.Equal(
+@"<member name=""P:Outer.C.I1"">
+    <summary>Description for I1</summary>
+</member>
+", property.GetDocumentationCommentXml());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
@@ -6930,5 +6930,406 @@ $@"<?xml version=""1.0""?>
 </doc>";
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_01()
+        {
+            var source = @"
+/// <summary>The record.</summary>
+/// <param name=""Value"">Parameter of the record.</param>
+record Rec(string Value);
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                //     public static class IsExternalInit
+                Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25));
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <member name=""T:Rec"">
+            <summary>The record.</summary>
+            <param name=""Value"">Parameter of the record.</param>
+        </member>
+        <member name=""M:Rec.#ctor(System.String)"">
+            <summary>The record.</summary>
+            <param name=""Value"">Parameter of the record.</param>
+        </member>
+        <member name=""P:Rec.Value"">
+            <summary>Parameter of the record.</summary>
+        </member>
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_02()
+        {
+            var source = @"
+/// <summary>The record.</summary>
+/// <param name=""Value"">Parameter of the record.
+record Rec(string Value);
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                //     public static class IsExternalInit
+                Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25));
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <!-- Badly formed XML comment ignored for member ""T:Rec"" -->
+        <!-- Badly formed XML comment ignored for member ""M:Rec.#ctor(System.String)"" -->
+        <!-- Badly formed XML comment ignored for member ""P:Rec.Value"" -->
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_03()
+        {
+            var source = @"
+/// <summary>The record.</summary>
+/// <param name=""Value"">Parameter of the record.</param>
+/// <param name=""Value"">Also the value of the record.</param>
+record Rec(string Value);
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                // (4,12): warning CS1571: XML comment has a duplicate param tag for 'Value'
+                // /// <param name="Value">Also the value of the record.</param>
+                Diagnostic(ErrorCode.WRN_DuplicateParamTag, @"name=""Value""").WithArguments("Value").WithLocation(4, 12),
+                // (4,12): warning CS1571: XML comment has a duplicate param tag for 'Value'
+                // /// <param name="Value">Also the value of the record.</param>
+                Diagnostic(ErrorCode.WRN_DuplicateParamTag, @"name=""Value""").WithArguments("Value").WithLocation(4, 12),
+                // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                //     public static class IsExternalInit
+                Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25));
+
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <member name=""T:Rec"">
+            <summary>The record.</summary>
+            <param name=""Value"">Parameter of the record.</param>
+            <param name=""Value"">Also the value of the record.</param>
+        </member>
+        <member name=""M:Rec.#ctor(System.String)"">
+            <summary>The record.</summary>
+            <param name=""Value"">Parameter of the record.</param>
+            <param name=""Value"">Also the value of the record.</param>
+        </member>
+        <member name=""P:Rec.Value"">
+            <summary>Parameter of the record.</summary>
+            <summary>Also the value of the record.</summary>
+        </member>
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_04()
+        {
+            var source = @"
+/// <summary>The record.</summary>
+/// <param name=""Item1"">First item in the record.</param>
+/// <param name=""Item2"">Second item in the record.</param>
+record Rec(string Item1, object Item2);
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                //     public static class IsExternalInit
+                Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25)
+);
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <member name=""T:Rec"">
+            <summary>The record.</summary>
+            <param name=""Item1"">First item in the record.</param>
+            <param name=""Item2"">Second item in the record.</param>
+        </member>
+        <member name=""M:Rec.#ctor(System.String,System.Object)"">
+            <summary>The record.</summary>
+            <param name=""Item1"">First item in the record.</param>
+            <param name=""Item2"">Second item in the record.</param>
+        </member>
+        <member name=""P:Rec.Item1"">
+            <summary>First item in the record.</summary>
+        </member>
+        <member name=""P:Rec.Item2"">
+            <summary>Second item in the record.</summary>
+        </member>
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_05()
+        {
+            var source = @"
+/// <summary>The record.</summary>
+/// <param name=""Item2"">Second item in the record.</param>
+record Rec(string Item1, object Item2);
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                    // (4,19): warning CS1573: Parameter 'Item1' has no matching param tag in the XML comment for 'Rec.Rec(string, object)' (but other parameters do)
+                    // record Rec(string Item1, object Item2);
+                    Diagnostic(ErrorCode.WRN_MissingParamTag, "Item1").WithArguments("Item1", "Rec.Rec(string, object)").WithLocation(4, 19),
+                    // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                    //     public static class IsExternalInit
+                    Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25));
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <member name=""T:Rec"">
+            <summary>The record.</summary>
+            <param name=""Item2"">Second item in the record.</param>
+        </member>
+        <member name=""M:Rec.#ctor(System.String,System.Object)"">
+            <summary>The record.</summary>
+            <param name=""Item2"">Second item in the record.</param>
+        </member>
+        <member name=""P:Rec.Item2"">
+            <summary>Second item in the record.</summary>
+        </member>
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_06()
+        {
+            var source = @"
+/// <summary>The record.</summary>
+/// <param name=""Item"">Item within the record.</param>
+record Rec(string Item)
+{
+    public string Item { get; init; } = Item;
+}
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                    // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                    //     public static class IsExternalInit
+                    Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25));
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <member name=""T:Rec"">
+            <summary>The record.</summary>
+            <param name=""Item"">Item within the record.</param>
+        </member>
+        <member name=""M:Rec.#ctor(System.String)"">
+            <summary>The record.</summary>
+            <param name=""Item"">Item within the record.</param>
+        </member>
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_07()
+        {
+            var source = @"
+/// <summary>The record.</summary>
+/// <param name=""Item"">Item within the record.</param1>
+record Rec(string Item)
+{
+}
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                    // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                    //     public static class IsExternalInit
+                    Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25));
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <!-- Badly formed XML comment ignored for member ""T:Rec"" -->
+        <!-- Badly formed XML comment ignored for member ""M:Rec.#ctor(System.String)"" -->
+        <!-- Badly formed XML comment ignored for member ""P:Rec.Item"" -->
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_08()
+        {
+            var source = @"
+/**
+ * <summary>The record.</summary>
+ * <param name=""Item"">Item within the record.</param>
+ * <remarks>The remarks.</remarks>
+ */
+record Rec(string Item)
+{
+}
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                    // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                    //     public static class IsExternalInit
+                    Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25));
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <member name=""T:Rec"">
+            <summary>The record.</summary>
+            <param name=""Item"">Item within the record.</param>
+            <remarks>The remarks.</remarks>
+        </member>
+        <member name=""M:Rec.#ctor(System.String)"">
+            <summary>The record.</summary>
+            <param name=""Item"">Item within the record.</param>
+            <remarks>The remarks.</remarks>
+        </member>
+        <member name=""P:Rec.Item"">
+            <summary>Item within the record.</summary>
+        </member>
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_09()
+        {
+            var source = @"
+/**
+ *<summary>The record.</summary>
+ *<param name=""Item"">Item within the record.</param>
+ *<remarks>The remarks.</remarks>
+ */
+record Rec(string Item)
+{
+}
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                    // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                    //     public static class IsExternalInit
+                    Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25));
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <member name=""T:Rec"">
+            <summary>The record.</summary>
+            <param name=""Item"">Item within the record.</param>
+            <remarks>The remarks.</remarks>
+        </member>
+        <member name=""M:Rec.#ctor(System.String)"">
+            <summary>The record.</summary>
+            <param name=""Item"">Item within the record.</param>
+            <remarks>The remarks.</remarks>
+        </member>
+        <member name=""P:Rec.Item"">
+            <summary>Item within the record.</summary>
+        </member>
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
+
+        [Fact]
+        [WorkItem(52663, "https://github.com/dotnet/roslyn/issues/52663")]
+        public void PositionalRecord_10()
+        {
+            var source = @"
+/**
+   <summary>The record.</summary>
+   <param name=""Item"">Item within the record.</param>
+   <remarks>The remarks.</remarks>
+ */
+record Rec(string Item)
+{
+}
+";
+            var comp = CreateCompilationUtil(new[] { source, IsExternalInitTypeDefinition });
+            var actual = GetDocumentationCommentText(comp,
+                    // (4,25): warning CS1591: Missing XML comment for publicly visible type or member 'IsExternalInit'
+                    //     public static class IsExternalInit
+                    Diagnostic(ErrorCode.WRN_MissingXMLComment, "IsExternalInit").WithArguments("System.Runtime.CompilerServices.IsExternalInit").WithLocation(4, 25));
+
+            // Ideally, the 'P:Rec.Item' summary would have exactly the same leading indentation as the param comment it was derived from.
+            // However, it doesn't seem essential for this to match in all cases.
+            var expected =
+@"<?xml version=""1.0""?>
+<doc>
+    <assembly>
+        <name>Test</name>
+    </assembly>
+    <members>
+        <member name=""T:Rec"">
+               <summary>The record.</summary>
+               <param name=""Item"">Item within the record.</param>
+               <remarks>The remarks.</remarks>
+        </member>
+        <member name=""M:Rec.#ctor(System.String)"">
+               <summary>The record.</summary>
+               <param name=""Item"">Item within the record.</param>
+               <remarks>The remarks.</remarks>
+        </member>
+        <member name=""P:Rec.Item"">
+            <summary>Item within the record.</summary>
+        </member>
+    </members>
+</doc>";
+            AssertEx.Equal(expected, actual);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -7537,6 +7537,23 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task QuickInfoRecordProperty()
+        {
+            await TestWithOptionsAsync(
+                Options.Regular.WithLanguageVersion(LanguageVersion.CSharp9),
+@"/// <param name=""First"">The person's first name.</param>
+record Person(string First, string Last)
+{
+    void M(Person p)
+    {
+        _ = p.$$First;
+    }
+}",
+    MainDescription("string Person.First { get; init; }"),
+    Documentation("The person's first name."));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         [WorkItem(51615, "https://github.com/dotnet/roslyn/issues/51615")]
         public async Task TestVarPatternOnVarKeyword()
         {


### PR DESCRIPTION
Closes #52663

This solution works by modifying the processing stage where crefs are replaced with doc comment IDs.

It requires some changes to the subsequent 'FormatComment' step which removes `///`, `/**` and similar exterior trivia, and adjusts the indenting of the comments to match the output XML file. Specifically, make a change to make this layer more tolerant of "fragments" of `/** */` multi-line comments.

In the medium or long term, I'd actually like to eliminate or vastly simplify the 'FormatComment' stage by modifying the initial parsing stage of XML comments. Ideally, we would have an invariant where:
- whitespaces which **shouldn't** be included in the output XML document are **trivia** on XML nodes.
- whitespaces which **should** be included in the output XML document are contained in XML text nodes.

Then I think we could write the XML to the documentation stream in one pass, simply replacing cref nodes with doc comment IDs as we go and inserting the appropriate amount of indentation immediately following each XmlNewLineToken.
