### PR TITLE
Do not hardcode position at which named arguments are starting for well-known attributes.

### DIFF
--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -13718,5 +13718,77 @@ public class C
                 Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "this[..]").WithArguments("C.this[System.Range].get", "error").WithLocation(27, 13)
                 );
         }
+
+        [Fact]
+        [WorkItem(59003, "https://github.com/dotnet/roslyn/issues/59003")]
+        public void ErrorInPropertyValue_01()
+        {
+            var source = @"
+class C
+{
+    public int Count
+    {
+        [System.Runtime.CompilerServices.MethodImpl(MethodCodeType = System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        get;
+        private set;
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,53): error CS0599: Invalid value for named attribute argument 'MethodCodeType'
+                //         [System.Runtime.CompilerServices.MethodImpl(MethodCodeType = System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                Diagnostic(ErrorCode.ERR_InvalidNamedArgument, "MethodCodeType = System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining").WithArguments("MethodCodeType").WithLocation(6, 53),
+                // (6,70): error CS0266: Cannot implicitly convert type 'System.Runtime.CompilerServices.MethodImplOptions' to 'System.Runtime.CompilerServices.MethodCodeType'. An explicit conversion exists (are you missing a cast?)
+                //         [System.Runtime.CompilerServices.MethodImpl(MethodCodeType = System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining").WithArguments("System.Runtime.CompilerServices.MethodImplOptions", "System.Runtime.CompilerServices.MethodCodeType").WithLocation(6, 70)
+                );
+        }
+
+        [Fact]
+        [WorkItem(59003, "https://github.com/dotnet/roslyn/issues/59003")]
+        public void ErrorInPropertyValue_02()
+        {
+            var source = @"
+class C
+{
+    public int Count
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.Synchronized, MethodCodeType = (System.Runtime.CompilerServices.MethodCodeType)System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        get;
+        private set;
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,117): error CS0599: Invalid value for named attribute argument 'MethodCodeType'
+                //         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.Synchronized, MethodCodeType = (System.Runtime.CompilerServices.MethodCodeType)System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                Diagnostic(ErrorCode.ERR_InvalidNamedArgument, "MethodCodeType = (System.Runtime.CompilerServices.MethodCodeType)System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining").WithArguments("MethodCodeType").WithLocation(6, 117)
+                );
+        }
+
+        [Fact]
+        public void ErrorInPropertyValue_03()
+        {
+            var source = @"
+using System.Runtime.InteropServices; 
+
+[StructLayout(CharSet=0)]
+public struct S1 { }
+
+[StructLayout(LayoutKind.Sequential, CharSet=0)]
+public struct S2 { }
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,2): error CS1729: 'StructLayoutAttribute' does not contain a constructor that takes 0 arguments
+                // [StructLayout(CharSet=0)]
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "StructLayout(CharSet=0)").WithArguments("System.Runtime.InteropServices.StructLayoutAttribute", "0").WithLocation(4, 2),
+                // (7,38): error CS0599: Invalid value for named attribute argument 'CharSet'
+                // [StructLayout(LayoutKind.Sequential, CharSet=0)]
+                Diagnostic(ErrorCode.ERR_InvalidNamedArgument, "CharSet=0").WithArguments("CharSet").WithLocation(7, 38)
+                );
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             MethodImplAttributes codeType = MethodImplAttributes.IL;
-            int position = 1;
+            int position = attribute.CommonConstructorArguments.Length;
             foreach (var namedArg in attribute.CommonNamedArguments)
             {
                 if (namedArg.Key == "MethodCodeType")
@@ -446,7 +446,7 @@ namespace Microsoft.CodeAnalysis
                     break;
             }
 
