### PR TITLE
Make CompletionOptions global

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/LoadDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/LoadDirectiveCompletionProviderTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
@@ -79,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
             using var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features);
             var provider = workspace.ExportProvider.GetExports<CompletionProvider, CompletionProviderMetadata>().Single(p => p.Metadata.Language == LanguageNames.CSharp && p.Metadata.Name == nameof(LoadDirectiveCompletionProvider)).Value;
             var languageServices = workspace.Services.GetLanguageServices(LanguageNames.CSharp);
-            Assert.Equal(expectedResult, provider.ShouldTriggerCompletion(languageServices, SourceText.From(text), position, trigger: default, CompletionOptions.Default));
+            Assert.Equal(expectedResult, provider.ShouldTriggerCompletion(languageServices, SourceText.From(text), position, trigger: default, CompletionOptions.Default, OptionValueSet.Empty));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ReferenceDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ReferenceDirectiveCompletionProviderTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
             using var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features);
             var provider = workspace.ExportProvider.GetExports<CompletionProvider, CompletionProviderMetadata>().Single(p => p.Metadata.Language == LanguageNames.CSharp && p.Metadata.Name == nameof(ReferenceDirectiveCompletionProvider)).Value;
             var languageServices = workspace.Services.GetLanguageServices(LanguageNames.CSharp);
-            Assert.Equal(expectedResult, provider.ShouldTriggerCompletion(languageServices, SourceText.From(text), position, trigger: default, CompletionOptions.Default));
+            Assert.Equal(expectedResult, provider.ShouldTriggerCompletion(languageServices, SourceText.From(text), position, trigger: default, CompletionOptions.Default, OptionValueSet.Empty));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests_NoInteractive.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests_NoInteractive.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Microsoft.VisualStudio.Text;
@@ -338,7 +339,7 @@ class C
             var service = CompletionService.GetService(document);
             var options = CompletionOptions.Default;
             var displayOptions = SymbolDescriptionOptions.Default;
-            var completions = await service.GetCompletionsAsync(document, position, options);
+            var completions = await service.GetCompletionsAsync(document, position, options, OptionValueSet.Empty);
 
             var item = completions.Items.First(i => i.DisplayText == "Beep");
             var edit = testDocument.GetTextBuffer().CreateEdit();

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion
         /// Ensure that 3rd party can set options on solution and access them from within a custom completion provider.
         /// </summary>
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task PassthroughOptions1()
+        public async Task PassThroughOptions1()
         {
             using var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features.AddParts(typeof(ThirdPartyCompletionProvider)));
 
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion
         /// Ensure that 3rd party can set options on solution and access them from within a custom completion provider.
         /// </summary>
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task PassthroughOptions2()
+        public async Task PassThroughOptions2()
         {
             using var workspace = new TestWorkspace(composition: EditorTestCompositions.EditorFeatures.AddParts(typeof(ThirdPartyCompletionProvider)));
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
@@ -42,7 +42,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion
             Assert.NotNull(service);
         }
 
-
         [ExportCompletionProvider(nameof(ThirdPartyCompletionProvider), LanguageNames.CSharp)]
         [ExtensionOrder(After = nameof(KeywordCompletionProvider))]
         [Shared]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
@@ -4,10 +4,18 @@
 
 #nullable disable
 
+using System;
+using System.Collections.Immutable;
+using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -32,6 +40,90 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion
 
             var service = CompletionService.GetService(document);
             Assert.NotNull(service);
+        }
+
+
+        [ExportCompletionProvider(nameof(ThirdPartyCompletionProvider), LanguageNames.CSharp)]
+        [ExtensionOrder(After = nameof(KeywordCompletionProvider))]
+        [Shared]
+        private sealed class ThirdPartyCompletionProvider : CompletionProvider
+        {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public ThirdPartyCompletionProvider()
+            {
+            }
+
+            public override Task ProvideCompletionsAsync(CompletionContext context)
+                => Task.CompletedTask;
+
+            public override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
+            {
+                Assert.Equal(1, options.GetOption(new OptionKey(ThirdPartyOption.Instance, LanguageNames.CSharp)));
+                return true;
+            }
+        }
+
+        private sealed class ThirdPartyOption : IOption
+        {
+            public static ThirdPartyOption Instance = new();
+
+            public string Feature => "TestOptions";
+            public string Name => "Option";
+            public Type Type => typeof(int);
+            public object DefaultValue => 0;
+            public bool IsPerLanguage => true;
+            public ImmutableArray<OptionStorageLocation> StorageLocations => ImmutableArray<OptionStorageLocation>.Empty;
+        }
+
+        /// <summary>
+        /// Ensure that 3rd party can set options on solution and access them from within a custom completion provider.
+        /// </summary>
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PassthroughOptions1()
+        {
+            using var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features.AddParts(typeof(ThirdPartyCompletionProvider)));
+
+            var text = SourceText.From("class C { }");
+
+            var document = workspace.CurrentSolution
+                .AddProject("TestProject", "Assembly", LanguageNames.CSharp)
+                .AddDocument("TestDocument.cs", text);
+
+            var service = CompletionService.GetService(document);
+            var options = new OptionValueSet(ImmutableDictionary<OptionKey, object>.Empty.Add(new OptionKey(ThirdPartyOption.Instance, LanguageNames.CSharp), 1));
+            service.ShouldTriggerCompletion(text, 1, CompletionTrigger.Invoke, options: options);
+
+#pragma warning disable RS0030 // Do not used banned APIs
+            await service.GetCompletionsAsync(document, 1, CompletionTrigger.Invoke, options: options);
+#pragma warning restore
+        }
+
+        /// <summary>
+        /// Ensure that 3rd party can set options on solution and access them from within a custom completion provider.
+        /// </summary>
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PassthroughOptions2()
+        {
+            using var workspace = new TestWorkspace(composition: EditorTestCompositions.EditorFeatures.AddParts(typeof(ThirdPartyCompletionProvider)));
+
+            var testDocument = new TestHostDocument("class C {}");
+            var project = new TestHostProject(workspace, testDocument, name: "project1");
+            workspace.AddTestProject(project);
+            workspace.OpenDocument(testDocument.Id);
+
+            Assert.True(workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(
+                workspace.CurrentSolution.Options.WithChangedOption(new OptionKey(ThirdPartyOption.Instance, LanguageNames.CSharp), 1))));
+
+            var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
+            var text = await document.GetTextAsync();
+
+            var service = CompletionService.GetService(document);
+            service.ShouldTriggerCompletion(text, 1, CompletionTrigger.Invoke, options: null);
+
+#pragma warning disable RS0030 // Do not used banned APIs
+            await service.GetCompletionsAsync(document, 1, CompletionTrigger.Invoke, options: null);
+#pragma warning restore
         }
 
         [Theory, CombinatorialData]
@@ -61,7 +153,7 @@ namespace N
             Assert.True(workspace.SetCurrentSolution(_ => project.Solution, WorkspaceChangeKind.SolutionChanged));
 
             var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
-            var compeltionService = document.GetLanguageService<CompletionService>();
+            var completionService = document.GetLanguageService<CompletionService>();
 
             Assert.Equal(0, generatorRanCount);
 
@@ -74,7 +166,7 @@ namespace N
 
             // We want to make sure import completion providers are also participating.
             var options = CompletionOptions.Default with { ShowItemsFromUnimportedNamespaces = true };
-            var completionList = await compeltionService.GetCompletionsAsync(document, position.Value, options: options);
+            var completionList = await completionService.GetCompletionsAsync(document, position.Value, options, OptionValueSet.Empty);
 
             // We expect completion to run on frozen partial semantic, which won't run source generator.
             Assert.Equal(0, generatorRanCount);

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
@@ -73,9 +73,8 @@ namespace N
             }
 
             // We want to make sure import completion providers are also participating.
-            var options = CompletionOptions.From(document.Project.Solution.Options, document.Project.Language);
-            var newOptions = options with { ShowItemsFromUnimportedNamespaces = true };
-            var completionList = await compeltionService.GetCompletionsAsync(document, position.Value, options: newOptions);
+            var options = CompletionOptions.Default with { ShowItemsFromUnimportedNamespaces = true };
+            var completionList = await compeltionService.GetCompletionsAsync(document, position.Value, options: options);
 
             // We expect completion to run on frozen partial semantic, which won't run source generator.
             Assert.Equal(0, generatorRanCount);

--- a/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_ComputeModel.cs
@@ -5,17 +5,15 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SignatureHelp;
 using Microsoft.CodeAnalysis.Text;
@@ -86,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                             }
                         }
 
-                        var options = SignatureHelpOptions.From(document.Project);
+                        var options = SignatureHelpOptions.From(Controller.GlobalOptions, document.Project.Language);
 
                         // first try to query the providers that can trigger on the specified character
                         var (provider, items) = await ComputeItemsAsync(

--- a/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_ComputeModel.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                             }
                         }
 
-                        var options = SignatureHelpOptions.From(Controller.GlobalOptions, document.Project.Language);
+                        var options = Controller.GlobalOptions.GetSignatureHelpOptions(document.Project.Language);
 
                         // first try to query the providers that can trigger on the specified character
                         var (provider, items) = await ComputeItemsAsync(

--- a/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.cs
+++ b/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SignatureHelp;
 using Microsoft.CodeAnalysis.Text;
@@ -37,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
         public string DisplayName => EditorFeaturesResources.Signature_Help;
 
         public Controller(
+            IGlobalOptionService globalOptions,
             IThreadingContext threadingContext,
             ITextView textView,
             ITextBuffer subjectBuffer,
@@ -45,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             IDocumentProvider documentProvider,
             IList<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> allProviders,
             IAsyncCompletionBroker completionBroker)
-            : base(threadingContext, textView, subjectBuffer, presenter, asyncListener, documentProvider, "SignatureHelp")
+            : base(globalOptions, threadingContext, textView, subjectBuffer, presenter, asyncListener, documentProvider, "SignatureHelp")
         {
             _completionBroker = completionBroker;
             _allProviders = allProviders;
@@ -53,6 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 
         // For testing purposes.
         internal Controller(
+            IGlobalOptionService globalOptions,
             IThreadingContext threadingContext,
             ITextView textView,
             ITextBuffer subjectBuffer,
@@ -61,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             IDocumentProvider documentProvider,
             IList<ISignatureHelpProvider> providers,
             IAsyncCompletionBroker completionBroker)
-            : base(threadingContext, textView, subjectBuffer, presenter, asyncListener, documentProvider, "SignatureHelp")
+            : base(globalOptions, threadingContext, textView, subjectBuffer, presenter, asyncListener, documentProvider, "SignatureHelp")
         {
             _providers = providers.ToImmutableArray();
             _completionBroker = completionBroker;

--- a/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 var workspace = document.Project.Solution.Workspace;
                 var supportsFeatureService = workspace.Services.GetRequiredService<ITextBufferSupportsFeatureService>();
 
-                var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: false);
+                var options = CodeActionOptionsFactory.GetCodeActionOptions(GlobalOptions, document.Project.Language, isBlocking: false);
 
                 var fixesTask = GetCodeFixesAsync(
                     state, supportsFeatureService, requestedActionCategories, workspace, document, range,

--- a/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 var workspace = document.Project.Solution.Workspace;
                 var supportsFeatureService = workspace.Services.GetRequiredService<ITextBufferSupportsFeatureService>();
 
-                var options = CodeActionOptionsFactory.GetCodeActionOptions(GlobalOptions, document.Project.Language, isBlocking: false);
+                var options = GlobalOptions.GetCodeActionOptions(document.Project.Language, isBlocking: false);
 
                 var fixesTask = GetCodeFixesAsync(
                     state, supportsFeatureService, requestedActionCategories, workspace, document, range,

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     Func<string, IDisposable?> addOperationScope =
                         description => operationContext?.AddScope(allowCancellation: true, string.Format(EditorFeaturesResources.Gathering_Suggestions_0, description));
 
-                    var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: true);
+                    var options = CodeActionOptionsFactory.GetCodeActionOptions(GlobalOptions, document.Project.Language, isBlocking: true);
 
                     // We convert the code fixes and refactorings to UnifiedSuggestedActionSets instead of
                     // SuggestedActionSets so that we can share logic between local Roslyn and LSP.
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (document == null)
                     return null;
 
-                var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: false);
+                var options = CodeActionOptionsFactory.GetCodeActionOptions(GlobalOptions, document.Project.Language, isBlocking: false);
 
                 using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var linkedToken = linkedTokenSource.Token;

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     Func<string, IDisposable?> addOperationScope =
                         description => operationContext?.AddScope(allowCancellation: true, string.Format(EditorFeaturesResources.Gathering_Suggestions_0, description));
 
-                    var options = CodeActionOptionsFactory.GetCodeActionOptions(GlobalOptions, document.Project.Language, isBlocking: true);
+                    var options = GlobalOptions.GetCodeActionOptions(document.Project.Language, isBlocking: true);
 
                     // We convert the code fixes and refactorings to UnifiedSuggestedActionSets instead of
                     // SuggestedActionSets so that we can share logic between local Roslyn and LSP.
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (document == null)
                     return null;
 
-                var options = CodeActionOptionsFactory.GetCodeActionOptions(GlobalOptions, document.Project.Language, isBlocking: false);
+                var options = GlobalOptions.GetCodeActionOptions(document.Project.Language, isBlocking: false);
 
                 using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var linkedToken = linkedTokenSource.Token;

--- a/src/EditorFeatures/Core/Implementation/AddImports/AbstractAddImportsPasteCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/AddImports/AbstractAddImportsPasteCommandHandler.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AddImports
                 var placement = await AddImportPlacementOptions.FromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
 
                 var options = new AddMissingImportsOptions(
-                    HideAdvancedMembers: _globalOptions.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language),
+                    HideAdvancedMembers: _globalOptions.GetOption(CompletionOptionsStorage.HideAdvancedMembers, document.Project.Language),
                     placement);
 
                 return await addMissingImportsService.AddMissingImportsAsync(document, textSpan, options, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/AddImports/AbstractAddImportsPasteCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/AddImports/AbstractAddImportsPasteCommandHandler.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AddImports
                 var placement = await AddImportPlacementOptions.FromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
 
                 var options = new AddMissingImportsOptions(
-                    HideAdvancedMembers: document.Project.Solution.Options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language),
+                    HideAdvancedMembers: _globalOptions.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, document.Project.Language),
                     placement);
 
                 return await addMissingImportsService.AddMissingImportsAsync(document, textSpan, options, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsFactory.cs
@@ -3,21 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SymbolSearch;
 
 namespace Microsoft.CodeAnalysis.CodeActions
 {
     internal static class CodeActionOptionsFactory
     {
-        internal static CodeActionOptions GetCodeActionOptions(Project project, bool isBlocking)
-        {
-            var options = project.Solution.Options;
-            var language = project.Language;
-
-            return new(
+        internal static CodeActionOptions GetCodeActionOptions(IGlobalOptionService globalOptions, string language, bool isBlocking)
+            => new(
                 IsBlocking: isBlocking,
-                SearchReferenceAssemblies: options.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, language),
-                HideAdvancedMembers: options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, language));
-        }
+                SearchReferenceAssemblies: globalOptions.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, language),
+                HideAdvancedMembers: globalOptions.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, language));
     }
 }

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsMetadata.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsMetadata.cs
@@ -8,12 +8,12 @@ using Microsoft.CodeAnalysis.SymbolSearch;
 
 namespace Microsoft.CodeAnalysis.CodeActions
 {
-    internal static class CodeActionOptionsFactory
+    internal static class CodeActionOptionsMetadata
     {
-        internal static CodeActionOptions GetCodeActionOptions(IGlobalOptionService globalOptions, string language, bool isBlocking)
+        internal static CodeActionOptions GetCodeActionOptions(this IGlobalOptionService globalOptions, string language, bool isBlocking)
             => new(
                 IsBlocking: isBlocking,
                 SearchReferenceAssemblies: globalOptions.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, language),
-                HideAdvancedMembers: globalOptions.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, language));
+                HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsMetadata.HideAdvancedMembers, language));
     }
 }

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsStorage.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionOptionsStorage.cs
@@ -8,12 +8,12 @@ using Microsoft.CodeAnalysis.SymbolSearch;
 
 namespace Microsoft.CodeAnalysis.CodeActions
 {
-    internal static class CodeActionOptionsMetadata
+    internal static class CodeActionOptionsStorage
     {
         internal static CodeActionOptions GetCodeActionOptions(this IGlobalOptionService globalOptions, string language, bool isBlocking)
             => new(
                 IsBlocking: isBlocking,
                 SearchReferenceAssemblies: globalOptions.GetOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, language),
-                HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsMetadata.HideAdvancedMembers, language));
+                HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsStorage.HideAdvancedMembers, language));
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AbstractController.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AbstractController.cs
@@ -7,6 +7,7 @@
 using System;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
@@ -17,6 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
         where TSession : class, ISession<TModel>
         where TPresenterSession : IIntelliSensePresenterSession
     {
+        protected readonly IGlobalOptionService GlobalOptions;
         protected readonly ITextView TextView;
         protected readonly ITextBuffer SubjectBuffer;
         protected readonly IIntelliSensePresenter<TPresenterSession, TEditorSession> Presenter;
@@ -32,9 +34,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
 
         protected bool IsSessionActive => sessionOpt != null;
 
-        protected AbstractController(IThreadingContext threadingContext, ITextView textView, ITextBuffer subjectBuffer, IIntelliSensePresenter<TPresenterSession, TEditorSession> presenter, IAsynchronousOperationListener asyncListener, IDocumentProvider documentProvider, string asyncOperationId)
+        protected AbstractController(
+            IGlobalOptionService globalOptions,
+            IThreadingContext threadingContext,
+            ITextView textView,
+            ITextBuffer subjectBuffer,
+            IIntelliSensePresenter<TPresenterSession, TEditorSession> presenter,
+            IAsynchronousOperationListener asyncListener,
+            IDocumentProvider documentProvider,
+            string asyncOperationId)
             : base(threadingContext)
         {
+            this.GlobalOptions = globalOptions;
             this.TextView = textView;
             this.SubjectBuffer = subjectBuffer;
             this.Presenter = presenter;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.CancelCommit);
             }
 
-            var options = CompletionOptions.From(_globalOptions, document.Project.Language);
+            var options = _globalOptions.GetCompletionOptions(document.Project.Language);
             var serviceRules = completionService.GetRules(options);
 
             // We can be called before for ShouldCommitCompletion. However, that call does not provide rules applied for the completion item.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -34,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         private readonly RecentItemsManager _recentItemsManager;
         private readonly ITextView _textView;
+        private readonly IGlobalOptionService _globalOptions;
 
         public IEnumerable<char> PotentialCommitCharacters
         {
@@ -51,8 +53,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
         }
 
-        internal CommitManager(ITextView textView, RecentItemsManager recentItemsManager, IThreadingContext threadingContext) : base(threadingContext)
+        internal CommitManager(ITextView textView, RecentItemsManager recentItemsManager, IGlobalOptionService globalOptions, IThreadingContext threadingContext)
+            : base(threadingContext)
         {
+            _globalOptions = globalOptions;
             _recentItemsManager = recentItemsManager;
             _textView = textView;
         }
@@ -114,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.CancelCommit);
             }
 
-            var options = CompletionOptions.From(document.Project);
+            var options = CompletionOptions.From(_globalOptions, document.Project.Language);
             var serviceRules = completionService.GetRules(options);
 
             // We can be called before for ShouldCommitCompletion. However, that call does not provide rules applied for the completion item.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManagerProvider.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
@@ -20,13 +21,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
     {
         private readonly IThreadingContext _threadingContext;
         private readonly RecentItemsManager _recentItemsManager;
+        private readonly IGlobalOptionService _globalOptions;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CommitManagerProvider(IThreadingContext threadingContext, RecentItemsManager recentItemsManager)
+        public CommitManagerProvider(IThreadingContext threadingContext, RecentItemsManager recentItemsManager, IGlobalOptionService globalOptions)
         {
             _threadingContext = threadingContext;
             _recentItemsManager = recentItemsManager;
+            _globalOptions = globalOptions;
         }
 
         IAsyncCompletionCommitManager? IAsyncCompletionCommitManagerProvider.GetOrCreate(ITextView textView)
@@ -36,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return null;
             }
 
-            return new CommitManager(textView, _recentItemsManager, _threadingContext);
+            return new CommitManager(textView, _recentItemsManager, _globalOptions, _threadingContext);
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return AsyncCompletionData.CompletionStartData.DoesNotParticipateInCompletion;
             }
 
-            var options = CompletionOptions.From(document.Project);
+            var options = CompletionOptions.From(_globalOptions, document.Project.Language);
 
             // The Editor supports the option per textView.
             // There could be mixed desired behavior per textView and even per same completion session.
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             if (service == null)
                 return null;
 
-            var options = CompletionOptions.From(document.Project);
+            var options = CompletionOptions.From(_globalOptions, document.Project.Language);
             var displayOptions = SymbolDescriptionOptions.From(document.Project);
             var description = await service.GetDescriptionAsync(document, roslynItem, options, displayOptions, cancellationToken).ConfigureAwait(false);
             if (description == null)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return AsyncCompletionData.CompletionStartData.DoesNotParticipateInCompletion;
             }
 
-            var options = CompletionOptions.From(_globalOptions, document.Project.Language);
+            var options = _globalOptions.GetCompletionOptions(document.Project.Language);
 
             // The Editor supports the option per textView.
             // There could be mixed desired behavior per textView and even per same completion session.
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             if (service == null)
                 return null;
 
-            var options = CompletionOptions.From(_globalOptions, document.Project.Language);
+            var options = _globalOptions.GetCompletionOptions(document.Project.Language);
             var displayOptions = SymbolDescriptionOptions.From(document.Project);
             var description = await service.GetDescriptionAsync(document, roslynItem, options, displayOptions, cancellationToken).ConfigureAwait(false);
             if (description == null)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             var roslynTrigger = Helpers.GetRoslynTrigger(trigger, triggerLocation);
 
             // The completion service decides that user may want a completion.
-            if (completionService.ShouldTriggerCompletion(document.Project, document.Project.LanguageServices, sourceText, triggerLocation.Position, roslynTrigger, options))
+            if (completionService.ShouldTriggerCompletion(document.Project, document.Project.LanguageServices, sourceText, triggerLocation.Position, roslynTrigger, options, document.Project.Solution.Options))
             {
                 return true;
             }
@@ -297,7 +297,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 : Helpers.GetRoslynTrigger(trigger, triggerLocation);
 
             var completionList = await completionService.GetCompletionsAsync(
-                document, triggerLocation, options, roslynTrigger, _roles, cancellationToken).ConfigureAwait(false);
+                document, triggerLocation, options, document.Project.Solution.Options, roslynTrigger, _roles, cancellationToken).ConfigureAwait(false);
 
             var filterSet = new FilterSet();
             var itemsBuilder = new ArrayBuilder<VSCompletionItem>(completionList.Items.Length);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return AsyncCompletionData.CompletionContext.Empty;
             }
 
-            var options = CompletionOptions.From(document.Project);
+            var options = _globalOptions.GetCompletionOptions(document.Project.Language);
             return await GetCompletionContextWorkerAsync(document, session, trigger, triggerLocation, options, cancellationToken).ConfigureAwait(false);
         }
 
