### PR TITLE
Avoid 0-length spans

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -271,11 +271,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                         textSpan = new TextSpan(text.Lines[endLine].Start, endOffSet);
                     }
 
-                    var updatedClassifiedSpan = new ClassifiedSpan(textSpan.Value, classificationType);
-
                     // Omit 0-length spans created in this fashion.
-                    if (updatedClassifiedSpan.TextSpan.Length != 0)
+                    if (textSpan.Value.Length > 0)
                     {
+                        var updatedClassifiedSpan = new ClassifiedSpan(textSpan.Value, classificationType);
                         updatedClassifiedSpans.Add(updatedClassifiedSpan);
                     }
 

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -272,7 +272,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                     }
 
                     var updatedClassifiedSpan = new ClassifiedSpan(textSpan.Value, classificationType);
-                    updatedClassifiedSpans.Add(updatedClassifiedSpan);
+
+                    // Omit 0-length spans created in this fashion.
+                    if (updatedClassifiedSpan.TextSpan.Length != 0)
+                    {
+                        updatedClassifiedSpans.Add(updatedClassifiedSpan);
+                    }
 
                     // Since spans are expected to be ordered, when breaking up a multi-line span, we may have to insert
                     // other spans in-between. For example, we may encounter this case when breaking up a multi-line verbatim

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
@@ -110,13 +110,14 @@ static class C { }
             // Testing as a Razor doc so we get both syntactic + semantic results; otherwise the results would be empty.
             var markup =
 @"{|caret:|}class C { /* one
+
 two
 three */ }
 ";
             using var testLspServer = await CreateTestLspServerAsync(markup);
 
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
-            var range = new LSP.Range { Start = new Position(0, 0), End = new Position(3, 0) };
+            var range = new LSP.Range { Start = new Position(0, 0), End = new Position(4, 0) };
             var (results, _) = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
                 document, SemanticTokensHelpers.TokenTypeToIndex, range, includeSyntacticClassifications: true, CancellationToken.None);
 
@@ -129,7 +130,7 @@ three */ }
                        0,     6,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.ClassName],   0, // 'C'
                        0,     2,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation], 0, // '{'
                        0,     2,     6,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Comment],      0, // '/* one'
-                       1,     0,     3,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Comment],      0, // 'two'
+                       2,     0,     3,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Comment],      0, // 'two'
                        1,     0,     8,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Comment],      0, // 'three */'
                        0,     9,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation], 0, // '}'
                 },


### PR DESCRIPTION
Basically we started splitting multi-line tokens into their own individual lines to accommodate Razor. This is fine, except it can result in 0-length spans if the line is empty as in 
```
\*
one

two
*\
```

And 0-length spans result in throwing:
```
Exception: System.InvalidOperationException: Unexpected false - line 363
   at Roslyn.Utilities.Contract.Fail(String message, Int32 lineNumber)
   at Roslyn.Utilities.Contract.ThrowIfFalse(Boolean condition, Int32 lineNumber)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens.SemanticTokensHelpers.ComputeNextToken(TextLineCollection lines, Int32& lastLineNumber, Int32& lastStartCharacter, ClassifiedSpan[] classifiedSpans, Int32 currentClassifiedSpanIndex, Dictionary`2 tokenTypesToIndex, Int32& deltaLineOut, Int32& startCharacterDeltaOut, Int32& tokenLengthOut, Int32& tokenTypeOut, Int32& tokenModifiersOut)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens.SemanticTokensHelpers.ComputeTokens(TextLineCollection lines, ClassifiedSpan[] classifiedSpans, Dictionary`2 tokenTypesToIndex)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens.SemanticTokensHelpers.<ComputeSemanticTokensDataAsync>d__4.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens.SemanticTokensRangeHandler.<HandleRequestAsync>d__8.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.RequestExecutionQueue.QueueItem`2.<CallbackAsync>d__30.MoveNext()
```
Solution: Omit any 0-length spans created by the `ConvertToSingleLineSpan` method.