### PR TITLE
Don't show colon suffix in property pattern completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PropertySubPatternCompletionProviderTests.cs
@@ -36,8 +36,8 @@ class Program
 }
 ";
             // VerifyItemExistsAsync also tests with the item typed.
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
         }
 
         [Fact]
@@ -57,8 +57,8 @@ public class Program
     public void Deconstruct(out int x, out int y) => throw null;
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
         }
 
         [Fact]
@@ -78,8 +78,8 @@ public class Program
     public void Deconstruct(out int x, out int y) => throw null;
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
         }
 
         [Fact]
@@ -98,8 +98,8 @@ class Program
     }
 }
 ";
-            await VerifyItemExistsAsync(markup, "@new", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "@struct", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "@new", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "@struct", displayTextSuffix: "");
         }
 
         [Fact]
@@ -138,8 +138,8 @@ class Derived
     public int P2 { get; set; }
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
         }
 
         [Fact]
@@ -160,8 +160,8 @@ class Other
     public int F2;
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "F2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "F2", displayTextSuffix: "");
         }
 
         [Fact]
@@ -203,7 +203,7 @@ class Derived : Program
     private int P2 { get; set; }
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
         }
 
         [Fact]
@@ -223,8 +223,8 @@ class Program
 }
 ";
             // VerifyItemExistsAsync also tests with the item typed.
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
         }
 
         [Fact]
@@ -247,8 +247,8 @@ class Program
 }
 ";
             // VerifyItemExistsAsync also tests with the item typed.
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
         }
 
         [Fact]
@@ -271,8 +271,8 @@ class Program
 }
 ";
             // VerifyItemExistsAsync also tests with the item typed.
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
         }
 
         [Fact]
@@ -291,8 +291,8 @@ class Program
     }
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
         }
 
         [Fact]
@@ -318,8 +318,8 @@ class Program
 ";
             await VerifyItemIsAbsentAsync(markup, "P1");
             await VerifyItemIsAbsentAsync(markup, "P2");
-            await VerifyItemExistsAsync(markup, "P3", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P4", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P3", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P4", displayTextSuffix: "");
         }
 
         [Fact]
@@ -345,8 +345,8 @@ class Program
 ";
             await VerifyItemIsAbsentAsync(markup, "P1");
             await VerifyItemIsAbsentAsync(markup, "F2");
-            await VerifyItemExistsAsync(markup, "P3", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P4", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P3", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P4", displayTextSuffix: "");
         }
 
         [Fact]
@@ -372,8 +372,8 @@ class Program
 ";
             await VerifyItemIsAbsentAsync(markup, "P1");
             await VerifyItemIsAbsentAsync(markup, "P2");
-            await VerifyItemExistsAsync(markup, "F3", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "F4", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "F3", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "F4", displayTextSuffix: "");
         }
 
         [Fact]
@@ -455,7 +455,7 @@ class Program
 }
 ";
             // VerifyItemExistsAsync also tests with the item typed.
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
             await VerifyItemIsAbsentAsync(markup, "P2");
         }
 
@@ -542,7 +542,7 @@ public class Program
     public void Deconstruct(out Program x, out Program y) => throw null;
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
         }
 
         [Fact]
@@ -562,7 +562,7 @@ public class Program
     public void Deconstruct(out Program x, out Program y) => throw null;
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
         }
 
         [Fact]
@@ -604,7 +604,7 @@ public class Program
     public void Deconstruct(out Program x, out Program y) => throw null;
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
         }
 
         [Fact]
@@ -624,7 +624,7 @@ public class Program
     public void Deconstruct(out Program x, out Program y) => throw null;
 }
 ";
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
         }
 
         [Fact]
@@ -665,8 +665,8 @@ class Program
 }
 ";
             // Ignore browsability limiting attributes if the symbol is declared in source.
-            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: ":");
-            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: ":");
+            await VerifyItemExistsAsync(markup, "P1", displayTextSuffix: "");
+            await VerifyItemExistsAsync(markup, "P2", displayTextSuffix: "");
         }
 
         [Fact]

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -50,10 +50,10 @@ public class C2
                 showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
 
                 state.SendTypeChars(".")
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=False)
 
                 state.SendTypeChars("IP")
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=True)
 
                 state.SendTab()
                 state.SendTypeChars(": 2 }")
@@ -121,10 +121,10 @@ End Class
                 </Workspace>, showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.SendTypeChars(".")
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=False)
 
                 state.SendTypeChars("IP")
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=True)
 
                 state.SendTab()
                 state.SendTypeChars(": 2 }")
@@ -158,10 +158,10 @@ public class C3
                 showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
 
                 state.SendTypeChars(".")
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=False)
 
                 state.SendTypeChars("IP")
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=True)
 
                 state.SendTab()
                 state.SendTypeChars(": 2 }")
@@ -195,16 +195,16 @@ public class C3
                 showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
 
                 state.SendTypeChars(".")
