### PR TITLE
Always allow the 'upgrade project' fixer to upgrade to 'preview' versions of C#

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Utilities/CSharpParseOptionsChangingService.cs
+++ b/src/VisualStudio/CSharp/Impl/Utilities/CSharpParseOptionsChangingService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Utilities
             else if (newCSharpOptions.LanguageVersion == LanguageVersion.Preview)
             {
                 // It's always fine to upgrade a project to 'preview'.  This allows users to try out new features to see
-                // how well they work, while also explicitly putting them into a *know* unsupported state (that's what
+                // how well they work, while also explicitly putting them into a *known* unsupported state (that's what
                 // preview is after all).  Importantly, this doesn't put them into an unrealized unsupported state (for
                 // example, picking some combo of a real lang version that isn't supported with their chosen framework
                 // version).

--- a/src/VisualStudio/CSharp/Impl/Utilities/CSharpParseOptionsChangingService.cs
+++ b/src/VisualStudio/CSharp/Impl/Utilities/CSharpParseOptionsChangingService.cs
@@ -38,6 +38,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Utilities
             {
                 return true;
             }
+            else if (newCSharpOptions.LanguageVersion == LanguageVersion.Preview)
+            {
+                // It's always fine to upgrade a project to 'preview'.  This allows users to try out new features to see
+                // how well they work, while also explicitly putting them into a *know* unsupported state (that's what
+                // preview is after all).  Importantly, this doesn't put them into an unrealized unsupported state (for
+                // example, picking some combo of a real lang version that isn't supported with their chosen framework
+                // version).
+                return true;
+            }
             else
             {
                 Contract.ThrowIfFalse(LanguageVersionFacts.TryParse(maxLangVersion, out var parsedMaxLanguageVersion));


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58742