### PR TITLE
Add nuget service connection to restore internal tools

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -122,7 +122,7 @@ stages:
     # Authenticate with service connections to be able to publish packages to external nuget feeds.
     - task: NuGetAuthenticate@0
       inputs:
-        nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering
+        nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, dotnet-core-internal-tooling
 
     # Needed because the build fails the NuGet Tools restore without it
     - task: UseDotNet@2

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -122,7 +122,7 @@ stages:
     # Authenticate with service connections to be able to publish packages to external nuget feeds.
     - task: NuGetAuthenticate@0
       inputs:
-        nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, dotnet-core-internal-tooling
+        nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, devdiv/dotnet-core-internal-tooling
 
     # Needed because the build fails the NuGet Tools restore without it
     - task: UseDotNet@2

--- a/eng/common/internal/NuGet.config
+++ b/eng/common/internal/NuGet.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-core-internal" value="https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal/nuget/v3/index.json" />
+    <add key="dotnet-core-internal" value="https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Fixes official build breaks such as https://dev.azure.com/dnceng/internal/_build/results?buildId=1578284&view=results