-            int position = 1;
+            int position = attribute.CommonConstructorArguments.Length;
             foreach (var namedArg in attribute.CommonNamedArguments)
             {
                 switch (namedArg.Key)

--- a/src/Compilers/Core/Portable/Symbols/Attributes/MarshalAsAttributeDecoder.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/MarshalAsAttributeDecoder.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis
             bool hasTypeSymbol = false;
             bool hasErrors = false;
 
-            int position = 1;
+            int position = arguments.Attribute.CommonConstructorArguments.Length;
             foreach (var namedArg in arguments.Attribute.NamedArguments)
             {
                 switch (namedArg.Key)
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert((object)arguments.AttributeSyntaxOpt != null);
 
             int? parameterIndex = null;
-            int position = 1;
+            int position = arguments.Attribute.CommonConstructorArguments.Length;
             bool hasErrors = false;
 
             foreach (var namedArg in arguments.Attribute.NamedArguments)
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis
             short? parameterIndex = null;
             bool hasErrors = false;
 
-            int position = 1;
+            int position = arguments.Attribute.CommonConstructorArguments.Length;
             foreach (var namedArg in arguments.Attribute.NamedArguments)
             {
                 switch (namedArg.Key)
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis
             int symbolIndex = -1;
             bool hasErrors = false;
 
-            int position = 1;
+            int position = arguments.Attribute.CommonConstructorArguments.Length;
             foreach (var namedArg in arguments.Attribute.NamedArguments)
             {
                 switch (namedArg.Key)
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert((object)arguments.AttributeSyntaxOpt != null);
 
             int elementCount = -1;
-            int position = 1;
+            int position = arguments.Attribute.CommonConstructorArguments.Length;
             bool hasErrors = false;
 
             foreach (var namedArg in arguments.Attribute.NamedArguments)

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -6593,5 +6593,88 @@ second",
                         Assert.Equal("transformNames", attribute.AttributeConstructor.Parameters.Single().Name)
                     End Sub)
         End Sub
+
+        <Fact>
+        <WorkItem(59003, "https://github.com/dotnet/roslyn/issues/59003")>
+        Public Sub ErrorInPropertyValue_01()
+            Dim source =
+<compilation>
+    <file><![CDATA[
+class C
+    <System.Runtime.CompilerServices.MethodImpl(MethodCodeType := System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
+    public Function Count() as Integer
+        return 0
+    end function
+end class
+]]>
+    </file>
+</compilation>
+
+            Dim compilation = CreateCompilation(source)
+            compilation.AssertTheseDiagnostics(
+<expected><![CDATA[
+BC30127: Attribute 'MethodImplAttribute' is not valid: Incorrect argument value.
+    <System.Runtime.CompilerServices.MethodImpl(MethodCodeType := System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
+                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>
+            )
+        End Sub
+
+        <Fact>
+        <WorkItem(59003, "https://github.com/dotnet/roslyn/issues/59003")>
+        Public Sub ErrorInPropertyValue_02()
+            Dim source =
+<compilation>
+    <file><![CDATA[
+class C
+    <System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.Synchronized, MethodCodeType := System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
+    public Function Count() as Integer
+        return 0
+    end function
+end class
+]]>
+    </file>
+</compilation>
+
+            Dim compilation = CreateCompilation(source)
+            compilation.AssertTheseDiagnostics(
+<expected><![CDATA[
+BC30127: Attribute 'MethodImplAttribute' is not valid: Incorrect argument value.
+    <System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.Synchronized, MethodCodeType := System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
+                                                                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></expected>
+            )
+        End Sub
+
+        <Fact()>
+        Public Sub ErrorInPropertyValue_03()
+            Dim source =
+<compilation>
+    <file><![CDATA[
+Imports System.Runtime.InteropServices
+
+<StructLayout(CharSet:=0)>
+public structure S1
+end structure
+
+<StructLayout(LayoutKind.Sequential, CharSet:=0)>
+public structure S2
+end structure
+]]>
+    </file>
+</compilation>
+
+            Dim compilation = CreateCompilation(source)
+            compilation.AssertTheseDiagnostics(
+<expected><![CDATA[
+BC30516: Overload resolution failed because no accessible 'New' accepts this number of arguments.
+<StructLayout(CharSet:=0)>
+ ~~~~~~~~~~~~
+BC30127: Attribute 'StructLayoutAttribute' is not valid: Incorrect argument value.
+<StructLayout(LayoutKind.Sequential, CharSet:=0)>
+                                     ~~~~~~~~~~
+]]></expected>
+            )
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #59003.