### PR TITLE
Merge the interpolated end tokens into a single token

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -880,8 +880,8 @@ this_expression
 interpolated_string_expression
   : '$"' interpolated_string_content* '"'
   | '$@"' interpolated_string_content* '"'
-  | interpolated_multi_line_raw_string_start_token interpolated_string_content* interpolated_multi_line_raw_string_end_token
-  | interpolated_single_line_raw_string_start_token interpolated_string_content* interpolated_single_line_raw_string_end_token
+  | interpolated_multi_line_raw_string_start_token interpolated_string_content* interpolated_raw_string_end_token
+  | interpolated_single_line_raw_string_start_token interpolated_string_content* interpolated_raw_string_end_token
   ;
 
 interpolated_string_content
@@ -1351,15 +1351,11 @@ identifier_token
   : /* see lexical specification */
   ;
 
-interpolated_multi_line_raw_string_end_token
-  : /* see lexical specification */
-  ;
-
 interpolated_multi_line_raw_string_start_token
   : /* see lexical specification */
   ;
 
-interpolated_single_line_raw_string_end_token
+interpolated_raw_string_end_token
   : /* see lexical specification */
   ;
 

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
@@ -37145,8 +37145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             switch (stringEndToken.Kind)
             {
                 case SyntaxKind.InterpolatedStringEndToken:
-                case SyntaxKind.InterpolatedSingleLineRawStringEndToken:
-                case SyntaxKind.InterpolatedMultiLineRawStringEndToken: break;
+                case SyntaxKind.InterpolatedRawStringEndToken: break;
                 default: throw new ArgumentException(nameof(stringEndToken));
             }
 #endif
@@ -42169,8 +42168,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             switch (stringEndToken.Kind)
             {
                 case SyntaxKind.InterpolatedStringEndToken:
-                case SyntaxKind.InterpolatedSingleLineRawStringEndToken:
-                case SyntaxKind.InterpolatedMultiLineRawStringEndToken: break;
+                case SyntaxKind.InterpolatedRawStringEndToken: break;
                 default: throw new ArgumentException(nameof(stringEndToken));
             }
 #endif

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -3514,8 +3514,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (stringEndToken.Kind())
             {
                 case SyntaxKind.InterpolatedStringEndToken:
-                case SyntaxKind.InterpolatedSingleLineRawStringEndToken:
-                case SyntaxKind.InterpolatedMultiLineRawStringEndToken: break;
+                case SyntaxKind.InterpolatedRawStringEndToken: break;
                 default: throw new ArgumentException(nameof(stringEndToken));
             }
             return (InterpolatedStringExpressionSyntax)Syntax.InternalSyntax.SyntaxFactory.InterpolatedStringExpression((Syntax.InternalSyntax.SyntaxToken)stringStartToken.Node!, contents.Node.ToGreenList<Syntax.InternalSyntax.InterpolatedStringContentSyntax>(), (Syntax.InternalSyntax.SyntaxToken)stringEndToken.Node!).CreateRed();

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
@@ -236,8 +236,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     {
                         Lexer.InterpolatedStringKind.Normal => SyntaxKind.InterpolatedStringEndToken,
                         Lexer.InterpolatedStringKind.Verbatim => SyntaxKind.InterpolatedStringEndToken,
-                        Lexer.InterpolatedStringKind.SingleLineRaw => SyntaxKind.InterpolatedSingleLineRawStringEndToken,
-                        Lexer.InterpolatedStringKind.MultiLineRaw => SyntaxKind.InterpolatedMultiLineRawStringEndToken,
+                        Lexer.InterpolatedStringKind.SingleLineRaw => SyntaxKind.InterpolatedRawStringEndToken,
+                        Lexer.InterpolatedStringKind.MultiLineRaw => SyntaxKind.InterpolatedRawStringEndToken,
                         _ => throw ExceptionUtilities.UnexpectedValue(kind),
                     },
                     originalText[closeQuoteRange],

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
-Microsoft.CodeAnalysis.CSharp.SyntaxKind.InterpolatedMultiLineRawStringEndToken = 9083 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
-Microsoft.CodeAnalysis.CSharp.SyntaxKind.InterpolatedMultiLineRawStringStartToken = 9082 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
-Microsoft.CodeAnalysis.CSharp.SyntaxKind.InterpolatedSingleLineRawStringEndToken = 9081 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.InterpolatedMultiLineRawStringStartToken = 9081 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.InterpolatedRawStringEndToken = 9082 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.InterpolatedSingleLineRawStringStartToken = 9080 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.MultiLineRawStringLiteralToken = 9073 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.SingleLineRawStringLiteralToken = 9072 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -1954,8 +1954,8 @@
     <Field Name="StringEndToken" Type="SyntaxToken">
       <Kind Name="InterpolatedStringEndToken"/>
       <Kind Name="InterpolatedStringEndToken"/>
