### PR TITLE
Consolidate classification of tracked item spans

### DIFF
--- a/src/Features/Core/Portable/ValueTracking/ValueTrackedItem.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTrackedItem.cs
@@ -21,14 +21,12 @@ namespace Microsoft.CodeAnalysis.ValueTracking
 
         public DocumentId DocumentId { get; }
         public TextSpan Span { get; }
-        public ImmutableArray<ClassifiedSpan> ClassifiedSpans { get; }
         public SourceText SourceText { get; }
         public Glyph Glyph { get; }
 
         private ValueTrackedItem(
             SymbolKey symbolKey,
             SourceText sourceText,
-            ImmutableArray<ClassifiedSpan> classifiedSpans,
             TextSpan textSpan,
             DocumentId documentId,
             Glyph glyph,
@@ -38,7 +36,6 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             Parent = parent;
             Glyph = glyph;
             Span = textSpan;
-            ClassifiedSpans = classifiedSpans;
             SourceText = sourceText;
             DocumentId = documentId;
         }
@@ -61,7 +58,6 @@ namespace Microsoft.CodeAnalysis.ValueTracking
         {
             var excerptService = document.Services.GetService<IDocumentExcerptService>();
             SourceText? sourceText = null;
-            ImmutableArray<ClassifiedSpan> classifiedSpans = default;
 
             if (excerptService != null)
             {
@@ -75,10 +71,6 @@ namespace Microsoft.CodeAnalysis.ValueTracking
 
             if (sourceText is null)
             {
-                var options = ClassificationOptions.From(document.Project);
-                var documentSpan = await ClassifiedSpansAndHighlightSpanFactory.GetClassifiedDocumentSpanAsync(document, textSpan, options, cancellationToken).ConfigureAwait(false);
-                var classificationResult = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(documentSpan, options, cancellationToken).ConfigureAwait(false);
-                classifiedSpans = classificationResult.ClassifiedSpans;
                 var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 sourceText = await syntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
             }
@@ -86,7 +78,6 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             return new ValueTrackedItem(
                         SymbolKey.Create(symbol, cancellationToken),
                         sourceText,
-                        classifiedSpans,
                         textSpan,
                         document.Id,
                         symbol.GetGlyph(),

--- a/src/Features/Core/Portable/ValueTracking/ValueTrackedItem.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTrackedItem.cs
@@ -51,21 +51,8 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             Contract.ThrowIfNull(location.SourceTree);
 
             var document = solution.GetRequiredDocument(location.SourceTree);
-
-            var excerptService = document.Services.GetService<IDocumentExcerptService>();
-            SourceText? sourceText = null;
-
-            if (excerptService != null)
-            {
-                var result = await excerptService.TryExcerptAsync(document, location.SourceSpan, ExcerptMode.SingleLine, cancellationToken).ConfigureAwait(false);
-                sourceText = result?.Content;
-            }
-
-            if (sourceText is null)
-            {
-                var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-                sourceText = await syntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            }
+            var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var sourceText = await syntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             return new ValueTrackedItem(
                 SymbolKey.Create(symbol, cancellationToken),

--- a/src/Features/Core/Portable/ValueTracking/ValueTrackingService.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTrackingService.cs
@@ -46,16 +46,8 @@ namespace Microsoft.CodeAnalysis.ValueTracking
                     return ImmutableArray<ValueTrackedItem>.Empty;
                 }
 
-                using var _ = PooledObjects.ArrayBuilder<ValueTrackedItem>.GetInstance(out var builder);
-
-                foreach (var item in result.Value)
-                {
-                    var rehydratedItem = await item.RehydrateAsync(document.Project.Solution, cancellationToken).ConfigureAwait(false);
-                    Contract.ThrowIfNull(rehydratedItem);
-                    builder.Add(rehydratedItem);
-                }
-
-                return builder.ToImmutable();
+                return await result.Value.SelectAsArrayAsync(
+                    (item, cancellationToken) => item.RehydrateAsync(solution, cancellationToken), cancellationToken).ConfigureAwait(false);
             }
 
             var progressTracker = new ValueTrackingProgressCollector();
@@ -89,11 +81,6 @@ namespace Microsoft.CodeAnalysis.ValueTracking
                 foreach (var item in result.Value)
                 {
                     var rehydratedItem = await item.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false);
-                    if (rehydratedItem is null)
-                    {
-                        throw new InvalidOperationException();
-                    }
-
                     builder.Add(rehydratedItem);
                 }
 

--- a/src/Features/Core/Portable/ValueTracking/ValueTrackingService.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTrackingService.cs
@@ -76,15 +76,8 @@ namespace Microsoft.CodeAnalysis.ValueTracking
                     return ImmutableArray<ValueTrackedItem>.Empty;
                 }
 
