### PR TITLE
Finalize New Inline Rename UI

### DIFF
--- a/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
+++ b/src/EditorFeatures/Core.Wpf/EditorFeaturesWpfResources.resx
@@ -153,4 +153,7 @@
   <data name="Interactive_host_process_platform" xml:space="preserve">
     <value>Interactive host process platform</value>
   </data>
+  <data name="Enter_to_rename_shift_enter_to_preview" xml:space="preserve">
+    <value>Enter to rename, Shift+Enter to preview</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornment.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornment.xaml
@@ -6,16 +6,19 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Microsoft.CodeAnalysis.Editor.InlineRename.Adornment"
              xmlns:rename="clr-namespace:Microsoft.CodeAnalysis.Editor.Implementation.InlineRename"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              MinWidth="200"
-             MinHeight="100"
              x:Name="control"
              KeyDown="Adornment_KeyDown"
              MouseDown="Adornment_ConsumeMouseEvent"
              MouseUp="Adornment_ConsumeMouseEvent"
              GotKeyboardFocus="Adornment_GotKeyboardFocus"
-             Focusable="True">
+             Focusable="False"
+             UseLayoutRounding="True"
+             Background="{DynamicResource {x:Static rename:InlineRenameColors.BackgroundBrushKey}}">
 
     <UserControl.Resources>
         <ResourceDictionary>
@@ -37,30 +40,80 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <StackPanel Orientation="Vertical">
-        <TextBox x:Name="IdentifierTextBox" Text="{Binding IdentifierText, UpdateSourceTrigger=PropertyChanged}" GotFocus="IdentifierTextBox_GotFocus"/>
+    <Border 
+        Background="{DynamicResource {x:Static rename:InlineRenameColors.BackgroundBrushKey}}" 
+        BorderThickness="1" 
+        BorderBrush="{DynamicResource {x:Static rename:InlineRenameColors.ButtonBorderBrush}}" >
+        <StackPanel Orientation="Vertical" Margin="5" >
+            <Grid Margin="0 0 0 10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="22" />
+                </Grid.ColumnDefinitions>
 
-        <Expander x:Name="OptionsExpander">
-            <Expander.Header>
-                <TextBlock Text="Options" />
-            </Expander.Header>
+                
+                <TextBox 
+                    Grid.Column="0"
+                    x:Name="IdentifierTextBox" 
+                    Text="{Binding IdentifierText, UpdateSourceTrigger=PropertyChanged}" 
+                    GotFocus="IdentifierTextBox_GotFocus" 
+                    HorizontalAlignment="Stretch" />
 
-            <Expander.Content>
-                <StackPanel Orientation="Vertical">
-                    <CheckBox Content="{Binding ElementName=control, Path=RenameOverloads}" Margin="0,0,0,0" IsChecked="{Binding Path=DefaultRenameOverloadFlag, Mode=TwoWay}"
-                      Name="OverloadsCheckbox" Visibility="{Binding RenameOverloadsVisibility}" IsEnabled="{Binding ElementName=control, Path=IsRenameOverloadsEditable}" />
-                    <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=control, Path=SearchInComments}" Margin="0,0,0,0" IsChecked="{Binding Path=RenameInCommentsFlag, Mode=TwoWay}" />
-                    <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=control, Path=SearchInStrings}" Margin="0,0,0,0" IsChecked="{Binding Path=RenameInStringsFlag, Mode=TwoWay}" />
-                    <CheckBox Name="FileRenameCheckbox" 
-                          Content="{Binding Path=FileRenameString}" 
-                          Margin="0" 
-                          IsChecked="{Binding Path=RenameFileFlag, Mode=TwoWay}" 
-                          IsEnabled="{Binding Path=AllowFileRename, Mode=OneWay}" 
-                          Visibility="{Binding Path=ShowFileRename, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
+                <!-- Expand/Collapse button and glyph -->
+                <Button x:Name="ToggleExpandButton" Grid.Column="1" Click="ToggleExpand" Background="Transparent">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="Button">
+                                        <Border Name="border" 
+                                        BorderThickness="1"
+                                        BorderBrush="{DynamicResource {x:Static rename:InlineRenameColors.BackgroundBrushKey}}"
+                                        Background="{TemplateBinding Background}">
+                                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource {x:Static rename:InlineRenameColors.ButtonBorderBrush}}" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </Button.Style>
+                    <imaging:CrispImage Grid.Column="0">
+                        <imaging:CrispImage.Style>
+                            <Style TargetType="imaging:CrispImage">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsCollapsed}" Value="True">
+                                        <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.ExpandDown}" />
+                                    </DataTrigger>
 
