### PR TITLE
Fix "merge main-vs-deps" task in official build

### DIFF
--- a/scripts/merge-vs-deps.ps1
+++ b/scripts/merge-vs-deps.ps1
@@ -15,6 +15,6 @@ else {
 
 if (-not $?)
 {
-    Write-Host "##vso[task.logissue type=error]Failed to merge main-vs-deps into source branch"
+    Write-Host "##vso[task.logissue type=warning]Unable to merge main-vs-deps into the source branch. This could mean that main-vs-deps doesn't exist or could indicate a network issue."
     exit 1
 }

--- a/scripts/merge-vs-deps.ps1
+++ b/scripts/merge-vs-deps.ps1
@@ -16,5 +16,4 @@ else {
 if (-not $?)
 {
     Write-Host "##vso[task.logissue type=warning]Unable to merge main-vs-deps into the source branch. This could mean that main-vs-deps doesn't exist or could indicate a network issue."
-    exit 1
 }


### PR DESCRIPTION
This just broke now since we deleted the main-vs-deps branch in the internal mirror. cc @joerobich

Internal build links (edit: oops, these actually aren't meaningful, since the behavior depends on branch name.):
f97ad50cfe82d7bc72d794e70f68928fb7858fd8 - https://dev.azure.com/dnceng/internal/_build/results?buildId=1571372&view=results
4624e5d0f5056ae3b0932c944e8d293155ddf00d - https://dev.azure.com/dnceng/internal/_build/results?buildId=1571379&view=results

Perhaps once we get one past this task, we should just merge.

Should we add steps about the internal repo to the [-vs-deps internal documentation](https://microsoft.sharepoint.com/teams/managedlanguages/_layouts/OneNote.aspx?id=%2Fteams%2Fmanagedlanguages%2Ffiles%2FTeam%20Notebook%2FRoslyn%20Team%20Notebook%20-%20New&wd=target%28Infrastructure.one%7C0E3C75FE-0827-41BF-9696-F5CD7105BC9A%2FVS-Deps%7CE61C822B-5A08-3E40-8E09-94DC264294FD%2F%29)?

