### PR TITLE
Avoid eagerly realizing the declaration table

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2589,7 +2589,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return _syntaxAndDeclarations.GetLazyState().DeclarationTable;
+                return _syntaxAndDeclarations.GetLazyState().DeclarationTableInput.GetDeclarationTable();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxAndDeclarationManager.LazyState.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxAndDeclarationManager.LazyState.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.CodeAnalysis.Collections;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -22,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal readonly ImmutableDictionary<SyntaxTree, ImmutableArray<LoadDirective>> LoadDirectiveMap;
             internal readonly ImmutableDictionary<string, SyntaxTree> LoadedSyntaxTreeMap;
             internal readonly ImmutableDictionary<SyntaxTree, Lazy<RootSingleNamespaceDeclaration>> RootNamespaces;
-            internal readonly DeclarationTable DeclarationTable;
+            internal readonly DeclarationTableInput DeclarationTableInput;
 
             internal State(
                 ImmutableArray<SyntaxTree> syntaxTrees,
@@ -30,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ImmutableDictionary<SyntaxTree, ImmutableArray<LoadDirective>> loadDirectiveMap,
                 ImmutableDictionary<string, SyntaxTree> loadedSyntaxTreeMap,
                 ImmutableDictionary<SyntaxTree, Lazy<RootSingleNamespaceDeclaration>> rootNamespaces,
-                DeclarationTable declarationTable)
+                DeclarationTableInput declarationTableInput)
             {
                 Debug.Assert(syntaxTrees.All(tree => syntaxTrees[syntaxTreeOrdinalMap[tree]] == tree));
                 Debug.Assert(syntaxTrees.SetEquals(rootNamespaces.Keys.AsImmutable(), EqualityComparer<SyntaxTree>.Default));
@@ -40,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.LoadDirectiveMap = loadDirectiveMap;
                 this.LoadedSyntaxTreeMap = loadedSyntaxTreeMap;
                 this.RootNamespaces = rootNamespaces;
-                this.DeclarationTable = declarationTable;
+                this.DeclarationTableInput = declarationTableInput;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTableInput.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTableInput.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed class DeclarationTableInput
+    {
+        public static readonly DeclarationTableInput Empty = new(DeclarationTable.Empty, ImmutableList<(bool isAdd, Lazy<RootSingleNamespaceDeclaration> lazyRoot)>.Empty);
+
+        private readonly DeclarationTable _initialTable;
+        private readonly ImmutableList<(bool isAdd, Lazy<RootSingleNamespaceDeclaration> lazyRoot)> _instructions;
+        private DeclarationTable? _finalTable;
+
+        private DeclarationTableInput(DeclarationTable initialTable, ImmutableList<(bool isAdd, Lazy<RootSingleNamespaceDeclaration> lazyRoot)> instructions)
+        {
+            _initialTable = initialTable;
+            _instructions = instructions;
+        }
+
+        internal DeclarationTableInput AddRootDeclaration(Lazy<RootSingleNamespaceDeclaration> lazyRoot)
+        {
+            var initialTable = _finalTable;
+            var baseInstructions = ImmutableList<(bool isAdd, Lazy<RootSingleNamespaceDeclaration> lazyRoot)>.Empty;
+            if (initialTable is null)
+            {
+                initialTable = _initialTable;
+                baseInstructions = _instructions;
+            }
+
+            var instructions = baseInstructions.Add((isAdd: true, lazyRoot));
+            return new DeclarationTableInput(initialTable, instructions);
+        }
+
+        internal DeclarationTableInput RemoveRootDeclaration(Lazy<RootSingleNamespaceDeclaration> lazyRoot)
+        {
+            var initialTable = _finalTable;
+            var baseInstructions = ImmutableList<(bool isAdd, Lazy<RootSingleNamespaceDeclaration> lazyRoot)>.Empty;
+            if (initialTable is null)
+            {
+                initialTable = _initialTable;
+                baseInstructions = _instructions;
+            }
+
+            var instructions = baseInstructions.Add((isAdd: false, lazyRoot));
+            return new DeclarationTableInput(initialTable, instructions);
+        }
+
+        internal DeclarationTableInput Reduce()
+        {
+            if (this is { _instructions.IsEmpty: false, _finalTable: { } finalTable })
+            {
+                return new DeclarationTableInput(finalTable, ImmutableList<(bool isAdd, Lazy<RootSingleNamespaceDeclaration> lazyRoot)>.Empty);
+            }
+
+            return this;
+        }
+
+        internal DeclarationTable GetDeclarationTable()
+        {
+            if (_finalTable is null)
+            {
+                var table = _initialTable;
+                foreach (var (isAdd, lazyRoot) in _instructions)
+                {
+                    if (isAdd)
+                        table = table.AddRootDeclaration(lazyRoot);
+                    else
+                        table = table.RemoveRootDeclaration(lazyRoot);
+                }
+
+                Interlocked.CompareExchange(ref _finalTable, table, null);
+            }
+
+            return _finalTable;
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -408,12 +408,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Same(cachedStateAfterFirstChange, cachedStateAfterSecondChange);
 
-            static object GetDeclarationManagerCachedStateForUnchangingTrees(Compilation compilation)
+            static object? GetDeclarationManagerCachedStateForUnchangingTrees(Compilation compilation)
             {
                 var syntaxAndDeclarationsManager = compilation.GetFieldValue("_syntaxAndDeclarations");
                 var state = syntaxAndDeclarationsManager.GetType().GetMethod("GetLazyState", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.Invoke(syntaxAndDeclarationsManager, null);
-                var declarationTable = state.GetFieldValue("DeclarationTable");
-                return declarationTable.GetFieldValue("_cache");
+                var declarationTable = state.GetFieldValue("DeclarationTableInput")?.GetFieldValue("_finalTable");
+                return declarationTable?.GetFieldValue("_cache");
             }
 
             static async Task<Project> MakeChangesToDocument(Project project)


### PR DESCRIPTION
Compiler changes extracted from #57830. These changes allow the compiler to more efficiently provide compilations with frozen partial semantics, regardless of whether the IDE is prepared to handle the operation in an asynchronous manner.