### PR TITLE
Avoid eagerly calling SyntaxTreeOptionsProvider.IsGenerated

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -257,8 +257,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Syntax.NullableContextState.State.Disabled => false,
                 Syntax.NullableContextState.State.ExplicitlyRestored => GetGlobalAnnotationState(),
                 Syntax.NullableContextState.State.Unknown =>
-                    !csTree.IsGeneratedCode(this.Compilation.Options.SyntaxTreeOptionsProvider, CancellationToken.None)
-                    && AreNullableAnnotationsGloballyEnabled(),
+                    // IsGeneratedCode may be slow, check global state first:
+                    AreNullableAnnotationsGloballyEnabled() &&
+                    !csTree.IsGeneratedCode(this.Compilation.Options.SyntaxTreeOptionsProvider, CancellationToken.None),
                 _ => throw ExceptionUtilities.UnexpectedValue(context.AnnotationsState)
             };
         }
@@ -267,12 +268,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             RoslynDebug.Assert(token.SyntaxTree is object);
             return AreNullableAnnotationsEnabled(token.SyntaxTree, token.SpanStart);
-        }
-
-        internal bool IsGeneratedCode(SyntaxToken token)
-        {
-            var tree = (CSharpSyntaxTree)token.SyntaxTree!;
-            return tree.IsGeneratedCode(Compilation.Options.SyntaxTreeOptionsProvider, CancellationToken.None);
         }
 
         internal virtual bool AreNullableAnnotationsGloballyEnabled()

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -157,11 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else if (diagnostics.DiagnosticBag is DiagnosticBag diagnosticBag)
                             {
-                                LazyMissingNonNullTypesContextDiagnosticInfo.ReportNullableReferenceTypesIfNeeded(
-                                    AreNullableAnnotationsEnabled(questionToken),
-                                    IsGeneratedCode(questionToken),
-                                    questionToken.GetLocation(),
-                                    diagnosticBag);
+                                LazyMissingNonNullTypesContextDiagnosticInfo.AddAll(this, questionToken, type: null, diagnosticBag);
                             }
                         }
                         else if (isForOverride || AreNullableAnnotationsEnabled(constraintSyntax.ClassOrStructKeyword))

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -490,30 +490,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             void reportNullableReferenceTypesIfNeeded(SyntaxToken questionToken, TypeWithAnnotations typeArgument = default)
             {
-                bool isNullableEnabled = AreNullableAnnotationsEnabled(questionToken);
-                bool isGeneratedCode = IsGeneratedCode(questionToken);
-                var location = questionToken.GetLocation();
-
                 if (diagnostics.DiagnosticBag is DiagnosticBag diagnosticBag)
                 {
                     // Inside a method body or other executable code, we can question IsValueType without causing cycles.
                     if (typeArgument.HasType && !ShouldCheckConstraints)
                     {
-                        LazyMissingNonNullTypesContextDiagnosticInfo.AddAll(
-                            isNullableEnabled,
-                            isGeneratedCode,
-                            typeArgument,
-                            location,
-                            diagnosticBag);
+                        LazyMissingNonNullTypesContextDiagnosticInfo.AddAll(this, questionToken, typeArgument, diagnosticBag);
                     }
-                    else
+                    else if (LazyMissingNonNullTypesContextDiagnosticInfo.IsNullableReference(typeArgument.Type))
                     {
-                        LazyMissingNonNullTypesContextDiagnosticInfo.ReportNullableReferenceTypesIfNeeded(
-                            isNullableEnabled,
-                            isGeneratedCode,
-                            typeArgument,
-                            location,
-                            diagnosticBag);
+                        LazyMissingNonNullTypesContextDiagnosticInfo.AddAll(this, questionToken, type: null, diagnosticBag);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
@@ -159,7 +159,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Syntax.NullableContextState.State.Disabled => false,
                     Syntax.NullableContextState.State.ExplicitlyRestored => nullableOption.WarningsEnabled(),
                     Syntax.NullableContextState.State.Unknown =>
-                        tree?.IsGeneratedCode(syntaxTreeOptions, cancellationToken) != true && nullableOption.WarningsEnabled(),
+                        // IsGeneratedCode may be slow, check the option first:
+                        nullableOption.WarningsEnabled() && tree?.IsGeneratedCode(syntaxTreeOptions, cancellationToken) != true,
                     null => nullableOption.WarningsEnabled(),
                     _ => throw ExceptionUtilities.UnexpectedValue(warningsState)
                 };

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5298,24 +5298,29 @@ namespace Microsoft.CodeAnalysis.CSharp
         public sealed override NullableContext GetNullableContext(int position)
         {
             var syntaxTree = (CSharpSyntaxTree)Root.SyntaxTree;
+
+            // IsGeneratedCode might be slow, only call it when needed:
+            NullableContextOptions getDefaultState()
+                => syntaxTree.IsGeneratedCode(Compilation.Options.SyntaxTreeOptionsProvider, CancellationToken.None)
+                    ? NullableContextOptions.Disable
+                    : Compilation.Options.NullableContextOptions;
+
             NullableContextState contextState = syntaxTree.GetNullableContextState(position);
-            var defaultState = syntaxTree.IsGeneratedCode(Compilation.Options.SyntaxTreeOptionsProvider, CancellationToken.None)
-                ? NullableContextOptions.Disable
-                : Compilation.Options.NullableContextOptions;
 
-            NullableContext context = getFlag(contextState.AnnotationsState, defaultState.AnnotationsEnabled(), NullableContext.AnnotationsContextInherited, NullableContext.AnnotationsEnabled);
-            context |= getFlag(contextState.WarningsState, defaultState.WarningsEnabled(), NullableContext.WarningsContextInherited, NullableContext.WarningsEnabled);
-
-            return context;
-
-            static NullableContext getFlag(NullableContextState.State contextState, bool defaultEnableState, NullableContext inheritedFlag, NullableContext enableFlag) =>
-                contextState switch
-                {
-                    NullableContextState.State.Enabled => enableFlag,
-                    NullableContextState.State.Disabled => NullableContext.Disabled,
-                    _ when defaultEnableState => (inheritedFlag | enableFlag),
-                    _ => inheritedFlag,
-                };
+            return contextState.AnnotationsState switch
+            {
+                NullableContextState.State.Enabled => NullableContext.AnnotationsEnabled,
+                NullableContextState.State.Disabled => NullableContext.Disabled,
+                _ when getDefaultState().AnnotationsEnabled() => NullableContext.AnnotationsContextInherited | NullableContext.AnnotationsEnabled,
+                _ => NullableContext.AnnotationsContextInherited,
+            }
+            | contextState.WarningsState switch
+            {
+                NullableContextState.State.Enabled => NullableContext.WarningsEnabled,
+                NullableContextState.State.Disabled => NullableContext.Disabled,
+                _ when getDefaultState().WarningsEnabled() => NullableContext.WarningsContextInherited | NullableContext.WarningsEnabled,
+                _ => NullableContext.WarningsContextInherited,
+            };
         }
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5299,12 +5299,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var syntaxTree = (CSharpSyntaxTree)Root.SyntaxTree;
 
-            // IsGeneratedCode might be slow, only call it when needed:
-            NullableContextOptions getDefaultState()
-                => syntaxTree.IsGeneratedCode(Compilation.Options.SyntaxTreeOptionsProvider, CancellationToken.None)
-                    ? NullableContextOptions.Disable
-                    : Compilation.Options.NullableContextOptions;
-
+            NullableContextOptions? lazyDefaultState = null;
             NullableContextState contextState = syntaxTree.GetNullableContextState(position);
 
             return contextState.AnnotationsState switch
@@ -5321,6 +5316,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _ when getDefaultState().WarningsEnabled() => NullableContext.WarningsContextInherited | NullableContext.WarningsEnabled,
                 _ => NullableContext.WarningsContextInherited,
             };
+
+            // IsGeneratedCode might be slow, only call it when needed:
+            NullableContextOptions getDefaultState()
+                => lazyDefaultState ??= syntaxTree.IsGeneratedCode(Compilation.Options.SyntaxTreeOptionsProvider, CancellationToken.None)
+                    ? NullableContextOptions.Disable
+                    : Compilation.Options.NullableContextOptions;
         }
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Errors/LazyMissingNonNullTypesContextDiagnosticInfo.cs
+++ b/src/Compilers/CSharp/Portable/Errors/LazyMissingNonNullTypesContextDiagnosticInfo.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Diagnostics;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -25,20 +26,32 @@ namespace Microsoft.CodeAnalysis.CSharp
             _info = info;
         }
 
