### PR TITLE
Associate 'Generate GetHashCode' with a span

### DIFF
--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 document, typeDeclaration, containingType, viableMembers,
                 hasEquals, hasGetHashCode, withDialog: true, cancellationToken).ConfigureAwait(false);
 
-            context.RegisterRefactorings(actions);
+            context.RegisterRefactorings(actions, textSpan);
         }
 
         private static bool HasOperators(INamedTypeSymbol containingType)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/41454