### PR TITLE
Set OutputEncoding to UTF8

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -792,6 +792,8 @@ namespace Microsoft.CodeAnalysis
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            Console.OutputEncoding = Encoding.UTF8;
+
             if (Arguments.DisplayVersion)
             {
                 PrintVersion(consoleOutput);


### PR DESCRIPTION
First try in the following image was with a dummy change to a resource to use a UTF 8 character but without setting `OutputEncoding`

Second try in the image is after I set `OutputEncoding`

![image](https://user-images.githubusercontent.com/31348972/150687204-03696c07-feb0-48a6-a7e2-0c2a2d11c341.png)

Fixes https://github.com/dotnet/roslyn/issues/58994
PR #41095 can be closed after this change.

I can't find a way to test this other than the manual test I performed.