-                Await state.AssertSelectedCompletionItem(displayText:="C3Field:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="C3Field", isHardSelected:=False)
 
                 state.SendTypeChars("CF")
-                Await state.AssertSelectedCompletionItem(displayText:="C3Field:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="C3Field", isHardSelected:=True)
 
                 state.SendTypeChars(".")
-                Await state.AssertSelectedCompletionItem(displayText:="IntField:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="IntField", isHardSelected:=False)
 
                 state.SendTypeChars("IF")
-                Await state.AssertSelectedCompletionItem(displayText:="IntField:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="IntField", isHardSelected:=True)
 
                 state.SendTab()
                 state.SendTypeChars(": 2 }")
@@ -258,17 +258,17 @@ public class C2
                 showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
 
                 state.SendTypeChars("{ ")
-                Await state.AssertSelectedCompletionItem(displayText:="CProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="CProperty", isHardSelected:=False)
 
                 state.SendTypeChars("CP")
-                Await state.AssertSelectedCompletionItem(displayText:="CProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="CProperty", isHardSelected:=True)
 
                 state.SendTypeChars(".")
                 Assert.Contains("c is { CProperty.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=False)
 
                 state.SendTypeChars("IP")
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=True)
 
                 state.SendTab()
                 state.SendTypeChars(": 2 }")
@@ -328,18 +328,18 @@ public class C2
                 showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
 
                 state.SendTypeChars(", ")
-                Await state.AssertSelectedCompletionItem(displayText:="CProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="CProperty", isHardSelected:=False)
 
                 state.SendTypeChars("CP")
-                Await state.AssertSelectedCompletionItem(displayText:="CProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="CProperty", isHardSelected:=True)
 
                 state.SendTypeChars(".")
                 Assert.Contains("is { CProperty.IntProperty: 2, CProperty.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 ' Note: same completion is offered a second time
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=False)
 
                 state.SendTypeChars("SP")
-                Await state.AssertSelectedCompletionItem(displayText:="ShortProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="ShortProperty", isHardSelected:=True)
 
                 state.SendTab()
                 state.SendTypeChars(": 3")
@@ -378,10 +378,10 @@ public class C2
                 state.SendTypeChars(".")
                 Assert.Contains("is { CProperty: { IntProperty: 2 }, CProperty.", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 ' Note: same completion is offered a second time
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=False)
 
                 state.SendTypeChars("SP")
-                Await state.AssertSelectedCompletionItem(displayText:="ShortProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="ShortProperty", isHardSelected:=True)
 
                 state.SendTab()
                 state.SendTypeChars(": 3")
@@ -412,10 +412,10 @@ public class C2
                 showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
 
                 state.SendTypeChars(" ")
-                Await state.AssertSelectedCompletionItem(displayText:="CProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="CProperty", isHardSelected:=False)
 
                 state.SendTypeChars("CP")
-                Await state.AssertSelectedCompletionItem(displayText:="CProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="CProperty", isHardSelected:=True)
 
                 state.SendTypeChars(".")
                 Assert.Contains("is { CProperty. CProperty.IntProperty: 2 }", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -452,10 +452,10 @@ public class C2
                 showCompletionInArgumentLists:=showCompletionInArgumentLists, languageVersion:=LanguageVersion.Preview)
 
                 state.SendTypeChars(" ")
-                Await state.AssertSelectedCompletionItem(displayText:="ShortProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="ShortProperty", isHardSelected:=False)
 
                 state.SendTypeChars("SP")
-                Await state.AssertSelectedCompletionItem(displayText:="ShortProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="ShortProperty", isHardSelected:=True)
 
                 state.SendTab()
                 state.SendTypeChars(": 3,")
@@ -1961,13 +1961,13 @@ class Class
                 state.SendTypeChars("C")
                 Await state.AssertSelectedCompletionItem(displayText:="Class", isHardSelected:=True)
                 state.SendTypeChars(" { P")
-                Await state.AssertSelectedCompletionItem(displayText:="Prop", displayTextSuffix:=":", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Prop", displayTextSuffix:="", isHardSelected:=True)
                 state.SendTypeChars(":")
                 Assert.Contains("{ Prop:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 state.SendTypeChars(" 0, ")
-                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", displayTextSuffix:=":", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", displayTextSuffix:="", isSoftSelected:=True)
                 state.SendTypeChars("O")
-                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", displayTextSuffix:=":", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", displayTextSuffix:="", isHardSelected:=True)
                 state.SendTypeChars(": 1 }")
                 Assert.Contains("is Class { Prop: 0, OtherProp: 1 }", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -1995,15 +1995,15 @@ class Class
                 state.SendTypeChars(" ")
                 Assert.Contains("is Class", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 state.SendTypeChars("{ P")
-                Await state.AssertSelectedCompletionItem(displayText:="Prop", displayTextSuffix:=":", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Prop", displayTextSuffix:="", isHardSelected:=True)
                 state.SendTypeChars(" ")
                 Assert.Contains("is Class { Prop ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 state.SendTypeChars(":")
                 Assert.Contains("is Class { Prop :", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 state.SendTypeChars(" 0, ")
-                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", displayTextSuffix:=":", isSoftSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", displayTextSuffix:="", isSoftSelected:=True)
                 state.SendTypeChars("O")
-                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", displayTextSuffix:=":", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="OtherProp", displayTextSuffix:="", isHardSelected:=True)
                 state.SendTypeChars(" ")
                 Assert.Contains("is Class { Prop : 0, OtherProp", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 state.SendTypeChars(": 1 }")

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -9428,10 +9428,10 @@ public class C
                 Await state.AssertSelectedCompletionItem(displayText:="async", isHardSelected:=False)
 
                 state.SendTypeChars("{ ")
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=False)
 
                 state.SendTypeChars("IP")
-                Await state.AssertSelectedCompletionItem(displayText:="IntProperty:", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="IntProperty", isHardSelected:=True)
 
                 state.SendTab()
                 state.SendTypeChars(": 1")

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PropertySubPatternCompletionProvider.cs
@@ -83,10 +83,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
             foreach (var member in members)
             {
-                const string ColonString = ":";
                 context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
                     displayText: member.Name.EscapeIdentifier(),
-                    displayTextSuffix: ColonString,
+                    displayTextSuffix: "",
                     insertionText: null,
                     symbols: ImmutableArray.Create(member),
                     contextPosition: context.Position,


### PR DESCRIPTION
This made sense before extended property patterns. But now that a property can be followed by "." it doesn't make sense to show ":".

cc @alrz