### PR TITLE
Handle param null check with else clause

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseParameterNullChecking/CSharpUseParameterNullCheckingDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseParameterNullChecking/CSharpUseParameterNullCheckingDiagnosticAnalyzer.cs
@@ -242,7 +242,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking
                             return null;
                         }
 
-                        return (parameterInBinary, ifStatement.GetLocation());
+                        // The if statement could be associated with an arbitrarily complex else clause. We only want to highlight the "if" part which is removed by the fix.
+                        var location = Location.Create(ifStatement.SyntaxTree, Text.TextSpan.FromBounds(ifStatement.SpanStart, ifStatement.Statement.Span.End));
+                        return (parameterInBinary, location);
 
                     // this.field = param ?? throw new ArgumentNullException(nameof(param));
                     case ExpressionStatementSyntax

--- a/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking
                         editor.ReplaceNode(nullCoalescing, parameterReferenceSyntax.WithAppendedTrailingTrivia(SyntaxFactory.ElasticMarker));
                         break;
                     case IfStatementSyntax { Else.Statement: BlockSyntax { Statements: var statementsWithinElse } } ifStatementWithElseBlock:
-                        var parent = (BlockSyntax)ifStatementWithElseBlock.Parent!;
+                        var parent = (BlockSyntax)ifStatementWithElseBlock.GetRequiredParent();
                         var newStatements = parent.Statements.ReplaceRange(ifStatementWithElseBlock, statementsWithinElse.Select(s => s.WithPrependedLeadingTrivia(SyntaxFactory.ElasticMarker)));
                         editor.ReplaceNode(parent, parent.WithStatements(newStatements));
                         break;

--- a/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
@@ -80,7 +80,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking
                                 newStatements.Add(statements[i]);
                             }
 
-                            parent.Statements.ReplaceRange(ifStatementWithElseBlock, newStatements);
                             editor.ReplaceNode(parent, parent.WithStatements(SyntaxFactory.List(newStatements)));
                             break;
                         }

--- a/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseParameterNullChecking/CSharpUseParameterNullCheckingCodeFixProvider.cs
@@ -60,18 +60,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking
                         var parameterReferenceSyntax = nullCoalescing.Left;
                         editor.ReplaceNode(nullCoalescing, parameterReferenceSyntax.WithAppendedTrailingTrivia(SyntaxFactory.ElasticMarker));
                         break;
-                    case IfStatementSyntax { Else.Statement: BlockSyntax blockWithinElse } ifStatementWithElseBlock:
+                    case IfStatementSyntax { Else.Statement: BlockSyntax { Statements: var statementsWithinElse } } ifStatementWithElseBlock:
                         {
                             var parent = (BlockSyntax)ifStatementWithElseBlock.Parent!;
                             var statements = parent.Statements;
                             var indexOfIfStatement = statements.IndexOf(ifStatementWithElseBlock);
-                            using var _1 = ArrayBuilder<StatementSyntax>.GetInstance(capacity: statements.Count + blockWithinElse.Statements.Count - 1, out var newStatements);
+                            using var _1 = ArrayBuilder<StatementSyntax>.GetInstance(capacity: statements.Count + statementsWithinElse.Count - 1, out var newStatements);
 
                             for (var i = 0; i < indexOfIfStatement; i++)
                             {
                                 newStatements.Add(statements[i]);
                             }
-                            foreach (var statementWithinElse in blockWithinElse.Statements)
+                            foreach (var statementWithinElse in statementsWithinElse)
                             {
                                 newStatements.Add(statementWithinElse.WithPrependedLeadingTrivia(SyntaxFactory.ElasticMarker));
                             }

--- a/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
@@ -1733,6 +1733,154 @@ public class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullCheckWithElse1()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+public class C
+{
+    public void M(string s)
+    {
+        [|if (s == null) throw new ArgumentNullException();|]
+        else Console.Write(1);
+    }
+}",
+                FixedCode = @"using System;
+public class C
+{
+    public void M(string s!!)
+    {
+        Console.Write(1);
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullCheckWithElse2()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+public class C
+{
+    public void M(string s)
+    {
+        [|if (s == null) throw new ArgumentNullException();|]
+        else if (s.Length == 0) Console.Write(1);
+    }
+}",
+                FixedCode = @"using System;
+public class C
+{
+    public void M(string s!!)
+    {
+        if (s.Length == 0) Console.Write(1);
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullCheckWithElse3()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+public class C
+{
+    public void M(string s)
+    {
+        Console.Write(0);
+        [|if (s == null) throw new ArgumentNullException();|]
+        else
+        {
+            Console.Write(1);
+            Console.Write(2);
+        }
+        Console.Write(3);
+    }
+}",
+                FixedCode = @"using System;
+public class C
+{
+    public void M(string s!!)
+    {
+        Console.Write(0);
+        Console.Write(1);
+        Console.Write(2);
+        Console.Write(3);
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullCheckWithElse4()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+public class C
+{
+    public void M(string s)
+    {
+        [|if (s == null) throw new ArgumentNullException();|]
+        else if (s.Length == 0)
+        {
+            Console.Write(1);
+            Console.Write(2);
+        }
+    }
+}",
+                FixedCode = @"using System;
+public class C
+{
+    public void M(string s!!)
+    {
+        if (s.Length == 0)
+        {
+            Console.Write(1);
+            Console.Write(2);
+        }
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullCheckWithElse5()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+public class C
+{
+    public void M(string s1, string s2)
+    {
+        [|if (s1 == null) throw new ArgumentNullException();|]
+        else if (s2 == null) throw new ArgumentNullException();
+    }
+}",
+                FixedCode = @"using System;
+public class C
+{
+    public void M(string s1!!, string s2!!)
+    {
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext,
+                NumberOfIncrementalIterations = 2,
+                NumberOfFixAllIterations = 2
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
         public async Task TestWithUserDefinedOperator()
         {
             await new VerifyCS.Test()

--- a/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseParameterNullChecking/UseParameterNullCheckingTests.cs
@@ -1881,6 +1881,62 @@ public class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullCheckWithElse6()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+public class C
+{
+    public void M(string s1)
+    {
+        [|if (s1 == null) throw new ArgumentNullException();|]
+        else /* comment1 */ s1.ToString() /* comment2 */; // comment3
+    }
+}",
+                FixedCode = @"using System;
+public class C
+{
+    public void M(string s1!!)
+    {
+        s1.ToString() /* comment2 */; // comment3
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
+        public async Task TestNullCheckWithElse7()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"using System;
+public class C
+{
+    public void M(string s1)
+    {
+        [|if (s1 == null) throw new ArgumentNullException();|]
+        else
+        {
+            /* comment1 */ s1.ToString() /* comment2 */; // comment3
+        }
+    }
+}",
+                FixedCode = @"using System;
+public class C
+{
+    public void M(string s1!!)
+    {
+        /* comment1 */
+        s1.ToString() /* comment2 */; // comment3
+    }
+}",
+                LanguageVersion = LanguageVersionExtensions.CSharpNext
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIsNullCheck)]
         public async Task TestWithUserDefinedOperator()
         {
             await new VerifyCS.Test()


### PR DESCRIPTION
Related to #36024

Gives a correct fix in a scenario like the following:
![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/5833655/152228843-435efd65-e569-4c56-899f-00ddeb414ba3.png)

cc @CyrusNajmabadi 