### PR TITLE
Add Razor External Access APIs to allow passing classification options through ExcerptService

### DIFF
--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -114,6 +114,7 @@
     <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.IntelliCode" Key="$(IntelliCodeKey)" Partner="IntelliCode" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.LiveUnitTesting.BuildManager" Partner="UnitTesting" Key="$(UnitTestingKey)" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.LiveUnitTesting.BuildManager.Core" Partner="UnitTesting" Key="$(UnitTestingKey)" />
+    <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.LiveUnitTesting.Orchestrator" Partner="UnitTesting" Key="$(UnitTestingKey)" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.UnitTesting.SourceBasedTestDiscovery" Partner="UnitTesting" Key="$(UnitTestingKey)" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.UnitTesting.SourceBasedTestDiscovery.Core" Partner="UnitTesting" Key="$(UnitTestingKey)" />
   </ItemGroup>

--- a/src/Tools/ExternalAccess/Razor/IRazorDocumentExcerptService.cs
+++ b/src/Tools/ExternalAccess/Razor/IRazorDocumentExcerptService.cs
@@ -2,14 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
+    [Obsolete("Use IRazorDocumentExcerptServiceImplementation instead")]
     internal interface IRazorDocumentExcerptService
     {
         Task<RazorExcerptResult?> TryExcerptAsync(Document document, TextSpan span, RazorExcerptMode mode, CancellationToken cancellationToken);
+    }
+
+    internal interface IRazorDocumentExcerptServiceImplementation
+    {
+        Task<RazorExcerptResult?> TryExcerptAsync(Document document, TextSpan span, RazorExcerptMode mode, RazorClassificationOptionsWrapper options, CancellationToken cancellationToken);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
+++ b/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
@@ -23,6 +23,7 @@
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.LanguageServer" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.LanguageServer.Test" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Razor.Workspaces" Key="$(RazorKey)" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Razor.Workspaces.Test" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Razor" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.Editor.Razor" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Razor" Key="$(RazorKey)" />

--- a/src/Tools/ExternalAccess/Razor/RazorClassificationOptionsWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorClassificationOptionsWrapper.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Classification;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal readonly struct RazorClassificationOptionsWrapper
+    {
+        internal readonly ClassificationOptions UnderlyingObject;
+
+        public RazorClassificationOptionsWrapper(ClassificationOptions underlyingObject)
+            => UnderlyingObject = underlyingObject;
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/RazorClassificationOptionsWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorClassificationOptionsWrapper.cs
@@ -8,6 +8,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 {
     internal readonly struct RazorClassificationOptionsWrapper
     {
+        public static RazorClassificationOptionsWrapper Default = new(ClassificationOptions.Default);
+
         internal readonly ClassificationOptions UnderlyingObject;
 
         public RazorClassificationOptionsWrapper(ClassificationOptions underlyingObject)

--- a/src/Tools/ExternalAccess/Razor/RazorClassifierAccessor.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorClassifierAccessor.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal static class RazorClassifierAccessor
+    {
+        public static async Task<IEnumerable<ClassifiedSpan>> GetClassifiedSpansAsync(Document document, TextSpan textSpan, RazorClassificationOptionsWrapper options, CancellationToken cancellationToken)
+        {
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            return Classifier.GetClassifiedSpans(document.Project.Solution.Workspace.Services, semanticModel, textSpan, options.UnderlyingObject, cancellationToken);
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/RazorDocumentServiceProviderWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDocumentServiceProviderWrapper.cs
@@ -50,8 +50,20 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                     ref _lazyExcerptService,
                     static documentServiceProvider =>
                     {
-                        var razorExcerptService = documentServiceProvider.GetService<IRazorDocumentExcerptService>();
-                        return razorExcerptService is not null ? new RazorDocumentExcerptServiceWrapper(razorExcerptService) : null;
+                        var impl = documentServiceProvider.GetService<IRazorDocumentExcerptServiceImplementation>();
+                        if (impl != null)
+                        {
+                            return new RazorDocumentExcerptServiceWrapper(impl);
+                        }
+
+#pragma warning disable CS0612, CS0618 // Type or member is obsolete
+                        var legacyImpl = documentServiceProvider.GetService<IRazorDocumentExcerptService>();
+                        if (legacyImpl != null)
+                        {
+                            return new RazorDocumentExcerptServiceWrapper(legacyImpl);
+                        }
+#pragma warning restore
+                        return null;
                     },
                     _innerDocumentServiceProvider);
 


### PR DESCRIPTION
Corresponding Razor change: https://github.com/dotnet/razor-tooling/pull/6069