### PR TITLE
Update tests to catch the MEF v2 creation failure

### DIFF
--- a/src/EditorFeatures/Test/Workspaces/DefaultMefHostTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/DefaultMefHostTests.cs
@@ -2,19 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
+    // We put [UseExportProvider] here even though the test ironically doesn't actually use the ExportProvider that's provided;
+    // setting this however still ensures the AfterTest portion runs which will clear out the existing catalog, and ensure that
+    // no other test accidentally uses the default catalog later if that other test is missing [UseExportProvider].
     [UseExportProvider]
-    public class WorkspaceTests
+    public class DefaultMefHostTests
     {
         [Fact]
         public void TestDefaultCompositionIncludesFeaturesLayer()
         {
+            // For this specific test, we want to test that our default container works, so we'll remove any hooks
+            // that were created by other tests.
+            MefHostServices.TestAccessor.HookServiceCreation(null);
+
             var ws = new AdhocWorkspace();
 
             var csservice = ws.Services.GetLanguageServices(LanguageNames.CSharp).GetService<Microsoft.CodeAnalysis.Completion.CompletionService>();


### PR DESCRIPTION
We had a test that looks like it was trying to test how our default container was created, but because it was testing with our VS MEF test infrastructure, it wasn't actually creating a workspace or MEF host like our public APIs would. This broke a lot of things, so now we have a test for it.