### PR TITLE
Fix Roslyn Diagnostic Window and add Workspace panel

### DIFF
--- a/src/Test/Diagnostics/PerfMargin/ActivityLevel.cs
+++ b/src/Test/Diagnostics/PerfMargin/ActivityLevel.cs
@@ -6,11 +6,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.Internal.Log;
-using Roslyn.Utilities;
 
 namespace Roslyn.Hosting.Diagnostics.PerfMargin
 {
@@ -21,7 +17,7 @@ namespace Roslyn.Hosting.Diagnostics.PerfMargin
     /// middle of an operation.  Features can be grouped into a parent ActivityLevel
     /// which is active when any of its children are active.
     /// </summary>
-    internal class ActivityLevel
+    internal sealed class ActivityLevel
     {
         private int _isActive;
         private readonly List<ActivityLevel> _children;

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/DiagnosticsWindow.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/DiagnosticsWindow.cs
@@ -2,22 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 using System.Windows.Controls;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.Shell;
 using Roslyn.Hosting.Diagnostics.PerfMargin;
-using Roslyn.VisualStudio.DiagnosticsWindow.Telemetry;
+using Roslyn.Utilities;
 
 namespace Roslyn.VisualStudio.DiagnosticsWindow
 {
     [Guid("b2da68d7-fd1c-491a-a9a0-24f597b9f56c")]
-    public class DiagnosticsWindow : ToolWindowPane
+    public sealed class DiagnosticsWindow : ToolWindowPane
     {
+        public VisualStudioWorkspace? Workspace { get; private set; }
+
         /// <summary>
         /// Standard constructor for the tool window.
         /// </summary>
@@ -49,6 +48,12 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow
                 Content = new TelemetryPanel()
             };
 
+            var workspacePanel = new TabItem()
+            {
+                Header = "Workspace",
+                Content = new WorkspacePanel(this)
+            };
+
             var tabControl = new TabControl
             {
                 TabStripPlacement = Dock.Bottom
@@ -56,8 +61,15 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow
 
             tabControl.Items.Add(perfMarginPanel);
             tabControl.Items.Add(telemetryPanel);
+            tabControl.Items.Add(workspacePanel);
 
-            base.Content = tabControl;
+            Content = tabControl;
+        }
+
+        public void Initialize(VisualStudioWorkspace workspace)
+        {
+            Contract.ThrowIfFalse(Workspace == null);
+            Workspace = workspace;
         }
     }
 }

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Panels/TelemetryPanel.xaml
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Panels/TelemetryPanel.xaml
@@ -1,9 +1,8 @@
-﻿<UserControl x:Class="Roslyn.VisualStudio.DiagnosticsWindow.Telemetry.TelemetryPanel"
+﻿<UserControl x:Class="Roslyn.VisualStudio.DiagnosticsWindow.TelemetryPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Roslyn.VisualStudio.DiagnosticsWindow.Telemetry"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Panels/TelemetryPanel.xaml.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Panels/TelemetryPanel.xaml.cs
@@ -17,7 +17,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 
-namespace Roslyn.VisualStudio.DiagnosticsWindow.Telemetry
+namespace Roslyn.VisualStudio.DiagnosticsWindow
 {
     /// <summary>
     /// Interaction logic for TelemetryPanel.xaml

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Panels/WorkspacePanel.xaml
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Panels/WorkspacePanel.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl x:Class="Roslyn.VisualStudio.DiagnosticsWindow.WorkspacePanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Visible" >
+            <StackPanel Orientation="Vertical" >
+                <ProgressBar x:Name="GenerationProgresBar" IsIndeterminate="False" />
+                <TextBox x:Name="Result" IsReadOnly="True" TextWrapping="Wrap" />
+            </StackPanel>
+        </ScrollViewer>
+        <StackPanel Grid.Row="1" Orientation="Horizontal">
+            <Button Content="Diagnose" x:Name="DiagnoseButton" Click="OnDiagnose"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Panels/WorkspacePanel.xaml.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/Panels/WorkspacePanel.xaml.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+namespace Roslyn.VisualStudio.DiagnosticsWindow
+{
+    /// <summary>
+    /// Interaction logic for TelemetryPanel.xaml
+    /// </summary>
+    public sealed partial class WorkspacePanel : UserControl
+    {
+        private readonly DiagnosticsWindow _window;
+
+        public WorkspacePanel(DiagnosticsWindow window)
+        {
+            _window = window;
+            InitializeComponent();
+        }
+
+        private void OnDiagnose(object sender, RoutedEventArgs e)
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                DiagnoseButton.IsEnabled = false;
+                GenerationProgresBar.IsIndeterminate = true;
+                Result.Text = "Comparing in-proc solution snapshot with files on disk ...";
+
+                await TaskScheduler.Default;
+
+                string text;
+                try
+                {
+                    text = await DiagnoseAsync(CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    text = e.ToString();
+                }
+
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                GenerationProgresBar.IsIndeterminate = false;
+                DiagnoseButton.IsEnabled = true;
+                Result.Text = text;
+            });
+        }
+
+        private async Task<string> DiagnoseAsync(CancellationToken cancellationToken)
+        {
+            var workspace = _window.Workspace;
+            if (workspace == null)
+            {
+                return "Workspace unavailable";
+            }
+
+            var output = new StringBuilder();
+            await CompareClosedDocumentsWithFileSystemAsync(workspace, output, cancellationToken).ConfigureAwait(false);
+            return output.ToString();
+        }
+
+        private static async Task CompareClosedDocumentsWithFileSystemAsync(Workspace workspace, StringBuilder output, CancellationToken cancellationToken)
+        {
+            var solution = workspace.CurrentSolution;
+            var outOfDateCount = 0;
+            var gate = new object();
+
+            var tasks = from project in solution.Projects
+                        from document in project.Documents
+                        where document.FilePath != null
+                        where !workspace.IsDocumentOpen(document.Id)
+                        select CompareDocumentAsync(document);
+
+            async Task CompareDocumentAsync(Document document)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var snapshotText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var snapshotChecksum = snapshotText.GetChecksum();
+
+                using var fileStream = File.OpenRead(document.FilePath);
+                var fileText = SourceText.From(fileStream, snapshotText.Encoding, snapshotText.ChecksumAlgorithm);
+                var fileChecksum = fileText.GetChecksum();
+
+                if (!fileChecksum.SequenceEqual(snapshotChecksum))
+                {
+                    lock (gate)
+                    {
+                        output.AppendLine($"{document.FilePath}: {BitConverter.ToString(snapshotChecksum.ToArray())} : {BitConverter.ToString(fileChecksum.ToArray())}");
+                        outOfDateCount++;
+                    }
+                }
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            output.AppendLine(outOfDateCount == 0 ?
+                "All closed documents up to date." :
+                $"{Environment.NewLine}{outOfDateCount} documents out of date.");
+        }
+    }
+}

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/VisualStudioDiagnosticsWindowPackage.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/VisualStudioDiagnosticsWindowPackage.cs
@@ -33,11 +33,13 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow
     [ProvideOptionPage(typeof(PerformanceFunctionIdPage), @"Roslyn\Performance", @"FunctionId", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true, SupportsProfiles = false)]
     [ProvideOptionPage(typeof(PerformanceLoggersPage), @"Roslyn\Performance", @"Loggers", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true, SupportsProfiles = false)]
     [ProvideOptionPage(typeof(InternalDiagnosticsPage), @"Roslyn\Diagnostics", @"Internal", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true, SupportsProfiles = false)]