-                    <CheckBox Name="PreviewChangesCheckbox" Content="{Binding ElementName=control, Path=PreviewChanges}" Margin="0,8,0,0" IsChecked="{Binding Path=DefaultPreviewChangesFlag, Mode=TwoWay}" />
-                </StackPanel>
-            </Expander.Content>
-        </Expander>
+                                    <DataTrigger Binding="{Binding IsCollapsed}" Value="False">
+                                        <Setter Property="Moniker" Value="{x:Static imagecatalog:KnownMonikers.CollapseUp}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </imaging:CrispImage.Style>
+                    </imaging:CrispImage>
+                </Button>
+            </Grid>
+            
+            <StackPanel Orientation="Vertical" Visibility="{Binding IsExpanded, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <CheckBox Content="{Binding ElementName=control, Path=RenameOverloads}" Margin="0,5,0,0" IsChecked="{Binding Path=RenameOverloadFlag, Mode=TwoWay}"
+                      Name="OverloadsCheckbox" Visibility="{Binding RenameOverloadsVisibility}" IsEnabled="{Binding IsRenameOverloadsEditable}" />
+                <CheckBox Name="CommentsCheckbox" Content="{Binding ElementName=control, Path=SearchInComments}" Margin="0,5,0,0" IsChecked="{Binding Path=RenameInCommentsFlag, Mode=TwoWay}" />
+                <CheckBox Name="StringsCheckbox" Content="{Binding ElementName=control, Path=SearchInStrings}" Margin="0,5,0,0" IsChecked="{Binding Path=RenameInStringsFlag, Mode=TwoWay}" />
+                <CheckBox Name="FileRenameCheckbox" 
+                    Content="{Binding Path=FileRenameString}" 
+                    Margin="0,5,0,0"
+                    IsChecked="{Binding Path=RenameFileFlag, Mode=TwoWay}" 
+                    IsEnabled="{Binding Path=AllowFileRename, Mode=OneWay}" 
+                    Visibility="{Binding Path=ShowFileRename, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
+            </StackPanel>
+
+            <TextBlock Text="{Binding ElementName=control, Path=SubmitText}" Foreground="LightGray" Margin="5, 5, 0, 0" FontStyle="Italic" />
     </StackPanel>
+    </Border>
 </UserControl>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornment.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornment.xaml.cs
@@ -43,6 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineRename.Adornment
         public string ApplyRename => EditorFeaturesResources.Apply1;
         public string CancelRename => EditorFeaturesResources.Cancel;
         public string PreviewChanges => EditorFeaturesResources.Preview_changes1;
+        public string SubmitText => EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview;
 #pragma warning restore CA1822 // Mark members as static
 
         private void TextView_CursorChanged(object sender, CaretPositionChangedEventArgs e)
@@ -99,9 +100,9 @@ namespace Microsoft.CodeAnalysis.Editor.InlineRename.Adornment
                 case Key.Tab:
                     // We don't want tab to lose focus for the adornment, so manually 
                     // loop focus back to the first item that is focusable.
-                    FrameworkElement lastItem = OptionsExpander.IsExpanded
-                        ? PreviewChangesCheckbox
-                        : OptionsExpander;
+                    FrameworkElement lastItem = _viewModel.IsExpanded
+                        ? FileRenameCheckbox
+                        : IdentifierTextBox;
 
                     if (lastItem.IsFocused)
                     {
@@ -125,8 +126,18 @@ namespace Microsoft.CodeAnalysis.Editor.InlineRename.Adornment
 
         private void Adornment_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
-            MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+            if (e.OldFocus == this)
+            {
+                return;
+            }
+
+            IdentifierTextBox.Focus();
             e.Handled = true;
+        }
+
+        private void ToggleExpand(object sender, RoutedEventArgs e)
+        {
+            _viewModel.IsExpanded = !_viewModel.IsExpanded;
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornmentViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornmentViewModel.cs
@@ -149,7 +149,8 @@ namespace Microsoft.CodeAnalysis.Editor.InlineRename.Adornment
             set => IsCollapsed = !value;
         }
 
-        public bool IsRenameOverloadsEditable => !_session.ForceRenameOverloads;
+        public bool IsRenameOverloadsEditable 
+            => !_session.MustRenameOverloads;
 
         public void Submit()
         {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornmentViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornmentViewModel.cs
@@ -130,6 +130,27 @@ namespace Microsoft.CodeAnalysis.Editor.InlineRename.Adornment
             }
         }
 
