### PR TITLE
Use new document formatter to format when a type is moved to a new document

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -1661,5 +1661,32 @@ class A
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
         }
+
+        [Fact]
+        public async Task MoveType_RemoveUsings()
+        {
+            await TestMoveTypeToNewFileAsync(
+                originalCode: @"
+using System;
+
+class A
+{
+}
+
+class [|B|]
+{
+}",
+                expectedSourceTextAfterRefactoring: @"
+using System;
+
+class A
+{
+}",
+                expectedDocumentName: "B.cs",
+                destinationDocumentText: @"
+class B
+{
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpAccessibilityModifiersNewDocumentFormattingProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Formatting
@@ -26,9 +27,8 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
         }
 
-        public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
+        public async Task<Document> FormatNewDocumentAsync(Document document, DocumentOptionSet documentOptions, Document? hintDocument, CancellationToken cancellationToken)
         {
-            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var accessibilityPreferences = documentOptions.GetOption(CodeStyleOptions2.RequireAccessibilityModifiers, document.Project.Language);
             if (accessibilityPreferences.Value == AccessibilityModifiersRequired.Never)
             {

--- a/src/Features/CSharp/Portable/Formatting/CSharpNamespaceDeclarationNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpNamespaceDeclarationNewDocumentFormattingProvider.cs
@@ -27,9 +27,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
         }
 
-        public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
+        public async Task<Document> FormatNewDocumentAsync(Document document, DocumentOptionSet optionSet, Document? hintDocument, CancellationToken cancellationToken)
         {
-            var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var root = (CompilationUnitSyntax)await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var namespaces = GetNamespacesToReplace(document, root, optionSet).ToList();

--- a/src/Features/CSharp/Portable/Formatting/CSharpOrganizeUsingsNewDocumentFormattingProvider.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpOrganizeUsingsNewDocumentFormattingProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
@@ -21,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
         }
 
-        public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
+        public async Task<Document> FormatNewDocumentAsync(Document document, DocumentOptionSet optionSet, Document? hintDocument, CancellationToken cancellationToken)
         {
             var organizedDocument = await Formatter.OrganizeImportsAsync(document, cancellationToken).ConfigureAwait(false);
             return await MisplacedUsingDirectivesCodeFixProvider.TransformDocumentIfRequiredAsync(organizedDocument, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/AddFileBanner/AbstractAddFileBannerNewDocumentFormattingProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.FileHeaders;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.AddFileBanner
@@ -19,10 +20,9 @@ namespace Microsoft.CodeAnalysis.AddFileBanner
         protected abstract SyntaxGeneratorInternal SyntaxGeneratorInternal { get; }
         protected abstract AbstractFileHeaderHelper FileHeaderHelper { get; }
 
-        public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
+        public async Task<Document> FormatNewDocumentAsync(Document document, DocumentOptionSet documentOptions, Document? hintDocument, CancellationToken cancellationToken)
         {
             var rootToFormat = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
             // Apply file header preferences
             var fileHeaderTemplate = documentOptions.GetOption(CodeStyleOptions2.FileHeaderTemplate);

--- a/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/AbstractNewDocumentFormattingService.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
@@ -32,6 +33,12 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         public async Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken)
         {
+            var optionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            return await FormatNewDocumentAsync(document, optionSet, hintDocument, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<Document> FormatNewDocumentAsync(Document document, DocumentOptionSet optionSet, Document? hintDocument, CancellationToken cancellationToken)
+        {
             foreach (var provider in GetProviders())
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -41,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 // other, so this shouldn't cause problems.
                 try
                 {
-                    document = await provider.FormatNewDocumentAsync(document, hintDocument, cancellationToken).ConfigureAwait(false);
+                    document = await provider.FormatNewDocumentAsync(document, optionSet, hintDocument, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex, cancellationToken, ErrorSeverity.General))
                 {

--- a/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
+++ b/src/Features/Core/Portable/Formatting/INewDocumentFormattingProvider.cs
@@ -4,12 +4,13 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
     internal interface INewDocumentFormattingProvider
     {
-        /// <inheritdoc cref="INewDocumentFormattingService.FormatNewDocumentAsync(Document, Document, CancellationToken)"/>
-        Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken);
+        /// <inheritdoc cref="INewDocumentFormattingService.FormatNewDocumentAsync(Document, DocumentOptionSet, Document, CancellationToken)"/>
+        Task<Document> FormatNewDocumentAsync(Document document, DocumentOptionSet optionSet, Document? hintDocument, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Formatting/INewDocumentFormattingService.cs
+++ b/src/Features/Core/Portable/Formatting/INewDocumentFormattingService.cs
@@ -5,17 +5,27 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
     internal interface INewDocumentFormattingService : ILanguageService
     {
         /// <summary>
-        /// Formats a new document that is being added to a project from the Add New Item dialog.
+        /// Formats a new document that is added from the New Item dialog or added via a code action.
         /// </summary>
         /// <param name="document">The document to format.</param>
         /// <param name="hintDocument">An optional additional document that can be used to inform the formatting operation.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         Task<Document> FormatNewDocumentAsync(Document document, Document? hintDocument, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Formats a new document that is added from the New Item dialog or added via a code action.
+        /// </summary>
+        /// <param name="document">The document to format.</param>
+        /// <param name="optionSet">The options to be considered for the new document</param>
+        /// <param name="hintDocument">An optional additional document that can be used to inform the formatting operation.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        Task<Document> FormatNewDocumentAsync(Document document, DocumentOptionSet optionSet, Document? hintDocument, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/VisualBasic/Portable/Formatting/VisualBasicOrganizeUsingsNewDocumentFormattingProvider.vb
+++ b/src/Features/VisualBasic/Portable/Formatting/VisualBasicOrganizeUsingsNewDocumentFormattingProvider.vb
@@ -6,6 +6,7 @@ Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Options
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
     <ExportNewDocumentFormattingProvider(LanguageNames.VisualBasic), [Shared]>
@@ -17,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Function FormatNewDocumentAsync(document As Document, hintDocument As Document, cancellationToken As CancellationToken) As Task(Of Document) Implements INewDocumentFormattingProvider.FormatNewDocumentAsync
+        Public Function FormatNewDocumentAsync(document As Document, optionSet As DocumentOptionSet, hintDocument As Document, cancellationToken As CancellationToken) As Task(Of Document) Implements INewDocumentFormattingProvider.FormatNewDocumentAsync
             Return Formatter.OrganizeImportsAsync(document, cancellationToken)
         End Function
     End Class


### PR DESCRIPTION
Fixes #58660