### PR TITLE
QuickInfo and Completion options follow-up

### DIFF
--- a/docs/Breaking API Changes.md
+++ b/docs/Breaking API Changes.md
@@ -53,3 +53,10 @@ PR: https://github.com/dotnet/roslyn/pull/11536
 
 The constructors of Microsoft.CodeAnalysis.Completion and Microsoft.CodeAnalysis.Completion.CompletionServiceWithProviders are now internal.
 Roslyn does not support implementing completion for arbitrary languages.
+
+# Version 4.2.0
+
+### Can no longer inherit from QuickInfoService
+
+The constructors of Microsoft.CodeAnalysis.QuickInfoService are now internal.
+Roslyn does not support implementing completion for arbitrary languages.

--- a/eng/config/BannedSymbols.txt
+++ b/eng/config/BannedSymbols.txt
@@ -5,3 +5,4 @@ M:Microsoft.CodeAnalysis.Completion.CompletionProvider.GetDescriptionAsync(Micro
 M:Microsoft.CodeAnalysis.Completion.CompletionService.GetCompletionsAsync(Microsoft.CodeAnalysis.Document,System.Int32,Microsoft.CodeAnalysis.Completion.CompletionTrigger,System.Collections.Immutable.ImmutableHashSet{System.String},Microsoft.CodeAnalysis.Options.OptionSet,System.Threading.CancellationToken); Use GetCompletionsInternalAsync instead
 M:Microsoft.CodeAnalysis.Completion.CompletionService.GetDescriptionAsync(Microsoft.CodeAnalysis.Document,Microsoft.CodeAnalysis.Completion.CompletionItem,System.Threading.CancellationToken); Use internal overload instead
 M:Microsoft.CodeAnalysis.Completion.CompletionService.GetRules; Use internal overload instead
+M:Microsoft.CodeAnalysis.QuickInfo.QuickInfoService.GetQuickInfoAsync(Microsoft.CodeAnalysis.Document,System.Int32,System.Threading.CancellationToken); Use internal overload instead

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -65,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.QuickInfo
 
         private static async Task TestWithOptionsAsync(Document document, QuickInfoService service, int position, Action<QuickInfoItem>[] expectedResults)
         {
-            var info = await service.GetQuickInfoAsync(document, position, cancellationToken: CancellationToken.None);
+            var info = await service.GetQuickInfoAsync(document, position, SymbolDescriptionOptions.Default, CancellationToken.None);
 
             if (expectedResults.Length == 0)
             {
@@ -100,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.QuickInfo
 
             var service = QuickInfoService.GetService(document);
 
-            var info = await service.GetQuickInfoAsync(document, position, cancellationToken: CancellationToken.None);
+            var info = await service.GetQuickInfoAsync(document, position, SymbolDescriptionOptions.Default, CancellationToken.None);
 
             if (expectedResults.Length == 0)
             {
@@ -244,7 +245,7 @@ using System.Linq;
 
             var service = QuickInfoService.GetService(document);
 
-            var info = await service.GetQuickInfoAsync(document, position, cancellationToken: CancellationToken.None);
+            var info = await service.GetQuickInfoAsync(document, position, SymbolDescriptionOptions.Default, CancellationToken.None);
 
             if (expectedResults.Length == 0)
             {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/QuickInfoSourceProvider.QuickInfoSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/QuickInfoSourceProvider.QuickInfoSource.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
@@ -69,7 +70,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        var item = await service.GetQuickInfoAsync(document, triggerPoint.Value, cancellationToken).ConfigureAwait(false);
+                        var options = SymbolDescriptionOptions.From(document.Project);
+                        var item = await service.GetQuickInfoAsync(document, triggerPoint.Value, options, cancellationToken).ConfigureAwait(false);
                         if (item != null)
                         {
                             var textVersion = snapshot.Version;

--- a/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Hover/HoverHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/LanguageServer/Handlers/Hover/HoverHandler.cs
@@ -49,9 +49,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             Contract.ThrowIfNull(document);
 
             var position = await document.GetPositionFromLinePositionAsync(ProtocolConversions.PositionToLinePosition(request.Position), cancellationToken).ConfigureAwait(false);
-
             var quickInfoService = document.Project.LanguageServices.GetRequiredService<QuickInfoService>();
-            var info = await quickInfoService.GetQuickInfoAsync(document, position, cancellationToken).ConfigureAwait(false);
+            var options = SymbolDescriptionOptions.From(document.Project);
+            var info = await quickInfoService.GetQuickInfoAsync(document, position, options, cancellationToken).ConfigureAwait(false);
             if (info == null)
             {
                 return null;

--- a/src/EditorFeatures/Test2/IntelliSense/AbstractIntellisenseQuickInfoBuilderTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/AbstractIntellisenseQuickInfoBuilderTests.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.QuickInfo
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.VisualStudio.Core.Imaging
@@ -67,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                 Dim languageServiceProvider = workspace.Services.GetLanguageServices(language)
                 Dim quickInfoService = languageServiceProvider.GetRequiredService(Of QuickInfoService)
 
-                Dim codeAnalysisQuickInfoItem = Await quickInfoService.GetQuickInfoAsync(document, cursorPosition, CancellationToken.None).ConfigureAwait(False)
+                Dim codeAnalysisQuickInfoItem = Await quickInfoService.GetQuickInfoAsync(document, cursorPosition, SymbolDescriptionOptions.Default, CancellationToken.None).ConfigureAwait(False)
 
                 Dim trackingSpan = New Mock(Of ITrackingSpan)(MockBehavior.Strict) With {
                     .DefaultValue = DefaultValue.Mock

--- a/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QuickInfo/SemanticQuickInfoSourceTests.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Classification.FormattedClassifi
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.QuickInfo
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
@@ -40,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.QuickInfo
         Private Shared Async Function TestSharedAsync(workspace As TestWorkspace, service As QuickInfoService, position As Integer, expectedResults() As Action(Of QuickInfoItem)) As Task
             Dim info = Await service.GetQuickInfoAsync(
                 workspace.CurrentSolution.Projects.First().Documents.First(),
-                position, cancellationToken:=CancellationToken.None)
+                position, SymbolDescriptionOptions.Default, CancellationToken.None)
 
             If expectedResults Is Nothing Then
                 Assert.Null(info)

--- a/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
@@ -34,7 +34,9 @@ namespace Microsoft.CodeAnalysis.Completion
         public sealed override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
         {
             Debug.Fail("For backwards API compat only, should not be called");
-            return ShouldTriggerCompletionImpl(text, caretPosition, trigger, CompletionOptions.From(options, Language));
+
+            // Publicly available options do not affect this API.
+            return ShouldTriggerCompletionImpl(text, caretPosition, trigger, CompletionOptions.Default);
         }
 
         internal override bool ShouldTriggerCompletion(HostLanguageServices languageServices, SourceText text, int caretPosition, CompletionTrigger trigger, CompletionOptions options)
@@ -54,7 +56,9 @@ namespace Microsoft.CodeAnalysis.Completion
         public sealed override Task<CompletionDescription?> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
         {
             Debug.Fail("For backwards API compat only, should not be called");
-            return GetDescriptionAsync(document, item, CompletionOptions.From(document.Project), SymbolDescriptionOptions.From(document.Project), cancellationToken);
+
+            // Publicly available options do not affect this API.
+            return GetDescriptionAsync(document, item, CompletionOptions.Default, SymbolDescriptionOptions.Default, cancellationToken);
         }
 
         internal override async Task<CompletionDescription?> GetDescriptionAsync(Document document, CompletionItem item, CompletionOptions options, SymbolDescriptionOptions displayOptions, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Completion/CompletionContext.cs
+++ b/src/Features/Core/Portable/Completion/CompletionContext.cs
@@ -99,10 +99,11 @@ namespace Microsoft.CodeAnalysis.Completion
                    position,
                    defaultSpan,
                    trigger,
-                   CompletionOptions.From(options ?? throw new ArgumentNullException(nameof(options)), document.Project.Language),
+                   // Publicly available options do not affect this API.
+                   CompletionOptions.Default,
                    cancellationToken)
         {
-            _lazyOptionSet = options;
+            _lazyOptionSet = options ?? throw new ArgumentNullException(nameof(options));
         }
 
         /// <summary>
@@ -131,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// The options that completion was started with.
         /// </summary>
         public OptionSet Options
-            => _lazyOptionSet ??= CompletionOptions.ToSet(Document.Project.Language);
+            => _lazyOptionSet ??= OptionValueSet.Empty;
 
         internal IReadOnlyList<CompletionItem> Items => _items;
 

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -162,7 +162,12 @@ namespace Microsoft.CodeAnalysis.Completion
             Document document,
             CompletionItem item,
             CancellationToken cancellationToken = default)
-            => GetDescriptionAsync(document, item, CompletionOptions.From(document.Project), SymbolDescriptionOptions.From(document.Project), cancellationToken);
+        {
+            Debug.Fail("For backwards API compat only, should not be called");
+
+            // Publicly available options do not affect this API.
+            return GetDescriptionAsync(document, item, CompletionOptions.Default, SymbolDescriptionOptions.Default, cancellationToken);
+        }
 
         /// <summary>
         /// Gets the description of the item.

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -67,7 +67,12 @@ namespace Microsoft.CodeAnalysis.Completion
         /// Backward compatibility only.
         /// </summary>
         public sealed override CompletionRules GetRules()
-            => GetRules(CompletionOptions.From(_workspace.CurrentSolution.Options, Language));
+        {
+            Debug.Fail("For backwards API compat only, should not be called");
+
+            // Publicly available options do not affect this API.
+            return GetRules(CompletionOptions.Default);
+        }
 
         /// <summary>
         /// Returns the providers always available to the service.
@@ -258,7 +263,8 @@ namespace Microsoft.CodeAnalysis.Completion
             OptionSet? options,
             CancellationToken cancellationToken)
         {
-            var completionOptions = CompletionOptions.From(options ?? document.Project.Solution.Options, document.Project.Language);
+            // Publicly available options do not affect this API.
+            var completionOptions = CompletionOptions.Default;
             var (completionList, _) = await GetCompletionsWithAvailabilityOfExpandedItemsAsync(document, caretPosition, trigger, roles, completionOptions, cancellationToken).ConfigureAwait(false);
             return completionList;
         }
@@ -569,9 +575,12 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         public sealed override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, ImmutableHashSet<string>? roles = null, OptionSet? options = null)
         {
+
             var document = text.GetOpenDocumentInCurrentContextWithChanges();
             var languageServices = document?.Project.LanguageServices ?? _workspace.Services.GetLanguageServices(Language);
-            var completionOptions = CompletionOptions.From(options ?? document?.Project.Solution.Options ?? _workspace.CurrentSolution.Options, document?.Project.Language ?? Language);
+
+            // Publicly available options do not affect this API.
+            var completionOptions = CompletionOptions.Default;
             return ShouldTriggerCompletion(document?.Project, languageServices, text, caretPosition, trigger, completionOptions, roles);
         }
 

--- a/src/Features/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Features/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 *REMOVED*Microsoft.CodeAnalysis.QuickInfo.QuickInfoService.QuickInfoService() -> void
+*REMOVED*virtual Microsoft.CodeAnalysis.QuickInfo.QuickInfoService.GetQuickInfoAsync(Microsoft.CodeAnalysis.Document document, int position, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.QuickInfo.QuickInfoItem>
+Microsoft.CodeAnalysis.QuickInfo.QuickInfoService.GetQuickInfoAsync(Microsoft.CodeAnalysis.Document document, int position, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.QuickInfo.QuickInfoItem>

--- a/src/Features/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Features/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-
+*REMOVED*Microsoft.CodeAnalysis.QuickInfo.QuickInfoService.QuickInfoService() -> void

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoService.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoService.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -31,11 +31,14 @@ namespace Microsoft.CodeAnalysis.QuickInfo
         /// <summary>
         /// Gets the <see cref="QuickInfoItem"/> associated with position in the document.
         /// </summary>
-        public virtual Task<QuickInfoItem?> GetQuickInfoAsync(
+        public Task<QuickInfoItem?> GetQuickInfoAsync(
             Document document,
             int position,
             CancellationToken cancellationToken = default)
-            => GetQuickInfoAsync(document, position, SymbolDescriptionOptions.Default, cancellationToken);
+        {
+            Debug.Fail("For backwards API compat only, should not be called");
+            return GetQuickInfoAsync(document, position, SymbolDescriptionOptions.Default, cancellationToken);
+        }
 
         internal virtual Task<QuickInfoItem?> GetQuickInfoAsync(
             Document document,

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoService.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoService.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -15,6 +17,11 @@ namespace Microsoft.CodeAnalysis.QuickInfo
     /// </summary>
     public abstract class QuickInfoService : ILanguageService
     {
+        // Prevent inheritance outside of Roslyn.
+        internal QuickInfoService()
+        {
+        }
+
         /// <summary>
         /// Gets the appropriate <see cref="QuickInfoService"/> for the specified document.
         /// </summary>
@@ -28,6 +35,13 @@ namespace Microsoft.CodeAnalysis.QuickInfo
             Document document,
             int position,
             CancellationToken cancellationToken = default)
+            => GetQuickInfoAsync(document, position, SymbolDescriptionOptions.Default, cancellationToken);
+
+        internal virtual Task<QuickInfoItem?> GetQuickInfoAsync(
+            Document document,
+            int position,
+            SymbolDescriptionOptions options,
+            CancellationToken cancellationToken)
         {
             return SpecializedTasks.Null<QuickInfoItem>();
         }

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoServiceWithProviders.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoServiceWithProviders.cs
@@ -46,10 +46,9 @@ namespace Microsoft.CodeAnalysis.QuickInfo
             return _providers;
         }
 
-        public override async Task<QuickInfoItem?> GetQuickInfoAsync(Document document, int position, CancellationToken cancellationToken)
+        internal override async Task<QuickInfoItem?> GetQuickInfoAsync(Document document, int position, SymbolDescriptionOptions options, CancellationToken cancellationToken)
         {
             var extensionManager = _services.WorkspaceServices.GetRequiredService<IExtensionManager>();
-            var options = SymbolDescriptionOptions.From(document.Project);
 
             // returns the first non-empty quick info found (based on provider order)
             foreach (var provider in GetProviders())


### PR DESCRIPTION
Pushes reading options in QuickInfoService up to its callers.

Prevent inheriting from the abstract QuickInfoService by adding an internal constructor as we do not support extending this service by 3rd party languages. This breaking change is in line with similar change to CompletionService made in 17.1.

Since all options used by QuickInfo service are internal and it is not feasible for 3rd party code to set them the legacy public API entry points do not need to read the options from the snapshot or given OptionSet. This will allow us to move all internal options to EditorFeatures layer in upcoming PRs. In this PR we remove reading the options for QuickInfoService and CompletionService legacy entry points. 