### PR TITLE
fix restore on nuget 6.2.0.33

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -166,6 +166,9 @@
     Nuget settings
   -->
   <PropertyGroup Condition="'$(RoslynEnforceCodeStyle)' != 'true'">
+    <!-- Don't warn that we are restoring .NET Framework proejct dependencies for .NET Core. -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
+
     <!-- Opt-in to faster up-to-date check for restore -->
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
 

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -13,10 +13,6 @@
     <CommonExtensionInstallationRoot>CommonExtensions</CommonExtensionInstallationRoot>
     <LanguageServicesExtensionInstallationFolder>Microsoft\VBCSharp\LanguageServices</LanguageServicesExtensionInstallationFolder>
 
-    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
-
-    <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->
-    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <ToolsetPackagesDir>$(RepoRoot)build\ToolsetPackages\</ToolsetPackagesDir>
     <UseSharedCompilation>true</UseSharedCompilation>
 
@@ -164,6 +160,17 @@
   <PropertyGroup Condition="'$(RoslynEnforceCodeStyle)' != 'true'">
     <!-- Don't treat FormattingAnalyzer as an error, even when TreatWarningsAsErrors is specified. -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);IDE0055</WarningsNotAsErrors>
+  </PropertyGroup>
+
+  <!--
+    Nuget settings
+  -->
+  <PropertyGroup Condition="'$(RoslynEnforceCodeStyle)' != 'true'">
+    <!-- Opt-in to faster up-to-date check for restore -->
+    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+
+    <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
 
   <!--

--- a/src/Tools/BuildActionTelemetryTable/BuildActionTelemetryTable.csproj
+++ b/src/Tools/BuildActionTelemetryTable/BuildActionTelemetryTable.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In this PR to nuget: https://github.com/NuGet/NuGet.Client/pull/4372 there was a behavior change that causes a series of cascading NU1701 warnings on Roslyn.sln. As soon as our CI updates to a version of nuget that includes this change our build will break.