### PR TITLE
Avoid duplicate syntax node callbacks for CompilationUnitSyntax nodes…

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -2531,12 +2531,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override bool ShouldSkipSyntaxNodeAnalysis(SyntaxNode node, ISymbol containingSymbol)
         {
-            // Skip the topmost record declaration syntax node when analyzing synthesized record declaration constructor
-            // to avoid duplicate syntax node callbacks.
-            // We will analyze this node when analyzing the record declaration type symbol.
-            if (node is RecordDeclarationSyntax && containingSymbol.Kind is SymbolKind.Method)
+            if (containingSymbol.Kind is SymbolKind.Method)
             {
-                return true;
+                switch (node)
+                {
+                    case RecordDeclarationSyntax:
+                        // Skip the topmost record declaration syntax node when analyzing synthesized record declaration constructor
+                        // to avoid duplicate syntax node callbacks.
+                        // We will analyze this node when analyzing the record declaration type symbol.
+                        return true;
+
+                    case CompilationUnitSyntax:
+                        // Skip compilation unit syntax node when analyzing synthesized top level entry point method
+                        // to avoid duplicate syntax node callbacks.
+                        // We will analyze this node when analyzing the global namespace symbol.
+                        return true;
+                }
             }
 
             return false;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TopLevelStatementsTests.cs
@@ -6374,8 +6374,6 @@ class B : A
             Assert.Equal(0, analyzer.FireCount2);
             Assert.Equal(1, analyzer.FireCount3);
             Assert.Equal(0, analyzer.FireCount4);
-            Assert.Equal(1, analyzer.FireCount5);
-            Assert.Equal(0, analyzer.FireCount6);
 
             var text2 = @"System.Console.WriteLine(2);";
 
@@ -6387,8 +6385,6 @@ class B : A
             Assert.Equal(1, analyzer.FireCount2);
             Assert.Equal(1, analyzer.FireCount3);
             Assert.Equal(1, analyzer.FireCount4);
-            Assert.Equal(1, analyzer.FireCount5);
-            Assert.Equal(1, analyzer.FireCount6);
         }
 
         private class AnalyzerActions_01_Analyzer : DiagnosticAnalyzer
@@ -6397,8 +6393,6 @@ class B : A
             public int FireCount2;
             public int FireCount3;
             public int FireCount4;
-            public int FireCount5;
-            public int FireCount6;
 
             private static readonly DiagnosticDescriptor Descriptor =
                new DiagnosticDescriptor("XY0000", "Test", "Test", "Test", DiagnosticSeverity.Warning, true, "Test", "Test");
@@ -6451,10 +6445,10 @@ class B : A
                 switch (unit.ToString())
                 {
                     case "System.Console.WriteLine(1);":
-                        Interlocked.Increment(ref context.ContainingSymbol.Kind == SymbolKind.Namespace ? ref FireCount5 : ref FireCount3);
+                        Interlocked.Increment(ref FireCount3);
                         break;
                     case "System.Console.WriteLine(2);":
-                        Interlocked.Increment(ref context.ContainingSymbol.Kind == SymbolKind.Namespace ? ref FireCount6 : ref FireCount4);
+                        Interlocked.Increment(ref FireCount4);
                         break;
                     default:
                         Assert.True(false);
@@ -6463,16 +6457,6 @@ class B : A
 
                 switch (context.ContainingSymbol.ToTestDisplayString())
                 {
-                    case "<top-level-statements-entry-point>":
-                        Assert.Same(unit.SyntaxTree, context.ContainingSymbol.DeclaringSyntaxReferences.Single().SyntaxTree);
-                        Assert.True(syntaxTreeModel.TestOnlyMemberModels.ContainsKey(unit));
-
-                        MemberSemanticModel mm = syntaxTreeModel.TestOnlyMemberModels[unit];
-
-                        Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(unit).IsDefaultOrEmpty);
-
-                        Assert.Same(mm, syntaxTreeModel.GetMemberModel(unit));
-                        break;
                     case "<global namespace>":
                         break;
                     default:
@@ -7022,7 +7006,6 @@ class Test
             Assert.Equal(1, analyzer.FireCount1);
             Assert.Equal(1, analyzer.FireCount2);
             Assert.Equal(1, analyzer.FireCount3);
-            Assert.Equal(1, analyzer.FireCount4);
 
             analyzer = new AnalyzerActions_09_Analyzer();
             comp = CreateCompilation(new[] { text1, text2 }, options: TestOptions.DebugExe, parseOptions: DefaultParseOptions);
@@ -7030,8 +7013,7 @@ class Test
 
             Assert.Equal(1, analyzer.FireCount1);
             Assert.Equal(1, analyzer.FireCount2);
-            Assert.Equal(1, analyzer.FireCount3);
-            Assert.Equal(2, analyzer.FireCount4);
+            Assert.Equal(2, analyzer.FireCount3);
         }
 
         private class AnalyzerActions_09_Analyzer : DiagnosticAnalyzer
