### PR TITLE
Fix completion not working for pointer-typed parameters

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -11532,5 +11532,256 @@ class Test
             await VerifyItemExistsAsync(source, "P1");
             await VerifyItemExistsAsync(source, "E1");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(58081, "https://github.com/dotnet/roslyn/issues/58081")]
+        public async Task CompletionOnPointerParameter()
+        {
+            var source = @"
+struct TestStruct
+{
+    public int X;
+    public int Y { get; }
+    public void Method() { }
+}
+
+unsafe class Test
+{
+    void TestMethod(TestStruct* a)
+    {
+        a->$$
+    }
+}
+";
+            await VerifyItemExistsAsync(source, "X");
+            await VerifyItemExistsAsync(source, "Y");
+            await VerifyItemExistsAsync(source, "Method");
+            await VerifyItemExistsAsync(source, "ToString");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(58081, "https://github.com/dotnet/roslyn/issues/58081")]
+        public async Task CompletionOnAwaitedPointerParameter()
+        {
+            var source = @"
+struct TestStruct
+{
+    public int X;
+    public int Y { get; }
+    public void Method() { }
+}
+
+unsafe class Test
+{
+    async void TestMethod(TestStruct* a)
+    {
+        await a->$$
+    }
+}
+";
+            await VerifyItemExistsAsync(source, "X");
+            await VerifyItemExistsAsync(source, "Y");
+            await VerifyItemExistsAsync(source, "Method");
+            await VerifyItemExistsAsync(source, "ToString");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(58081, "https://github.com/dotnet/roslyn/issues/58081")]
+        public async Task CompletionOnLambdaPointerParameter()
+        {
+            var source = @"
+struct TestStruct
+{
+    public int X;
+    public int Y { get; }
+    public void Method() { }
+}
+
+unsafe class Test
+{
+    delegate void TestLambda(TestStruct* a);
+
+    TestLambda TestMethod()
+    {
+        return a => a->$$
+    }
+}
+";
+            await VerifyItemExistsAsync(source, "X");
+            await VerifyItemExistsAsync(source, "Y");
+            await VerifyItemExistsAsync(source, "Method");
+            await VerifyItemExistsAsync(source, "ToString");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(58081, "https://github.com/dotnet/roslyn/issues/58081")]
+        public async Task CompletionOnOverloadedLambdaPointerParameter()
+        {
+
+            var source = @"
+struct TestStruct1
+{
+    public int X;
+}
+
+struct TestStruct2
+{
+    public int Y;
+}
+
+unsafe class Test
+{
+    delegate void TestLambda1(TestStruct1* a);
+    delegate void TestLambda2(TestStruct2* a);
+
+    void Overloaded(TestLambda1 lambda)
+    {
+    }
+
+    void Overloaded(TestLambda2 lambda)
+    {
+    }
+
+    void TestMethod()
+        => Overloaded(a => a->$$);
+}
+";
+            await VerifyItemExistsAsync(source, "X");
+            await VerifyItemExistsAsync(source, "Y");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(58081, "https://github.com/dotnet/roslyn/issues/58081")]
+        public async Task CompletionOnOverloadedLambdaPointerParameterWithExplicitType()
+        {
+
+            var source = @"
+struct TestStruct1
+{
+    public int X;
+}
+
+struct TestStruct2
+{
+    public int Y;
+}
+
+unsafe class Test
+{
+    delegate void TestLambda1(TestStruct1* a);
+    delegate void TestLambda2(TestStruct2* a);
+
+    void Overloaded(TestLambda1 lambda)
+    {
+    }
+
+    void Overloaded(TestLambda2 lambda)
+    {
+    }
+
+    void TestMethod()
+        => Overloaded((TestStruct1* a) => a->$$);
+}
+";
+            await VerifyItemExistsAsync(source, "X");
+            await VerifyItemIsAbsentAsync(source, "Y");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(58081, "https://github.com/dotnet/roslyn/issues/58081")]
+        public async Task CompletionOnPointerParameterWithSimpleMemberAccess()
+        {
+            var source = @"
+struct TestStruct
+{
+    public int X;
+    public int Y { get; }
+    public void Method() { }
+}
+
+unsafe class Test
+{
+    void TestMethod(TestStruct* a)
+    {
+        a.$$
+    }
+}
+";
+            await VerifyItemIsAbsentAsync(source, "X");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(58081, "https://github.com/dotnet/roslyn/issues/58081")]
+        public async Task CompletionOnOverloadedLambdaPointerParameterWithSimpleMemberAccess()
+        {
+
+            var source = @"
+struct TestStruct1
+{
+    public int X;
+}
+
+struct TestStruct2
+{
+    public int Y;
+}
+
+unsafe class Test
+{
+    delegate void TestLambda1(TestStruct1* a);
+    delegate void TestLambda2(TestStruct2* a);
+
+    void Overloaded(TestLambda1 lambda)
+    {
+    }
+
+    void Overloaded(TestLambda2 lambda)
+    {
+    }
+
+    void TestMethod()
+        => Overloaded(a => a.$$);
+}
+";
+            await VerifyItemIsAbsentAsync(source, "X");
+            await VerifyItemIsAbsentAsync(source, "Y");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(58081, "https://github.com/dotnet/roslyn/issues/58081")]
+        public async Task CompletionOnOverloadedLambdaPointerParameterWithSimpleMemberAccessAndExplicitType()
+        {
+
+            var source = @"
+struct TestStruct1
+{
+    public int X;
+}
+
+struct TestStruct2
+{
+    public int Y;
+}
+
+unsafe class Test
+{
+    delegate void TestLambda1(TestStruct1* a);
+    delegate void TestLambda2(TestStruct2* a);
+
+    void Overloaded(TestLambda1 lambda)
+    {
+    }
+
+    void Overloaded(TestLambda2 lambda)
+    {
+    }
+
+    void TestMethod()
+        => Overloaded((TestStruct1* a) => a.$$);
+}
+";
+            await VerifyItemIsAbsentAsync(source, "X");
+            await VerifyItemIsAbsentAsync(source, "Y");
+        }
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
@@ -294,7 +294,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                     .SelectMany(Function(n) LookupSymbolsInContainer(n, position, excludeInstance)) _
                     .ToImmutableArray()
             Else
