### PR TITLE
Fix DeclaringCompilation for source methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<RefKind> parameterRefKinds,
             RefKind refKind,
             TypeWithAnnotations returnType) :
-            base(unboundLambda.Syntax.GetReference())
+            base(unboundLambda.Syntax.GetReference(), compilation)
         {
             Debug.Assert(syntaxReferenceOpt is not null);
             _binder = binder;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Binder binder,
             Symbol containingSymbol,
             LocalFunctionStatementSyntax syntax)
-            : base(syntax.GetReference())
+            : base(syntax.GetReference(), binder.Compilation)
         {
             _containingSymbol = containingSymbol;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             SyntaxReference syntaxReferenceOpt,
             ImmutableArray<Location> locations,
             bool isIterator)
-            : base(syntaxReferenceOpt)
+            : base(syntaxReferenceOpt, containingType.DeclaringCompilation)
         {
             Debug.Assert((object)containingType != null);
             Debug.Assert(!locations.IsEmpty);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -15,6 +15,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal abstract class SourceMethodSymbol : MethodSymbol
     {
+        readonly CSharpCompilation _compilation;
+
+        public SourceMethodSymbol(CSharpCompilation compilation) : base()
+        {
+            _compilation = compilation;
+        }
+
         /// <summary>
         /// If there are no constraints, returns an empty immutable array. Otherwise, returns an immutable
         /// array of types, indexed by the constrained type parameter in <see cref="MethodSymbol.TypeParameters"/>.
@@ -26,6 +33,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// array of kinds, indexed by the constrained type parameter in <see cref="MethodSymbol.TypeParameters"/>.
         /// </summary>
         public abstract ImmutableArray<TypeParameterConstraintKind> GetTypeParameterConstraintKinds();
+
+        internal sealed override CSharpCompilation DeclaringCompilation
+            => _compilation;
 
         protected static void ReportBadRefToken(TypeSyntax returnTypeSyntax, BindingDiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -27,7 +27,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         // some symbols may not have a syntax (e.g. lambdas, synthesized event accessors)
         protected readonly SyntaxReference syntaxReferenceOpt;
-        protected SourceMethodSymbolWithAttributes(SyntaxReference syntaxReferenceOpt)
+
+        protected SourceMethodSymbolWithAttributes(SyntaxReference syntaxReferenceOpt, CSharpCompilation compilation)
+            : base(compilation)
         {
             this.syntaxReferenceOpt = syntaxReferenceOpt;
         }
@@ -765,7 +767,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // Default value of charset is inherited from the module (only if specified).
             // This might be different from ContainingType.DefaultMarshallingCharSet. If the charset is not specified on module
-            // ContainingType.DefaultMarshallingCharSet would be Ansi (the class is emitted with "Ansi" charset metadata flag) 
+            // ContainingType.DefaultMarshallingCharSet would be Ansi (the class is emitted with "Ansi" charset metadata flag)
             // while the charset in P/Invoke metadata should be "None".
             CharSet charSet = this.GetEffectiveDefaultMarshallingCharSet() ?? Cci.Constants.CharSet_None;
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -1021,7 +1021,7 @@ class C
         }
 
         [WorkItem(1160855, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1160855")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/58198")]
+        [Fact]
         public void AwaitDynamic()
         {
             var source = @"

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -2304,7 +2304,7 @@ class C
         /// normally be allowed.
         /// </remarks>
         [WorkItem(1075258, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1075258")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/58198")]
+        [Fact]
         public void Await()
         {
             var source = @"
@@ -2340,7 +2340,7 @@ class C
         /// This would be illegal in any non-debugger context.
         /// </remarks>
         [WorkItem(1075258, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1075258")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/58198")]
+        [Fact]
         public void AwaitInUnsafeContext()
         {
             var source = @"
@@ -6087,7 +6087,7 @@ class C
         /// <summary>
         /// Ignore accessibility in async rewriter.
         /// </summary>
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/58198")]
+        [Fact]
         public void AsyncRewriterIgnoreAccessibility()
         {
             var source =


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58198

The problem: 
`Symbol.DeclaringCompilation` relies on `ContainingModule`/`ContainingSymbol` to get the declaring compilation. But for lambdas in an EE scenario the containing symbol may be from PE. So in such scenarios, we'd get a null declaring compilation.
This breaks `SourceMethodSymbolWithAttributes` which uses several calls to `DeclaringCompilation.GetWellKnownType(...)`.

Relates to https://github.com/dotnet/roslyn/pull/59069 (recent related fix) and https://github.com/dotnet/roslyn/issues/59111 (follow-up issue about definite assignment)