@@ -257,11 +257,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 var document = initialTriggerLocation.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
                 if (document != null)
                 {
-                    var options = CompletionOptions.From(document.Project);
-
                     // User selected expander explicitly, which means we need to collect and return
                     // items from unimported namespace (and only those items) regardless of whether it's enabled.
-                    options = options with
+                    var options = _globalOptions.GetCompletionOptions(document.Project.Language) with
                     {
                         ShowItemsFromUnimportedNamespaces = true,
                         ExpandedCompletionBehavior = ExpandedCompletionMode.ExpandedItemsOnly

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 if (_document != null)
                 {
                     _completionService = _document.GetLanguageService<CompletionService>();
-                    _completionRules = _completionService?.GetRules(CompletionOptions.From(_document.Project)) ?? CompletionRules.Default;
+                    _completionRules = _completionService?.GetRules(CompletionOptions.From(globalOptions, _document.Project.Language)) ?? CompletionRules.Default;
 
                     // Let us make the completion Helper used for non-Roslyn items case-sensitive.
                     // We can change this if get requests from partner teams.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 if (_document != null)
                 {
                     _completionService = _document.GetLanguageService<CompletionService>();
-                    _completionRules = _completionService?.GetRules(CompletionOptions.From(globalOptions, _document.Project.Language)) ?? CompletionRules.Default;
+                    _completionRules = _completionService?.GetRules(globalOptions.GetCompletionOptions(_document.Project.Language)) ?? CompletionRules.Default;
 
                     // Let us make the completion Helper used for non-Roslyn items case-sensitive.
                     // We can change this if get requests from partner teams.

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionResolveHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionResolveHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -36,15 +37,18 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly CodeActionsCache _codeActionsCache;
         private readonly ICodeFixService _codeFixService;
         private readonly ICodeRefactoringService _codeRefactoringService;
+        private readonly IGlobalOptionService _globalOptions;
 
         public CodeActionResolveHandler(
             CodeActionsCache codeActionsCache,
             ICodeFixService codeFixService,
-            ICodeRefactoringService codeRefactoringService)
+            ICodeRefactoringService codeRefactoringService,
+            IGlobalOptionService globalOptions)
         {
             _codeActionsCache = codeActionsCache;
             _codeFixService = codeFixService;
             _codeRefactoringService = codeRefactoringService;
+            _globalOptions = globalOptions;
         }
 
         public string Method => LSP.Methods.CodeActionResolveName;
@@ -63,10 +67,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var data = ((JToken)codeAction.Data!).ToObject<CodeActionResolveData>();
             Assumes.Present(data);
 
+            var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
+
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
                 _codeActionsCache,
                 document,
                 data.Range,
+                options,
                 _codeFixService,
                 _codeRefactoringService,
                 cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionResolveHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionResolveHandler.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var data = ((JToken)codeAction.Data!).ToObject<CodeActionResolveData>();
             Assumes.Present(data);
 
-            var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
+            var options = _globalOptions.GetCodeActionOptions(document.Project.Language, isBlocking: false);
 
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
                 _codeActionsCache,

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionsHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionsHandler.cs
@@ -5,9 +5,11 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Utilities;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -28,6 +30,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly CodeActionsCache _codeActionsCache;
         private readonly ICodeFixService _codeFixService;
         private readonly ICodeRefactoringService _codeRefactoringService;
+        private readonly IGlobalOptionService _globalOptions;
 
         internal const string RunCodeActionCommandName = "Roslyn.RunCodeAction";
 
@@ -39,11 +42,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         public CodeActionsHandler(
             CodeActionsCache codeActionsCache,
             ICodeFixService codeFixService,
-            ICodeRefactoringService codeRefactoringService)
+            ICodeRefactoringService codeRefactoringService,
+            IGlobalOptionService globalOptions)
         {
             _codeActionsCache = codeActionsCache;
             _codeFixService = codeFixService;
             _codeRefactoringService = codeRefactoringService;
+            _globalOptions = globalOptions;
         }
 
         public TextDocumentIdentifier? GetTextDocumentIdentifier(CodeActionParams request) => request.TextDocument;
@@ -53,8 +58,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var document = context.Document;
             Contract.ThrowIfNull(document);
 
+            var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
+
             var codeActions = await CodeActionHelpers.GetVSCodeActionsAsync(
-                request, _codeActionsCache, document, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);
+                request, _codeActionsCache, document, options, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);
 
             return codeActions;
         }

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionsHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionsHandler.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var document = context.Document;
             Contract.ThrowIfNull(document);
 
-            var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
+            var options = _globalOptions.GetCodeActionOptions(document.Project.Language, isBlocking: false);
 
             var codeActions = await CodeActionHelpers.GetVSCodeActionsAsync(
                 request, _codeActionsCache, document, options, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionsHandlerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/CodeActionsHandlerProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Commands;
+using Microsoft.CodeAnalysis.Options;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -28,26 +29,29 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly ICodeFixService _codeFixService;
         private readonly ICodeRefactoringService _codeRefactoringService;
         private readonly IThreadingContext _threadingContext;
+        private readonly IGlobalOptionService _globalOptions;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CodeActionsHandlerProvider(
             ICodeFixService codeFixService,
             ICodeRefactoringService codeRefactoringService,
-            IThreadingContext threadingContext)
+            IThreadingContext threadingContext,
+            IGlobalOptionService globalOptions)
         {
             _codeFixService = codeFixService;
             _codeRefactoringService = codeRefactoringService;
             _threadingContext = threadingContext;
+            _globalOptions = globalOptions;
         }
 
         public override ImmutableArray<IRequestHandler> CreateRequestHandlers(WellKnownLspServerKinds serverKind)
         {
             var codeActionsCache = new CodeActionsCache();
             return ImmutableArray.Create<IRequestHandler>(
-                new CodeActionsHandler(codeActionsCache, _codeFixService, _codeRefactoringService),
-                new CodeActionResolveHandler(codeActionsCache, _codeFixService, _codeRefactoringService),
-                new RunCodeActionHandler(codeActionsCache, _codeFixService, _codeRefactoringService, _threadingContext));
+                new CodeActionsHandler(codeActionsCache, _codeFixService, _codeRefactoringService, _globalOptions),
+                new CodeActionResolveHandler(codeActionsCache, _codeFixService, _codeRefactoringService, _globalOptions),
+                new RunCodeActionHandler(codeActionsCache, _codeFixService, _codeRefactoringService, _globalOptions, _threadingContext));
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/RunCodeActionHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/RunCodeActionHandler.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var runRequest = ((JToken)request.Arguments.Single()).ToObject<CodeActionResolveData>();
             Assumes.Present(runRequest);
 
-            var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
+            var options = _globalOptions.GetCodeActionOptions(document.Project.Language, isBlocking: false);
 
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
                 _codeActionsCache, document, runRequest.Range, options, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/RunCodeActionHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/CodeActions/RunCodeActionHandler.cs
@@ -5,11 +5,13 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Commands;
+using Microsoft.CodeAnalysis.Options;
 using Newtonsoft.Json.Linq;
 using Roslyn.Utilities;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -33,17 +35,20 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         private readonly CodeActionsCache _codeActionsCache;
         private readonly ICodeFixService _codeFixService;
         private readonly ICodeRefactoringService _codeRefactoringService;
+        private readonly IGlobalOptionService _globalOptions;
         private readonly IThreadingContext _threadingContext;
 
         public RunCodeActionHandler(
             CodeActionsCache codeActionsCache,
             ICodeFixService codeFixService,
             ICodeRefactoringService codeRefactoringService,
+            IGlobalOptionService globalOptions,
             IThreadingContext threadingContext)
         {
             _codeActionsCache = codeActionsCache;
             _codeFixService = codeFixService;
             _codeRefactoringService = codeRefactoringService;
+            _globalOptions = globalOptions;
             _threadingContext = threadingContext;
         }
 
@@ -68,8 +73,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var runRequest = ((JToken)request.Arguments.Single()).ToObject<CodeActionResolveData>();
             Assumes.Present(runRequest);
 
+            var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
+
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
-                _codeActionsCache, document, runRequest.Range, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);
+                _codeActionsCache, document, runRequest.Range, options, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);
 
             var actionToRun = CodeActionHelpers.GetCodeActionToResolve(runRequest.UniqueIdentifier, codeActions);
             Contract.ThrowIfNull(actionToRun);

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandler.cs
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // 2.  We need to figure out how to provide the text edits along with the completion item or provide them in the resolve request.
             //     https://devdiv.visualstudio.com/DevDiv/_workitems/edit/985860/
             // 3.  LSP client should support completion filters / expanders
-            return CompletionOptions.From(_globalOptions, document.Project.Language) with
+            return _globalOptions.GetCompletionOptions(document.Project.Language) with
             {
                 ShowItemsFromUnimportedNamespaces = false,
                 ExpandedCompletionBehavior = ExpandedCompletionMode.NonExpandedItemsOnly

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandler.cs
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             CompletionListCache completionListCache,
             CancellationToken cancellationToken)
         {
-            var completionList = await completionService.GetCompletionsAsync(document, position, completionOptions, document.Project.Solution.Options, completionTrigger, cancellationToken).ConfigureAwait(false);
+            var completionList = await completionService.GetCompletionsAsync(document, position, completionOptions, document.Project.Solution.Options, completionTrigger, cancellationToken: cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             if (completionList.Items.IsEmpty)
             {

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandler.cs
@@ -545,7 +545,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             return completionItem.Rules.MatchPriority == MatchPriority.Preselect && completionItem.Rules.SelectionBehavior == CompletionItemSelectionBehavior.HardSelection;
         }
 
-        internal static CompletionOptions GetCompletionOptions(Document document)
+        internal CompletionOptions GetCompletionOptions(Document document)
         {
             // Filter out unimported types for now as there are two issues with providing them:
             // 1.  LSP client does not currently provide a way to provide detail text on the completion item to show the namespace.
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // 2.  We need to figure out how to provide the text edits along with the completion item or provide them in the resolve request.
             //     https://devdiv.visualstudio.com/DevDiv/_workitems/edit/985860/
             // 3.  LSP client should support completion filters / expanders
-            return CompletionOptions.From(document.Project) with
+            return CompletionOptions.From(_globalOptions, document.Project.Language) with
             {
                 ShowItemsFromUnimportedNamespaces = false,
                 ExpandedCompletionBehavior = ExpandedCompletionMode.NonExpandedItemsOnly

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandler.cs
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             CompletionListCache completionListCache,
             CancellationToken cancellationToken)
         {
-            var completionList = await completionService.GetCompletionsAsync(document, position, completionOptions, completionTrigger, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var completionList = await completionService.GetCompletionsAsync(document, position, completionOptions, document.Project.Solution.Options, completionTrigger, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             if (completionList.Items.IsEmpty)
             {

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandlerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionHandlerProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var completionListCache = new CompletionListCache();
             return ImmutableArray.Create<IRequestHandler>(
                 new CompletionHandler(_globalOptions, _completionProviders, completionListCache),
-                new CompletionResolveHandler(completionListCache));
+                new CompletionResolveHandler(_globalOptions, completionListCache));
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionResolveHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionResolveHandler.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return completionItem;
             }
 
-            var options = CompletionOptions.From(_globalOptions, document.Project.Language);
+            var options = _globalOptions.GetCompletionOptions(document.Project.Language);
             var displayOptions = SymbolDescriptionOptions.From(document.Project);
             var description = await completionService.GetDescriptionAsync(document, selectedItem, options, displayOptions, cancellationToken).ConfigureAwait(false)!;
             if (description != null)

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionResolveHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Completion/CompletionResolveHandler.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Completion;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.Text.Adornments;
 using Newtonsoft.Json.Linq;
 using Roslyn.Utilities;
@@ -24,17 +25,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// references to VS icon types and classified text runs are removed.
     /// See https://github.com/dotnet/roslyn/issues/55142
     /// </summary>
-    internal class CompletionResolveHandler : IRequestHandler<LSP.CompletionItem, LSP.CompletionItem>
+    internal sealed class CompletionResolveHandler : IRequestHandler<LSP.CompletionItem, LSP.CompletionItem>
     {
         private readonly CompletionListCache _completionListCache;
+        private readonly IGlobalOptionService _globalOptions;
 
         public string Method => LSP.Methods.TextDocumentCompletionResolveName;
 
         public bool MutatesSolutionState => false;
         public bool RequiresLSPSolution => true;
 
-        public CompletionResolveHandler(CompletionListCache completionListCache)
+        public CompletionResolveHandler(IGlobalOptionService globalOptions, CompletionListCache completionListCache)
         {
+            _globalOptions = globalOptions;
             _completionListCache = completionListCache;
         }
 
@@ -64,7 +67,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return completionItem;
             }
 
-            var options = CompletionOptions.From(document.Project);
+            var options = CompletionOptions.From(_globalOptions, document.Project.Language);
             var displayOptions = SymbolDescriptionOptions.From(document.Project);
             var description = await completionService.GetDescriptionAsync(document, selectedItem, options, displayOptions, cancellationToken).ConfigureAwait(false)!;
             if (description != null)

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             var span = documentsWithSelections.Single().SelectedSpans.Single();
             var actions = ArrayBuilder<(CodeAction, TextSpan?)>.GetInstance();
             var document = workspace.CurrentSolution.GetDocument(documentsWithSelections.Single().Id);
-            var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: false);
+            var options = CodeActionOptions.Default;
             var context = new CodeRefactoringContext(document, span, (a, t) => actions.Add((a, t)), options, CancellationToken.None);
             await provider.ComputeRefactoringsAsync(context);
 

--- a/src/EditorFeatures/Test/Completion/CompletionServiceTests.cs
+++ b/src/EditorFeatures/Test/Completion/CompletionServiceTests.cs
@@ -45,7 +45,7 @@ class Test {
 
             var document = project.Documents.Single();
             var caretPosition = workspace.DocumentWithCursor.CursorPosition ?? throw new InvalidOperationException();
-            var completions = await completionService.GetCompletionsAsync(document, caretPosition, CompletionOptions.Default);
+            var completions = await completionService.GetCompletionsAsync(document, caretPosition, CompletionOptions.Default, OptionValueSet.Empty);
 
             Assert.False(completions.IsEmpty);
             var item = Assert.Single(completions.Items.Where(item => item.ProviderName == typeof(DebugAssertTestCompletionProvider).FullName));

--- a/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
+++ b/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences({analyzerReference}))
 
                 Dim project = workspace.CurrentSolution.Projects(0)
-                Dim options = CodeActionOptionsFactory.GetCodeActionOptions(project, isBlocking:=False)
+                Dim options = CodeActionOptions.Default
 
                 Assert.IsType(Of MockDiagnosticUpdateSourceRegistrationService)(workspace.GetService(Of IDiagnosticUpdateSourceRegistrationService)())
                 Dim diagnosticService = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
@@ -129,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences({analyzerReference}))
 
                 Dim project = workspace.CurrentSolution.Projects(0)
-                Dim options = CodeActionOptionsFactory.GetCodeActionOptions(project, isBlocking:=False)
+                Dim options = CodeActionOptions.Default
 
                 Assert.IsType(Of MockDiagnosticUpdateSourceRegistrationService)(workspace.GetService(Of IDiagnosticUpdateSourceRegistrationService)())
                 Dim diagnosticService = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -794,7 +794,7 @@ class C
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars("repl")
                 state.SendTab()
@@ -1056,7 +1056,7 @@ class Class1
 }</Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMin")
                 state.SendReturn()
@@ -1086,7 +1086,7 @@ class Class1
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
+                    New OptionKey(CompletionOptionsStorage.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMinutes")
                 state.SendReturn()
@@ -1444,7 +1444,7 @@ class Variable
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
@@ -1474,7 +1474,7 @@ class Variable
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
@@ -4024,7 +4024,7 @@ class$$ C
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -4055,7 +4055,7 @@ class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -4779,7 +4779,7 @@ class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 For Each c In "Offset"
                     state.SendBackspace()
@@ -4809,7 +4809,7 @@ class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 For Each c In "Offset."
                     state.SendBackspace()
@@ -5442,7 +5442,7 @@ class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="Environment", isHardSelected:=True)
@@ -5752,7 +5752,7 @@ class C
                               </Document>)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars("""")
 
@@ -5991,7 +5991,7 @@ public class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 state.SendBackspace()
@@ -6017,7 +6017,7 @@ public class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 state.SelectAndMoveCaret(-6)
@@ -6068,7 +6068,7 @@ class C
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionItemsContainAll("WriteLine")
@@ -6315,7 +6315,7 @@ class C
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -6343,7 +6343,7 @@ class C
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -6431,7 +6431,7 @@ class C
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of IntelliCodeMockProvider)().Single()
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -6542,7 +6542,7 @@ class C
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of IntelliCodeMockProvider)().Single()
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars(".nor")
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -6594,7 +6594,7 @@ class C
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of IntelliCodeMockProvider)().Single()
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars(".nor")
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -6670,8 +6670,8 @@ namespace NS2
                 Dim completionService = CType(document.GetLanguageService(Of CompletionService)(), CompletionServiceWithProviders)
                 completionService.GetTestAccessor().SuppressPartialSemantics()
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -6728,8 +6728,8 @@ namespace NS2
                 Dim completionService = CType(document.GetLanguageService(Of CompletionService)(), CompletionServiceWithProviders)
                 completionService.GetTestAccessor().SuppressPartialSemantics()
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -6766,8 +6766,8 @@ namespace NS2
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
                 ' trigger completion with import completion disabled
                 state.SendInvokeCompletionList()
@@ -6835,8 +6835,8 @@ namespace NS2
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion enabled
                 state.SendInvokeCompletionList()
@@ -6877,9 +6877,9 @@ namespace NS1
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion enabled
                 state.SendInvokeCompletionList()
@@ -7320,9 +7320,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7389,9 +7389,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7458,9 +7458,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7527,9 +7527,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7597,9 +7597,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7636,9 +7636,9 @@ namespace OtherNS
 </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7680,7 +7680,7 @@ namespace NS
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
+                    New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
                 state.SendTypeChars("task")
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -7732,8 +7732,8 @@ namespace NS2
 </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion disabled
                 state.SendInvokeCompletionList()
@@ -7747,8 +7747,8 @@ namespace NS2
                 state.SendEscape()
                 Await state.AssertNoCompletionSession()
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendTypeChars("mytask")
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -7793,7 +7793,7 @@ namespace NS
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.ShowNameSuggestions, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.ShowNameSuggestions, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("foo123Bar", "foo123", "foo", "bar")
@@ -7824,7 +7824,7 @@ namespace NS
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.ShowNameSuggestions, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.ShowNameSuggestions, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("foo123", "foo")
@@ -8258,8 +8258,8 @@ namespace B
     }
 }                              </Document>)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
 
                 state.SendInvokeCompletionList()
                 state.AssertItemsInOrder(New String() {
@@ -8578,8 +8578,8 @@ public class AA
     }
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
 
                 Dim expectedText = $"
 using CC;
@@ -8625,8 +8625,8 @@ public class AA
     }
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.BlockOnExpandedCompletion), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8681,7 +8681,7 @@ public class AA
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8730,7 +8730,7 @@ public class AA
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8773,7 +8773,7 @@ public class AA
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8823,7 +8823,7 @@ namespace Bar1
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8873,7 +8873,7 @@ public unsafe class AA
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -9238,7 +9238,7 @@ class C
                            showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem("xml", isSoftSelected:=True).ConfigureAwait(True)
@@ -9294,7 +9294,7 @@ class Repro
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll({"★ length", "length", "Length"})

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -794,7 +794,7 @@ class C
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars("repl")
                 state.SendTab()
@@ -1056,7 +1056,7 @@ class Class1
 }</Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMin")
                 state.SendReturn()
@@ -1086,7 +1086,7 @@ class Class1
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
+                    New OptionKey(CompletionOptionsMetadata.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMinutes")
                 state.SendReturn()
@@ -1444,7 +1444,7 @@ class Variable
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
@@ -1474,7 +1474,7 @@ class Variable
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
@@ -4024,7 +4024,7 @@ class$$ C
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -4055,7 +4055,7 @@ class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -4779,7 +4779,7 @@ class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 For Each c In "Offset"
                     state.SendBackspace()
@@ -4809,7 +4809,7 @@ class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 For Each c In "Offset."
                     state.SendBackspace()
@@ -5442,7 +5442,7 @@ class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="Environment", isHardSelected:=True)
@@ -5752,7 +5752,7 @@ class C
                               </Document>)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars("""")
 
@@ -5991,7 +5991,7 @@ public class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 state.SendBackspace()
@@ -6017,7 +6017,7 @@ public class Program
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 state.SelectAndMoveCaret(-6)
@@ -6068,7 +6068,7 @@ class C
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionItemsContainAll("WriteLine")
@@ -6315,7 +6315,7 @@ class C
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -6343,7 +6343,7 @@ class C
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -6431,7 +6431,7 @@ class C
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of IntelliCodeMockProvider)().Single()
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -6542,7 +6542,7 @@ class C
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of IntelliCodeMockProvider)().Single()
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars(".nor")
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -6594,7 +6594,7 @@ class C
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of IntelliCodeMockProvider)().Single()
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars(".nor")
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -6670,8 +6670,8 @@ namespace NS2
                 Dim completionService = CType(document.GetLanguageService(Of CompletionService)(), CompletionServiceWithProviders)
                 completionService.GetTestAccessor().SuppressPartialSemantics()
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -6728,8 +6728,8 @@ namespace NS2
                 Dim completionService = CType(document.GetLanguageService(Of CompletionService)(), CompletionServiceWithProviders)
                 completionService.GetTestAccessor().SuppressPartialSemantics()
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -6766,8 +6766,8 @@ namespace NS2
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
                 ' trigger completion with import completion disabled
                 state.SendInvokeCompletionList()
@@ -6835,8 +6835,8 @@ namespace NS2
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion enabled
                 state.SendInvokeCompletionList()
@@ -6877,9 +6877,9 @@ namespace NS1
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion enabled
                 state.SendInvokeCompletionList()
@@ -7320,9 +7320,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7389,9 +7389,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7458,9 +7458,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7527,9 +7527,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7597,9 +7597,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7636,9 +7636,9 @@ namespace OtherNS
 </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7680,7 +7680,7 @@ namespace NS
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
+                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
                 state.SendTypeChars("task")
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -7732,8 +7732,8 @@ namespace NS2
 </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion disabled
                 state.SendInvokeCompletionList()
@@ -7747,8 +7747,8 @@ namespace NS2
                 state.SendEscape()
                 Await state.AssertNoCompletionSession()
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendTypeChars("mytask")
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -7793,7 +7793,7 @@ namespace NS
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.ShowNameSuggestions, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.ShowNameSuggestions, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("foo123Bar", "foo123", "foo", "bar")
@@ -7824,7 +7824,7 @@ namespace NS
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.ShowNameSuggestions, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.ShowNameSuggestions, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("foo123", "foo")
@@ -8258,8 +8258,8 @@ namespace B
     }
 }                              </Document>)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
 
                 state.SendInvokeCompletionList()
                 state.AssertItemsInOrder(New String() {
@@ -8578,8 +8578,8 @@ public class AA
     }
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
 
                 Dim expectedText = $"
 using CC;
@@ -8625,8 +8625,8 @@ public class AA
     }
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsMetadata.BlockOnExpandedCompletion), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8681,7 +8681,7 @@ public class AA
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8730,7 +8730,7 @@ public class AA
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8773,7 +8773,7 @@ public class AA
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8823,7 +8823,7 @@ namespace Bar1
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8873,7 +8873,7 @@ public unsafe class AA
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -9238,7 +9238,7 @@ class C
                            showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem("xml", isSoftSelected:=True).ConfigureAwait(True)