-      <Kind Name="InterpolatedSingleLineRawStringEndToken"/>
-      <Kind Name="InterpolatedMultiLineRawStringEndToken"/>
+      <Kind Name="InterpolatedRawStringEndToken"/>
+      <Kind Name="InterpolatedRawStringEndToken"/>
       <PropertyComment>
         <summary>The closing quote of the interpolated string.</summary>
       </PropertyComment>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -875,8 +875,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         MultiLineRawStringLiteralToken = 9073,
 
         InterpolatedSingleLineRawStringStartToken = 9080,   // $"""
-        InterpolatedSingleLineRawStringEndToken = 9081,     // """
-        InterpolatedMultiLineRawStringStartToken = 9082,    // $"""<whitespace><newline>
-        InterpolatedMultiLineRawStringEndToken = 9083,      // <newline><whitespace>"""
+        InterpolatedMultiLineRawStringStartToken = 9081,    // $""" (whitespace and newline are included in the Text for this token)
+        InterpolatedRawStringEndToken = 9082,               // """ (preceding whitespace and newline are included in the Text for this token)
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -203,11 +203,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.InterpolatedStringStartToken:
                 case SyntaxKind.InterpolatedVerbatimStringStartToken:
                 case SyntaxKind.InterpolatedMultiLineRawStringStartToken:
-                case SyntaxKind.InterpolatedMultiLineRawStringEndToken:
                 case SyntaxKind.InterpolatedSingleLineRawStringStartToken:
-                case SyntaxKind.InterpolatedSingleLineRawStringEndToken:
                 case SyntaxKind.InterpolatedStringTextToken:
                 case SyntaxKind.InterpolatedStringEndToken:
+                case SyntaxKind.InterpolatedRawStringEndToken:
                 case SyntaxKind.LoadKeyword:
                 case SyntaxKind.NullableKeyword:
                 case SyntaxKind.EnableKeyword:

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     }
                     N(SyntaxKind.CloseBraceToken);
                 }
-                N(SyntaxKind.InterpolatedSingleLineRawStringEndToken);
+                N(SyntaxKind.InterpolatedRawStringEndToken);
             }
             EOF();
         }
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     N(SyntaxKind.InterpolatedStringTextToken);
                 }
-                N(SyntaxKind.InterpolatedSingleLineRawStringEndToken);
+                N(SyntaxKind.InterpolatedRawStringEndToken);
             }
             EOF();
         }
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     }
                     N(SyntaxKind.CloseBraceToken);
                 }
-                N(SyntaxKind.InterpolatedMultiLineRawStringEndToken);
+                N(SyntaxKind.InterpolatedRawStringEndToken);
             }
             EOF();
         }
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     N(SyntaxKind.InterpolatedStringTextToken);
                 }