-        public static void AddAll(bool isNullableEnabled, bool isGeneratedCode, TypeWithAnnotations type, Location location, DiagnosticBag diagnostics)
+#nullable enable
+        /// <summary>
+        /// A `?` annotation on a type that isn't a value type causes:
+        /// - an error before C# 8.0
+        /// - a warning outside of a NonNullTypes context
+        /// </summary>
+        public static void AddAll(Binder binder, SyntaxToken questionToken, TypeWithAnnotations? type, DiagnosticBag diagnostics)
         {
+            var location = questionToken.GetLocation();
+
             var rawInfos = ArrayBuilder<DiagnosticInfo>.GetInstance();
-            GetRawDiagnosticInfos(isNullableEnabled, isGeneratedCode, (CSharpSyntaxTree)location.SourceTree, rawInfos);
+            GetRawDiagnosticInfos(binder, questionToken, rawInfos);
             foreach (var rawInfo in rawInfos)
             {
-                diagnostics.Add(new LazyMissingNonNullTypesContextDiagnosticInfo(type, rawInfo), location);
+                var info = (type.HasValue) ? new LazyMissingNonNullTypesContextDiagnosticInfo(type.Value, rawInfo) : rawInfo;
+                diagnostics.Add(info, location);
             }
+
             rawInfos.Free();
         }
 
