### PR TITLE
Document recent warning waves

### DIFF
--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -7,15 +7,12 @@ without taking action to enable them.
 For that purpose, we have the compiler flag "`/warn:n`"
 where `n` is a whole number.
 
-The compiler shipped with dotnet 5 (the C# 9 compiler) contains some warnings, documented below, that
-are reported only under `/warn:5` or higher.
-
-The default warning level when the command-line compiler is used is `4`.
-
-If you want the compiler to produce all applicable warnings, you can specify
+The default warning level when the command-line compiler is used is `4`. If you want the compiler to produce all applicable warnings, you can specify
 `/warn:9999`.
 
-The table below describes all of the warnings controlled by warning levels `5` or greater.
+## Warning level 5
+
+The compiler shipped with .NET 5 (the C# 9 compiler) contains the following warnings which are reported only under `/warn:5` or higher.
 
 | Warning ID | warning level | Description |
 |------------|---------|-------------|
@@ -33,4 +30,19 @@ The table below describes all of the warnings controlled by warning levels `5` o
 | CS8892 | 5 | [Multiple entry points](https://github.com/dotnet/roslyn/issues/46831) |
 | CS8897 | 5 | [Static class used as the parameter type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
 | CS8898 | 5 | [Static class used as the return type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
+
+# Warning level 6
+
+The compiler shipped with .NET 6 (the C# 10 compiler) contains the following warnings which are reported only under `/warn:6` or higher.
+
+| Warning ID | warning level | Description |
+|------------|---------|-------------|
+| CS8826 | 6 | [Partial method declarations have signature differences](https://github.com/dotnet/roslyn/issues/47838) |
+
+## Warning level 7
+
+The compiler shipped with .NET 7 (the C# 11 compiler) contains the following warnings which are reported only under `/warn:7` or higher.
+
+| Warning ID | warning level | Description |
+|------------|---------|-------------|
 | CS8981 | 7 | [Type names only containing lower-cased ascii characters may become reserved for the language](https://github.com/dotnet/roslyn/issues/56653) |

--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -9,26 +9,13 @@ where `n` is a whole number.
 
 The default warning level when the command-line compiler is used is `4`. If you want the compiler to produce all applicable warnings, you can specify `/warn:9999`.
 
-## Warning level 5
+## Warning level 7
 
-The compiler shipped with .NET 5 (the C# 9 compiler) contains the following warnings which are reported only under `/warn:5` or higher.
+The compiler shipped with .NET 7 (the C# 11 compiler) contains the following warnings which are reported only under `/warn:7` or higher.
 
 | Warning ID | Description |
 |------------|-------------|
-| CS8898 | [Static class used as the return type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
-| CS8897 | [Static class used as the parameter type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
-| CS8892 | [Multiple entry points](https://github.com/dotnet/roslyn/issues/46831) |
-| CS8887 | [Local variable used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8886 | [Out parameter used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8885 | [Struct constructor reads 'this' before assigning all fields (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8884 | [Field used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8883 | [Auto-property used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8882 | [Out parameter not assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8881 | [Struct constructor does not assign field (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8880 | [Struct constructor does not assign auto property (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8848 | [Diagnose precedence error with query expression](https://github.com/dotnet/roslyn/issues/30231) |
-| CS8073 | [Expression always true (or false) when comparing a struct to null](https://github.com/dotnet/roslyn/issues/45744) |
-| CS7023 | [A static type is used in an 'is' or 'as' expression](https://github.com/dotnet/roslyn/issues/30198) |
+| CS8981 | [Type names only containing lower-cased ascii characters may become reserved for the language](https://github.com/dotnet/roslyn/issues/56653) |
 
 # Warning level 6
 
@@ -38,10 +25,23 @@ The compiler shipped with .NET 6 (the C# 10 compiler) contains the following war
 |------------|-------------|
 | CS8826 | [Partial method declarations have signature differences](https://github.com/dotnet/roslyn/issues/47838) |
 
-## Warning level 7
+## Warning level 5
 
-The compiler shipped with .NET 7 (the C# 11 compiler) contains the following warnings which are reported only under `/warn:7` or higher.
+The compiler shipped with .NET 5 (the C# 9 compiler) contains the following warnings which are reported only under `/warn:5` or higher.
 
 | Warning ID | Description |
 |------------|-------------|
-| CS8981 | [Type names only containing lower-cased ascii characters may become reserved for the language](https://github.com/dotnet/roslyn/issues/56653) |
+| CS7023 | [A static type is used in an 'is' or 'as' expression](https://github.com/dotnet/roslyn/issues/30198) |
+| CS8073 | [Expression always true (or false) when comparing a struct to null](https://github.com/dotnet/roslyn/issues/45744) |
+| CS8848 | [Diagnose precedence error with query expression](https://github.com/dotnet/roslyn/issues/30231) |
+| CS8880 | [Struct constructor does not assign auto property (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8881 | [Struct constructor does not assign field (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8882 | [Out parameter not assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8883 | [Auto-property used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8884 | [Field used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8885 | [Struct constructor reads 'this' before assigning all fields (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8886 | [Out parameter used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8887 | [Local variable used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8892 | [Multiple entry points](https://github.com/dotnet/roslyn/issues/46831) |
+| CS8897 | [Static class used as the parameter type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
+| CS8898 | [Static class used as the return type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |

--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -7,42 +7,41 @@ without taking action to enable them.
 For that purpose, we have the compiler flag "`/warn:n`"
 where `n` is a whole number.
 
-The default warning level when the command-line compiler is used is `4`. If you want the compiler to produce all applicable warnings, you can specify
-`/warn:9999`.
+The default warning level when the command-line compiler is used is `4`. If you want the compiler to produce all applicable warnings, you can specify `/warn:9999`.
 
 ## Warning level 5
 
 The compiler shipped with .NET 5 (the C# 9 compiler) contains the following warnings which are reported only under `/warn:5` or higher.
 
-| Warning ID | warning level | Description |
-|------------|---------|-------------|
-| CS7023 | 5 | [A static type is used in an 'is' or 'as' expression](https://github.com/dotnet/roslyn/issues/30198) |
-| CS8073 | 5 | [Expression always true (or false) when comparing a struct to null](https://github.com/dotnet/roslyn/issues/45744) |
-| CS8848 | 5 | [Diagnose precedence error with query expression](https://github.com/dotnet/roslyn/issues/30231) |
-| CS8880 | 5 | [Struct constructor does not assign auto property (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8881 | 5 | [Struct constructor does not assign field (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8882 | 5 | [Out parameter not assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8883 | 5 | [Auto-property used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8884 | 5 | [Field used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8885 | 5 | [Struct constructor reads 'this' before assigning all fields (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8886 | 5 | [Out parameter used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8887 | 5 | [Local variable used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8892 | 5 | [Multiple entry points](https://github.com/dotnet/roslyn/issues/46831) |
-| CS8897 | 5 | [Static class used as the parameter type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
-| CS8898 | 5 | [Static class used as the return type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
+| Warning ID | Description |
+|------------|-------------|
+| CS7023 | [A static type is used in an 'is' or 'as' expression](https://github.com/dotnet/roslyn/issues/30198) |
+| CS8073 | [Expression always true (or false) when comparing a struct to null](https://github.com/dotnet/roslyn/issues/45744) |
+| CS8848 | [Diagnose precedence error with query expression](https://github.com/dotnet/roslyn/issues/30231) |
+| CS8880 | [Struct constructor does not assign auto property (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8881 | [Struct constructor does not assign field (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8882 | [Out parameter not assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8883 | [Auto-property used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8884 | [Field used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8885 | [Struct constructor reads 'this' before assigning all fields (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8886 | [Out parameter used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8887 | [Local variable used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8892 | [Multiple entry points](https://github.com/dotnet/roslyn/issues/46831) |
+| CS8897 | [Static class used as the parameter type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
+| CS8898 | [Static class used as the return type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
 
 # Warning level 6
 
 The compiler shipped with .NET 6 (the C# 10 compiler) contains the following warnings which are reported only under `/warn:6` or higher.
 
-| Warning ID | warning level | Description |
-|------------|---------|-------------|
-| CS8826 | 6 | [Partial method declarations have signature differences](https://github.com/dotnet/roslyn/issues/47838) |
+| Warning ID | Description |
+|------------|-------------|
+| CS8826 | [Partial method declarations have signature differences](https://github.com/dotnet/roslyn/issues/47838) |
 
 ## Warning level 7
 
 The compiler shipped with .NET 7 (the C# 11 compiler) contains the following warnings which are reported only under `/warn:7` or higher.
 
-| Warning ID | warning level | Description |
-|------------|---------|-------------|
-| CS8981 | 7 | [Type names only containing lower-cased ascii characters may become reserved for the language](https://github.com/dotnet/roslyn/issues/56653) |
+| Warning ID | Description |
+|------------|-------------|
+| CS8981 | [Type names only containing lower-cased ascii characters may become reserved for the language](https://github.com/dotnet/roslyn/issues/56653) |

--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -15,20 +15,20 @@ The compiler shipped with .NET 5 (the C# 9 compiler) contains the following warn
 
 | Warning ID | Description |
 |------------|-------------|
-| CS7023 | [A static type is used in an 'is' or 'as' expression](https://github.com/dotnet/roslyn/issues/30198) |
-| CS8073 | [Expression always true (or false) when comparing a struct to null](https://github.com/dotnet/roslyn/issues/45744) |
-| CS8848 | [Diagnose precedence error with query expression](https://github.com/dotnet/roslyn/issues/30231) |
-| CS8880 | [Struct constructor does not assign auto property (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8881 | [Struct constructor does not assign field (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8882 | [Out parameter not assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8883 | [Auto-property used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8884 | [Field used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8885 | [Struct constructor reads 'this' before assigning all fields (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8886 | [Out parameter used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8887 | [Local variable used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
-| CS8892 | [Multiple entry points](https://github.com/dotnet/roslyn/issues/46831) |
-| CS8897 | [Static class used as the parameter type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
 | CS8898 | [Static class used as the return type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
+| CS8897 | [Static class used as the parameter type of a method in an interface type](https://github.com/dotnet/roslyn/issues/38256) |
+| CS8892 | [Multiple entry points](https://github.com/dotnet/roslyn/issues/46831) |
+| CS8887 | [Local variable used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8886 | [Out parameter used before being assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8885 | [Struct constructor reads 'this' before assigning all fields (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8884 | [Field used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8883 | [Auto-property used before assigned in struct constructor (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8882 | [Out parameter not assigned (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8881 | [Struct constructor does not assign field (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8880 | [Struct constructor does not assign auto property (imported struct type with private fields)](https://github.com/dotnet/roslyn/issues/30194) |
+| CS8848 | [Diagnose precedence error with query expression](https://github.com/dotnet/roslyn/issues/30231) |
+| CS8073 | [Expression always true (or false) when comparing a struct to null](https://github.com/dotnet/roslyn/issues/45744) |
+| CS7023 | [A static type is used in an 'is' or 'as' expression](https://github.com/dotnet/roslyn/issues/30198) |
 
 # Warning level 6
 


### PR DESCRIPTION
Fixes #59013

Commit-by-commit review will have a cleaner diff to review.

- A warning of level 6 was missing documentation
- A warning of level 7 was documented under the following paragraph:

    > The table below describes all of the warnings controlled by warning levels `5` or greater.

I separated each warning level under a separate header.