### PR TITLE
Add support for unsafe local functions in IDE0062 code fix

### DIFF
--- a/src/Analyzers/CSharp/Tests/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
@@ -524,5 +524,19 @@ static void A()
 }",
 parseOptions: CSharp8ParseOptions);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
+        [WorkItem(59286, "https://github.com/dotnet/roslyn/issues/59286")]
+        public async Task TestUnsafeLocalFunction()
+        {
+            await TestAsync(@"
+unsafe void [||]A()
+{
+}", @"
+static unsafe void A()
+{
+}",
+parseOptions: CSharp8ParseOptions);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1454,6 +1454,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         private static readonly DeclarationModifiers s_localFunctionModifiers =
             DeclarationModifiers.Async |
             DeclarationModifiers.Static |
+            DeclarationModifiers.Unsafe |
             DeclarationModifiers.Extern;
 
         private static readonly DeclarationModifiers s_lambdaModifiers =


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/59286