@@ -7039,7 +7021,6 @@ class Test
             public int FireCount1;
             public int FireCount2;
             public int FireCount3;
-            public int FireCount4;
 
             private static readonly DiagnosticDescriptor Descriptor =
                new DiagnosticDescriptor("XY0000", "Test", "Test", "Test", DiagnosticSeverity.Warning, true, "Test", "Test");
@@ -7095,20 +7076,8 @@ class Test
 
                 switch (context.ContainingSymbol.ToTestDisplayString())
                 {
-                    case @"<top-level-statements-entry-point>":
-                        Interlocked.Increment(ref FireCount3);
-
-                        Assert.True(syntaxTreeModel.TestOnlyMemberModels.ContainsKey(node));
-
-                        MemberSemanticModel mm = syntaxTreeModel.TestOnlyMemberModels[node];
-
-                        Assert.False(mm.TestOnlyTryGetBoundNodesFromMap(node).IsDefaultOrEmpty);
-
-                        Assert.Same(mm, syntaxTreeModel.GetMemberModel(node));
-                        break;
-
                     case "<global namespace>":
-                        Interlocked.Increment(ref FireCount4);
+                        Interlocked.Increment(ref FireCount3);
                         break;
 
                     default:
@@ -7151,7 +7120,6 @@ class MyAttribute : System.Attribute
             Assert.Equal(1, analyzer.FireCount2);
             Assert.Equal(1, analyzer.FireCount3);
             Assert.Equal(1, analyzer.FireCount4);
-            Assert.Equal(1, analyzer.FireCount5);
 
             analyzer = new AnalyzerActions_10_Analyzer();
             comp = CreateCompilation(new[] { text1, text2, text3 }, options: TestOptions.DebugExe, parseOptions: DefaultParseOptions);
@@ -7160,8 +7128,7 @@ class MyAttribute : System.Attribute
             Assert.Equal(1, analyzer.FireCount1);
             Assert.Equal(1, analyzer.FireCount2);
             Assert.Equal(1, analyzer.FireCount3);
-            Assert.Equal(1, analyzer.FireCount4);
-            Assert.Equal(3, analyzer.FireCount5);
+            Assert.Equal(3, analyzer.FireCount4);
         }
 
         private class AnalyzerActions_10_Analyzer : DiagnosticAnalyzer
@@ -7170,7 +7137,6 @@ class MyAttribute : System.Attribute
             public int FireCount2;
             public int FireCount3;
             public int FireCount4;
-            public int FireCount5;
 
             private static readonly DiagnosticDescriptor Descriptor =
                new DiagnosticDescriptor("XY0000", "Test", "Test", "Test", DiagnosticSeverity.Warning, true, "Test", "Test");
@@ -7215,12 +7181,8 @@ class MyAttribute : System.Attribute
             {
                 switch (context.ContainingSymbol.ToTestDisplayString())
                 {
-                    case @"<top-level-statements-entry-point>":
-                        Interlocked.Increment(ref FireCount4);
-                        break;
-
                     case @"<global namespace>":
-                        Interlocked.Increment(ref FireCount5);
+                        Interlocked.Increment(ref FireCount4);
                         break;
 
                     default:


### PR DESCRIPTION
… for files with top level statements

Fixes #58561
Follow-up change to #58482