### PR TITLE
Clean up IDocumentProvider

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/DocumentProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/DocumentProvider.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
+{
+    internal class DocumentProvider : IDocumentProvider
+    {
+        private readonly IThreadingContext _threadingContext;
+
+        public DocumentProvider(IThreadingContext threadingContext)
+        {
+            _threadingContext = threadingContext;
+        }
+
+        public Document? GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken)
+        {
+            _threadingContext.ThrowIfNotOnBackgroundThread();
+            return snapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/IDocumentProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/IDocumentProvider.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
@@ -15,16 +15,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
         Document? GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken);
     }
 
-    internal class DocumentProvider : ForegroundThreadAffinitizedObject, IDocumentProvider
+    internal class DocumentProvider : IDocumentProvider
     {
+        private readonly IThreadingContext _threadingContext;
+
         public DocumentProvider(IThreadingContext threadingContext)
-            : base(threadingContext)
         {
+            _threadingContext = threadingContext;
         }
 
         public Document? GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken)
         {
-            AssertIsBackground();
+            _threadingContext.ThrowIfNotOnBackgroundThread();
             return snapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
         }
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/IDocumentProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/IDocumentProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -14,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
 {
     internal interface IDocumentProvider
     {
-        Document GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken);
+        Document? GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken);
     }
 
     internal class DocumentProvider : ForegroundThreadAffinitizedObject, IDocumentProvider
@@ -24,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
         {
         }
 
-        public Document GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken)
+        public Document? GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken)
         {
             AssertIsBackground();
             return snapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/IDocumentProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/IDocumentProvider.cs
@@ -3,9 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
@@ -13,21 +10,5 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
     internal interface IDocumentProvider
     {
         Document? GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken);
-    }
-
-    internal class DocumentProvider : IDocumentProvider
-    {
-        private readonly IThreadingContext _threadingContext;
-
-        public DocumentProvider(IThreadingContext threadingContext)
-        {
-            _threadingContext = threadingContext;
-        }
-
-        public Document? GetDocument(ITextSnapshot snapshot, CancellationToken cancellationToken)
-        {
-            _threadingContext.ThrowIfNotOnBackgroundThread();
-            return snapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
-        }
     }
 }

--- a/src/EditorFeatures/Core/Shared/Extensions/IThreadingContextExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/IThreadingContextExtensions.cs
@@ -11,5 +11,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
     {
         public static void ThrowIfNotOnUIThread(this IThreadingContext threadingContext)
             => Contract.ThrowIfFalse(threadingContext.JoinableTaskContext.IsOnMainThread);
+
+        public static void ThrowIfNotOnBackgroundThread(this IThreadingContext threadingContext)
+            => Contract.ThrowIfTrue(threadingContext.JoinableTaskContext.IsOnMainThread);
     }
 }


### PR DESCRIPTION
* Enable nullable reference types
* Remove `ForegroundThreadAffinitizedObject` dependency
* One type per file