### PR TITLE
Run MacOS CI on 10.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ jobs:
     buildJobName: Build_Unix_Debug
     testArtifactName: Transport_Artifacts_Unix_Debug
     configuration: Debug
-    testArguments: --testCoreClr --helixQueueName OSX.1014.Amd64.Open
+    testArguments: --testCoreClr --helixQueueName OSX.1015.Amd64.Open
 
 # Build Correctness Jobs
 


### PR DESCRIPTION
Fixes
```
/home/vsts/.nuget/packages/microsoft.dotnet.helix.sdk/7.0.0-beta.22053.2/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(46,5): error : Helix API does not contain an entry for OSX.1014.Amd64.Open
```