-                symbols = GetMemberSymbols(container, position, excludeInstance, useBaseReferenceAccessibility, unwrapNullable)
+                symbols = GetMemberSymbols(container, position, excludeInstance, useBaseReferenceAccessibility, unwrapNullable, isForDereference:=False)
             End If
 
             If excludeShared Then


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58081
Fixes https://github.com/dotnet/roslyn/issues/54919

The source of this bug was special logic to handle completion on lambda parameters. Previously completion worked in non-lambda scenarios due to some fallback logic which was mistakenly altered during a refactoring.

The fix provided this PR is to delay "dereferencing" the pointer type until later on in the recommender pipeline. This ensures consistent handling of pointer types between the common case and the parameter case.

-----------

### Excessive details on the cause of the regression

<details>
<summary>Click to expand...</summary>

I ended up narrowing down this regression to https://github.com/dotnet/roslyn/pull/51811.

Previously this situation was handled by a combination of:

https://github.com/dotnet/roslyn/blob/7dbb61b10ba2b7d16446f3a4d3c3f203e45fe0aa/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs#L484-L489

and the later fallback check at

https://github.com/dotnet/roslyn/blob/7dbb61b10ba2b7d16446f3a4d3c3f203e45fe0aa/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs#L525-L532

Basically the old implementation attempted to use the special parameter-specific logic and fall back to the normal path if that didn't return anything.

I believe Cyrus's intent was to handle the same fallback logic here:

https://github.com/dotnet/roslyn/blob/8da536d778b7980305b9d00c1291b6d5a0d03a39/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs#L49-L52

However this does not consider the `PointerMemberAccessExpression` situation which has extra logic to "dereference" the `IPointerTypeSymbol`:

https://github.com/dotnet/roslyn/blob/8da536d778b7980305b9d00c1291b6d5a0d03a39/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs#L367-L371

This caused `GetMemberSymbols` to attempt to find members of the `IPointerTypeSymbol`, of which there are none.

It's also worth pointing out that `TryGetMemberSymbolsForLambdaParameter` (previously `GetSymbols(IParameterSymbol, int)` in the first code snippet above) seems to have never handled pointers correctly either. This PR fixes it too.

</details>
