### PR TITLE
Address a few param-nullchecking feedback items

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
@@ -1394,9 +1394,350 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
-        public async Task TestNotWithUserDefinedOperator()
+        public async Task TestNotAfterReturn1()
         {
             var testCode = @"using System;
+class C
+{
+    static void M(C c)
+    {
+        return;
+        if (c == null)
+            throw new ArgumentNullException(nameof(c));
+    }
+}";
+            await new VerifyCS.Test()
+            {
+                TestCode = testCode,
+                FixedCode = testCode,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNotAfterReturn2()
+        {
+            var testCode = @"using System;
+class C
+{
+    static void M(C c, bool b)
+    {
+        if (b)
+            return;
+
+        if (c == null)
+            throw new ArgumentNullException(nameof(c));
+    }
+}";
+            await new VerifyCS.Test()
+            {
+                TestCode = testCode,
+                FixedCode = testCode,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNotAfterReturn3()
+        {
+            var testCode = @"using System;
+class C
+{
+    static void M(C c, bool b)
+    {
+        if (b)
+        {
+            return;
+        }
+
+        if (c == null)
+            throw new ArgumentNullException(nameof(c));
+    }
+}";
+            await new VerifyCS.Test()
+            {
+                TestCode = testCode,
+                FixedCode = testCode,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNotAfterReturn4()
+        {
+            var testCode = @"using System;
+class C
+{
+    static int M(C c, bool b)
+    {
+        if (b)
+        {
+            return 0;
+        }
+
+        if (c == null)
+            throw new ArgumentNullException(nameof(c));
+
+        return 0;
+    }
+}";
+            await new VerifyCS.Test()
+            {
+                TestCode = testCode,
+                FixedCode = testCode,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestBeforeReturn1()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+class C
+{
+    static int M(C c)
+    {
+        [|if (c == null)
+            throw new ArgumentNullException(nameof(c));|]
+
+        return 0;
+    }
+}",
+                FixedCode = @"using System;
+class C
+{
+    static int M(C c!!)
+    {
+        return 0;
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestBeforeReturn2()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+class C
+{
+    static void M(C c, bool b)
+    {
+        [|if (c == null)
+            throw new ArgumentNullException(nameof(c));|]
+
+        if (b)
+            return;
+    }
+}",
+                FixedCode = @"using System;
+class C
+{
+    static void M(C c!!, bool b)
+    {
+        if (b)
+            return;
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestAfterThrow1()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+class C
+{
+    static void M(C c)
+    {
+        throw new ArgumentOutOfRangeException();
+
+        [|if (c == null)
+            throw new ArgumentNullException(nameof(c));|]
+    }
+}",
+                FixedCode = @"using System;
+class C
+{
+    static void M(C c!!)
+    {
+        throw new ArgumentOutOfRangeException();
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestAfterThrow2()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+class C
+{
+    static void M(int i, C c)
+    {
+        if (i < 0)
+            throw new ArgumentOutOfRangeException();
+
+        [|if (c == null)
+            throw new ArgumentNullException(nameof(c));|]
+    }
+}",
+                FixedCode = @"using System;
+class C
+{
+    static void M(int i, C c!!)
+    {
+        if (i < 0)
+            throw new ArgumentOutOfRangeException();
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestExtensionMethod()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+interface I { }
+static class C
+{
+    static void M(this I i)
+    {
+        [|if (i == null)
+            throw new ArgumentNullException(nameof(i));|]
+    }
+}",
+                FixedCode = @"using System;
+interface I { }
+static class C
+{
+    static void M(this I i!!)
+    {
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullCheckInBaseClause()
+        {
+            // Applying code fix introduces CS8602: Dereference of a possibly null reference.
+            // In this case, the user needs to change '?.' to '.' in the base clause.
+            await new VerifyCS.Test()
+            {
+                TestCode = @"#nullable enable
+using System;
+
+class Base { public Base(string? x) { } }
+class C : Base
+{
+    public C(string x) : base(x?.ToString())
+    {
+        [|if (x == null) { throw new ArgumentNullException(); }|]
+        x.ToString();
+    }
+}",
+                FixedCode = @"#nullable enable
+using System;
+
+class Base { public Base(string? x) { } }
+class C : Base
+{
+    public C(string x!!) : base(x?.ToString())
+    {
+        {|CS8602:x|}.ToString();
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestLabeledNullCheck()
+        {
+            // A label syntactically contains the following statement
+            // and we don't offer the fix on nested statements within the body.
+            var testCode = @"using System;
+public class C
+{
+    public void M(string s)
+    {
+        label1:
+        if (s == null) throw new ArgumentNullException();
+    }
+}";
+            await new VerifyCS.Test()
+            {
+                TestCode = testCode,
+                FixedCode = testCode,
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestReturnBackwardsBranchToNullCheck()
+        {
+            // In this scenario, applying the fix makes us throw instead of returning.
+            // However, we think it's esoteric enough that we don't need to address it.
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+public class C
+{
+    public void M(string s, int i = 0)
+    {
+        goto label2;
+        
+        label1:
+        ;
+        [|if (s == null) throw new ArgumentNullException();|]
+        return;
+        
+        label2:
+        if (i < 0) return;
+        goto label1;
+    }
+}",
+                FixedCode = @"using System;
+public class C
+{
+    public void M(string s!!, int i = 0)
+    {
+        goto label2;
+        
+        label1:
+        ;
+        return;
+        
+        label2:
+        if (i < 0) return;
+        goto label1;
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestWithUserDefinedOperator()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
 class C
 {
     public static bool operator ==(C c1, C c2) => true;
@@ -1404,15 +1745,22 @@ class C
 
     static void M(C c)
     {
-        if (c == null)
-            throw new ArgumentNullException(nameof(c));
+        [|if (c == null)
+            throw new ArgumentNullException(nameof(c));|]
     }
 }
-";
-            await new VerifyCS.Test()
-            {
-                TestCode = testCode,
-                FixedCode = testCode,
+",
+                FixedCode = @"using System;
+class C
+{
+    public static bool operator ==(C c1, C c2) => true;
+    public static bool operator !=(C c1, C c2) => false;
+
+    static void M(C c!!)
+    {
+    }
+}
+",
                 LanguageVersion = LanguageVersionExtensions.CSharpNext
             }.RunAsync();
         }


### PR DESCRIPTION
Addresses some of the feedback from Stephen with the new param-nullchecking code fix.

Still outstanding is the issue where IConfigurationBuilder and some other interfaces don't get null-checked: https://github.com/stephentoub/runtime/blob/0a9e46af4cdef876af8dd5fc27c465debbc8fa1a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationExtensions.cs#L23-L28