+        private bool _isCollapsed;
+        public bool IsCollapsed
+        {
+            get => _isCollapsed;
+            set
+            {
+                if (Set(ref _isCollapsed, value))
+                {
+                    NotifyPropertyChanged(nameof(IsExpanded));
+                }
+            }
+        }
+
+        public bool IsExpanded
+        {
+            get => !IsCollapsed;
+            set => IsCollapsed = !value;
+        }
+
+        public bool IsRenameOverloadsEditable => !_session.ForceRenameOverloads;
+
         public void Submit()
         {
             _session.Commit();

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornmentViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornmentViewModel.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineRename.Adornment
             set => IsCollapsed = !value;
         }
 
-        public bool IsRenameOverloadsEditable 
+        public bool IsRenameOverloadsEditable
             => !_session.MustRenameOverloads;
 
         public void Submit()

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
@@ -70,7 +70,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 _dashboardColorUpdater?.UpdateColors();
 
                 var useInlineAdornment = _globalOptionService.GetOption(InlineRenameExperimentationOptions.UseInlineAdornment);
-
                 if (useInlineAdornment)
                 {
                     var adornment = new InlineRenameAdornment(
@@ -94,7 +93,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     _adornmentLayer.AddAdornment(AdornmentPositioningBehavior.ViewportRelative, null, null, newAdornment,
                         (tag, adornment) => ((Dashboard)adornment).Dispose());
                 }
-#pragma warning restore CS0162 // Unreachable code detected
             }
         }
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameColors.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameColors.cs
@@ -20,5 +20,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public static object BackgroundBrushKey { get; set; } = "BackgroundBrush";
         public static object AccentBarColorKey { get; set; } = "AccentBarBrush";
         public static object ButtonStyleKey { get; set; } = "ButtonStyle";
+        public static object ButtonBorderBrush { get; set; } = "ButtonBorderBrush";
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameColors.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameColors.xaml
@@ -11,5 +11,6 @@
     <SolidColorBrush x:Key="CheckBoxTextBrush"  Color="Black"/>
     <SolidColorBrush x:Key="BackgroundBrush">LightGray</SolidColorBrush>
     <SolidColorBrush x:Key="AccentBarBrush">Blue</SolidColorBrush>
+    <SolidColorBrush x:Key="ButtonBorderBrush">White</SolidColorBrush>
     <Style TargetType="Button" x:Key="ButtonStyle" BasedOn="{StaticResource {x:Type Button}}"/>
 </ResourceDictionary>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Výběr se kopíruje do okna Interactive.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Nepovedlo se provést přejmenování: {0}</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Die Auswahl wird in Interactive-Fenster kopiert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Fehler beim Umbenennen: "{0}"</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Copiando selección en ventana interactiva.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Error al realizar el cambio de nombre: "{0}"</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Copie de la sélection dans la fenêtre interactive.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Erreur au moment du renommage : '{0}'</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Copia della selezione nella finestra interattiva.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Si è verificato un errore durante la ridenominazione: '{0}'</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">インタラクティブ ウィンドウに選択内容をコピーしています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">名前変更の実行でエラーが発生しました: '{0}'</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">선택 영역을 대화형 창으로 복사하는 중입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">이름 바꾸기 수행 중 오류 발생: '{0}'</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Kopiowanie zaznaczenia do okna Interactive.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Błąd podczas wykonywania operacji zmiany nazwy: „{0}”</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Copiando seleção para a Janela Interativa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Erro ao executar a renomeação: '{0}'</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Копирование выделенного фрагмента в интерактивное окно.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Ошибка при выполнении переименования: "{0}"</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Seçim, Etkileşimli Pencere'ye kopyalanıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">Yeniden adlandırma işlemi gerçekleştirilirken hata oluştu: '{0}'</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">将所选内容复制到交互窗口。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">执行重命名时出错:“{0}”</target>

--- a/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core.Wpf/xlf/EditorFeaturesWpfResources.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">正在將選取範圍複製到互動視窗。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Enter_to_rename_shift_enter_to_preview">
+        <source>Enter to rename, Shift+Enter to preview</source>
+        <target state="new">Enter to rename, Shift+Enter to preview</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Error_performing_rename_0">
         <source>Error performing rename: '{0}'</source>
         <target state="translated">執行重新命名時發生錯誤: '{0}'</target>


### PR DESCRIPTION
This is the final spec for the rename UI. Shown are the two states: collapsed and expanded.

### Expanded 

![image](https://user-images.githubusercontent.com/475144/152887428-15586375-27fa-41d0-aaf6-d86afaf2e89e.png)
