### PR TITLE
Update analyzer-suggestion.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/analyzer-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/analyzer-suggestion.md
@@ -1,12 +1,15 @@
 ---
 name: Analyzer suggestion
-about: Suggest a Roslyn analyzer related to code style. Semantic/code quality analyzers are developed in roslyn-analyzers repository.
+about: Suggest a Roslyn analyzer related to code style.
 labels: [Area-IDE, Feature Request]
 ---
 
+<!-- This issue template is **only** for analyzers related to code style. -->
+<!-- To propose a semantic/code quality analyzer, please follow the guidelines at https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md. -->
+
 **Brief description:**
 
-Describe your suggestion here.
+Describe your **code style** rule here.
 
 **Languages applicable:**
 


### PR DESCRIPTION
cc @jmarolf @Youssef1313

I wanted to make it easier for people to find the code quality analyzer guidelines. When you create a new issue you will see the HTML comments, but wasn't sure if it would be fine to just include it as plain text? Perhaps harder to miss it in that case?