### PR TITLE
Insert release/dev17.2 branch to VS rel branch

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -220,7 +220,7 @@
       "version": "4.2.*",
       "packageFeeds": "default",
       "channels": [],
-      "vsBranch": "main",
+      "vsBranch": "rel/d17.2",
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[d17.2p1]"
     },


### PR DESCRIPTION
We inserted all our 17.2-preview1 stuff to main in advance of the divisional snap, so we should start targeting insertions of this branch to rel/d17.2.

cc @JoeRobich 