### PR TITLE
Add explicit exit to merge-vs-deps script

### DIFF
--- a/scripts/merge-vs-deps.ps1
+++ b/scripts/merge-vs-deps.ps1
@@ -16,4 +16,5 @@ else {
 if (-not $?)
 {
     Write-Host "##vso[task.logissue type=warning]Unable to merge main-vs-deps into the source branch. This could mean that main-vs-deps doesn't exist or could indicate a network issue."
+    exit 0
 }


### PR DESCRIPTION
It turns out the last PR #59058 didn't fix the official build. Would like to try this for expediency.