### PR TITLE
Only consider the best possible naming rule match for a symbol or type kind

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -140,7 +140,8 @@ dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
 dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
 
-dotnet_naming_symbols.all_members.applicable_kinds = *
+# All except local_function, field, parameter, and local, which are covered by other rules
+dotnet_naming_symbols.all_members.applicable_kinds = namespace, class, struct, interface, enum, property, method, event, delegate, type_parameter
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -140,8 +140,7 @@ dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
 dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
 
-# All except local_function, field, parameter, and local, which are covered by other rules
-dotnet_naming_symbols.all_members.applicable_kinds = namespace, class, struct, interface, enum, property, method, event, delegate, type_parameter
+dotnet_naming_symbols.all_members.applicable_kinds = *
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -286,6 +286,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                                     result.Add((uniqueName.Text, symbolKind));
                             }
                         }
+
+                        // Only consider the first matching specification for each potential symbol or type kind.
+                        // https://github.com/dotnet/roslyn/issues/36248
+                        break;
                     }
                 }
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -245,13 +246,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             ArrayBuilder<(string name, SymbolKind kind)> result,
             CancellationToken cancellationToken)
         {
-            var rules = await document.GetNamingRulesAsync(FallbackNamingRules.CompletionOfferingRules, cancellationToken).ConfigureAwait(false);
+            var rules = await document.GetNamingRulesAsync(FallbackNamingRules.CompletionFallbackRules, cancellationToken).ConfigureAwait(false);
+            var supplementaryRules = FallbackNamingRules.CompletionSupplementaryRules;
             var semanticFactsService = context.GetLanguageService<ISemanticFactsService>();
 
             using var _1 = PooledHashSet<string>.GetInstance(out var seenBaseNames);
             using var _2 = PooledHashSet<string>.GetInstance(out var seenUniqueNames);
 
             foreach (var kind in declarationInfo.PossibleSymbolKinds)
+            {
+                ProcessRules(rules, firstMatchOnly: true, kind, baseNames, declarationInfo, context, result, semanticFactsService, seenBaseNames, seenUniqueNames, cancellationToken);
+                ProcessRules(supplementaryRules, firstMatchOnly: false, kind, baseNames, declarationInfo, context, result, semanticFactsService, seenBaseNames, seenUniqueNames, cancellationToken);
+            }
+
+            static void ProcessRules(
+                ImmutableArray<NamingRule> rules,
+                bool firstMatchOnly,
+                SymbolSpecification.SymbolKindOrTypeKind kind,
+                ImmutableArray<ImmutableArray<string>> baseNames,
+                NameDeclarationInfo declarationInfo,
+                CSharpSyntaxContext context,
+                ArrayBuilder<(string name, SymbolKind kind)> result,
+                ISemanticFactsService semanticFactsService,
+                PooledHashSet<string> seenBaseNames,
+                PooledHashSet<string> seenUniqueNames,
+                CancellationToken cancellationToken)
             {
                 // There's no special glyph for local functions.
                 // We don't need to differentiate them at this point.
@@ -287,9 +306,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                             }
                         }
 
-                        // Only consider the first matching specification for each potential symbol or type kind.
-                        // https://github.com/dotnet/roslyn/issues/36248
-                        break;
+                        if (firstMatchOnly)
+                        {
+                            // Only consider the first matching specification for each potential symbol or type kind.
+                            // https://github.com/dotnet/roslyn/issues/36248
+                            break;
+                        }
                     }
                 }
             }

--- a/src/Features/Core/Portable/Shared/Naming/FallbackNamingRules.cs
+++ b/src/Features/Core/Portable/Shared/Naming/FallbackNamingRules.cs
@@ -46,10 +46,17 @@ namespace Microsoft.CodeAnalysis.Shared.Naming
                 enforcementLevel: ReportDiagnostic.Hidden));
 
         /// <summary>
-        /// Standard name rules for name suggestion/completion utilities.
+        /// Standard name rules for name suggestion/completion utilities. These are fallback rules that run if a user
+        /// hasn't provided any other naming rule matching the scenario.
         /// </summary>
-        internal static readonly ImmutableArray<NamingRule> CompletionOfferingRules = ImmutableArray.Create(
-            CreateCamelCaseFieldsAndParametersRule(),
+        internal static readonly ImmutableArray<NamingRule> CompletionFallbackRules = ImmutableArray.Create(
+            CreateCamelCaseFieldsAndParametersRule());
+
+        /// <summary>
+        /// Standard name rules for name suggestion/completion utilities. These are supplementary rules that run in
+        /// addition to any other rules defined by the user in order to provide additional valid suggestions.
+        /// </summary>
+        internal static readonly ImmutableArray<NamingRule> CompletionSupplementaryRules = ImmutableArray.Create(
             CreateEndWithAsyncRule(),
             CreateGetAsyncRule(),
             CreateMethodStartsWithGetRule());


### PR DESCRIPTION
Prevents certain incorrect naming styles from appearing in the completion list.

Before:
![image](https://user-images.githubusercontent.com/1408396/153099411-aaec2ce1-e695-45cc-9028-23e34df1cee1.png)

After:
![image](https://user-images.githubusercontent.com/1408396/153099360-84b5c5fd-ec84-4fd8-945c-3857ea6fbdd4.png)

Fixes #36248