@@ -9294,7 +9294,7 @@ class Repro
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll({"★ length", "length", "Length"})

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -793,9 +793,8 @@ class C
                               </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
-                    CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars("repl")
                 state.SendTab()
@@ -1057,9 +1056,7 @@ class Class1
 }</Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.CSharp, EnterKeyRule.AfterFullyTypedWord)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMin")
                 state.SendReturn()
@@ -1087,9 +1084,9 @@ class Class1
     }
 }</Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.CSharp, EnterKeyRule.AfterFullyTypedWord)))
+
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.CSharp), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMinutes")
                 state.SendReturn()
@@ -1446,9 +1443,8 @@ class Variable
 }]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
@@ -1477,9 +1473,8 @@ class Variable
 }]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
@@ -4028,9 +4023,8 @@ class$$ C
 }]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -4060,9 +4054,8 @@ class Program
 }]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -4785,9 +4778,8 @@ class Program
             ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 For Each c In "Offset"
                     state.SendBackspace()
@@ -4816,9 +4808,8 @@ class Program
             ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 For Each c In "Offset."
                     state.SendBackspace()
@@ -4948,8 +4939,8 @@ class C
                 Dim completionService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetRequiredService(Of CompletionService)(), CompletionServiceWithProviders)
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of BooleanTaskControlledCompletionProvider)().Single()
 
-                Dim globalOptions = state.Workspace.GetService(Of IGlobalOptionService)
-                globalOptions.SetGlobalOption(New OptionKey(CompletionViewOptions.BlockForCompletionItems, LanguageNames.CSharp), False)
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionViewOptions.BlockForCompletionItems, LanguageNames.CSharp), False)
 
                 state.SendTypeChars("Sys.")
                 Await state.AssertNoCompletionSession()
@@ -4969,8 +4960,8 @@ class C
                               extraExportedTypes:={GetType(CompletedTaskControlledCompletionProvider)}.ToList(),
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim globalOptions = state.Workspace.GetService(Of IGlobalOptionService)
-                globalOptions.SetGlobalOption(New OptionKey(CompletionViewOptions.BlockForCompletionItems, LanguageNames.CSharp), False)
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionViewOptions.BlockForCompletionItems, LanguageNames.CSharp), False)
 
                 state.SendTypeChars("Sys")
                 Await state.AssertSelectedCompletionItem(displayText:="System")
@@ -5003,8 +4994,8 @@ class C
                 Dim completionService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetRequiredService(Of CompletionService)(), CompletionServiceWithProviders)
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of BooleanTaskControlledCompletionProvider)().Single()
 
-                Dim globalOptions = state.Workspace.GetService(Of IGlobalOptionService)
-                globalOptions.SetGlobalOption(New OptionKey(CompletionViewOptions.BlockForCompletionItems, LanguageNames.CSharp), False)
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionViewOptions.BlockForCompletionItems, LanguageNames.CSharp), False)
 
                 state.SendTypeChars("Sys")
 
@@ -5450,11 +5441,8 @@ class Program
                               </Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim key = New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp)