-                N(SyntaxKind.InterpolatedMultiLineRawStringEndToken);
+                N(SyntaxKind.InterpolatedRawStringEndToken);
             }
             EOF();
         }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -135,11 +135,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         {
             if (token.IsKind(SyntaxKind.InterpolatedStringStartToken) ||
                 token.IsKind(SyntaxKind.InterpolatedStringEndToken) ||
+                token.IsKind(SyntaxKind.InterpolatedRawStringEndToken) ||
                 token.IsKind(SyntaxKind.InterpolatedStringTextToken) ||
                 token.IsKind(SyntaxKind.InterpolatedSingleLineRawStringStartToken) ||
-                token.IsKind(SyntaxKind.InterpolatedSingleLineRawStringEndToken) ||
-                token.IsKind(SyntaxKind.InterpolatedMultiLineRawStringStartToken) ||
-                token.IsKind(SyntaxKind.InterpolatedMultiLineRawStringEndToken))
+                token.IsKind(SyntaxKind.InterpolatedMultiLineRawStringStartToken))
             {
                 text = "$_CSharpKeyword";
                 return true;

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -146,10 +146,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 || token.IsKind(SyntaxKind.InterpolatedVerbatimStringStartToken)
                 || token.IsKind(SyntaxKind.InterpolatedStringTextToken)
                 || token.IsKind(SyntaxKind.InterpolatedStringEndToken)
+                || token.IsKind(SyntaxKind.InterpolatedRawStringEndToken)
                 || token.IsKind(SyntaxKind.InterpolatedSingleLineRawStringStartToken)
-                || token.IsKind(SyntaxKind.InterpolatedSingleLineRawStringEndToken)
                 || token.IsKind(SyntaxKind.InterpolatedMultiLineRawStringStartToken)
-                || token.IsKind(SyntaxKind.InterpolatedMultiLineRawStringEndToken)
                 || token.IsKind(SyntaxKind.SingleLineRawStringLiteralToken)
                 || token.IsKind(SyntaxKind.MultiLineRawStringLiteralToken);
         }

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
             {
                 var interpolatedExpression = token.GetAncestor<InterpolatedStringExpressionSyntax>();
                 Contract.ThrowIfNull(interpolatedExpression);
-                if (interpolatedExpression.StringEndToken.IsKind(SyntaxKind.InterpolatedMultiLineRawStringEndToken))
+                if (interpolatedExpression.StringStartToken.IsKind(SyntaxKind.InterpolatedMultiLineRawStringStartToken))
                 {
                     var endLinePosition = sourceText.Lines.GetLineFromPosition(interpolatedExpression.StringEndToken.Span.End);
                     var nonWhitespaceOffset = endLinePosition.GetFirstNonWhitespaceOffset();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -428,10 +428,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     SyntaxKind.InterpolatedStringStartToken,
                     SyntaxKind.InterpolatedStringTextToken,
                     SyntaxKind.InterpolatedStringEndToken,
+                    SyntaxKind.InterpolatedRawStringEndToken,
                     SyntaxKind.InterpolatedSingleLineRawStringStartToken,
-                    SyntaxKind.InterpolatedSingleLineRawStringEndToken,
-                    SyntaxKind.InterpolatedMultiLineRawStringStartToken,
-                    SyntaxKind.InterpolatedMultiLineRawStringEndToken))
+                    SyntaxKind.InterpolatedMultiLineRawStringStartToken))
             {
                 return token.SpanStart < position && token.Span.End > position;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
@@ -463,8 +463,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             // No space before " at the end of an interpolated string
             if (currentKind is SyntaxKind.InterpolatedStringEndToken or
-                               SyntaxKind.InterpolatedSingleLineRawStringEndToken or
-                               SyntaxKind.InterpolatedMultiLineRawStringEndToken)
+                               SyntaxKind.InterpolatedRawStringEndToken)
             {
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpaces);
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -471,12 +471,11 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
                 case SyntaxKind.FalseKeyword:
                 case SyntaxKind.InterpolatedStringStartToken:
                 case SyntaxKind.InterpolatedStringEndToken:
+                case SyntaxKind.InterpolatedRawStringEndToken:
                 case SyntaxKind.InterpolatedVerbatimStringStartToken:
                 case SyntaxKind.InterpolatedStringTextToken:
                 case SyntaxKind.InterpolatedSingleLineRawStringStartToken:
-                case SyntaxKind.InterpolatedSingleLineRawStringEndToken:
                 case SyntaxKind.InterpolatedMultiLineRawStringStartToken:
-                case SyntaxKind.InterpolatedMultiLineRawStringEndToken:
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
Fallout of the design meeting.  We don't ever really need this on the compiler or IDE side.  Any code that cares if it's multi-line can trivially determine this from the start token.

Relates to test plan https://github.com/dotnet/roslyn/issues/55306