### PR TITLE
Bump MS.VS.RpcContract version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -66,7 +66,7 @@
     <RefOnlyMicrosoftBuildRuntimeVersion>$(RefOnlyMicrosoftBuildPackagesVersion)</RefOnlyMicrosoftBuildRuntimeVersion>
     <RefOnlyMicrosoftBuildTasksCoreVersion>$(RefOnlyMicrosoftBuildPackagesVersion)</RefOnlyMicrosoftBuildTasksCoreVersion>
     <NuGetVisualStudioContractsVersion>6.0.0-preview.0.15</NuGetVisualStudioContractsVersion>
-    <MicrosoftVisualStudioRpcContractsVersion>16.10.23</MicrosoftVisualStudioRpcContractsVersion>
+    <MicrosoftVisualStudioRpcContractsVersion>17.0.51</MicrosoftVisualStudioRpcContractsVersion>
     <!--
       Since the Microsoft.CodeAnalysis.Analyzers package is a public dependency of our NuGet
       packages we will keep it untied to the RoslynDiagnosticsNugetPackageVersion we use for


### PR DESCRIPTION
Fixing error below when restore

```
C:\Users\gel\roslyn2\src\Workspaces\Remote\ServiceHub.CoreComponents\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreCompo
nents.csproj : error NU1605: Detected package downgrade: Microsoft.VisualStudio.RpcContracts from 17.0.50-preview-0001-
0001 to 16.10.23. Reference the package directly from the project to select a different version.  [C:\Users\gel\roslyn2
\Roslyn.sln]
C:\Users\gel\roslyn2\src\Workspaces\Remote\ServiceHub.CoreComponents\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreCompo
nents.csproj : error NU1605:  Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents -> Microsoft.CodeAnalysis.Remote.
ServiceHub -> Microsoft.CodeAnalysis.EditorFeatures.Common -> Microsoft.VisualStudio.LanguageServer.Client 17.0.5139-g7
b8c8bd49d -> Microsoft.VisualStudio.Utilities 17.0.0-previews-1-31410-258 -> Microsoft.VisualStudio.RpcContracts (>= 17
.0.50-preview-0001-0001)  [C:\Users\gel\roslyn2\Roslyn.sln]
C:\Users\gel\roslyn2\src\Workspaces\Remote\ServiceHub.CoreComponents\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreCompo
nents.csproj : error NU1605:  Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents -> Microsoft.CodeAnalysis.Remote.
ServiceHub -> Microsoft.VisualStudio.RpcContracts (>= 16.10.23) [C:\Users\gel\roslyn2\Roslyn.sln]
```