+    [ProvideToolWindow(typeof(DiagnosticsWindow))]
     [Guid(GuidList.guidVisualStudioDiagnosticsWindowPkgString)]
     [Description("Roslyn Diagnostics Window")]
     public sealed class VisualStudioDiagnosticsWindowPackage : AsyncPackage
     {
         private IThreadingContext _threadingContext;
+        private VisualStudioWorkspace _workspace;
 
         /// <summary>
         /// This function is called when the user clicks the menu item that shows the 
@@ -50,7 +52,8 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow
 
             JoinableTaskFactory.RunAsync(async () =>
             {
-                await ShowToolWindowAsync(typeof(DiagnosticsWindow), id: 0, create: true, this.DisposalToken).ConfigureAwait(true);
+                var window = (DiagnosticsWindow)await ShowToolWindowAsync(typeof(DiagnosticsWindow), id: 0, create: true, this.DisposalToken).ConfigureAwait(true);
+                window.Initialize(_workspace);
             });
         }
 
@@ -78,8 +81,8 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow
 
             _threadingContext = componentModel.GetService<IThreadingContext>();
 
-            var workspace = componentModel.GetService<VisualStudioWorkspace>();
-            _ = new ForceLowMemoryMode(workspace.Services.GetService<IOptionService>());
+            _workspace = componentModel.GetService<VisualStudioWorkspace>();
+            _ = new ForceLowMemoryMode(_workspace.Services.GetService<IOptionService>());
 
             // Add our command handlers for menu (commands must exist in the .vsct file)
             if (menuCommandService is OleMenuCommandService mcs)
@@ -92,7 +95,7 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow
 
             // set logger at start up
             var globalOptions = componentModel.GetService<IGlobalOptionService>();
-            PerformanceLoggersPage.SetLoggers(globalOptions, _threadingContext, workspace.Services);
+            PerformanceLoggersPage.SetLoggers(globalOptions, _threadingContext, _workspace.Services);
         }
         #endregion
 


### PR DESCRIPTION
A couple of issues:
- ProvideToolWindow attribute was missing
- PerfMargin.DataModel was incorrectly indexing into array