-
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(key, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="Environment", isHardSelected:=True)
@@ -5763,9 +5751,8 @@ class C
 }
                               </Document>)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars("""")
 
@@ -6003,9 +5990,8 @@ public class Program
                               </Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 state.SendBackspace()
@@ -6030,9 +6016,8 @@ public class Program
                               </Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 state.SelectAndMoveCaret(-6)
@@ -6082,9 +6067,8 @@ class C
 }</Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionItemsContainAll("WriteLine")
@@ -6330,9 +6314,8 @@ class C
                               </Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -6359,9 +6342,8 @@ class C
                               </Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -6448,9 +6430,8 @@ class C
                 Dim completionService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetRequiredService(Of CompletionService)(), CompletionServiceWithProviders)
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of IntelliCodeMockProvider)().Single()
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -6560,9 +6541,8 @@ class C
                 Dim completionService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetRequiredService(Of CompletionService)(), CompletionServiceWithProviders)
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of IntelliCodeMockProvider)().Single()
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars(".nor")
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -6613,9 +6593,8 @@ class C
                 Dim completionService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetRequiredService(Of CompletionService)(), CompletionServiceWithProviders)
                 Dim provider = completionService.GetTestAccessor().GetAllProviders(ImmutableHashSet(Of String).Empty).OfType(Of IntelliCodeMockProvider)().Single()
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendTypeChars(".nor")
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -6691,10 +6670,8 @@ namespace NS2
                 Dim completionService = CType(document.GetLanguageService(Of CompletionService)(), CompletionServiceWithProviders)
                 completionService.GetTestAccessor().SuppressPartialSemantics()
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -6751,10 +6728,8 @@ namespace NS2
                 Dim completionService = CType(document.GetLanguageService(Of CompletionService)(), CompletionServiceWithProviders)
                 completionService.GetTestAccessor().SuppressPartialSemantics()
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -6791,10 +6766,8 @@ namespace NS2
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
                 ' trigger completion with import completion disabled
                 state.SendInvokeCompletionList()
@@ -6862,10 +6835,8 @@ namespace NS2
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion enabled
                 state.SendInvokeCompletionList()
@@ -6906,11 +6877,9 @@ namespace NS1
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion enabled
                 state.SendInvokeCompletionList()
@@ -7351,11 +7320,9 @@ namespace NS2
 }
 "
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7422,11 +7389,9 @@ namespace NS2
 }
 "
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7493,11 +7458,9 @@ namespace NS2
 }
 "
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7564,11 +7527,9 @@ namespace NS2
 }
 "
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7636,11 +7597,9 @@ namespace NS2
 }
 "
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7677,11 +7636,9 @@ namespace OtherNS
 </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7722,9 +7679,8 @@ namespace NS
 } </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
                 state.SendTypeChars("task")
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -7776,10 +7732,8 @@ namespace NS2
 </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ForceExpandedCompletionIndexCreation), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion disabled
                 state.SendInvokeCompletionList()
@@ -7793,9 +7747,8 @@ namespace NS2
                 state.SendEscape()
                 Await state.AssertNoCompletionSession()
 
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendTypeChars("mytask")
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -7838,9 +7791,9 @@ namespace NS
 }
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowNameSuggestions, LanguageNames.CSharp, True)))
+
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.ShowNameSuggestions, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("foo123Bar", "foo123", "foo", "bar")
@@ -7869,9 +7822,9 @@ namespace NS
 }
 ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowNameSuggestions, LanguageNames.CSharp, True)))
+
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.ShowNameSuggestions, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("foo123", "foo")
@@ -8304,9 +8257,10 @@ namespace B
         }
     }
 }                              </Document>)
-                state.Workspace.SetOptions(state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True))
+
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
+
                 state.SendInvokeCompletionList()
                 state.AssertItemsInOrder(New String() {
                     "A", ' Method, properties, and imported extension methods alphabetical ordered
@@ -8624,9 +8578,8 @@ public class AA
     }
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.SetOptions(state.Workspace.Options _
-                                           .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True) _
-                                           .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
 
                 Dim expectedText = $"
 using CC;
@@ -8672,9 +8625,8 @@ public class AA
     }
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.SetOptions(state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True) _
-                    .WithChangedOption(CompletionOptions.Metadata.BlockOnExpandedCompletion, True))
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
+                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptions.Metadata.BlockOnExpandedCompletion), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8727,7 +8679,9 @@ public class AA
     }
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.SetOptions(state.Workspace.Options.WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True))
+
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8774,7 +8728,9 @@ public class AA
     }
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.SetOptions(state.Workspace.Options.WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True))
+
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8815,7 +8771,9 @@ public class AA
     private static T GetSomething&lt;T&gt;() => (T)Activator.GetInstance(typeof(T));
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.SetOptions(state.Workspace.Options.WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True))
+
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8863,7 +8821,9 @@ namespace Bar1
     }
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.SetOptions(state.Workspace.Options.WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True))
+
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -8911,7 +8871,9 @@ public unsafe class AA
     public static void Bar() {}
 }</Document>,
                 showCompletionInArgumentLists:=showCompletionInArgumentLists)
-                state.Workspace.SetOptions(state.Workspace.Options.WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True))
+
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -9275,9 +9237,8 @@ class C
 }]]></Document>,
                            showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
-                    CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem("xml", isSoftSelected:=True).ConfigureAwait(True)
@@ -9332,9 +9293,8 @@ class Repro
                               extraExportedTypes:={GetType(PreselectionProvider)}.ToList(),
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, True)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp), True)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll({"★ length", "length", "Length"})

--- a/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 Dim completionService = New TestCompletionService(workspace)
 
                 Dim list = Await completionService.GetCompletionsAsync(
-                    document, caretPosition:=0, options:=CompletionOptions.Default, trigger:=CompletionTrigger.Invoke)
+                    document, caretPosition:=0, CompletionOptions.Default, OptionValueSet.Empty, CompletionTrigger.Invoke)
 
                 Assert.NotEmpty(list.Items)
                 Assert.True(list.Items.Length = 1, "Completion list contained more than one item")

--- a/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests_Exclusivitiy.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests_Exclusivitiy.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 Dim completionService = New TestCompletionService(workspace)
 
                 Dim list = Await completionService.GetCompletionsAsync(
-                    document, caretPosition:=0, options:=CompletionOptions.Default, trigger:=CompletionTrigger.Invoke)
+                    document, caretPosition:=0, CompletionOptions.Default, OptionValueSet.Empty, CompletionTrigger.Invoke)
 
                 Assert.NotEmpty(list.Items)
                 Assert.True(list.Items.Length = 2, "Completion List does not contain exactly two items.")

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -278,16 +278,18 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                                  Optional triggerSession As Boolean = True) As Controller
             Dim document As Document =
                 (Function()
-                     Dim workspace = TestWorkspace.CreateWorkspace(
+                     Dim w = TestWorkspace.CreateWorkspace(
                          <Workspace>
                              <Project Language="C#">
                                  <Document>
                                  </Document>
                              </Project>
                          </Workspace>)
-                     Return workspace.CurrentSolution.GetDocument(workspace.Documents.Single().Id)
+                     Return w.CurrentSolution.GetDocument(w.Documents.Single().Id)
                  End Function)()
-            Dim threadingContext = DirectCast(document.Project.Solution.Workspace, TestWorkspace).GetService(Of IThreadingContext)
+
+            Dim workspace = DirectCast(document.Project.Solution.Workspace, TestWorkspace)
+            Dim threadingContext = workspace.GetService(Of IThreadingContext)
             Dim bufferFactory As ITextBufferFactoryService = DirectCast(document.Project.Solution.Workspace, TestWorkspace).GetService(Of ITextBufferFactoryService)
             Dim buffer = bufferFactory.CreateTextBuffer()
             Dim view = CreateMockTextView(buffer)
@@ -312,6 +314,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             mockCompletionBroker.Setup(Function(b) b.GetSession(It.IsAny(Of ITextView))).Returns(DirectCast(Nothing, IAsyncCompletionSession))
 
             Dim controller = New Controller(
+                workspace.GlobalOptions,
                 threadingContext,
                 view.Object,
                 buffer,

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -1834,7 +1834,7 @@ End Class
 </Document>)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
+                    New OptionKey(CompletionOptionsMetadata.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMin")
                 state.SendReturn()
@@ -1860,7 +1860,7 @@ End Class
 </Document>)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
+                    New OptionKey(CompletionOptionsMetadata.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMinutes")
                 state.SendReturn()
@@ -2165,7 +2165,7 @@ End Class
             ]]></Document>)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.TriggerOnTyping, LanguageNames.VisualBasic), False)
+                    New OptionKey(CompletionOptionsMetadata.TriggerOnTyping, LanguageNames.VisualBasic), False)
 
                 state.SendBackspace()
                 Await state.AssertNoCompletionSession()
@@ -2656,7 +2656,7 @@ End Class
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                    New OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
 
                 state.SendTypeChars("Shortcu")
                 Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
@@ -2678,7 +2678,7 @@ End Class
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                    New OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
 
                 state.SendTypeChars("Shortcu")
                 Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
@@ -2701,7 +2701,7 @@ End Class
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                    New OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("x", "Shortcut")

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -1834,7 +1834,7 @@ End Class
 </Document>)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
+                    New OptionKey(CompletionOptionsStorage.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMin")
                 state.SendReturn()
@@ -1860,7 +1860,7 @@ End Class
 </Document>)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
+                    New OptionKey(CompletionOptionsStorage.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMinutes")
                 state.SendReturn()
@@ -2165,7 +2165,7 @@ End Class
             ]]></Document>)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.TriggerOnTyping, LanguageNames.VisualBasic), False)
+                    New OptionKey(CompletionOptionsStorage.TriggerOnTyping, LanguageNames.VisualBasic), False)
 
                 state.SendBackspace()
                 Await state.AssertNoCompletionSession()
@@ -2656,7 +2656,7 @@ End Class
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                    New OptionKey(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
 
                 state.SendTypeChars("Shortcu")
                 Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
@@ -2678,7 +2678,7 @@ End Class
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                    New OptionKey(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
 
                 state.SendTypeChars("Shortcu")
                 Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
@@ -2701,7 +2701,7 @@ End Class
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
                 state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                    New OptionKey(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("x", "Shortcut")

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -8,6 +8,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Snippets
 Imports Microsoft.CodeAnalysis.Tags
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -1832,9 +1833,9 @@ Class Class1
 End Class
 </Document>)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.VisualBasic, EnterKeyRule.AfterFullyTypedWord)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
+
                 state.SendTypeChars("System.TimeSpan.FromMin")
                 state.SendReturn()
                 Assert.Equal(<text>
@@ -1858,9 +1859,8 @@ Class Class1
 End Class
 </Document>)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.VisualBasic, EnterKeyRule.AfterFullyTypedWord)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.EnterKeyBehavior, LanguageNames.VisualBasic), EnterKeyRule.AfterFullyTypedWord)
 
                 state.SendTypeChars("System.TimeSpan.FromMinutes")
                 state.SendReturn()
@@ -2164,9 +2164,9 @@ Class G
 End Class
             ]]></Document>)
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.TriggerOnTyping, LanguageNames.VisualBasic, False)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.TriggerOnTyping, LanguageNames.VisualBasic), False)
+
                 state.SendBackspace()
                 Await state.AssertNoCompletionSession()
             End Using
@@ -2655,9 +2655,8 @@ End Class
 }]]></Document>,
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic, SnippetsRule.AlwaysInclude)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
 
                 state.SendTypeChars("Shortcu")
                 Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
@@ -2678,9 +2677,8 @@ End Class
 }]]></Document>,
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic, SnippetsRule.AlwaysInclude)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
 
                 state.SendTypeChars("Shortcu")
                 Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
@@ -2702,9 +2700,8 @@ End Class
 }]]></Document>,
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
-                Dim workspace = state.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic, SnippetsRule.AlwaysInclude)))
+                state.Workspace.GlobalOptions.SetGlobalOption(
+                    New OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("x", "Shortcut")

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -484,7 +484,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
             MarkupTestFile.GetPosition(expectedCodeAfterCommit, out var actualExpectedCode, out int expectedCaretPosition);
 
-            var options = CompletionOptions.From(document.Project);
+            var options = GetCompletionOptions();
 
             if (commitChar.HasValue &&
                 !CommitManager.IsCommitCharacter(service.GetRules(options), completionItem, commitChar.Value))
@@ -526,7 +526,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             MarkupTestFile.GetPosition(expectedCodeAfterCommit, out var actualExpectedCode, out int expectedCaretPosition);
 
             var workspace = workspaceFixture.Target.GetWorkspace();
-            var options = CompletionOptions.From(workspace.CurrentSolution.Options, service.Language);
+            var options = GetCompletionOptions();
 
             if (commitChar.HasValue &&
                 !CommitManager.IsCommitCharacter(service.GetRules(options), completionItem, commitChar.Value))
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             var commitChar = commitCharOpt ?? '\t';
 
             var text = await document.GetTextAsync();
-            var options = CompletionOptions.From(document.Project);
+            var options = GetCompletionOptions();
 
             if (commitChar == '\t' ||
                 CommitManager.IsCommitCharacter(service.GetRules(options), firstItem, commitChar))
@@ -1067,7 +1067,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected async Task VerifyCommitCharactersAsync(string initialMarkup, string textTypedSoFar, char[] validChars, char[] invalidChars = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
         {
             Assert.NotNull(validChars);
-            invalidChars = invalidChars ?? new[] { 'x' };
+            invalidChars ??= new[] { 'x' };
 
             using (var workspace = CreateWorkspace(initialMarkup))
             {
@@ -1077,7 +1077,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                 var documentId = workspace.GetDocumentId(hostDocument);
                 var document = workspace.CurrentSolution.GetDocument(documentId);
                 var position = hostDocument.CursorPosition.Value;
-                var options = CompletionOptions.From(document.Project);
+                var options = GetCompletionOptions();
 
                 var service = GetCompletionService(document.Project);
                 var completionList = await GetCompletionListAsync(service, document, position, RoslynCompletion.CompletionTrigger.Invoke);

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             int position,
             RoslynCompletion.CompletionTrigger triggerInfo,
             CompletionOptions? options = null)
-            => service.GetCompletionsAsync(document, position, options ?? GetCompletionOptions(), triggerInfo, GetRoles(document));
+            => service.GetCompletionsAsync(document, position, options ?? GetCompletionOptions(), OptionValueSet.Empty, triggerInfo, GetRoles(document));
 
         private protected async Task CheckResultsAsync(
             Document document, int position, string expectedItemOrNull,
@@ -1037,7 +1037,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
                     TriggerInArgumentLists = showCompletionInArgumentLists
                 };
 
-                var isTextualTriggerCharacterResult = service.ShouldTriggerCompletion(document.Project, document.Project.LanguageServices, text, position + 1, trigger, options, GetRoles(document));
+                var isTextualTriggerCharacterResult = service.ShouldTriggerCompletion(document.Project, document.Project.LanguageServices, text, position + 1, trigger, options, document.Project.Solution.Options, GetRoles(document));
 
                 if (expectedTriggerCharacter)
                 {

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public IList<TestHostDocument> AdditionalDocuments { get; }
         public IList<TestHostDocument> AnalyzerConfigDocuments { get; }
         public IList<TestHostDocument> ProjectionDocuments { get; }
+        internal IGlobalOptionService GlobalOptions { get; }
 
         internal override bool IgnoreUnchangeableDocumentsWhenApplyingChanges { get; }
 
@@ -79,6 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
             this.CanApplyChangeDocument = true;
             this.IgnoreUnchangeableDocumentsWhenApplyingChanges = ignoreUnchangeableDocumentsWhenApplyingChanges;
+            this.GlobalOptions = GetService<IGlobalOptionService>();
 
             if (Services.GetService<INotificationService>() is INotificationServiceCallback callback)
             {

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -445,7 +445,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Dim document = Me.Workspace.CurrentSolution.Projects.First().Documents.First()
             Dim service = CompletionService.GetService(document)
             Dim roslynItem = GetSelectedItem()
-            Dim options = CompletionOptions.From(document.Project)
+            Dim options = CompletionOptions.Default
             Dim displayOptions = SymbolDescriptionOptions.From(document.Project)
             Return Await service.GetDescriptionAsync(document, roslynItem, options, displayOptions)
         End Function

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
@@ -4,6 +4,7 @@
 
 Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Options
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
     Friend Class TestStateFactory
@@ -24,8 +25,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                  excludedTypes, extraExportedTypes,
                                  includeFormatCommandHandler, workspaceKind:=Nothing)
 
-            testState.Workspace.SetOptions(
-                testState.Workspace.Options.WithChangedOption(CompletionOptions.Metadata.TriggerInArgumentLists, LanguageNames.CSharp, showCompletionInArgumentLists))
+            testState.Workspace.GlobalOptions.SetGlobalOption(
+                New OptionKey(CompletionOptions.Metadata.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
 
             Return testState
         End Function
@@ -52,8 +53,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Dim testState = New TestState(
                 workspaceElement, excludedTypes:=Nothing, extraExportedTypes, includeFormatCommandHandler:=False, workspaceKind)
 
-            testState.Workspace.SetOptions(
-                testState.Workspace.Options.WithChangedOption(CompletionOptions.Metadata.TriggerInArgumentLists, LanguageNames.CSharp, showCompletionInArgumentLists))
+            testState.Workspace.GlobalOptions.SetGlobalOption(
+                New OptionKey(CompletionOptions.Metadata.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
 
             Return testState
         End Function

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                  includeFormatCommandHandler, workspaceKind:=Nothing)
 
             testState.Workspace.GlobalOptions.SetGlobalOption(
-                New OptionKey(CompletionOptions.Metadata.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
+                New OptionKey(CompletionOptionsMetadata.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
 
             Return testState
         End Function
@@ -54,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 workspaceElement, excludedTypes:=Nothing, extraExportedTypes, includeFormatCommandHandler:=False, workspaceKind)
 
             testState.Workspace.GlobalOptions.SetGlobalOption(
-                New OptionKey(CompletionOptions.Metadata.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
+                New OptionKey(CompletionOptionsMetadata.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
 
             Return testState
         End Function

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                  includeFormatCommandHandler, workspaceKind:=Nothing)
 
             testState.Workspace.GlobalOptions.SetGlobalOption(
-                New OptionKey(CompletionOptionsMetadata.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
+                New OptionKey(CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
 
             Return testState
         End Function
@@ -54,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 workspaceElement, excludedTypes:=Nothing, extraExportedTypes, includeFormatCommandHandler:=False, workspaceKind)
 
             testState.Workspace.GlobalOptions.SetGlobalOption(
-                New OptionKey(CompletionOptionsMetadata.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
+                New OptionKey(CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
 
             Return testState
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
@@ -375,7 +375,7 @@ End Class</a>
                 workspaceFixture.GetWorkspace(ExportProvider)
                 Dim document1 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular)
 
-                Dim options = CompletionOptions.From(document1.Project.Solution.Options, document1.Project.Language)
+                Dim options = CompletionOptions.Default
 
                 If useDebuggerOptions Then
                     options.FilterOutOfScopeLocals = False

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
@@ -375,11 +375,12 @@ End Class</a>
                 workspaceFixture.GetWorkspace(ExportProvider)
                 Dim document1 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular)
 
-                Dim options = CompletionOptions.Default
+                Dim options As CompletionOptions
 
                 If useDebuggerOptions Then
-                    options.FilterOutOfScopeLocals = False
-                    options.ShowXmlDocCommentCompletion = False
+                    options = New CompletionOptions(FilterOutOfScopeLocals:=False, ShowXmlDocCommentCompletion:=False)
+                Else
+                    options = CompletionOptions.Default
                 End If
 
                 Await CheckResultsAsync(document1, position, isBuilder, triggerInfo, options)

--- a/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Completion
             return ShouldTriggerCompletionImpl(text, caretPosition, trigger, CompletionOptions.Default);
         }
 
-        internal override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options)
+        internal override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions)
             => ShouldTriggerCompletionImpl(text, caretPosition, trigger, options);
 
         private bool ShouldTriggerCompletionImpl(SourceText text, int caretPosition, CompletionTrigger trigger, in CompletionOptions options)

--- a/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Completion
             return ShouldTriggerCompletionImpl(text, caretPosition, trigger, CompletionOptions.Default);
         }
 
-        internal override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions)
+        internal override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passThroughOptions)
             => ShouldTriggerCompletionImpl(text, caretPosition, trigger, options);
 
         private bool ShouldTriggerCompletionImpl(SourceText text, int caretPosition, CompletionTrigger trigger, in CompletionOptions options)

--- a/src/Features/Core/Portable/Completion/CommonCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionService.cs
@@ -40,12 +40,12 @@ namespace Microsoft.CodeAnalysis.Completion
             Document document,
             int caretPosition,
             CompletionOptions options,
-            OptionSet passthroughOptions,
+            OptionSet passThroughOptions,
             CompletionTrigger trigger,
             ImmutableHashSet<string>? roles,
             CancellationToken cancellationToken)
         {
-            return GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, options, passthroughOptions, trigger, roles, cancellationToken);
+            return GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, options, passThroughOptions, trigger, roles, cancellationToken);
         }
 
         protected static bool IsKeywordItem(CompletionItem item)

--- a/src/Features/Core/Portable/Completion/CommonCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionService.cs
@@ -39,11 +39,12 @@ namespace Microsoft.CodeAnalysis.Completion
             Document document,
             int caretPosition,
             CompletionOptions options,
+            OptionSet passthroughOptions,
             CompletionTrigger trigger,
             ImmutableHashSet<string>? roles,
             CancellationToken cancellationToken)
         {
-            return GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, options, trigger, roles, cancellationToken);
+            return GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, options, passthroughOptions, trigger, roles, cancellationToken);
         }
 
         protected static bool IsKeywordItem(CompletionItem item)

--- a/src/Features/Core/Portable/Completion/CommonCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionService.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PatternMatching;
 using Microsoft.CodeAnalysis.Tags;
 

--- a/src/Features/Core/Portable/Completion/CompletionContext.cs
+++ b/src/Features/Core/Portable/Completion/CompletionContext.cs
@@ -117,7 +117,9 @@ namespace Microsoft.CodeAnalysis.Completion
                    CompletionOptions.Default,
                    cancellationToken)
         {
+#pragma warning disable RS0030 // Do not used banned APIs
             Options = options ?? OptionValueSet.Empty;
+#pragma warning restore
         }
 
         /// <summary>
@@ -139,8 +141,11 @@ namespace Microsoft.CodeAnalysis.Completion
             Trigger = trigger;
             CompletionOptions = options;
             CancellationToken = cancellationToken;
-            Options = OptionValueSet.Empty;
             _items = new List<CompletionItem>();
+
+#pragma warning disable RS0030 // Do not used banned APIs
+            Options = OptionValueSet.Empty;
+#pragma warning restore
         }
 
         internal IReadOnlyList<CompletionItem> Items => _items;

--- a/src/Features/Core/Portable/Completion/CompletionContext.cs
+++ b/src/Features/Core/Portable/Completion/CompletionContext.cs
@@ -43,10 +43,11 @@ namespace Microsoft.CodeAnalysis.Completion
         [Obsolete("Not used anymore. Use CompletionListSpan instead.", error: true)]
         public TextSpan DefaultItemSpan { get; }
 
+#pragma warning disable RS0030 // Do not used banned APIs
         /// <summary>
         /// The span of the document the completion list corresponds to.  It will be set initially to
         /// the result of <see cref="CompletionService.GetDefaultCompletionListSpan"/>, but it can
-        /// be overwritten during <see cref="CompletionService.GetCompletionsAsync(Document, int, CompletionOptions, CompletionTrigger, ImmutableHashSet{string}, CancellationToken)"/>.
+        /// be overwritten during <see cref="CompletionService.GetCompletionsAsync(Document, int, CompletionTrigger, ImmutableHashSet{string}, OptionSet, CancellationToken)"/>.
         /// The purpose of the span is to:
         ///     1. Signify where the completions should be presented.
         ///     2. Designate any existing text in the document that should be used for filtering.
@@ -54,6 +55,7 @@ namespace Microsoft.CodeAnalysis.Completion
         ///        item is committed.
         /// </summary>
         public TextSpan CompletionListSpan { get; set; }
+#pragma warning restore
 
         /// <summary>
         /// The triggering action that caused completion to be started.

--- a/src/Features/Core/Portable/Completion/CompletionContext.cs
+++ b/src/Features/Core/Portable/Completion/CompletionContext.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis.Completion
         private readonly List<CompletionItem> _items;
 
         private CompletionItem? _suggestionModeItem;
-        private OptionSet? _lazyOptionSet;
         private bool _isExclusive;
 
         internal CompletionProvider Provider { get; }
@@ -92,6 +91,11 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         /// <summary>
+        /// The options that completion was started with.
+        /// </summary>
+        public OptionSet Options { get; }
+
+        /// <summary>
         /// Creates a <see cref="CompletionContext"/> instance.
         /// </summary>
         public CompletionContext(
@@ -100,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Completion
             int position,
             TextSpan defaultSpan,
             CompletionTrigger trigger,
-            OptionSet options,
+            OptionSet? options,
             CancellationToken cancellationToken)
             : this(provider ?? throw new ArgumentNullException(nameof(provider)),
                    document ?? throw new ArgumentNullException(nameof(document)),
@@ -111,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Completion
                    CompletionOptions.Default,
                    cancellationToken)
         {
-            _lazyOptionSet = options ?? throw new ArgumentNullException(nameof(options));
+            Options = options ?? OptionValueSet.Empty;
         }
 
         /// <summary>
@@ -133,14 +137,9 @@ namespace Microsoft.CodeAnalysis.Completion
             Trigger = trigger;
             CompletionOptions = options;
             CancellationToken = cancellationToken;
+            Options = OptionValueSet.Empty;
             _items = new List<CompletionItem>();
         }
-
-        /// <summary>
-        /// The options that completion was started with.
-        /// </summary>
-        public OptionSet Options
-            => _lazyOptionSet ??= OptionValueSet.Empty;
 
         internal IReadOnlyList<CompletionItem> Items => _items;
 

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Recommendations;
 
 namespace Microsoft.CodeAnalysis.Completion
 {
-    internal record struct CompletionOptions(
+    internal readonly record struct CompletionOptions(
         bool TriggerOnTyping = true,
         bool TriggerOnTypingLetters = true,
         bool? TriggerOnDeletion = null,

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -2,206 +2,37 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Immutable;
-using System.Composition;
-using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Options.Providers;
 using Microsoft.CodeAnalysis.Recommendations;
 
 namespace Microsoft.CodeAnalysis.Completion
 {
     internal record struct CompletionOptions(
-        bool TriggerOnTyping,
-        bool TriggerOnTypingLetters,
-        bool? TriggerOnDeletion,
-        bool TriggerInArgumentLists,
-        EnterKeyRule EnterKeyBehavior,
-        SnippetsRule SnippetsBehavior,
-        bool HideAdvancedMembers,
-        bool ShowNameSuggestions,
-        bool? ShowItemsFromUnimportedNamespaces,
-        bool UnnamedSymbolCompletionDisabled,
-        bool TargetTypedCompletionFilter,
-        bool TypeImportCompletion,
-        bool ProvideDateAndTimeCompletions,
-        bool ProvideRegexCompletions,
-        bool ForceExpandedCompletionIndexCreation,
-        bool BlockOnExpandedCompletion,
+        bool TriggerOnTyping = true,
+        bool TriggerOnTypingLetters = true,
+        bool? TriggerOnDeletion = null,
+        bool TriggerInArgumentLists = true,
+        EnterKeyRule EnterKeyBehavior = EnterKeyRule.Default,
+        SnippetsRule SnippetsBehavior = SnippetsRule.Default,
+        bool HideAdvancedMembers = false,
+        bool ShowNameSuggestions = true,
+        bool? ShowItemsFromUnimportedNamespaces = null,
+        bool UnnamedSymbolCompletionDisabled = false,
+        bool TargetTypedCompletionFilter = false,
+        bool TypeImportCompletion = false,
+        bool ProvideDateAndTimeCompletions = true,
+        bool ProvideRegexCompletions = true,
+        bool ForceExpandedCompletionIndexCreation = false,
+        bool BlockOnExpandedCompletion = false,
         bool FilterOutOfScopeLocals = true,
         bool ShowXmlDocCommentCompletion = true,
         ExpandedCompletionMode ExpandedCompletionBehavior = ExpandedCompletionMode.AllItems)
     {
-        public static readonly CompletionOptions Default
-          = new(
-              TriggerOnTyping: Metadata.TriggerOnTyping.DefaultValue,
-              TriggerOnTypingLetters: Metadata.TriggerOnTypingLetters.DefaultValue,
-              TriggerOnDeletion: Metadata.TriggerOnDeletion.DefaultValue,
-              TriggerInArgumentLists: Metadata.TriggerInArgumentLists.DefaultValue,
-              EnterKeyBehavior: Metadata.EnterKeyBehavior.DefaultValue,
-              SnippetsBehavior: Metadata.SnippetsBehavior.DefaultValue,
-              HideAdvancedMembers: Metadata.HideAdvancedMembers.DefaultValue,
-              ShowNameSuggestions: Metadata.ShowNameSuggestions.DefaultValue,
-              ShowItemsFromUnimportedNamespaces: Metadata.ShowItemsFromUnimportedNamespaces.DefaultValue,
-              UnnamedSymbolCompletionDisabled: Metadata.UnnamedSymbolCompletionDisabledFeatureFlag.DefaultValue,
-              TargetTypedCompletionFilter: Metadata.TargetTypedCompletionFilterFeatureFlag.DefaultValue,
-              TypeImportCompletion: Metadata.TypeImportCompletionFeatureFlag.DefaultValue,
-              ProvideDateAndTimeCompletions: Metadata.ProvideDateAndTimeCompletions.DefaultValue,
-              ProvideRegexCompletions: Metadata.ProvideRegexCompletions.DefaultValue,
-              ForceExpandedCompletionIndexCreation: Metadata.ForceExpandedCompletionIndexCreation.DefaultValue,
-              BlockOnExpandedCompletion: Metadata.BlockOnExpandedCompletion.DefaultValue);
-
-        public static CompletionOptions From(IGlobalOptionService options, string language)
-          => new(
-              TriggerOnTyping: options.GetOption(Metadata.TriggerOnTyping, language),
-              TriggerOnTypingLetters: options.GetOption(Metadata.TriggerOnTypingLetters, language),
-              TriggerOnDeletion: options.GetOption(Metadata.TriggerOnDeletion, language),
-              TriggerInArgumentLists: options.GetOption(Metadata.TriggerInArgumentLists, language),
-              IsExpandedCompletion: options.GetOption(Metadata.IsExpandedCompletion),
-              EnterKeyBehavior: options.GetOption(Metadata.EnterKeyBehavior, language),
-              SnippetsBehavior: options.GetOption(Metadata.SnippetsBehavior, language),
-              HideAdvancedMembers: options.GetOption(Metadata.HideAdvancedMembers, language),
-              ShowNameSuggestions: options.GetOption(Metadata.ShowNameSuggestions, language),
-              ShowItemsFromUnimportedNamespaces: options.GetOption(Metadata.ShowItemsFromUnimportedNamespaces, language),
-              UnnamedSymbolCompletionDisabled: options.GetOption(Metadata.UnnamedSymbolCompletionDisabledFeatureFlag),
-              TargetTypedCompletionFilter: options.GetOption(Metadata.TargetTypedCompletionFilterFeatureFlag),
-              TypeImportCompletion: options.GetOption(Metadata.TypeImportCompletionFeatureFlag),
-              ProvideDateAndTimeCompletions: options.GetOption(Metadata.ProvideDateAndTimeCompletions, language),
-              ProvideRegexCompletions: options.GetOption(Metadata.ProvideRegexCompletions, language),
-              TimeoutInMillisecondsForExtensionMethodImportCompletion: options.GetOption(Metadata.TimeoutInMillisecondsForExtensionMethodImportCompletion));
-
-        /// <summary>
-        /// Supports legacy public APIs.
-        /// </summary>
-        [Obsolete("Read from global options instead")]
-        public static CompletionOptions From(OptionSet options, string language)
-          => new(
-              TriggerOnTyping: options.GetOption(Metadata.TriggerOnTyping, language),
-              TriggerOnTypingLetters: options.GetOption(Metadata.TriggerOnTypingLetters, language),
-              TriggerOnDeletion: options.GetOption(Metadata.TriggerOnDeletion, language),
-              TriggerInArgumentLists: options.GetOption(Metadata.TriggerInArgumentLists, language),
-              EnterKeyBehavior: options.GetOption(Metadata.EnterKeyBehavior, language),
-              SnippetsBehavior: options.GetOption(Metadata.SnippetsBehavior, language),
-              HideAdvancedMembers: options.GetOption(Metadata.HideAdvancedMembers, language),
-              ShowNameSuggestions: options.GetOption(Metadata.ShowNameSuggestions, language),
-              ShowItemsFromUnimportedNamespaces: options.GetOption(Metadata.ShowItemsFromUnimportedNamespaces, language),
-              UnnamedSymbolCompletionDisabled: options.GetOption(Metadata.UnnamedSymbolCompletionDisabledFeatureFlag),
-              TargetTypedCompletionFilter: options.GetOption(Metadata.TargetTypedCompletionFilterFeatureFlag),
-              TypeImportCompletion: options.GetOption(Metadata.TypeImportCompletionFeatureFlag),
-              ProvideDateAndTimeCompletions: options.GetOption(Metadata.ProvideDateAndTimeCompletions, language),
-              ProvideRegexCompletions: options.GetOption(Metadata.ProvideRegexCompletions, language),
-              ForceExpandedCompletionIndexCreation: options.GetOption(Metadata.ForceExpandedCompletionIndexCreation),
-              BlockOnExpandedCompletion: options.GetOption(Metadata.BlockOnExpandedCompletion));
-
-        /// <summary>
-        /// Supports legacy public APIs.
-        /// </summary>
-        [Obsolete("Read from global options instead")]
-        public OptionSet WithChangedOptions(OptionSet set, string language)
-            => set.
-                WithChangedOption(Metadata.TriggerOnTyping, language, TriggerOnTyping).
-                WithChangedOption(Metadata.TriggerOnTypingLetters, language, TriggerOnTypingLetters).
-                WithChangedOption(Metadata.TriggerOnDeletion, language, TriggerOnDeletion).
-                WithChangedOption(Metadata.TriggerInArgumentLists, language, TriggerInArgumentLists).
-                WithChangedOption(Metadata.EnterKeyBehavior, language, EnterKeyBehavior).
-                WithChangedOption(Metadata.SnippetsBehavior, language, SnippetsBehavior).
-                WithChangedOption(Metadata.HideAdvancedMembers, language, HideAdvancedMembers).
-                WithChangedOption(Metadata.ShowNameSuggestions, language, ShowNameSuggestions).
-                WithChangedOption(Metadata.ShowItemsFromUnimportedNamespaces, language, ShowItemsFromUnimportedNamespaces).
-                WithChangedOption(Metadata.UnnamedSymbolCompletionDisabledFeatureFlag, UnnamedSymbolCompletionDisabled).
-                WithChangedOption(Metadata.TargetTypedCompletionFilterFeatureFlag, TargetTypedCompletionFilter).
-                WithChangedOption(Metadata.TypeImportCompletionFeatureFlag, TypeImportCompletion).
-                WithChangedOption(Metadata.ProvideDateAndTimeCompletions, language, ProvideDateAndTimeCompletions).
-                WithChangedOption(Metadata.ProvideRegexCompletions, language, ProvideRegexCompletions).
-                WithChangedOption(Metadata.ForceExpandedCompletionIndexCreation, ForceExpandedCompletionIndexCreation).
-                WithChangedOption(Metadata.BlockOnExpandedCompletion, BlockOnExpandedCompletion);
-
-        /// <summary>
-        /// Supports legacy public APIs.
-        /// </summary>
-        [Obsolete("Read from global options instead")]
-        public OptionSet ToSet(string language)
-            => WithChangedOptions(OptionValueSet.Empty, language);
+        // note: must pass at least one parameter to avoid calling default ctor:
+        public static readonly CompletionOptions Default = new(TriggerOnTyping: true);
 
         public RecommendationServiceOptions ToRecommendationServiceOptions()
             => new(
                 FilterOutOfScopeLocals: FilterOutOfScopeLocals,
                 HideAdvancedMembers: HideAdvancedMembers);
-
-        internal sealed class Metadata
-        {
-            // feature flags
-
-            public static readonly Option2<bool> TypeImportCompletionFeatureFlag = new(nameof(CompletionOptions), nameof(TypeImportCompletionFeatureFlag), defaultValue: false,
-                new FeatureFlagStorageLocation("Roslyn.TypeImportCompletion"));
-
-            public static readonly Option2<bool> TargetTypedCompletionFilterFeatureFlag = new(nameof(CompletionOptions), nameof(TargetTypedCompletionFilterFeatureFlag), defaultValue: false,
-                new FeatureFlagStorageLocation("Roslyn.TargetTypedCompletionFilter"));
-
-            public static readonly Option2<bool> UnnamedSymbolCompletionDisabledFeatureFlag = new(nameof(CompletionOptions), nameof(UnnamedSymbolCompletionDisabledFeatureFlag), defaultValue: false,
-                new FeatureFlagStorageLocation("Roslyn.UnnamedSymbolCompletionDisabled"));
-
-            // This is serialized by the Visual Studio-specific LanguageSettingsPersister
-            public static readonly PerLanguageOption2<bool> HideAdvancedMembers = new(nameof(CompletionOptions), nameof(HideAdvancedMembers), defaultValue: false);
-
-            // This is serialized by the Visual Studio-specific LanguageSettingsPersister
-            public static readonly PerLanguageOption2<bool> TriggerOnTyping = new(nameof(CompletionOptions), nameof(TriggerOnTyping), defaultValue: true);
-
-            public static readonly PerLanguageOption2<bool> TriggerOnTypingLetters = new(nameof(CompletionOptions), nameof(TriggerOnTypingLetters), defaultValue: true,
-                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerOnTypingLetters"));
-
-            public static readonly PerLanguageOption2<bool?> TriggerOnDeletion = new(nameof(CompletionOptions), nameof(TriggerOnDeletion), defaultValue: null,
-                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerOnDeletion"));
-
-            public static readonly PerLanguageOption2<EnterKeyRule> EnterKeyBehavior =
-                new(nameof(CompletionOptions), nameof(EnterKeyBehavior), defaultValue: EnterKeyRule.Default,
-                    storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.EnterKeyBehavior"));
-
-            public static readonly PerLanguageOption2<SnippetsRule> SnippetsBehavior =
-                new(nameof(CompletionOptions), nameof(SnippetsBehavior), defaultValue: SnippetsRule.Default,
-                    storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SnippetsBehavior"));
-
-            public static readonly PerLanguageOption2<bool> ShowNameSuggestions =
-                new(nameof(CompletionOptions), nameof(ShowNameSuggestions), defaultValue: true,
-                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowNameSuggestions"));
-
-            //Dev16 options
-
-            // Use tri-value so the default state can be used to turn on the feature with experimentation service.
-            public static readonly PerLanguageOption2<bool?> ShowItemsFromUnimportedNamespaces =
-                new(nameof(CompletionOptions), nameof(ShowItemsFromUnimportedNamespaces), defaultValue: null,
-                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowItemsFromUnimportedNamespaces"));
-
-            public static readonly PerLanguageOption2<bool> TriggerInArgumentLists =
-                new(nameof(CompletionOptions), nameof(TriggerInArgumentLists), defaultValue: true,
-                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerInArgumentLists"));
-
-            // Test-only option
-            public static readonly Option2<bool> ForceExpandedCompletionIndexCreation
-                = new(nameof(CompletionOptions), nameof(ForceExpandedCompletionIndexCreation), defaultValue: false);
-
-            // Test-only option
-            // Set this to true to have a deterministic behavior for expand items. Otherwise, expand items might not
-            // be included in the completion list if the calculation is slow.
-            public static readonly Option2<bool> BlockOnExpandedCompletion
-                = new(nameof(CompletionOptions), nameof(BlockOnExpandedCompletion), defaultValue: false);
-
-            // Embedded languages:
-
-            public static PerLanguageOption2<bool> ProvideRegexCompletions =
-                new(
-                    "RegularExpressionsOptions",
-                    nameof(ProvideRegexCompletions),
-                    defaultValue: true,
-                    storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ProvideRegexCompletions"));
-
-            public static readonly PerLanguageOption2<bool> ProvideDateAndTimeCompletions =
-                new(
-                    "DateAndTime",
-                    nameof(ProvideDateAndTimeCompletions),
-                    defaultValue: true,
-                    storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ProvideDateAndTimeCompletions"));
-        }
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -52,9 +52,29 @@ namespace Microsoft.CodeAnalysis.Completion
               ForceExpandedCompletionIndexCreation: Metadata.ForceExpandedCompletionIndexCreation.DefaultValue,
               BlockOnExpandedCompletion: Metadata.BlockOnExpandedCompletion.DefaultValue);
 
-        public static CompletionOptions From(Project project)
-            => From(project.Solution.Options, project.Language);
+        public static CompletionOptions From(IGlobalOptionService options, string language)
+          => new(
+              TriggerOnTyping: options.GetOption(Metadata.TriggerOnTyping, language),
+              TriggerOnTypingLetters: options.GetOption(Metadata.TriggerOnTypingLetters, language),
+              TriggerOnDeletion: options.GetOption(Metadata.TriggerOnDeletion, language),
+              TriggerInArgumentLists: options.GetOption(Metadata.TriggerInArgumentLists, language),
+              IsExpandedCompletion: options.GetOption(Metadata.IsExpandedCompletion),
+              EnterKeyBehavior: options.GetOption(Metadata.EnterKeyBehavior, language),
+              SnippetsBehavior: options.GetOption(Metadata.SnippetsBehavior, language),
+              HideAdvancedMembers: options.GetOption(Metadata.HideAdvancedMembers, language),
+              ShowNameSuggestions: options.GetOption(Metadata.ShowNameSuggestions, language),
+              ShowItemsFromUnimportedNamespaces: options.GetOption(Metadata.ShowItemsFromUnimportedNamespaces, language),
+              UnnamedSymbolCompletionDisabled: options.GetOption(Metadata.UnnamedSymbolCompletionDisabledFeatureFlag),
+              TargetTypedCompletionFilter: options.GetOption(Metadata.TargetTypedCompletionFilterFeatureFlag),
+              TypeImportCompletion: options.GetOption(Metadata.TypeImportCompletionFeatureFlag),
+              ProvideDateAndTimeCompletions: options.GetOption(Metadata.ProvideDateAndTimeCompletions, language),
+              ProvideRegexCompletions: options.GetOption(Metadata.ProvideRegexCompletions, language),
+              TimeoutInMillisecondsForExtensionMethodImportCompletion: options.GetOption(Metadata.TimeoutInMillisecondsForExtensionMethodImportCompletion));
 
+        /// <summary>
+        /// Supports legacy public APIs.
+        /// </summary>
+        [Obsolete("Read from global options instead")]
         public static CompletionOptions From(OptionSet options, string language)
           => new(
               TriggerOnTyping: options.GetOption(Metadata.TriggerOnTyping, language),
@@ -74,6 +94,10 @@ namespace Microsoft.CodeAnalysis.Completion
               ForceExpandedCompletionIndexCreation: options.GetOption(Metadata.ForceExpandedCompletionIndexCreation),
               BlockOnExpandedCompletion: options.GetOption(Metadata.BlockOnExpandedCompletion));
 
+        /// <summary>
+        /// Supports legacy public APIs.
+        /// </summary>
+        [Obsolete("Read from global options instead")]
         public OptionSet WithChangedOptions(OptionSet set, string language)
             => set.
                 WithChangedOption(Metadata.TriggerOnTyping, language, TriggerOnTyping).
@@ -93,39 +117,20 @@ namespace Microsoft.CodeAnalysis.Completion
                 WithChangedOption(Metadata.ForceExpandedCompletionIndexCreation, ForceExpandedCompletionIndexCreation).
                 WithChangedOption(Metadata.BlockOnExpandedCompletion, BlockOnExpandedCompletion);
 
+        /// <summary>
+        /// Supports legacy public APIs.
+        /// </summary>
+        [Obsolete("Read from global options instead")]
+        public OptionSet ToSet(string language)
+            => WithChangedOptions(OptionValueSet.Empty, language);
+
         public RecommendationServiceOptions ToRecommendationServiceOptions()
             => new(
                 FilterOutOfScopeLocals: FilterOutOfScopeLocals,
                 HideAdvancedMembers: HideAdvancedMembers);
 
-        public OptionSet ToSet(string language)
-            => WithChangedOptions(OptionValueSet.Empty, language);
-
-        [ExportSolutionOptionProvider, Shared]
-        internal sealed class Metadata : IOptionProvider
+        internal sealed class Metadata
         {
-            [ImportingConstructor]
-            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public Metadata()
-            {
-            }
-
-            public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
-                TypeImportCompletionFeatureFlag,
-                TargetTypedCompletionFilterFeatureFlag,
-                UnnamedSymbolCompletionDisabledFeatureFlag,
-                HideAdvancedMembers,
-                TriggerOnTyping,
-                TriggerOnTypingLetters,
-                EnterKeyBehavior,
-                SnippetsBehavior,
-                ShowItemsFromUnimportedNamespaces,
-                TriggerInArgumentLists,
-                ProvideRegexCompletions,
-                ProvideDateAndTimeCompletions,
-                ForceExpandedCompletionIndexCreation,
-                BlockOnExpandedCompletion);
-
             // feature flags
 
             public static readonly Option2<bool> TypeImportCompletionFeatureFlag = new(nameof(CompletionOptions), nameof(TypeImportCompletionFeatureFlag), defaultValue: false,

--- a/src/Features/Core/Portable/Completion/CompletionOptionsMetadata.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptionsMetadata.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Completion
+{
+    // TODO: Move to EditorFeatures https://github.com/dotnet/roslyn/issues/59184
+    internal static class CompletionOptionsMetadata
+    {
+        public static CompletionOptions GetCompletionOptions(this IGlobalOptionService options, string language)
+          => new(
+              TriggerOnTyping: options.GetOption(TriggerOnTyping, language),
+              TriggerOnTypingLetters: options.GetOption(TriggerOnTypingLetters, language),
+              TriggerOnDeletion: options.GetOption(TriggerOnDeletion, language),
+              TriggerInArgumentLists: options.GetOption(TriggerInArgumentLists, language),
+              IsExpandedCompletion: options.GetOption(IsExpandedCompletion),
+              EnterKeyBehavior: options.GetOption(EnterKeyBehavior, language),
+              SnippetsBehavior: options.GetOption(SnippetsBehavior, language),
+              HideAdvancedMembers: options.GetOption(HideAdvancedMembers, language),
+              ShowNameSuggestions: options.GetOption(ShowNameSuggestions, language),
+              ShowItemsFromUnimportedNamespaces: options.GetOption(ShowItemsFromUnimportedNamespaces, language),
+              UnnamedSymbolCompletionDisabled: options.GetOption(UnnamedSymbolCompletionDisabledFeatureFlag),
+              TargetTypedCompletionFilter: options.GetOption(TargetTypedCompletionFilterFeatureFlag),
+              TypeImportCompletion: options.GetOption(TypeImportCompletionFeatureFlag),
+              ProvideDateAndTimeCompletions: options.GetOption(ProvideDateAndTimeCompletions, language),
+              ProvideRegexCompletions: options.GetOption(ProvideRegexCompletions, language),
+              TimeoutInMillisecondsForExtensionMethodImportCompletion: options.GetOption(TimeoutInMillisecondsForExtensionMethodImportCompletion));
+
+        // feature flags
+
+        public static readonly Option2<bool> TypeImportCompletionFeatureFlag = new(nameof(CompletionOptions), nameof(TypeImportCompletionFeatureFlag),
+            CompletionOptions.Default.TypeImportCompletion,
+            new FeatureFlagStorageLocation("Roslyn.TypeImportCompletion"));
+
+        public static readonly Option2<bool> TargetTypedCompletionFilterFeatureFlag = new(nameof(CompletionOptions), nameof(TargetTypedCompletionFilterFeatureFlag),
+            CompletionOptions.Default.TargetTypedCompletionFilter,
+            new FeatureFlagStorageLocation("Roslyn.TargetTypedCompletionFilter"));
+
+        public static readonly Option2<bool> UnnamedSymbolCompletionDisabledFeatureFlag = new(nameof(CompletionOptions), nameof(UnnamedSymbolCompletionDisabledFeatureFlag),
+            CompletionOptions.Default.UnnamedSymbolCompletionDisabled,
+            new FeatureFlagStorageLocation("Roslyn.UnnamedSymbolCompletionDisabled"));
+
+        // This is serialized by the Visual Studio-specific LanguageSettingsPersister
+        public static readonly PerLanguageOption2<bool> HideAdvancedMembers = new(nameof(CompletionOptions), nameof(HideAdvancedMembers), CompletionOptions.Default.HideAdvancedMembers);
+
+        // This is serialized by the Visual Studio-specific LanguageSettingsPersister
+        public static readonly PerLanguageOption2<bool> TriggerOnTyping = new(nameof(CompletionOptions), nameof(TriggerOnTyping), CompletionOptions.Default.TriggerOnTyping);
+
+        public static readonly PerLanguageOption2<bool> TriggerOnTypingLetters = new(nameof(CompletionOptions), nameof(TriggerOnTypingLetters), CompletionOptions.Default.TriggerOnTypingLetters,
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerOnTypingLetters"));
+
+        public static readonly PerLanguageOption2<bool?> TriggerOnDeletion = new(nameof(CompletionOptions), nameof(TriggerOnDeletion), CompletionOptions.Default.TriggerOnDeletion,
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerOnDeletion"));
+
+        public static readonly PerLanguageOption2<EnterKeyRule> EnterKeyBehavior =
+            new(nameof(CompletionOptions), nameof(EnterKeyBehavior), CompletionOptions.Default.EnterKeyBehavior,
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.EnterKeyBehavior"));
+
+        public static readonly PerLanguageOption2<SnippetsRule> SnippetsBehavior =
+            new(nameof(CompletionOptions), nameof(SnippetsBehavior), CompletionOptions.Default.SnippetsBehavior,
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.SnippetsBehavior"));
+
+        public static readonly PerLanguageOption2<bool> ShowNameSuggestions =
+            new(nameof(CompletionOptions), nameof(ShowNameSuggestions), CompletionOptions.Default.ShowNameSuggestions,
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowNameSuggestions"));
+
+        //Dev16 options
+
+        // Use tri-value so the default state can be used to turn on the feature with experimentation service.
+        public static readonly PerLanguageOption2<bool?> ShowItemsFromUnimportedNamespaces =
+            new(nameof(CompletionOptions), nameof(ShowItemsFromUnimportedNamespaces), CompletionOptions.Default.ShowItemsFromUnimportedNamespaces,
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowItemsFromUnimportedNamespaces"));
+
+        public static readonly PerLanguageOption2<bool> TriggerInArgumentLists =
+            new(nameof(CompletionOptions), nameof(TriggerInArgumentLists), CompletionOptions.Default.TriggerInArgumentLists,
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerInArgumentLists"));
+
+        /// <summary>
+        /// Indicates if the completion is trigger by toggle the expander.
+        /// </summary>
+        public static readonly Option2<bool> IsExpandedCompletion
+            = new("CompletionServiceOptions", nameof(IsExpandedCompletion), CompletionOptions.Default.IsExpandedCompletion);
+
+        /// <summary>
+        /// Timeout value used for time-boxing completion of unimported extension methods.
+        /// Value less than 0 means no timebox; value == 0 means immediate timeout (for testing purpose)
+        /// </summary>
+        public static readonly Option2<int> TimeoutInMillisecondsForExtensionMethodImportCompletion
+            = new("CompletionServiceOptions", nameof(TimeoutInMillisecondsForExtensionMethodImportCompletion), CompletionOptions.Default.TimeoutInMillisecondsForExtensionMethodImportCompletion);
+
+        // Embedded languages:
+
+        public static PerLanguageOption2<bool> ProvideRegexCompletions =
+            new(
+                "RegularExpressionsOptions",
+                nameof(ProvideRegexCompletions),
+                CompletionOptions.Default.ProvideRegexCompletions,
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ProvideRegexCompletions"));
+
+        public static readonly PerLanguageOption2<bool> ProvideDateAndTimeCompletions =
+            new(
+                "DateAndTime",
+                nameof(ProvideDateAndTimeCompletions),
+                CompletionOptions.Default.ProvideDateAndTimeCompletions,
+                storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ProvideDateAndTimeCompletions"));
+    }
+}

--- a/src/Features/Core/Portable/Completion/CompletionOptionsStorage.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptionsStorage.cs
@@ -15,7 +15,6 @@ namespace Microsoft.CodeAnalysis.Completion
               TriggerOnTypingLetters: options.GetOption(TriggerOnTypingLetters, language),
               TriggerOnDeletion: options.GetOption(TriggerOnDeletion, language),
               TriggerInArgumentLists: options.GetOption(TriggerInArgumentLists, language),
-              IsExpandedCompletion: options.GetOption(IsExpandedCompletion),
               EnterKeyBehavior: options.GetOption(EnterKeyBehavior, language),
               SnippetsBehavior: options.GetOption(SnippetsBehavior, language),
               HideAdvancedMembers: options.GetOption(HideAdvancedMembers, language),
@@ -26,7 +25,8 @@ namespace Microsoft.CodeAnalysis.Completion
               TypeImportCompletion: options.GetOption(TypeImportCompletionFeatureFlag),
               ProvideDateAndTimeCompletions: options.GetOption(ProvideDateAndTimeCompletions, language),
               ProvideRegexCompletions: options.GetOption(ProvideRegexCompletions, language),
-              TimeoutInMillisecondsForExtensionMethodImportCompletion: options.GetOption(TimeoutInMillisecondsForExtensionMethodImportCompletion));
+              ForceExpandedCompletionIndexCreation: options.GetOption(ForceExpandedCompletionIndexCreation),
+              BlockOnExpandedCompletion: options.GetOption(BlockOnExpandedCompletion));
 
         // feature flags
 
@@ -77,18 +77,15 @@ namespace Microsoft.CodeAnalysis.Completion
             new(nameof(CompletionOptions), nameof(TriggerInArgumentLists), CompletionOptions.Default.TriggerInArgumentLists,
             storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerInArgumentLists"));
 
-        /// <summary>
-        /// Indicates if the completion is trigger by toggle the expander.
-        /// </summary>
-        public static readonly Option2<bool> IsExpandedCompletion
-            = new("CompletionServiceOptions", nameof(IsExpandedCompletion), CompletionOptions.Default.IsExpandedCompletion);
+        // Test-only option
+        public static readonly Option2<bool> ForceExpandedCompletionIndexCreation
+            = new(nameof(CompletionOptions), nameof(ForceExpandedCompletionIndexCreation), defaultValue: false);
 
-        /// <summary>
-        /// Timeout value used for time-boxing completion of unimported extension methods.
-        /// Value less than 0 means no timebox; value == 0 means immediate timeout (for testing purpose)
-        /// </summary>
-        public static readonly Option2<int> TimeoutInMillisecondsForExtensionMethodImportCompletion
-            = new("CompletionServiceOptions", nameof(TimeoutInMillisecondsForExtensionMethodImportCompletion), CompletionOptions.Default.TimeoutInMillisecondsForExtensionMethodImportCompletion);
+        // Test-only option
+        // Set this to true to have a deterministic behavior for expand items. Otherwise, expand items might not
+        // be included in the completion list if the calculation is slow.
+        public static readonly Option2<bool> BlockOnExpandedCompletion
+            = new(nameof(CompletionOptions), nameof(BlockOnExpandedCompletion), defaultValue: false);
 
         // Embedded languages:
 

--- a/src/Features/Core/Portable/Completion/CompletionOptionsStorage.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptionsStorage.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Options;
 namespace Microsoft.CodeAnalysis.Completion
 {
     // TODO: Move to EditorFeatures https://github.com/dotnet/roslyn/issues/59184
-    internal static class CompletionOptionsMetadata
+    internal static class CompletionOptionsStorage
     {
         public static CompletionOptions GetCompletionOptions(this IGlobalOptionService options, string language)
           => new(

--- a/src/Features/Core/Portable/Completion/CompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CompletionProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="trigger">The triggering action.</param>
         /// <param name="options">The set of options in effect.</param>
         internal virtual bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options)
-#pragma warning disable RS0030 // Do not use banned APIs
+#pragma warning disable RS0030, CS0618 // Do not used banned/obsolete APIs
             => ShouldTriggerCompletion(text, caretPosition, trigger, options.ToSet(languageServices.Language));
 #pragma warning restore
 

--- a/src/Features/Core/Portable/Completion/CompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CompletionProvider.cs
@@ -44,9 +44,9 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="caretPosition">The position of the caret after the triggering action.</param>
         /// <param name="trigger">The triggering action.</param>
         /// <param name="options">The set of options in effect.</param>
-        internal virtual bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions)
+        internal virtual bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passThroughOptions)
 #pragma warning disable RS0030, CS0618 // Do not used banned/obsolete APIs
-            => ShouldTriggerCompletion(text, caretPosition, trigger, passthroughOptions);
+            => ShouldTriggerCompletion(text, caretPosition, trigger, passThroughOptions);
 #pragma warning restore
 
         /// <summary>

--- a/src/Features/Core/Portable/Completion/CompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CompletionProvider.cs
@@ -44,9 +44,9 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="caretPosition">The position of the caret after the triggering action.</param>
         /// <param name="trigger">The triggering action.</param>
         /// <param name="options">The set of options in effect.</param>
-        internal virtual bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options)
+        internal virtual bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions)
 #pragma warning disable RS0030, CS0618 // Do not used banned/obsolete APIs
-            => ShouldTriggerCompletion(text, caretPosition, trigger, options.ToSet(languageServices.Language));
+            => ShouldTriggerCompletion(text, caretPosition, trigger, passthroughOptions);
 #pragma warning restore
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// an augmenting provider instead.
         /// </summary>
         internal virtual async Task<bool> IsSyntacticTriggerCharacterAsync(Document document, int caretPosition, CompletionTrigger trigger, CompletionOptions options, CancellationToken cancellationToken)
-            => ShouldTriggerCompletion(document.Project.LanguageServices, await document.GetTextAsync(cancellationToken).ConfigureAwait(false), caretPosition, trigger, options);
+            => ShouldTriggerCompletion(document.Project.LanguageServices, await document.GetTextAsync(cancellationToken).ConfigureAwait(false), caretPosition, trigger, options, document.Project.Solution.Options);
 
         /// <summary>
         /// Gets the description of the specified item.

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -78,6 +78,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="caretPosition">The position of the caret after the triggering action.</param>
         /// <param name="trigger">The potential triggering action.</param>
         /// <param name="options">Options.</param>
+        /// <param name="passthroughOptions">Options originating either from external caller of the <see cref="CompletionService"/> or set externally to <see cref="Solution.Options"/>.</param>
         /// <param name="roles">Optional set of roles associated with the editor state.</param>
         /// <remarks>
         /// We pass the project here to retrieve information about the <see cref="Project.AnalyzerReferences"/>,
@@ -91,12 +92,11 @@ namespace Microsoft.CodeAnalysis.Completion
             int caretPosition,
             CompletionTrigger trigger,
             CompletionOptions options,
+            OptionSet passthroughOptions,
             ImmutableHashSet<string>? roles = null)
         {
-#pragma warning disable CS0618 // Obsolete API
             Debug.Fail("Backward compat only, should not be called");
-            return ShouldTriggerCompletion(text, caretPosition, trigger, roles, options.ToSet(languageServices.Language));
-#pragma warning restore
+            return ShouldTriggerCompletion(text, caretPosition, trigger, roles, passthroughOptions);
         }
 
         /// <summary>
@@ -145,13 +145,13 @@ namespace Microsoft.CodeAnalysis.Completion
              Document document,
              int caretPosition,
              CompletionOptions options,
+             OptionSet passthroughOptions,
              CompletionTrigger trigger = default,
              ImmutableHashSet<string>? roles = null,
              CancellationToken cancellationToken = default)
         {
 #pragma warning disable RS0030 // Do not use banned APIs
-            return await GetCompletionsAsync(document, caretPosition, trigger, roles,
-                options.ToSet(document.Project.Language), cancellationToken).ConfigureAwait(false) ?? CompletionList.Empty;
+            return await GetCompletionsAsync(document, caretPosition, trigger, roles, passthroughOptions, cancellationToken).ConfigureAwait(false) ?? CompletionList.Empty;
 #pragma warning restore
         }
 

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// <param name="caretPosition">The position of the caret after the triggering action.</param>
         /// <param name="trigger">The potential triggering action.</param>
         /// <param name="options">Options.</param>
-        /// <param name="passthroughOptions">Options originating either from external caller of the <see cref="CompletionService"/> or set externally to <see cref="Solution.Options"/>.</param>
+        /// <param name="passThroughOptions">Options originating either from external caller of the <see cref="CompletionService"/> or set externally to <see cref="Solution.Options"/>.</param>
         /// <param name="roles">Optional set of roles associated with the editor state.</param>
         /// <remarks>
         /// We pass the project here to retrieve information about the <see cref="Project.AnalyzerReferences"/>,
@@ -92,11 +92,11 @@ namespace Microsoft.CodeAnalysis.Completion
             int caretPosition,
             CompletionTrigger trigger,
             CompletionOptions options,
-            OptionSet passthroughOptions,
+            OptionSet passThroughOptions,
             ImmutableHashSet<string>? roles = null)
         {
             Debug.Fail("Backward compat only, should not be called");
-            return ShouldTriggerCompletion(text, caretPosition, trigger, roles, passthroughOptions);
+            return ShouldTriggerCompletion(text, caretPosition, trigger, roles, passThroughOptions);
         }
 
         /// <summary>
@@ -145,13 +145,13 @@ namespace Microsoft.CodeAnalysis.Completion
              Document document,
              int caretPosition,
              CompletionOptions options,
-             OptionSet passthroughOptions,
+             OptionSet passThroughOptions,
              CompletionTrigger trigger = default,
              ImmutableHashSet<string>? roles = null,
              CancellationToken cancellationToken = default)
         {
 #pragma warning disable RS0030 // Do not use banned APIs
-            return await GetCompletionsAsync(document, caretPosition, trigger, roles, passthroughOptions, cancellationToken).ConfigureAwait(false) ?? CompletionList.Empty;
+            return await GetCompletionsAsync(document, caretPosition, trigger, roles, passThroughOptions, cancellationToken).ConfigureAwait(false) ?? CompletionList.Empty;
 #pragma warning restore
         }
 

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -93,8 +93,10 @@ namespace Microsoft.CodeAnalysis.Completion
             CompletionOptions options,
             ImmutableHashSet<string>? roles = null)
         {
+#pragma warning disable CS0618 // Obsolete API
             Debug.Fail("Backward compat only, should not be called");
             return ShouldTriggerCompletion(text, caretPosition, trigger, roles, options.ToSet(languageServices.Language));
+#pragma warning restore
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -97,13 +97,16 @@ namespace Microsoft.CodeAnalysis.Completion
         {
             // Publicly available options do not affect this API.
             var completionOptions = CompletionOptions.Default;
-            return await GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, completionOptions, trigger, roles, cancellationToken).ConfigureAwait(false);
+            var passthroughOptions = options ?? document.Project.Solution.Options;
+
+            return await GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, completionOptions, trigger, roles, passthroughOptions, cancellationToken).ConfigureAwait(false);
         }
 
         private protected async Task<CompletionList> GetCompletionsWithAvailabilityOfExpandedItemsAsync(
             Document document,
             int caretPosition,
             CompletionOptions options,
+            OptionSet passthroughOptions,
             CompletionTrigger trigger,
             ImmutableHashSet<string>? roles,
             CancellationToken cancellationToken)
@@ -114,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Completion
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var defaultItemSpan = GetDefaultCompletionListSpan(text, caretPosition);
 
-            var providers = _providerManager.GetFilteredProviders(document.Project, roles, trigger, options);
+            var providers = _providerManager.GetFilteredProviders(document.Project, roles, trigger, options, passthroughOptions);
 
             // Phase 1: Completion Providers decide if they are triggered based on textual analysis
             // Phase 2: Completion Providers use syntax to confirm they are triggered, or decide they are not actually triggered and should become an augmenting provider

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -216,7 +216,9 @@ namespace Microsoft.CodeAnalysis.Completion
 
             // Publicly available options do not affect this API.
             var completionOptions = CompletionOptions.Default;
-            return ShouldTriggerCompletion(document?.Project, languageServices, text, caretPosition, trigger, completionOptions, options ?? OptionValueSet.Empty, roles);
+            var passThroughOptions = options ?? document?.Project.Solution.Options ?? OptionValueSet.Empty;
+
+            return ShouldTriggerCompletion(document?.Project, languageServices, text, caretPosition, trigger, completionOptions, passThroughOptions, roles);
         }
 
         internal sealed override bool ShouldTriggerCompletion(

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -97,16 +97,16 @@ namespace Microsoft.CodeAnalysis.Completion
         {
             // Publicly available options do not affect this API.
             var completionOptions = CompletionOptions.Default;
-            var passthroughOptions = options ?? document.Project.Solution.Options;
+            var passThroughOptions = options ?? document.Project.Solution.Options;
 
-            return await GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, completionOptions, passthroughOptions, trigger, roles, cancellationToken).ConfigureAwait(false);
+            return await GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, completionOptions, passThroughOptions, trigger, roles, cancellationToken).ConfigureAwait(false);
         }
 
         private protected async Task<CompletionList> GetCompletionsWithAvailabilityOfExpandedItemsAsync(
             Document document,
             int caretPosition,
             CompletionOptions options,
-            OptionSet passthroughOptions,
+            OptionSet passThroughOptions,
             CompletionTrigger trigger,
             ImmutableHashSet<string>? roles,
             CancellationToken cancellationToken)
@@ -172,9 +172,9 @@ namespace Microsoft.CodeAnalysis.Completion
                     case CompletionTriggerKind.Insertion:
                     case CompletionTriggerKind.Deletion:
 
-                        if (ShouldTriggerCompletion(document.Project, document.Project.LanguageServices, text, caretPosition, trigger, options, passthroughOptions, roles))
+                        if (ShouldTriggerCompletion(document.Project, document.Project.LanguageServices, text, caretPosition, trigger, options, passThroughOptions, roles))
                         {
-                            var triggeredProviders = providers.Where(p => p.ShouldTriggerCompletion(document.Project.LanguageServices, text, caretPosition, trigger, options, passthroughOptions)).ToImmutableArrayOrEmpty();
+                            var triggeredProviders = providers.Where(p => p.ShouldTriggerCompletion(document.Project.LanguageServices, text, caretPosition, trigger, options, passThroughOptions)).ToImmutableArrayOrEmpty();
 
                             Debug.Assert(ValidatePossibleTriggerCharacterSet(trigger.Kind, triggeredProviders, document, text, caretPosition, options));
                             return triggeredProviders.IsEmpty ? providers.ToImmutableArray() : triggeredProviders;
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         internal sealed override bool ShouldTriggerCompletion(
-            Project? project, HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions, ImmutableHashSet<string>? roles = null)
+            Project? project, HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passThroughOptions, ImmutableHashSet<string>? roles = null)
         {
             if (!options.TriggerOnTyping)
             {
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Completion
             }
 
             var providers = _providerManager.GetFilteredProviders(project, roles, trigger, options);
-            return providers.Any(p => p.ShouldTriggerCompletion(languageServices, text, caretPosition, trigger, options, passthroughOptions));
+            return providers.Any(p => p.ShouldTriggerCompletion(languageServices, text, caretPosition, trigger, options, passThroughOptions));
         }
 
         internal virtual bool SupportsTriggerOnDeletion(CompletionOptions options)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAggregateEmbeddedLanguageCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAggregateEmbeddedLanguageCompletionProvider.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public override ImmutableHashSet<char> TriggerCharacters { get; }
 
-        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options)
+        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions)
         {
             foreach (var language in GetLanguageProviders(languageServices))
             {

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAggregateEmbeddedLanguageCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAggregateEmbeddedLanguageCompletionProvider.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public override ImmutableHashSet<char> TriggerCharacters { get; }
 
-        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions)
+        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passThroughOptions)
         {
             foreach (var language in GetLanguageProviders(languageServices))
             {

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionProvider.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             return ShouldTriggerCompletionImpl(text, caretPosition, trigger, CompletionOptions.Default.TriggerOnTypingLetters);
         }
 
-        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions)
+        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passThroughOptions)
             => ShouldTriggerCompletionImpl(text, caretPosition, trigger, options.TriggerOnTypingLetters);
 
         protected abstract bool ShouldTriggerCompletionImpl(SourceText text, int caretPosition, CompletionTrigger trigger, bool triggerOnTypingLetters);

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionProvider.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
@@ -13,11 +14,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
     {
         public sealed override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
         {
-            var triggerOnTypingLetters = options.GetOption(CompletionOptions.Metadata.TriggerOnTypingLetters, InternalLanguageNames.TypeScript);
-            return ShouldTriggerCompletionImpl(text, caretPosition, trigger, triggerOnTypingLetters);
+            Debug.Fail("For backwards API compat only, should not be called");
+            return ShouldTriggerCompletionImpl(text, caretPosition, trigger, CompletionOptions.Default.TriggerOnTypingLetters);
         }
 
-        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options)
+        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions)
             => ShouldTriggerCompletionImpl(text, caretPosition, trigger, options.TriggerOnTypingLetters);
 
         protected abstract bool ShouldTriggerCompletionImpl(SourceText text, int caretPosition, CompletionTrigger trigger, bool triggerOnTypingLetters);

--- a/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptions.cs
+++ b/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptions.cs
@@ -10,11 +10,8 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
     internal readonly record struct SignatureHelpOptions(
         bool HideAdvancedMembers)
     {
-        public static SignatureHelpOptions From(Project project)
-            => From(project.Solution.Options, project.Language);
-
-        public static SignatureHelpOptions From(OptionSet options, string language)
+        public static SignatureHelpOptions From(IGlobalOptionService globalOptions, string language)
           => new(
-              HideAdvancedMembers: options.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, language));
+              HideAdvancedMembers: globalOptions.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, language));
     }
 }

--- a/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptions.cs
+++ b/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptions.cs
@@ -3,15 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.SignatureHelp
 {
     internal readonly record struct SignatureHelpOptions(
         bool HideAdvancedMembers)
     {
-        public static SignatureHelpOptions From(IGlobalOptionService globalOptions, string language)
-          => new(
-              HideAdvancedMembers: globalOptions.GetOption(CompletionOptions.Metadata.HideAdvancedMembers, language));
+        public static readonly SignatureHelpOptions Default = new(CompletionOptions.Default.HideAdvancedMembers);
     }
 }

--- a/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptionsMetadata.cs
+++ b/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptionsMetadata.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.SignatureHelp
+{
+    // TODO: Move to EditorFeatures https://github.com/dotnet/roslyn/issues/59184
+    internal static class SignatureHelpOptionsMetadata
+    {
+        public static SignatureHelpOptions GetSignatureHelpOptions(this IGlobalOptionService globalOptions, string language)
+          => new(
+              HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsMetadata.HideAdvancedMembers, language));
+    }
+}

--- a/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptionsStorage.cs
+++ b/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptionsStorage.cs
@@ -8,10 +8,10 @@ using Microsoft.CodeAnalysis.Options;
 namespace Microsoft.CodeAnalysis.SignatureHelp
 {
     // TODO: Move to EditorFeatures https://github.com/dotnet/roslyn/issues/59184
-    internal static class SignatureHelpOptionsMetadata
+    internal static class SignatureHelpOptionsStorage
     {
         public static SignatureHelpOptions GetSignatureHelpOptions(this IGlobalOptionService globalOptions, string language)
           => new(
-              HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsMetadata.HideAdvancedMembers, language));
+              HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsStorage.HideAdvancedMembers, language));
     }
 }

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -122,8 +122,10 @@ namespace Microsoft.CodeAnalysis.SpellCheck
                 ExpandedCompletionBehavior = ExpandedCompletionMode.NonExpandedItemsOnly
             };
 
+            var passthroughOptions = document.Project.Solution.Options;
+
             var completionList = await service.GetCompletionsAsync(
-                document, nameToken.SpanStart, options, cancellationToken: cancellationToken).ConfigureAwait(false);
+                document, nameToken.SpanStart, options, passthroughOptions, cancellationToken).ConfigureAwait(false);
             if (completionList.Items.IsEmpty)
             {
                 return;

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -113,8 +113,9 @@ namespace Microsoft.CodeAnalysis.SpellCheck
             // -    It's very unlikely the user would ever misspell a snippet, then use spell-checking to fix it, 
             //      then try to invoke the snippet.
             // -    We believe spell-check should only compare what you have typed to what symbol would be offered here.
-            var options = CompletionOptions.From(document.Project.Solution.Options, document.Project.Language) with
+            var options = CompletionOptions.Default with
             {
+                HideAdvancedMembers = context.Options.HideAdvancedMembers,
                 SnippetsBehavior = SnippetsRule.NeverInclude,
                 ShowItemsFromUnimportedNamespaces = false,
                 TargetTypedCompletionFilter = false,

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -122,10 +122,10 @@ namespace Microsoft.CodeAnalysis.SpellCheck
                 ExpandedCompletionBehavior = ExpandedCompletionMode.NonExpandedItemsOnly
             };
 
-            var passthroughOptions = document.Project.Solution.Options;
+            var passThroughOptions = document.Project.Solution.Options;
 
             var completionList = await service.GetCompletionsAsync(
-                document, nameToken.SpanStart, options, passthroughOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
+                document, nameToken.SpanStart, options, passThroughOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (completionList.Items.IsEmpty)
             {
                 return;

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
             var passthroughOptions = document.Project.Solution.Options;
 
             var completionList = await service.GetCompletionsAsync(
-                document, nameToken.SpanStart, options, passthroughOptions, cancellationToken).ConfigureAwait(false);
+                document, nameToken.SpanStart, options, passthroughOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (completionList.Items.IsEmpty)
             {
                 return;

--- a/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var providers = _allProviders.Where(p => p.Metadata.Language == document.Project.Language);
             var triggerInfo = new SignatureHelpTriggerInfo(SignatureHelpTriggerReason.InvokeSignatureHelpCommand);
-            var options = SignatureHelpOptions.From(_globalOptions, document.Project.Language);
+            var options = _globalOptions.GetSignatureHelpOptions(document.Project.Language);
 
             foreach (var provider in providers)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SignatureHelp/SignatureHelpHandler.cs
@@ -12,8 +12,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.SignatureHelp;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.Text.Adornments;
-using Roslyn.Utilities;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -23,18 +23,22 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     internal class SignatureHelpHandler : AbstractStatelessRequestHandler<LSP.TextDocumentPositionParams, LSP.SignatureHelp?>
     {
         private readonly IEnumerable<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> _allProviders;
+        private readonly IGlobalOptionService _globalOptions;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public SignatureHelpHandler(
+            [ImportMany] IEnumerable<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> allProviders,
+            IGlobalOptionService globalOptions)
+        {
+            _allProviders = allProviders;
+            _globalOptions = globalOptions;
+        }
 
         public override string Method => LSP.Methods.TextDocumentSignatureHelpName;
 
         public override bool MutatesSolutionState => false;
         public override bool RequiresLSPSolution => true;
-
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public SignatureHelpHandler([ImportMany] IEnumerable<Lazy<ISignatureHelpProvider, OrderableLanguageMetadata>> allProviders)
-        {
-            _allProviders = allProviders;
-        }
 
         public override LSP.TextDocumentIdentifier? GetTextDocumentIdentifier(LSP.TextDocumentPositionParams request) => request.TextDocument;
 
@@ -48,7 +52,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var providers = _allProviders.Where(p => p.Metadata.Language == document.Project.Language);
             var triggerInfo = new SignatureHelpTriggerInfo(SignatureHelpTriggerReason.InvokeSignatureHelpCommand);
-            var options = SignatureHelpOptions.From(document.Project);
+            var options = SignatureHelpOptions.From(_globalOptions, document.Project.Language);
 
             foreach (var provider in providers)
             {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -460,7 +460,7 @@ link text";
                 return Task.FromResult(CompletionChange.Create(textChange, newPosition: 0));
             }
 
-            internal override bool ShouldTriggerCompletion(Project project, HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CodeAnalysis.Completion.CompletionOptions options, ImmutableHashSet<string> roles = null)
+            internal override bool ShouldTriggerCompletion(Project project, HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CodeAnalysis.Completion.CompletionOptions options, OptionSet passthroughOptions, ImmutableHashSet<string> roles = null)
                 => false;
 
             internal override CompletionRules GetRules(CodeAnalysis.Completion.CompletionOptions options)

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var solution = testLspServer.TestWorkspace.CurrentSolution;
 
             // Make sure the unimported types option is on by default.
-            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(new OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), true);
+            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(new OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), true);
 
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             using var testLspServer = await CreateTestLspServerAsync(markup);
 
             testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(
-                new OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.CSharp), SnippetsRule.NeverInclude);
+                new OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.CSharp), SnippetsRule.NeverInclude);
 
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -181,8 +181,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var solution = testLspServer.TestWorkspace.CurrentSolution;
 
             // Make sure the unimported types option is on by default.
-            testLspServer.TestWorkspace.SetOptions(testLspServer.TestWorkspace.CurrentSolution.Options
-                .WithChangedOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, true));
+            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(new OptionKey(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), true);
 
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
@@ -203,9 +202,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
     {|caret:|}
 }";
             using var testLspServer = await CreateTestLspServerAsync(markup);
-            var solution = testLspServer.TestWorkspace.CurrentSolution;
-            solution = solution.WithOptions(solution.Options
-                .WithChangedOption(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.CSharp, SnippetsRule.NeverInclude));
+
+            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(
+                new OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.CSharp), SnippetsRule.NeverInclude);
 
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var solution = testLspServer.TestWorkspace.CurrentSolution;
 
             // Make sure the unimported types option is on by default.
-            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(new OptionKey(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), true);
+            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(new OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), true);
 
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             using var testLspServer = await CreateTestLspServerAsync(markup);
 
             testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(
-                new OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.CSharp), SnippetsRule.NeverInclude);
+                new OptionKey(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.CSharp), SnippetsRule.NeverInclude);
 
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),

--- a/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
@@ -3,17 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion;
-using Microsoft.CodeAnalysis.LanguageServer.UnitTests.ProjectContext;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.UnitTests;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -171,10 +169,8 @@ class A
         var completionItems = await CompletionTests.RunGetCompletionsAsync(testLspServer, completionParams);
         Assert.Contains(completionItems.Items, item => item.Label == "d");
 
-        // Modify an option via the workspace.
-        var solutionWithChangedOption = testLspServer.TestWorkspace.CurrentSolution.WithOptions(
-            testLspServer.TestWorkspace.Options.WithChangedOption(CodeAnalysis.Completion.CompletionOptions.Metadata.ProvideDateAndTimeCompletions, LanguageNames.CSharp, false));
-        await testLspServer.TestWorkspace.ChangeSolutionAsync(solutionWithChangedOption);
+        testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(
+            new OptionKey(Microsoft.CodeAnalysis.Completion.CompletionOptions.Metadata.ProvideDateAndTimeCompletions, LanguageNames.CSharp), false);
 
         // Assert that the LSP incremental solution is cleared.
         Assert.Null(GetManagerWorkspaceState(testLspServer.TestWorkspace, testLspServer));

--- a/src/Tools/ExternalAccess/FSharp/Completion/FSharpCompletionProviderBase.cs
+++ b/src/Tools/ExternalAccess/FSharp/Completion/FSharpCompletionProviderBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
         public sealed override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
             => ShouldTriggerCompletionImpl(text, caretPosition, trigger);
 
-        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options)
+        internal sealed override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options, OptionSet passthroughOptions)
             => ShouldTriggerCompletionImpl(text, caretPosition, trigger);
 
         protected abstract bool ShouldTriggerCompletionImpl(SourceText text, int caretPosition, CompletionTrigger trigger);

--- a/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Completion
             CancellationToken cancellationToken)
         {
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            return completionService.ShouldTriggerCompletion(document.Project, document.Project.LanguageServices, text, caretPosition, trigger, options.ToCompletionOptions(), roles);
+            return completionService.ShouldTriggerCompletion(document.Project, document.Project.LanguageServices, text, caretPosition, trigger, options.ToCompletionOptions(), document.Project.Solution.Options, roles);
         }
 
         public static Task<CompletionList> GetCompletionsAsync(
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Completion
            OmniSharpCompletionOptions options,
            CancellationToken cancellationToken)
         {
-            return completionService.GetCompletionsAsync(document, caretPosition, options.ToCompletionOptions(), trigger, roles, cancellationToken);
+            return completionService.GetCompletionsAsync(document, caretPosition, options.ToCompletionOptions(), document.Project.Solution.Options, trigger, roles, cancellationToken);
         }
 
         public static string? GetProviderName(this CompletionItem completionItem) => completionItem.ProviderName;

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCodeCleanupFixer.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
@@ -16,12 +17,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 {
     [Export(typeof(AbstractCodeCleanUpFixer))]
     [ContentType(ContentTypeNames.CSharpContentType)]
-    internal class CSharpCodeCleanUpFixer : AbstractCodeCleanUpFixer
+    internal sealed class CSharpCodeCleanUpFixer : AbstractCodeCleanUpFixer
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpCodeCleanUpFixer(IThreadingContext threadingContext, VisualStudioWorkspaceImpl workspace, IVsHierarchyItemManager vsHierarchyItemManager)
-            : base(threadingContext, workspace, vsHierarchyItemManager)
+        public CSharpCodeCleanUpFixer(IThreadingContext threadingContext, VisualStudioWorkspaceImpl workspace, IVsHierarchyItemManager vsHierarchyItemManager, IGlobalOptionService globalOptions)
+            : base(threadingContext, workspace, vsHierarchyItemManager, globalOptions)
         {
         }
     }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCreateServicesOnTextViewConnection.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Completion.Providers.ImportCompletion;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
@@ -36,9 +37,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpCreateServicesOnTextViewConnection(
             VisualStudioWorkspace workspace,
+            IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
             IThreadingContext threadingContext)
-            : base(workspace, listenerProvider, threadingContext, LanguageNames.CSharp)
+            : base(workspace, globalOptions, listenerProvider, threadingContext, LanguageNames.CSharp)
         {
         }
 

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCreateServicesOnTextViewConnection.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
         protected override Task InitializeServiceForOpenedDocumentAsync(Document document)
         {
             // Only pre-populate cache if import completion is enabled
-            if (GlobalOptions.GetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp) != true)
+            if (GlobalOptions.GetOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp) != true)
                 return Task.CompletedTask;
 
             lock (_gate)

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpCreateServicesOnTextViewConnection.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
         protected override Task InitializeServiceForOpenedDocumentAsync(Document document)
         {
             // Only pre-populate cache if import completion is enabled
-            if (this.Workspace.Options.GetOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp) != true)
+            if (GlobalOptions.GetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp) != true)
                 return Task.CompletedTask;
 
             lock (_gate)

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Colorize_regular_expressions, ClassificationOptions.Metadata.ColorizeRegexPatterns, LanguageNames.CSharp);
             BindToOption(Report_invalid_regular_expressions, RegularExpressionsOptions.ReportInvalidRegexPatterns, LanguageNames.CSharp);
             BindToOption(Highlight_related_regular_expression_components_under_cursor, RegularExpressionsOptions.HighlightRelatedRegexComponentsUnderCursor, LanguageNames.CSharp);
-            BindToOption(Show_completion_list, CompletionOptions.Metadata.ProvideRegexCompletions, LanguageNames.CSharp);
+            BindToOption(Show_completion_list, CompletionOptionsStorage.ProvideRegexCompletions, LanguageNames.CSharp);
 
             BindToOption(Detect_and_offer_editor_features_for_likely_JSON_strings, JsonFeatureOptions.DetectAndOfferEditorFeaturesForProbableJsonStrings, LanguageNames.CSharp);
             BindToOption(Colorize_JSON_strings, ClassificationOptions.Metadata.ColorizeJsonPatterns, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.Completion.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.Completion.cs
@@ -10,8 +10,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
     {
         public int BringUpOnIdentifier
         {
-            get { return GetBooleanOption(CompletionOptions.Metadata.TriggerOnTypingLetters); }
-            set { SetBooleanOption(CompletionOptions.Metadata.TriggerOnTypingLetters, value); }
+            get { return GetBooleanOption(CompletionOptionsMetadata.TriggerOnTypingLetters); }
+            set { SetBooleanOption(CompletionOptionsMetadata.TriggerOnTypingLetters, value); }
         }
 
         public int HighlightMatchingPortionsOfCompletionListItems
@@ -28,32 +28,32 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         public int ShowItemsFromUnimportedNamespaces
         {
-            get { return GetBooleanOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces); }
-            set { SetBooleanOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, value); }
+            get { return GetBooleanOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces); }
+            set { SetBooleanOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, value); }
         }
 
         public int InsertNewlineOnEnterWithWholeWord
         {
-            get { return (int)GetOption(CompletionOptions.Metadata.EnterKeyBehavior); }
-            set { SetOption(CompletionOptions.Metadata.EnterKeyBehavior, (EnterKeyRule)value); }
+            get { return (int)GetOption(CompletionOptionsMetadata.EnterKeyBehavior); }
+            set { SetOption(CompletionOptionsMetadata.EnterKeyBehavior, (EnterKeyRule)value); }
         }
 
         public int EnterKeyBehavior
         {
-            get { return (int)GetOption(CompletionOptions.Metadata.EnterKeyBehavior); }
-            set { SetOption(CompletionOptions.Metadata.EnterKeyBehavior, (EnterKeyRule)value); }
+            get { return (int)GetOption(CompletionOptionsMetadata.EnterKeyBehavior); }
+            set { SetOption(CompletionOptionsMetadata.EnterKeyBehavior, (EnterKeyRule)value); }
         }
 
         public int SnippetsBehavior
         {
-            get { return (int)GetOption(CompletionOptions.Metadata.SnippetsBehavior); }
-            set { SetOption(CompletionOptions.Metadata.SnippetsBehavior, (SnippetsRule)value); }
+            get { return (int)GetOption(CompletionOptionsMetadata.SnippetsBehavior); }
+            set { SetOption(CompletionOptionsMetadata.SnippetsBehavior, (SnippetsRule)value); }
         }
 
         public int TriggerInArgumentLists
         {
-            get { return GetBooleanOption(CompletionOptions.Metadata.TriggerInArgumentLists); }
-            set { SetBooleanOption(CompletionOptions.Metadata.TriggerInArgumentLists, value); }
+            get { return GetBooleanOption(CompletionOptionsMetadata.TriggerInArgumentLists); }
+            set { SetBooleanOption(CompletionOptionsMetadata.TriggerInArgumentLists, value); }
         }
 
         public int EnableArgumentCompletionSnippets

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.Completion.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.Completion.cs
@@ -10,8 +10,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
     {
         public int BringUpOnIdentifier
         {
-            get { return GetBooleanOption(CompletionOptionsMetadata.TriggerOnTypingLetters); }
-            set { SetBooleanOption(CompletionOptionsMetadata.TriggerOnTypingLetters, value); }
+            get { return GetBooleanOption(CompletionOptionsStorage.TriggerOnTypingLetters); }
+            set { SetBooleanOption(CompletionOptionsStorage.TriggerOnTypingLetters, value); }
         }
 
         public int HighlightMatchingPortionsOfCompletionListItems
@@ -28,32 +28,32 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         public int ShowItemsFromUnimportedNamespaces
         {
-            get { return GetBooleanOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces); }
-            set { SetBooleanOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, value); }
+            get { return GetBooleanOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces); }
+            set { SetBooleanOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, value); }
         }
 
         public int InsertNewlineOnEnterWithWholeWord
         {
-            get { return (int)GetOption(CompletionOptionsMetadata.EnterKeyBehavior); }
-            set { SetOption(CompletionOptionsMetadata.EnterKeyBehavior, (EnterKeyRule)value); }
+            get { return (int)GetOption(CompletionOptionsStorage.EnterKeyBehavior); }
+            set { SetOption(CompletionOptionsStorage.EnterKeyBehavior, (EnterKeyRule)value); }
         }
 
         public int EnterKeyBehavior
         {
-            get { return (int)GetOption(CompletionOptionsMetadata.EnterKeyBehavior); }
-            set { SetOption(CompletionOptionsMetadata.EnterKeyBehavior, (EnterKeyRule)value); }
+            get { return (int)GetOption(CompletionOptionsStorage.EnterKeyBehavior); }
+            set { SetOption(CompletionOptionsStorage.EnterKeyBehavior, (EnterKeyRule)value); }
         }
 
         public int SnippetsBehavior
         {
-            get { return (int)GetOption(CompletionOptionsMetadata.SnippetsBehavior); }
-            set { SetOption(CompletionOptionsMetadata.SnippetsBehavior, (SnippetsRule)value); }
+            get { return (int)GetOption(CompletionOptionsStorage.SnippetsBehavior); }
+            set { SetOption(CompletionOptionsStorage.SnippetsBehavior, (SnippetsRule)value); }
         }
 
         public int TriggerInArgumentLists
         {
-            get { return GetBooleanOption(CompletionOptionsMetadata.TriggerInArgumentLists); }
-            set { SetBooleanOption(CompletionOptionsMetadata.TriggerInArgumentLists, value); }
+            get { return GetBooleanOption(CompletionOptionsStorage.TriggerInArgumentLists); }
+            set { SetBooleanOption(CompletionOptionsStorage.TriggerInArgumentLists, value); }
         }
 
         public int EnableArgumentCompletionSnippets

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.ObsoleteAndUnused.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.ObsoleteAndUnused.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                return GetOption(CompletionOptions.Metadata.SnippetsBehavior) == SnippetsRule.AlwaysInclude
+                return GetOption(CompletionOptionsMetadata.SnippetsBehavior) == SnippetsRule.AlwaysInclude
                     ? 1 : 0;
             }
 
@@ -55,11 +55,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             {
                 if (value == 0)
                 {
-                    SetOption(CompletionOptions.Metadata.SnippetsBehavior, SnippetsRule.NeverInclude);
+                    SetOption(CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.NeverInclude);
                 }
                 else
                 {
-                    SetOption(CompletionOptions.Metadata.SnippetsBehavior, SnippetsRule.AlwaysInclude);
+                    SetOption(CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.AlwaysInclude);
                 }
             }
         }

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.ObsoleteAndUnused.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject/AutomationObject.ObsoleteAndUnused.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                return GetOption(CompletionOptionsMetadata.SnippetsBehavior) == SnippetsRule.AlwaysInclude
+                return GetOption(CompletionOptionsStorage.SnippetsBehavior) == SnippetsRule.AlwaysInclude
                     ? 1 : 0;
             }
 
@@ -55,11 +55,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             {
                 if (value == 0)
                 {
-                    SetOption(CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.NeverInclude);
+                    SetOption(CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.NeverInclude);
                 }
                 else
                 {
-                    SetOption(CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.AlwaysInclude);
+                    SetOption(CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.AlwaysInclude);
                 }
             }
         }

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -23,22 +23,22 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Show_completion_item_filters, CompletionViewOptions.ShowCompletionItemFilters, LanguageNames.CSharp);
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptions.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.CSharp);
 
-            BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsMetadata.TriggerOnTypingLetters, LanguageNames.CSharp);
-            Show_completion_list_after_a_character_is_deleted.IsChecked = this.OptionStore.GetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp) == true;
+            BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsStorage.TriggerOnTypingLetters, LanguageNames.CSharp);
+            Show_completion_list_after_a_character_is_deleted.IsChecked = this.OptionStore.GetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp) == true;
             Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked == true;
 
-            BindToOption(Never_include_snippets, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.CSharp);
-            BindToOption(Always_include_snippets, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.CSharp);
-            BindToOption(Include_snippets_when_question_Tab_is_typed_after_an_identifier, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.IncludeAfterTypingIdentifierQuestionTab, LanguageNames.CSharp);
+            BindToOption(Never_include_snippets, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.CSharp);
+            BindToOption(Always_include_snippets, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.CSharp);
+            BindToOption(Include_snippets_when_question_Tab_is_typed_after_an_identifier, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.IncludeAfterTypingIdentifierQuestionTab, LanguageNames.CSharp);
 
-            BindToOption(Never_add_new_line_on_enter, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.Never, LanguageNames.CSharp);
-            BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.CSharp);
-            BindToOption(Always_add_new_line_on_enter, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.CSharp);
+            BindToOption(Never_add_new_line_on_enter, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.Never, LanguageNames.CSharp);
+            BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.CSharp);
+            BindToOption(Always_add_new_line_on_enter, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.CSharp);
 
-            BindToOption(Show_name_suggestions, CompletionOptionsMetadata.ShowNameSuggestions, LanguageNames.CSharp);
-            BindToOption(Automatically_show_completion_list_in_argument_lists, CompletionOptionsMetadata.TriggerInArgumentLists, LanguageNames.CSharp);
+            BindToOption(Show_name_suggestions, CompletionOptionsStorage.ShowNameSuggestions, LanguageNames.CSharp);
+            BindToOption(Automatically_show_completion_list_in_argument_lists, CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp);
 
-            Show_items_from_unimported_namespaces.IsChecked = this.OptionStore.GetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp);
+            Show_items_from_unimported_namespaces.IsChecked = this.OptionStore.GetOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp);
             Tab_twice_to_insert_arguments.IsChecked = this.OptionStore.GetOption(CompletionViewOptions.EnableArgumentCompletionSnippets, LanguageNames.CSharp);
 
         }
@@ -54,15 +54,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         }
 
         private void Show_completion_list_after_a_character_is_deleted_Checked(object sender, RoutedEventArgs e)
-            => this.OptionStore.SetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp, value: true);
+            => this.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, value: true);
 
         private void Show_completion_list_after_a_character_is_deleted_Unchecked(object sender, RoutedEventArgs e)
-            => this.OptionStore.SetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp, value: false);
+            => this.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, value: false);
 
         private void Show_items_from_unimported_namespaces_CheckedChanged(object sender, RoutedEventArgs e)
         {
             Show_items_from_unimported_namespaces.IsThreeState = false;
-            this.OptionStore.SetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, value: Show_items_from_unimported_namespaces.IsChecked);
+            this.OptionStore.SetOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, value: Show_items_from_unimported_namespaces.IsChecked);
         }
 
         private void Tab_twice_to_insert_arguments_CheckedChanged(object sender, RoutedEventArgs e)

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -23,22 +23,22 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             BindToOption(Show_completion_item_filters, CompletionViewOptions.ShowCompletionItemFilters, LanguageNames.CSharp);
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptions.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.CSharp);
 
-            BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptions.Metadata.TriggerOnTypingLetters, LanguageNames.CSharp);
-            Show_completion_list_after_a_character_is_deleted.IsChecked = this.OptionStore.GetOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp) == true;
+            BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsMetadata.TriggerOnTypingLetters, LanguageNames.CSharp);
+            Show_completion_list_after_a_character_is_deleted.IsChecked = this.OptionStore.GetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp) == true;
             Show_completion_list_after_a_character_is_deleted.IsEnabled = Show_completion_list_after_a_character_is_typed.IsChecked == true;
 
-            BindToOption(Never_include_snippets, CompletionOptions.Metadata.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.CSharp);
-            BindToOption(Always_include_snippets, CompletionOptions.Metadata.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.CSharp);
-            BindToOption(Include_snippets_when_question_Tab_is_typed_after_an_identifier, CompletionOptions.Metadata.SnippetsBehavior, SnippetsRule.IncludeAfterTypingIdentifierQuestionTab, LanguageNames.CSharp);
+            BindToOption(Never_include_snippets, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.CSharp);
+            BindToOption(Always_include_snippets, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.CSharp);
+            BindToOption(Include_snippets_when_question_Tab_is_typed_after_an_identifier, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.IncludeAfterTypingIdentifierQuestionTab, LanguageNames.CSharp);
 
-            BindToOption(Never_add_new_line_on_enter, CompletionOptions.Metadata.EnterKeyBehavior, EnterKeyRule.Never, LanguageNames.CSharp);
-            BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptions.Metadata.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.CSharp);
-            BindToOption(Always_add_new_line_on_enter, CompletionOptions.Metadata.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.CSharp);
+            BindToOption(Never_add_new_line_on_enter, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.Never, LanguageNames.CSharp);
+            BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.CSharp);
+            BindToOption(Always_add_new_line_on_enter, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.CSharp);
 
-            BindToOption(Show_name_suggestions, CompletionOptions.Metadata.ShowNameSuggestions, LanguageNames.CSharp);
-            BindToOption(Automatically_show_completion_list_in_argument_lists, CompletionOptions.Metadata.TriggerInArgumentLists, LanguageNames.CSharp);
+            BindToOption(Show_name_suggestions, CompletionOptionsMetadata.ShowNameSuggestions, LanguageNames.CSharp);
+            BindToOption(Automatically_show_completion_list_in_argument_lists, CompletionOptionsMetadata.TriggerInArgumentLists, LanguageNames.CSharp);
 
-            Show_items_from_unimported_namespaces.IsChecked = this.OptionStore.GetOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp);
+            Show_items_from_unimported_namespaces.IsChecked = this.OptionStore.GetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp);
             Tab_twice_to_insert_arguments.IsChecked = this.OptionStore.GetOption(CompletionViewOptions.EnableArgumentCompletionSnippets, LanguageNames.CSharp);
 
         }
@@ -54,15 +54,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         }
 
         private void Show_completion_list_after_a_character_is_deleted_Checked(object sender, RoutedEventArgs e)
-            => this.OptionStore.SetOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, value: true);
+            => this.OptionStore.SetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp, value: true);
 
         private void Show_completion_list_after_a_character_is_deleted_Unchecked(object sender, RoutedEventArgs e)
-            => this.OptionStore.SetOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.CSharp, value: false);
+            => this.OptionStore.SetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.CSharp, value: false);
 
         private void Show_items_from_unimported_namespaces_CheckedChanged(object sender, RoutedEventArgs e)
         {
             Show_items_from_unimported_namespaces.IsThreeState = false;
-            this.OptionStore.SetOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, value: Show_items_from_unimported_namespaces.IsChecked);
+            this.OptionStore.SetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, value: Show_items_from_unimported_namespaces.IsChecked);
         }
 
         private void Tab_twice_to_insert_arguments_CheckedChanged(object sender, RoutedEventArgs e)

--- a/src/VisualStudio/Core/Def/Implementation/CodeCleanup/AbstractCodeCleanUpFixer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeCleanup/AbstractCodeCleanUpFixer.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -43,15 +44,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
         private readonly IThreadingContext _threadingContext;
         private readonly VisualStudioWorkspaceImpl _workspace;
         private readonly IVsHierarchyItemManager _vsHierarchyItemManager;
+        private readonly IGlobalOptionService _globalOptions;
 
         protected AbstractCodeCleanUpFixer(
             IThreadingContext threadingContext,
             VisualStudioWorkspaceImpl workspace,
-            IVsHierarchyItemManager vsHierarchyItemManager)
+            IVsHierarchyItemManager vsHierarchyItemManager,
+            IGlobalOptionService globalOptions)
         {
             _threadingContext = threadingContext;
             _workspace = workspace;
             _vsHierarchyItemManager = vsHierarchyItemManager;
+            _globalOptions = globalOptions;
         }
 
         public Task<bool> FixAsync(ICodeCleanUpScope scope, ICodeCleanUpExecutionContext context)
@@ -129,7 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
                     }
 
                     var document = solution.GetRequiredDocument(documentId);
-                    var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: false);
+                    var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
                     return await FixDocumentAsync(document, options, context).ConfigureAwait(true);
                 }
             }
@@ -198,7 +202,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
                 var document = buffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
                 Contract.ThrowIfNull(document);
 
-                var options = CodeActionOptionsFactory.GetCodeActionOptions(document.Project, isBlocking: false);
+                var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
                 var newDoc = await FixDocumentAsync(document, context.EnabledFixIds, progressTracker, options, cancellationToken).ConfigureAwait(true);
                 return newDoc.Project.Solution;
             }
@@ -238,7 +242,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
             }
         }
 
-        private static async Task<Solution> FixSolutionAsync(
+        private async Task<Solution> FixSolutionAsync(
             Solution solution,
             FixIdContainer enabledFixIds,
             ProgressTracker progressTracker,
@@ -268,7 +272,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
             return solution;
         }
 
-        private static async Task<Project> FixProjectAsync(
+        private async Task<Project> FixProjectAsync(
             Project project,
             FixIdContainer enabledFixIds,
             ProgressTracker progressTracker,
@@ -285,7 +289,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
                 progressTracker.AddItems(project.DocumentIds.Count);
             }
 
-            var options = CodeActionOptionsFactory.GetCodeActionOptions(project, isBlocking: false);
+            var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, project.Language, isBlocking: false);
 
             foreach (var documentId in project.DocumentIds)
             {

--- a/src/VisualStudio/Core/Def/Implementation/CodeCleanup/AbstractCodeCleanUpFixer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeCleanup/AbstractCodeCleanUpFixer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
                     }
 
                     var document = solution.GetRequiredDocument(documentId);
-                    var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
+                    var options = _globalOptions.GetCodeActionOptions(document.Project.Language, isBlocking: false);
                     return await FixDocumentAsync(document, options, context).ConfigureAwait(true);
                 }
             }
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
                 var document = buffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
                 Contract.ThrowIfNull(document);
 
-                var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, document.Project.Language, isBlocking: false);
+                var options = _globalOptions.GetCodeActionOptions(document.Project.Language, isBlocking: false);
                 var newDoc = await FixDocumentAsync(document, context.EnabledFixIds, progressTracker, options, cancellationToken).ConfigureAwait(true);
                 return newDoc.Project.Solution;
             }
@@ -289,7 +289,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
                 progressTracker.AddItems(project.DocumentIds.Count);
             }
 
-            var options = CodeActionOptionsFactory.GetCodeActionOptions(_globalOptions, project.Language, isBlocking: false);
+            var options = _globalOptions.GetCodeActionOptions(project.Language, isBlocking: false);
 
             foreach (var documentId in project.DocumentIds)
             {

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.VisualStudio.Text;
@@ -29,6 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         private bool _initialized = false;
 
         protected VisualStudioWorkspace Workspace { get; }
+        protected IGlobalOptionService GlobalOptions { get; }
 
         protected virtual Task InitializeServiceForOpenedDocumentAsync(Document document)
             => Task.CompletedTask;
@@ -40,11 +42,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         public AbstractCreateServicesOnTextViewConnection(
             VisualStudioWorkspace workspace,
+            IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
             IThreadingContext threadingContext,
             string languageName)
         {
             Workspace = workspace;
+            GlobalOptions = globalOptions;
+
             _listener = listenerProvider.GetListener(FeatureAttribute.Workspace);
             _threadingContext = threadingContext;
             _languageName = languageName;

--- a/src/VisualStudio/Core/Def/Implementation/Options/LanguageSettingsPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/LanguageSettingsPersister.cs
@@ -92,8 +92,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             FormattingOptions.TabSize,
             FormattingOptions.SmartIndent,
             FormattingOptions.IndentationSize,
-            CompletionOptions.Metadata.HideAdvancedMembers,
-            CompletionOptions.Metadata.TriggerOnTyping,
+            CompletionOptionsMetadata.HideAdvancedMembers,
+            CompletionOptionsMetadata.TriggerOnTyping,
             SignatureHelpViewOptions.ShowSignatureHelp,
             NavigationBarViewOptions.ShowNavigationBar
         };
@@ -159,11 +159,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                         return FormattingOptions.IndentStyle.Smart;
                 }
             }
-            else if (option == CompletionOptions.Metadata.HideAdvancedMembers)
+            else if (option == CompletionOptionsMetadata.HideAdvancedMembers)
             {
                 return languagePreference.fHideAdvancedAutoListMembers != 0;
             }
-            else if (option == CompletionOptions.Metadata.TriggerOnTyping)
+            else if (option == CompletionOptionsMetadata.TriggerOnTyping)
             {
                 return languagePreference.fAutoListMembers != 0;
             }
@@ -210,11 +210,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                         break;
                 }
             }
-            else if (option == CompletionOptions.Metadata.HideAdvancedMembers)
+            else if (option == CompletionOptionsMetadata.HideAdvancedMembers)
             {
                 languagePreference.fHideAdvancedAutoListMembers = Convert.ToUInt32((bool)value ? 1 : 0);
             }
-            else if (option == CompletionOptions.Metadata.TriggerOnTyping)
+            else if (option == CompletionOptionsMetadata.TriggerOnTyping)
             {
                 languagePreference.fAutoListMembers = Convert.ToUInt32((bool)value ? 1 : 0);
             }

--- a/src/VisualStudio/Core/Def/Implementation/Options/LanguageSettingsPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/LanguageSettingsPersister.cs
@@ -92,8 +92,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             FormattingOptions.TabSize,
             FormattingOptions.SmartIndent,
             FormattingOptions.IndentationSize,
-            CompletionOptionsMetadata.HideAdvancedMembers,
-            CompletionOptionsMetadata.TriggerOnTyping,
+            CompletionOptionsStorage.HideAdvancedMembers,
+            CompletionOptionsStorage.TriggerOnTyping,
             SignatureHelpViewOptions.ShowSignatureHelp,
             NavigationBarViewOptions.ShowNavigationBar
         };
@@ -159,11 +159,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                         return FormattingOptions.IndentStyle.Smart;
                 }
             }
-            else if (option == CompletionOptionsMetadata.HideAdvancedMembers)
+            else if (option == CompletionOptionsStorage.HideAdvancedMembers)
             {
                 return languagePreference.fHideAdvancedAutoListMembers != 0;
             }
-            else if (option == CompletionOptionsMetadata.TriggerOnTyping)
+            else if (option == CompletionOptionsStorage.TriggerOnTyping)
             {
                 return languagePreference.fAutoListMembers != 0;
             }
@@ -210,11 +210,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                         break;
                 }
             }
-            else if (option == CompletionOptionsMetadata.HideAdvancedMembers)
+            else if (option == CompletionOptionsStorage.HideAdvancedMembers)
             {
                 languagePreference.fHideAdvancedAutoListMembers = Convert.ToUInt32((bool)value ? 1 : 0);
             }
-            else if (option == CompletionOptionsMetadata.TriggerOnTyping)
+            else if (option == CompletionOptionsStorage.TriggerOnTyping)
             {
                 languagePreference.fAutoListMembers = Convert.ToUInt32((bool)value ? 1 : 0);
             }

--- a/src/VisualStudio/Core/Def/Implementation/Options/LanguageSettingsPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/LanguageSettingsPersister.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
     internal sealed class LanguageSettingsPersister : ForegroundThreadAffinitizedObject, IVsTextManagerEvents4, IOptionPersister
     {
         private readonly IVsTextManager4 _textManager;
-        private readonly IGlobalOptionService _optionService;
+        private readonly IGlobalOptionService _globalOptions;
 
 #pragma warning disable IDE0052 // Remove unread private members - https://github.com/dotnet/roslyn/issues/46167
         private readonly ComEventSink _textManagerEvents2Sink;
@@ -51,11 +51,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         public LanguageSettingsPersister(
             IThreadingContext threadingContext,
             IVsTextManager4 textManager,
-            IGlobalOptionService optionService)
+            IGlobalOptionService globalOptions)
             : base(threadingContext, assertIsForeground: true)
         {
             _textManager = textManager;
-            _optionService = optionService;
+            _globalOptions = globalOptions;
 
             var languageMap = BidirectionalMap<string, Tuple<Guid>>.Empty;
 
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 var keyWithLanguage = new OptionKey(option, languageName);
                 var newValue = GetValueForOption(option, langPrefs[0]);
 
-                _optionService.RefreshOption(keyWithLanguage, newValue);
+                _globalOptions.RefreshOption(keyWithLanguage, newValue);
             }
         }
 

--- a/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
@@ -82,8 +82,7 @@ End Class</File>.Value
             Dim testState = SnippetTestState.CreateTestState(markup, LanguageNames.VisualBasic, extraParts:={GetType(MockSnippetInfoService)})
             Using testState
                 Dim workspace = testState.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(New Options.OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)))
+                workspace.GlobalOptions.SetGlobalOption(New Options.OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
                 testState.SendTypeChars("'T")
                 Await testState.AssertNoCompletionSession()
             End Using
@@ -100,8 +99,7 @@ End Class</File>.Value
             Dim testState = SnippetTestState.CreateTestState(markup, LanguageNames.VisualBasic, extraParts:={GetType(MockSnippetInfoService)})
             Using testState
                 Dim workspace = testState.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(New Options.OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)))
+                workspace.GlobalOptions.SetGlobalOption(New Options.OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
                 testState.SendTypeChars("'''T")
                 Await testState.AssertNoCompletionSession()
             End Using
@@ -117,8 +115,7 @@ End Class</File>.Value
             Dim testState = SnippetTestState.CreateTestState(markup, LanguageNames.VisualBasic, extraParts:={GetType(MockSnippetInfoService)})
             Using testState
                 Dim workspace = testState.Workspace
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(New Options.OptionKey(CompletionOptions.Metadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)))
+                workspace.GlobalOptions.SetGlobalOption(New Options.OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
                 testState.SendTypeChars("Shortcut")
                 Await testState.AssertSelectedCompletionItem(displayText:="Shortcut")
             End Using

--- a/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
@@ -82,7 +82,7 @@ End Class</File>.Value
             Dim testState = SnippetTestState.CreateTestState(markup, LanguageNames.VisualBasic, extraParts:={GetType(MockSnippetInfoService)})
             Using testState
                 Dim workspace = testState.Workspace
-                workspace.GlobalOptions.SetGlobalOption(New Options.OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                workspace.GlobalOptions.SetGlobalOption(New Options.OptionKey(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
                 testState.SendTypeChars("'T")
                 Await testState.AssertNoCompletionSession()
             End Using
@@ -99,7 +99,7 @@ End Class</File>.Value
             Dim testState = SnippetTestState.CreateTestState(markup, LanguageNames.VisualBasic, extraParts:={GetType(MockSnippetInfoService)})
             Using testState
                 Dim workspace = testState.Workspace
-                workspace.GlobalOptions.SetGlobalOption(New Options.OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                workspace.GlobalOptions.SetGlobalOption(New Options.OptionKey(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
                 testState.SendTypeChars("'''T")
                 Await testState.AssertNoCompletionSession()
             End Using
@@ -115,7 +115,7 @@ End Class</File>.Value
             Dim testState = SnippetTestState.CreateTestState(markup, LanguageNames.VisualBasic, extraParts:={GetType(MockSnippetInfoService)})
             Using testState
                 Dim workspace = testState.Workspace
-                workspace.GlobalOptions.SetGlobalOption(New Options.OptionKey(CompletionOptionsMetadata.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                workspace.GlobalOptions.SetGlobalOption(New Options.OptionKey(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
                 testState.SendTypeChars("Shortcut")
                 Await testState.AssertSelectedCompletionItem(displayText:="Shortcut")
             End Using

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
@@ -89,6 +89,16 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             SetOption(optionKey, result);
         }
 
+        public object? GetGlobalOption(string feature, string optionName, string? language)
+        {
+            object? result = null;
+            InvokeOnUIThread(_ => result = _globalOptions.GetOption(new OptionKey(GetOption(optionName, feature), language)));
+            return result;
+        }
+
+        public void SetGlobalOption(string feature, string optionName, string? language, object? value)
+            => InvokeOnUIThread(_ => _globalOptions.SetGlobalOption(new OptionKey(GetOption(optionName, feature), language), value));
+
         private static object GetValue(object value, IOption option)
         {
             object result;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -89,15 +90,15 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             SetOption(optionKey, result);
         }
 
-        public object? GetGlobalOption(string feature, string optionName, string? language)
+        public object? GetGlobalOption(WellKnownGlobalOption option, string? language)
         {
             object? result = null;
-            InvokeOnUIThread(_ => result = _globalOptions.GetOption(new OptionKey(GetOption(optionName, feature), language)));
+            InvokeOnUIThread(_ => result = _globalOptions.GetOption(option.GetKey(language)));
             return result;
         }
 
-        public void SetGlobalOption(string feature, string optionName, string? language, object? value)
-            => InvokeOnUIThread(_ => _globalOptions.SetGlobalOption(new OptionKey(GetOption(optionName, feature), language), value));
+        public void SetGlobalOption(WellKnownGlobalOption option, string? language, object? value)
+            => InvokeOnUIThread(_ => _globalOptions.SetGlobalOption(option.GetKey(language), value));
 
         private static object GetValue(object value, IOption option)
         {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
@@ -6,6 +6,7 @@ using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
@@ -59,8 +60,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void SetImportCompletionOption(bool value)
         {
-            SetGlobalOption("CompletionOptions", "ShowItemsFromUnimportedNamespaces", LanguageNames.CSharp, value);
-            SetGlobalOption("CompletionOptions", "ShowItemsFromUnimportedNamespaces", LanguageNames.VisualBasic, value);
+            SetGlobalOption(WellKnownGlobalOption.CompletionOptions_ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, value);
+            SetGlobalOption(WellKnownGlobalOption.CompletionOptions_ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, value);
         }
 
         public void SetEnableDecompilationOption(bool value)
@@ -70,12 +71,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void SetArgumentCompletionSnippetsOption(bool value)
         {
-            SetGlobalOption("CompletionOptions", "EnableArgumentCompletionSnippets", LanguageNames.CSharp, value);
-            SetGlobalOption("CompletionOptions", "EnableArgumentCompletionSnippets", LanguageNames.VisualBasic, value);
+            SetGlobalOption(WellKnownGlobalOption.CompletionViewOptions_EnableArgumentCompletionSnippets, LanguageNames.CSharp, value);
+            SetGlobalOption(WellKnownGlobalOption.CompletionViewOptions_EnableArgumentCompletionSnippets, LanguageNames.VisualBasic, value);
         }
 
         public void SetTriggerCompletionInArgumentLists(bool value)
-            => SetGlobalOption("CompletionOptions", "TriggerInArgumentLists", LanguageNames.CSharp, value);
+            => SetGlobalOption(WellKnownGlobalOption.CompletionOptions_TriggerInArgumentLists, LanguageNames.CSharp, value);
 
         public void SetFullSolutionAnalysis(bool value)
         {
@@ -106,11 +107,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void SetFeatureOption(string feature, string optionName, string language, string? valueString)
             => _inProc.SetFeatureOption(feature, optionName, language, valueString);
 
-        public object? GetGlobalOption(string feature, string optionName, string? language)
-            => _inProc.GetGlobalOption(feature, optionName, language);
+        public object? GetGlobalOption(WellKnownGlobalOption option, string? language)
+            => _inProc.GetGlobalOption(option, language);
 
-        public void SetGlobalOption(string feature, string optionName, string? language, object? value)
-            => _inProc.SetGlobalOption(feature, optionName, language, value);
+        public void SetGlobalOption(WellKnownGlobalOption option, string? language, object? value)
+            => _inProc.SetGlobalOption(option, language, value);
 
         public string? GetWorkingFolder() => _inProc.GetWorkingFolder();
     }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
@@ -59,17 +59,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void SetImportCompletionOption(bool value)
         {
-            SetPerLanguageOption(
-                optionName: "ShowItemsFromUnimportedNamespaces",
-                feature: "CompletionOptions",
-                language: LanguageNames.CSharp,
-                value: value);
-
-            SetPerLanguageOption(
-                optionName: "ShowItemsFromUnimportedNamespaces",
-                feature: "CompletionOptions",
-                language: LanguageNames.VisualBasic,
-                value: value);
+            SetGlobalOption("CompletionOptions", "ShowItemsFromUnimportedNamespaces", LanguageNames.CSharp, value);
+            SetGlobalOption("CompletionOptions", "ShowItemsFromUnimportedNamespaces", LanguageNames.VisualBasic, value);
         }
 
         public void SetEnableDecompilationOption(bool value)
@@ -79,27 +70,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void SetArgumentCompletionSnippetsOption(bool value)
         {
-            SetPerLanguageOption(
-                optionName: CompletionViewOptions.EnableArgumentCompletionSnippets.Name,
-                feature: CompletionViewOptions.EnableArgumentCompletionSnippets.Feature,
-                language: LanguageNames.CSharp,
-                value: value);
-
-            SetPerLanguageOption(
-                optionName: CompletionViewOptions.EnableArgumentCompletionSnippets.Name,
-                feature: CompletionViewOptions.EnableArgumentCompletionSnippets.Feature,
-                language: LanguageNames.VisualBasic,
-                value: value);
+            SetGlobalOption("CompletionOptions", "EnableArgumentCompletionSnippets", LanguageNames.CSharp, value);
+            SetGlobalOption("CompletionOptions", "EnableArgumentCompletionSnippets", LanguageNames.VisualBasic, value);
         }
 
         public void SetTriggerCompletionInArgumentLists(bool value)
-        {
-            SetPerLanguageOption(
-                optionName: CompletionOptions.Metadata.TriggerInArgumentLists.Name,
-                feature: CompletionOptions.Metadata.TriggerInArgumentLists.Feature,
-                language: LanguageNames.CSharp,
-                value: value);
-        }
+            => SetGlobalOption("CompletionOptions", "TriggerInArgumentLists", LanguageNames.CSharp, value);
 
         public void SetFullSolutionAnalysis(bool value)
         {
@@ -129,6 +105,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void SetFeatureOption(string feature, string optionName, string language, string? valueString)
             => _inProc.SetFeatureOption(feature, optionName, language, valueString);
+
+        public object? GetGlobalOption(string feature, string optionName, string? language)
+            => _inProc.GetGlobalOption(feature, optionName, language);
+
+        public void SetGlobalOption(string feature, string optionName, string? language, object? value)
+            => _inProc.SetGlobalOption(feature, optionName, language, value);
 
         public string? GetWorkingFolder() => _inProc.GetWorkingFolder();
     }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownGlobalOptions.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownGlobalOptions.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Options;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities
+{
+    /// <summary>
+    /// Options settable by integration tests.
+    /// 
+    /// TODO: Options are currently explicitly listed since <see cref="OptionKey"/> is not serializable.
+    /// https://github.com/dotnet/roslyn/issues/59267
+    /// </summary>
+    public enum WellKnownGlobalOption
+    {
+        CompletionOptions_ShowItemsFromUnimportedNamespaces,
+        CompletionViewOptions_EnableArgumentCompletionSnippets,
+        CompletionOptions_TriggerInArgumentLists,
+    }
+
+    public static class WellKnownGlobalOptions
+    {
+        public static IOption GetOption(this WellKnownGlobalOption option)
+            => option switch
+            {
+                WellKnownGlobalOption.CompletionOptions_ShowItemsFromUnimportedNamespaces => CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces,
+                WellKnownGlobalOption.CompletionOptions_TriggerInArgumentLists => CompletionOptionsStorage.TriggerInArgumentLists,
+                WellKnownGlobalOption.CompletionViewOptions_EnableArgumentCompletionSnippets => CompletionViewOptions.EnableArgumentCompletionSnippets,
+                _ => throw ExceptionUtilities.Unreachable
+            };
+
+        public static OptionKey GetKey(this WellKnownGlobalOption option, string? language)
+            => new OptionKey(GetOption(option), language);
+    }
+}

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCodeCleanupFixer.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCodeCleanupFixer.vb
@@ -7,6 +7,7 @@ Imports System.ComponentModel.Composition
 Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.Shell
@@ -20,8 +21,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.LanguageService
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
-        Public Sub New(threadingContext As IThreadingContext, workspace As VisualStudioWorkspaceImpl, vsHierarchyItemManager As IVsHierarchyItemManager)
-            MyBase.New(threadingContext, workspace, vsHierarchyItemManager)
+        Public Sub New(threadingContext As IThreadingContext, workspace As VisualStudioWorkspaceImpl, vsHierarchyItemManager As IVsHierarchyItemManager, globalOptions As IGlobalOptionService)
+            MyBase.New(threadingContext, workspace, vsHierarchyItemManager, globalOptions)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCreateServicesOnTextViewConnection.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicCreateServicesOnTextViewConnection.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 Imports Microsoft.VisualStudio.Text.Editor
 Imports Microsoft.VisualStudio.Utilities
@@ -23,10 +24,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New(
             workspace As VisualStudioWorkspace,
+            globalOptions As IGlobalOptionService,
             listenerProvider As IAsynchronousOperationListenerProvider,
             threadingContext As IThreadingContext)
 
-            MyBase.New(workspace, listenerProvider, threadingContext, languageName:=LanguageNames.VisualBasic)
+            MyBase.New(workspace, globalOptions, listenerProvider, threadingContext, languageName:=LanguageNames.VisualBasic)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -125,7 +125,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             BindToOption(Colorize_regular_expressions, ClassificationOptions.Metadata.ColorizeRegexPatterns, LanguageNames.VisualBasic)
             BindToOption(Report_invalid_regular_expressions, RegularExpressionsOptions.ReportInvalidRegexPatterns, LanguageNames.VisualBasic)
             BindToOption(Highlight_related_regular_expression_components_under_cursor, RegularExpressionsOptions.HighlightRelatedRegexComponentsUnderCursor, LanguageNames.VisualBasic)
-            BindToOption(Show_completion_list, CompletionOptions.Metadata.ProvideRegexCompletions, LanguageNames.VisualBasic)
+            BindToOption(Show_completion_list, CompletionOptionsStorage.ProvideRegexCompletions, LanguageNames.VisualBasic)
 
             BindToOption(Detect_and_offer_editor_features_for_likely_JSON_strings, JsonFeatureOptions.DetectAndOfferEditorFeaturesForProbableJsonStrings, LanguageNames.VisualBasic)
             BindToOption(Colorize_JSON_strings, ClassificationOptions.Metadata.ColorizeJsonPatterns, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.Completion.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.Completion.vb
@@ -8,10 +8,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
     Partial Public Class AutomationObject
         Public Property Option_TriggerOnTypingLetters As Boolean
             Get
-                Return GetBooleanOption(CompletionOptions.Metadata.TriggerOnTypingLetters)
+                Return GetBooleanOption(CompletionOptionsMetadata.TriggerOnTypingLetters)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(CompletionOptions.Metadata.TriggerOnTypingLetters, value)
+                SetBooleanOption(CompletionOptionsMetadata.TriggerOnTypingLetters, value)
             End Set
         End Property
 
@@ -26,37 +26,37 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
         Public Property Option_EnterKeyBehavior As Integer
             Get
-                Return GetOption(CompletionOptions.Metadata.EnterKeyBehavior)
+                Return GetOption(CompletionOptionsMetadata.EnterKeyBehavior)
             End Get
             Set(value As Integer)
-                SetOption(CompletionOptions.Metadata.EnterKeyBehavior, DirectCast(value, EnterKeyRule))
+                SetOption(CompletionOptionsMetadata.EnterKeyBehavior, DirectCast(value, EnterKeyRule))
             End Set
         End Property
 
         Public Property Option_SnippetsBehavior As Integer
             Get
-                Return GetOption(CompletionOptions.Metadata.SnippetsBehavior)
+                Return GetOption(CompletionOptionsMetadata.SnippetsBehavior)
             End Get
             Set(value As Integer)
-                SetOption(CompletionOptions.Metadata.SnippetsBehavior, DirectCast(value, SnippetsRule))
+                SetOption(CompletionOptionsMetadata.SnippetsBehavior, DirectCast(value, SnippetsRule))
             End Set
         End Property
 
         Public Property Option_ShowItemsFromUnimportedNamespaces As Integer
             Get
-                Return GetBooleanOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces)
+                Return GetBooleanOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces)
             End Get
             Set(value As Integer)
-                SetBooleanOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, value)
+                SetBooleanOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, value)
             End Set
         End Property
 
         Public Property Option_TriggerInArgumentLists As Boolean
             Get
-                Return GetBooleanOption(CompletionOptions.Metadata.TriggerInArgumentLists)
+                Return GetBooleanOption(CompletionOptionsMetadata.TriggerInArgumentLists)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(CompletionOptions.Metadata.TriggerInArgumentLists, value)
+                SetBooleanOption(CompletionOptionsMetadata.TriggerInArgumentLists, value)
             End Set
         End Property
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.Completion.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject/AutomationObject.Completion.vb
@@ -8,10 +8,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
     Partial Public Class AutomationObject
         Public Property Option_TriggerOnTypingLetters As Boolean
             Get
-                Return GetBooleanOption(CompletionOptionsMetadata.TriggerOnTypingLetters)
+                Return GetBooleanOption(CompletionOptionsStorage.TriggerOnTypingLetters)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(CompletionOptionsMetadata.TriggerOnTypingLetters, value)
+                SetBooleanOption(CompletionOptionsStorage.TriggerOnTypingLetters, value)
             End Set
         End Property
 
@@ -26,37 +26,37 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
         Public Property Option_EnterKeyBehavior As Integer
             Get
-                Return GetOption(CompletionOptionsMetadata.EnterKeyBehavior)
+                Return GetOption(CompletionOptionsStorage.EnterKeyBehavior)
             End Get
             Set(value As Integer)
-                SetOption(CompletionOptionsMetadata.EnterKeyBehavior, DirectCast(value, EnterKeyRule))
+                SetOption(CompletionOptionsStorage.EnterKeyBehavior, DirectCast(value, EnterKeyRule))
             End Set
         End Property
 
         Public Property Option_SnippetsBehavior As Integer
             Get
-                Return GetOption(CompletionOptionsMetadata.SnippetsBehavior)
+                Return GetOption(CompletionOptionsStorage.SnippetsBehavior)
             End Get
             Set(value As Integer)
-                SetOption(CompletionOptionsMetadata.SnippetsBehavior, DirectCast(value, SnippetsRule))
+                SetOption(CompletionOptionsStorage.SnippetsBehavior, DirectCast(value, SnippetsRule))
             End Set
         End Property
 
         Public Property Option_ShowItemsFromUnimportedNamespaces As Integer
             Get
-                Return GetBooleanOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces)
+                Return GetBooleanOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces)
             End Get
             Set(value As Integer)
-                SetBooleanOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, value)
+                SetBooleanOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, value)
             End Set
         End Property
 
         Public Property Option_TriggerInArgumentLists As Boolean
             Get
-                Return GetBooleanOption(CompletionOptionsMetadata.TriggerInArgumentLists)
+                Return GetBooleanOption(CompletionOptionsStorage.TriggerInArgumentLists)
             End Get
             Set(value As Boolean)
-                SetBooleanOption(CompletionOptionsMetadata.TriggerInArgumentLists, value)
+                SetBooleanOption(CompletionOptionsStorage.TriggerInArgumentLists, value)
             End Set
         End Property
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
@@ -15,36 +15,36 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             MyBase.New(optionStore)
             InitializeComponent()
 
-            BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptions.Metadata.TriggerOnTypingLetters, LanguageNames.VisualBasic)
+            BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsMetadata.TriggerOnTypingLetters, LanguageNames.VisualBasic)
             Show_completion_list_after_a_character_is_deleted.IsChecked = Me.OptionStore.GetOption(
-                CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.VisualBasic) <> False
+                CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.VisualBasic) <> False
 
             BindToOption(Show_completion_item_filters, CompletionViewOptions.ShowCompletionItemFilters, LanguageNames.VisualBasic)
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptions.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.VisualBasic)
 
-            BindToOption(Never_include_snippets, CompletionOptions.Metadata.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.VisualBasic)
-            BindToOption(Always_include_snippets, CompletionOptions.Metadata.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.VisualBasic)
-            BindToOption(Include_snippets_when_question_Tab_is_typed_after_an_identifier, CompletionOptions.Metadata.SnippetsBehavior, SnippetsRule.IncludeAfterTypingIdentifierQuestionTab, LanguageNames.VisualBasic)
+            BindToOption(Never_include_snippets, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.VisualBasic)
+            BindToOption(Always_include_snippets, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.VisualBasic)
+            BindToOption(Include_snippets_when_question_Tab_is_typed_after_an_identifier, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.IncludeAfterTypingIdentifierQuestionTab, LanguageNames.VisualBasic)
 
-            BindToOption(Never_add_new_line_on_enter, CompletionOptions.Metadata.EnterKeyBehavior, EnterKeyRule.Never, LanguageNames.VisualBasic)
-            BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptions.Metadata.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.VisualBasic)
-            BindToOption(Always_add_new_line_on_enter, CompletionOptions.Metadata.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.VisualBasic)
+            BindToOption(Never_add_new_line_on_enter, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.Never, LanguageNames.VisualBasic)
+            BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.VisualBasic)
+            BindToOption(Always_add_new_line_on_enter, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.VisualBasic)
 
-            Show_items_from_unimported_namespaces.IsChecked = Me.OptionStore.GetOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic)
+            Show_items_from_unimported_namespaces.IsChecked = Me.OptionStore.GetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic)
             Tab_twice_to_insert_arguments.IsChecked = Me.OptionStore.GetOption(CompletionViewOptions.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic)
         End Sub
 
         Private Sub Show_completion_list_after_a_character_is_deleted_Checked(sender As Object, e As RoutedEventArgs)
-            Me.OptionStore.SetOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.VisualBasic, value:=True)
+            Me.OptionStore.SetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.VisualBasic, value:=True)
         End Sub
 
         Private Sub Show_completion_list_after_a_character_is_deleted_Unchecked(sender As Object, e As RoutedEventArgs)
-            Me.OptionStore.SetOption(CompletionOptions.Metadata.TriggerOnDeletion, LanguageNames.VisualBasic, value:=False)
+            Me.OptionStore.SetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.VisualBasic, value:=False)
         End Sub
 
         Private Sub Show_items_from_unimported_namespaces_CheckedChanged(sender As Object, e As RoutedEventArgs)
             Show_items_from_unimported_namespaces.IsThreeState = False
-            Me.OptionStore.SetOption(CompletionOptions.Metadata.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, Show_items_from_unimported_namespaces.IsChecked)
+            Me.OptionStore.SetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, Show_items_from_unimported_namespaces.IsChecked)
         End Sub
 
         Private Sub Tab_twice_to_insert_arguments_CheckedChanged(sender As Object, e As RoutedEventArgs)

--- a/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/IntelliSenseOptionPageControl.xaml.vb
@@ -15,36 +15,36 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             MyBase.New(optionStore)
             InitializeComponent()
 
-            BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsMetadata.TriggerOnTypingLetters, LanguageNames.VisualBasic)
+            BindToOption(Show_completion_list_after_a_character_is_typed, CompletionOptionsStorage.TriggerOnTypingLetters, LanguageNames.VisualBasic)
             Show_completion_list_after_a_character_is_deleted.IsChecked = Me.OptionStore.GetOption(
-                CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.VisualBasic) <> False
+                CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic) <> False
 
             BindToOption(Show_completion_item_filters, CompletionViewOptions.ShowCompletionItemFilters, LanguageNames.VisualBasic)
             BindToOption(Highlight_matching_portions_of_completion_list_items, CompletionViewOptions.HighlightMatchingPortionsOfCompletionListItems, LanguageNames.VisualBasic)
 
-            BindToOption(Never_include_snippets, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.VisualBasic)
-            BindToOption(Always_include_snippets, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.VisualBasic)
-            BindToOption(Include_snippets_when_question_Tab_is_typed_after_an_identifier, CompletionOptionsMetadata.SnippetsBehavior, SnippetsRule.IncludeAfterTypingIdentifierQuestionTab, LanguageNames.VisualBasic)
+            BindToOption(Never_include_snippets, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.NeverInclude, LanguageNames.VisualBasic)
+            BindToOption(Always_include_snippets, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.AlwaysInclude, LanguageNames.VisualBasic)
+            BindToOption(Include_snippets_when_question_Tab_is_typed_after_an_identifier, CompletionOptionsStorage.SnippetsBehavior, SnippetsRule.IncludeAfterTypingIdentifierQuestionTab, LanguageNames.VisualBasic)
 
-            BindToOption(Never_add_new_line_on_enter, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.Never, LanguageNames.VisualBasic)
-            BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.VisualBasic)
-            BindToOption(Always_add_new_line_on_enter, CompletionOptionsMetadata.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.VisualBasic)
+            BindToOption(Never_add_new_line_on_enter, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.Never, LanguageNames.VisualBasic)
+            BindToOption(Only_add_new_line_on_enter_with_whole_word, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.AfterFullyTypedWord, LanguageNames.VisualBasic)
+            BindToOption(Always_add_new_line_on_enter, CompletionOptionsStorage.EnterKeyBehavior, EnterKeyRule.Always, LanguageNames.VisualBasic)
 
-            Show_items_from_unimported_namespaces.IsChecked = Me.OptionStore.GetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic)
+            Show_items_from_unimported_namespaces.IsChecked = Me.OptionStore.GetOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic)
             Tab_twice_to_insert_arguments.IsChecked = Me.OptionStore.GetOption(CompletionViewOptions.EnableArgumentCompletionSnippets, LanguageNames.VisualBasic)
         End Sub
 
         Private Sub Show_completion_list_after_a_character_is_deleted_Checked(sender As Object, e As RoutedEventArgs)
-            Me.OptionStore.SetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.VisualBasic, value:=True)
+            Me.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, value:=True)
         End Sub
 
         Private Sub Show_completion_list_after_a_character_is_deleted_Unchecked(sender As Object, e As RoutedEventArgs)
-            Me.OptionStore.SetOption(CompletionOptionsMetadata.TriggerOnDeletion, LanguageNames.VisualBasic, value:=False)
+            Me.OptionStore.SetOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.VisualBasic, value:=False)
         End Sub
 
         Private Sub Show_items_from_unimported_namespaces_CheckedChanged(sender As Object, e As RoutedEventArgs)
             Show_items_from_unimported_namespaces.IsThreeState = False
-            Me.OptionStore.SetOption(CompletionOptionsMetadata.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, Show_items_from_unimported_namespaces.IsChecked)
+            Me.OptionStore.SetOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic, Show_items_from_unimported_namespaces.IsChecked)
         End Sub
 
         Private Sub Tab_twice_to_insert_arguments_CheckedChanged(sender As Object, e As RoutedEventArgs)

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/CodeActions/CodeActionsHandlerProvider.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/CodeActions/CodeActionsHandlerProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Commands;
@@ -34,26 +35,29 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer.Handler
         private readonly ICodeFixService _codeFixService;
         private readonly ICodeRefactoringService _codeRefactoringService;
         private readonly IThreadingContext _threadingContext;
+        private readonly IGlobalOptionService _globalOptions;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CodeActionsHandlerProvider(
             ICodeFixService codeFixService,
             ICodeRefactoringService codeRefactoringService,
-            IThreadingContext threadingContext)
+            IThreadingContext threadingContext,
+            IGlobalOptionService globalOptions)
         {
             _codeFixService = codeFixService;
             _codeRefactoringService = codeRefactoringService;
             _threadingContext = threadingContext;
+            _globalOptions = globalOptions;
         }
 
         public override ImmutableArray<IRequestHandler> CreateRequestHandlers(WellKnownLspServerKinds serverKind)
         {
             var codeActionsCache = new CodeActionsCache();
             return ImmutableArray.Create<IRequestHandler>(
-                new CodeActionsHandler(codeActionsCache, _codeFixService, _codeRefactoringService),
-                new CodeActionResolveHandler(codeActionsCache, _codeFixService, _codeRefactoringService),
-                new RunCodeActionHandler(codeActionsCache, _codeFixService, _codeRefactoringService, _threadingContext));
+                new CodeActionsHandler(codeActionsCache, _codeFixService, _codeRefactoringService, _globalOptions),
+                new CodeActionResolveHandler(codeActionsCache, _codeFixService, _codeRefactoringService, _globalOptions),
+                new RunCodeActionHandler(codeActionsCache, _codeFixService, _codeRefactoringService, _globalOptions, _threadingContext));
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -49,6 +49,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         internal static Document WithSolutionOptions(this Document document, OptionSet options)
-            => document.Project.Solution.WithOptions(options).GetDocument(document.Id)!;
+            => document.Project.Solution.WithOptions(options).GetRequiredDocument(document.Id);
     }
 }


### PR DESCRIPTION
Removes CompletionOptions from Solution snapshot. The options are now only stored in global options. 

Establishes a new pattern: Option definitions move from being nested as `XyzOptions.Metadata` to a separate type `XyzOptionsStorage` (`CompilationOptionsStorage` in this case) that also defines an extension method `GetXyzOptions` on `IGlobalOptionService` used to fetch them. This type is to be moved to client code (editor features).

This completes the separation of options from their metadata and storage.

While working on this refactoring I realized that certain scenarios were broken by previous completion options changes. When 3rd party code passes OptionSet containing their custom options into our public completion APIs these options got lost and were not available to their custom CompletionProvider. This PR fixes that by passing 3rd party options through.
