### PR TITLE
Fix Go To Base for a symbol with a single metadata location

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -115,14 +115,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
 
             // Generate new source or retrieve existing source for the symbol in question
+            return ThreadingContext.JoinableTaskFactory.Run(() => TryNavigateToMetadataAsync(project, symbol, options, cancellationToken));
+        }
+
+        private async Task<bool> TryNavigateToMetadataAsync(Project project, ISymbol symbol, OptionSet options, CancellationToken cancellationToken)
+        {
             var allowDecompilation = _globalOptions.GetOption(FeatureOnOffOptions.NavigateToDecompiledSources);
-            var result = ThreadingContext.JoinableTaskFactory.Run(() => _metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol, signaturesOnly: false, allowDecompilation, cancellationToken));
+
+            var result = await _metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol, signaturesOnly: false, allowDecompilation, cancellationToken).ConfigureAwait(false);
+
+            await this.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             var vsRunningDocumentTable4 = IServiceProviderExtensions.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable4>(_serviceProvider);
             var fileAlreadyOpen = vsRunningDocumentTable4.IsMonikerValid(result.FilePath);
 
             var openDocumentService = IServiceProviderExtensions.GetService<SVsUIShellOpenDocument, IVsUIShellOpenDocument>(_serviceProvider);
-            openDocumentService.OpenDocumentViaProject(result.FilePath, VSConstants.LOGVIEWID.TextView_guid, out var localServiceProvider, out var hierarchy, out var itemId, out var windowFrame);
+            openDocumentService.OpenDocumentViaProject(result.FilePath, VSConstants.LOGVIEWID.TextView_guid, out _, out _, out _, out var windowFrame);
 
             var documentCookie = vsRunningDocumentTable4.GetDocumentCookie(result.FilePath);
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToBase.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToBase.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.Shell;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
+
+namespace Roslyn.VisualStudio.IntegrationTests.CSharp
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class CSharpGoToBase : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.CSharp;
+
+        public CSharpGoToBase(VisualStudioInstanceFactory instanceFactory)
+                    : base(instanceFactory, nameof(CSharpGoToBase))
+        {
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.GoToBase)]
+        public void GoToBaseFromMetadataAsSource()
+        {
+            var project = new ProjectUtils.Project(ProjectName);
+            VisualStudio.SolutionExplorer.AddFile(project, "C.cs");
+            VisualStudio.SolutionExplorer.OpenFile(project, "C.cs");
+            VisualStudio.Editor.SetText(
+@"using System;
+
+class C
+{
+    public override string ToString()
+    {
+        return ""C"";
+    }
+}");
+            VisualStudio.Editor.PlaceCaret("ToString", charsOffset: -1);
+            VisualStudio.Editor.GoToBase("Object [from metadata]");
+            VisualStudio.Editor.Verify.TextContains(@"public virtual string ToString$$()", assertCaretPosition: true);
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -799,6 +799,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public void GoToImplementation()
             => ExecuteCommand(WellKnownCommandNames.Edit_GoToImplementation);
 
+        public void GoToBase()
+            => ExecuteCommand(WellKnownCommandNames.Edit_GoToBase);
+
         /// <summary>
         /// Gets the spans where a particular tag appears in the active text view.
         /// </summary>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -387,6 +387,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             _editorInProc.WaitForActiveWindow(expectedWindowName);
         }
 
+        public void GoToBase(string expectedWindowName)
+        {
+            _instance.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.Workspace);
+            _editorInProc.GoToBase();
+            _instance.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.GoToBase);
+            _editorInProc.WaitForActiveWindow(expectedWindowName);
+        }
+
         public void SendExplicitFocus()
             => _editorInProc.SendExplicitFocus();
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         public const string Edit_GoToAll = "Edit.GoToAll";
         public const string Edit_GoToDefinition = "Edit.GoToDefinition";
         public const string Edit_GoToImplementation = "Edit.GoToImplementation";
+        public const string Edit_GoToBase = "Edit.GoToBase";
         public const string Edit_ListMembers = "Edit.ListMembers";
         public const string Edit_ParameterInfo = "Edit.ParameterInfo";
         public const string Edit_ToggleCompletionMode = "Edit.ToggleCompletionMode";


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58964

Not sure when this broke, but it works in 17.0.4 and not in 17.1 Preview 2.

https://github.com/dotnet/roslyn/pull/55891 is too early and https://github.com/dotnet/roslyn/pull/58617 is too late, and it still repro'd when I reverted https://github.com/dotnet/roslyn/pull/58051

Nothing else jumped out at me as a possible culprit ¯\\\_(ツ)_/¯