-                using var _ = PooledObjects.ArrayBuilder<ValueTrackedItem>.GetInstance(out var builder);
-
-                foreach (var item in result.Value)
-                {
-                    var rehydratedItem = await item.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false);
-                    builder.Add(rehydratedItem);
-                }
-
-                return builder.ToImmutable();
+                return await result.Value.SelectAsArrayAsync(
+                    (item, cancellationToken) => item.RehydrateAsync(solution, cancellationToken), cancellationToken).ConfigureAwait(false);
             }
 
             var progressTracker = new ValueTrackingProgressCollector();

--- a/src/VisualStudio/Core/Def/ValueTracking/TreeItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/TreeItemViewModel.cs
@@ -57,8 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             IGlyphService glyphService,
             IThreadingContext threadingContext,
             Workspace workspace,
-            ImmutableArray<TreeItemViewModel> children = default)
-            : base()
+            ImmutableArray<TreeItemViewModel> children)
         {
             FileName = fileName;
             TextSpan = textSpan;

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackedTreeItemViewModel.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
                   glyphService,
                   threadingContext,
                   solution.Workspace,
-                  children: children)
+                  children)
         {
 
             _trackedItem = trackedItem;
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             _glyphService = glyphService;
             _valueTrackingService = valueTrackingService;
 
-            if (children.IsDefaultOrEmpty)
+            if (children.IsEmpty)
             {
                 // Add an empty item so the treeview has an expansion showing to calculate
                 // the actual children of the node
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
                 valueTrackingService,
                 threadingContext,
                 fileName,
-                children: default);
+                children: ImmutableArray<TreeItemViewModel>.Empty);
         }
 
         private void CalculateChildren()
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             var computingItem = new ComputingTreeViewItem();
             ChildItems.Add(computingItem);
 
-            System.Threading.Tasks.Task.Run(async () =>
+            Task.Run(async () =>
             {
                 try
                 {

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
@@ -152,7 +152,9 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             var classificationFormatMap = _classificationFormatMapService.GetClassificationFormatMap(textView);
 
             var childItems = await valueTrackingService.TrackValueSourceAsync(solution, item, cancellationToken).ConfigureAwait(false);
-            var childViewModels = childItems.SelectAsArray(child => CreateViewModel(child));
+
+            var childViewModels = await childItems.SelectAsArrayAsync((item, cancellationToken) =>
+                ValueTrackedTreeItemViewModel.CreateAsync(solution, item, toolWindow.ViewModel, _glyphService, valueTrackingService, _threadingContext, cancellationToken), cancellationToken).ConfigureAwait(false);
 
             RoslynDebug.AssertNotNull(location.SourceTree);
             var document = solution.GetRequiredDocument(location.SourceTree);
@@ -181,22 +183,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
             toolWindow.ViewModel.Roots.Add(root);
 
             await ShowToolWindowAsync(cancellationToken).ConfigureAwait(true);
-
-            TreeItemViewModel CreateViewModel(ValueTrackedItem valueTrackedItem, ImmutableArray<TreeItemViewModel> children = default)
-            {
-                var document = solution.GetRequiredDocument(valueTrackedItem.DocumentId);
-                var fileName = document.FilePath ?? document.Name;
-
-                return new ValueTrackedTreeItemViewModel(
-                   valueTrackedItem,
-                   solution,
-                   toolWindow.ViewModel,
-                   _glyphService,
-                   valueTrackingService,
-                   _threadingContext,
-                   fileName,
-                   children);
-            }
         }
 
         private async Task ShowToolWindowAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
                 _glyphService,
                 _threadingContext,
                 solution.Workspace,
-                children: childViewModels);
+                childViewModels);
 
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTreeViewModel.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingTreeViewModel.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.Text.Classification;
 
 namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
 {
-    internal class ValueTrackingTreeViewModel : INotifyPropertyChanged
+    internal sealed class ValueTrackingTreeViewModel : INotifyPropertyChanged
     {
         private Brush? _highlightBrush;
         public Brush? HighlightBrush


### PR DESCRIPTION
Previously the classification was performed in multiple places, on client and server. For some items the client also re-classified items that were already classified on server (but the classification spans not serialized to client). This change moves all classifications to the client.

Removes dependency on IDocumentExcerptService. This service is a workaround to support Razor in FAR and needs to be replaced by LSP - https://github.com/dotnet/roslyn/issues/59386.

Follow up: https://github.com/dotnet/roslyn/issues/59378
