### PR TITLE
Cache the unescaped form of globalconfig section names

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerConfigTests.cs
@@ -2536,6 +2536,29 @@ a = b
             }
         }
 
+
+        [Fact]
+        public void CorrectlyMergeGlobalConfigWithEscapedPaths()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+is_global = true
+[/Test.cs]
+a = a
+[/\Test.cs]
+b = b
+", "/.editorconfig"));
+
+            var configSet = AnalyzerConfigSet.Create(configs, out var diagnostics);
+            configs.Free();
+
+            var options = configSet.GetOptionsForSourcePath("/Test.cs");
+
+            Assert.Equal(2, options.AnalyzerOptions.Count);
+            Assert.Equal("a", options.AnalyzerOptions["a"]);
+            Assert.Equal("b", options.AnalyzerOptions["b"]);
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis
                 numberRangePairs.ToImmutableAndFree());
         }
 
-        internal static bool TryUnescapeSectionName(string sectionName, out string? escapedSectionName)
+        internal static string UnescapeSectionName(string sectionName)
         {
             var sb = new StringBuilder();
             SectionNameLexer lexer = new SectionNameLexer(sectionName);
@@ -125,9 +125,14 @@ namespace Microsoft.CodeAnalysis
                 {
                     sb.Append(lexer.EatCurrentCharacter());
                 }
+                else
+                {
+                    // We only call this on strings that were already passed through IsAbsoluteEditorConfigPath, so
+                    // we shouldn't have any other token kinds here.
+                    throw ExceptionUtilities.UnexpectedValue(tokenKind);
+                }
             }
-            escapedSectionName = sb.ToString();
-            return true;
+            return sb.ToString();
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -298,7 +298,8 @@ namespace Microsoft.CodeAnalysis
             }
 
             /// <summary>
-            /// The name as present directly in the section specification of the editorconfig file.
+            /// For regular files, the name as present directly in the section specification of the editorconfig file. For sections in
+            /// global configs, this is the unescaped full file path.
             /// </summary>
             public string Name { get; }
 


### PR DESCRIPTION
We were unescaping section names each time we were trying to find the applicable config rules for a file; if we were computing options for each file in a compilation this resulted in a huge amount of duplicate work.

Fixes [AB#1472298](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1472298)