-#nullable enable
-        private static void GetRawDiagnosticInfos(bool isNullableEnabled, bool isGeneratedCode, CSharpSyntaxTree tree, ArrayBuilder<DiagnosticInfo> infos)
+        private static void GetRawDiagnosticInfos(Binder binder, SyntaxToken questionToken, ArrayBuilder<DiagnosticInfo> infos)
         {
+            Debug.Assert(questionToken.SyntaxTree != null);
+            var tree = (CSharpSyntaxTree)questionToken.SyntaxTree;
+
             const MessageID featureId = MessageID.IDS_FeatureNullableReferenceTypes;
             var info = featureId.GetFeatureAvailabilityDiagnosticInfo(tree.Options);
             if (info is object)
@@ -46,9 +59,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 infos.Add(info);
             }
 
-            if (!isNullableEnabled && info?.Severity != DiagnosticSeverity.Error)
+            if (info?.Severity != DiagnosticSeverity.Error && !binder.AreNullableAnnotationsEnabled(questionToken))
             {
-                var code = isGeneratedCode
+                var code = tree.IsGeneratedCode(binder.Compilation.Options.SyntaxTreeOptionsProvider, CancellationToken.None)
                     ? ErrorCode.WRN_MissingNonNullTypesContextForAnnotationInGeneratedCode
                     : ErrorCode.WRN_MissingNonNullTypesContextForAnnotation;
                 infos.Add(new CSDiagnosticInfo(code));
@@ -56,43 +69,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 #nullable disable
 
-        private static bool IsNullableReference(TypeSymbol type)
+        internal static bool IsNullableReference(TypeSymbol type)
             => type is null || !(type.IsValueType || type.IsErrorType());
 
         protected override DiagnosticInfo ResolveInfo() => IsNullableReference(_type.Type) ? _info : null;
-
-        /// <summary>
-        /// A `?` annotation on a type that isn't a value type causes:
-        /// - an error before C# 8.0
-        /// - a warning outside of a NonNullTypes context
-        /// </summary>
-        public static void ReportNullableReferenceTypesIfNeeded(
-            bool isNullableEnabled,
-            bool isGeneratedCode,
-            TypeWithAnnotations type,
-            Location location,
-            DiagnosticBag diagnostics)
-        {
-            if (IsNullableReference(type.Type))
-            {
-                ReportNullableReferenceTypesIfNeeded(isNullableEnabled, isGeneratedCode, location, diagnostics);
-            }
-        }
-
-        public static void ReportNullableReferenceTypesIfNeeded(
-            bool isNullableEnabled,
-            bool isGeneratedCode,
-            Location location,
-            DiagnosticBag diagnostics)
-        {
-            var rawInfos = ArrayBuilder<DiagnosticInfo>.GetInstance();
-            GetRawDiagnosticInfos(isNullableEnabled, isGeneratedCode, (CSharpSyntaxTree)location.SourceTree, rawInfos);
-            foreach (var rawInfo in rawInfos)
-            {
-                diagnostics.Add(rawInfo, location);
-            }
-            rawInfos.Free();
-        }
     }
 }
 


### PR DESCRIPTION
Hot Reload perf traces show that IsGenerated might be expensive to calculate. We need to investigate the IDE side -- why is it actually slow, but the compiler can also do better in not calling IsGenerated until it's actually needed.

Contributes to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1425627

![image](https://user-images.githubusercontent.com/41759/152444504-84e25ad2-0743-4973-8c77-a03d89765670.png)

