### PR TITLE
Try to reuse previously parsed trees when changing parse options

### DIFF
--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.RecoverableSyntaxTree.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.RecoverableSyntaxTree.cs
@@ -67,7 +67,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             options,
                             text,
                             encoding,
-                            root.FullSpan.Length));
+                            root.FullSpan.Length,
+                            root.ContainsDirectives));
                 }
 
                 public override string FilePath
@@ -145,6 +146,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CompilationUnitSyntax IRecoverableSyntaxTree<CompilationUnitSyntax>.CloneNodeAsRoot(CompilationUnitSyntax root)
                     => CloneNodeAsRoot(root);
 
+                public bool ContainsDirectives => _info.ContainsDirectives;
+
                 public override SyntaxTree WithRootAndOptions(SyntaxNode root, ParseOptions options)
                 {
                     if (ReferenceEquals(_info.Options, options) && this.TryGetRoot(out var oldRoot) && ReferenceEquals(root, oldRoot))
@@ -163,6 +166,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     return new RecoverableSyntaxTree(this, _info.WithFilePath(path));
+                }
+
+                public SyntaxTree WithOptions(ParseOptions parseOptions)
+                {
+                    if (ReferenceEquals(_info.Options, parseOptions))
+                    {
+                        return this;
+                    }
+
+                    return new RecoverableSyntaxTree(this, _info.WithOptions(parseOptions));
                 }
             }
         }

--- a/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/Workspace/LanguageServices/CSharpSyntaxTreeFactoryService.cs
@@ -59,6 +59,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     preprocessorSymbols: metadata.TryGetValue("define", out var defines) ? defines.Split(',') : null);
             }
 
+            public override bool OptionsDifferOnlyByPreprocessorDirectives(ParseOptions options1, ParseOptions options2)
+            {
+                var csharpOptions1 = (CSharpParseOptions)options1;
+                var csharpOptions2 = (CSharpParseOptions)options2;
+
+                // The easy way to figure out if these only differ by a single field is to update one with the preprocessor symbols of the
+                // other, and then do an equality check from there; this is future proofed if another value is ever added.
+                return csharpOptions1.WithPreprocessorSymbols(csharpOptions2.PreprocessorSymbolNames) == csharpOptions2;
+            }
+
             public override SyntaxTree CreateSyntaxTree(string filePath, ParseOptions options, Encoding encoding, SyntaxNode root)
             {
                 options ??= GetDefaultParseOptions();

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
@@ -22,19 +22,22 @@ namespace Microsoft.CodeAnalysis.Host
             public readonly ValueSource<TextAndVersion> TextSource;
             public readonly Encoding Encoding;
             public readonly int Length;
+            public readonly bool ContainsDirectives;
 
             public SyntaxTreeInfo(
                 string filePath,
                 ParseOptions options,
                 ValueSource<TextAndVersion> textSource,
                 Encoding encoding,
-                int length)
+                int length,
+                bool containsDirectives)
             {
                 FilePath = filePath ?? string.Empty;
                 Options = options;
                 TextSource = textSource;
                 Encoding = encoding;
                 Length = length;
+                ContainsDirectives = containsDirectives;
             }
 
             internal bool TryGetText([NotNullWhen(true)] out SourceText? text)
@@ -62,7 +65,8 @@ namespace Microsoft.CodeAnalysis.Host
                     Options,
                     TextSource,
                     Encoding,
-                    Length);
+                    Length,
+                    ContainsDirectives);
             }
 
             internal SyntaxTreeInfo WithOptionsAndLength(ParseOptions options, int length)
@@ -72,7 +76,19 @@ namespace Microsoft.CodeAnalysis.Host
                     options,
                     TextSource,
                     Encoding,
-                    length);
+                    length,
+                    ContainsDirectives);
+            }
+
+            internal SyntaxTreeInfo WithOptions(ParseOptions options)
+            {
+                return new SyntaxTreeInfo(
+                    FilePath,
+                    options,
+                    TextSource,
+                    Encoding,
+                    Length,
+                    ContainsDirectives);
             }
         }
 
@@ -161,10 +177,16 @@ namespace Microsoft.CodeAnalysis.Host
         }
     }
 
-    internal interface IRecoverableSyntaxTree<TRoot> where TRoot : SyntaxNode
+    internal interface IRecoverableSyntaxTree<TRoot> : IRecoverableSyntaxTree where TRoot : SyntaxNode
+    {
+        TRoot CloneNodeAsRoot(TRoot root);
+    }
+
+    internal interface IRecoverableSyntaxTree
     {
         string FilePath { get; }
 
-        TRoot CloneNodeAsRoot(TRoot root);
+        bool ContainsDirectives { get; }
+        SyntaxTree WithOptions(ParseOptions parseOptions);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.cs
@@ -29,12 +29,13 @@ namespace Microsoft.CodeAnalysis.Host
         }
 
         public abstract ParseOptions GetDefaultParseOptions();
+        public abstract ParseOptions GetDefaultParseOptionsWithLatestLanguageVersion();
+        public abstract bool OptionsDifferOnlyByPreprocessorDirectives(ParseOptions options1, ParseOptions options2);
+        public abstract ParseOptions TryParsePdbParseOptions(IReadOnlyDictionary<string, string> metadata);
         public abstract SyntaxTree CreateSyntaxTree(string filePath, ParseOptions options, Encoding encoding, SyntaxNode root);
         public abstract SyntaxTree ParseSyntaxTree(string filePath, ParseOptions options, SourceText text, CancellationToken cancellationToken);
         public abstract SyntaxTree CreateRecoverableTree(ProjectId cacheKey, string filePath, ParseOptions options, ValueSource<TextAndVersion> text, Encoding encoding, SyntaxNode root);
         public abstract SyntaxNode DeserializeNodeFrom(Stream stream, CancellationToken cancellationToken);
-        public abstract ParseOptions GetDefaultParseOptionsWithLatestLanguageVersion();
-        public abstract ParseOptions TryParsePdbParseOptions(IReadOnlyDictionary<string, string> metadata);
 
         public virtual bool CanCreateRecoverableTree(SyntaxNode root)
             => root.FullSpan.Length > _minimumLengthForRecoverableTree;

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/ISyntaxTreeFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/ISyntaxTreeFactoryService.cs
@@ -22,6 +22,12 @@ namespace Microsoft.CodeAnalysis.Host
 
         ParseOptions TryParsePdbParseOptions(IReadOnlyDictionary<string, string> compilationOptionsMetadata);
 
+        /// <summary>
+        /// Returns true if the two options differ only by preprocessor directives; this allows for us to reuse trees
+        /// if they don't have preprocessor directives in them.
+        /// </summary>
+        bool OptionsDifferOnlyByPreprocessorDirectives(ParseOptions options1, ParseOptions options2);
+
         // new tree from root node
         SyntaxTree CreateSyntaxTree(string? filePath, ParseOptions options, Encoding? encoding, SyntaxNode root);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -547,9 +547,12 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
+            var onlyPreprocessorDirectiveChange = ParseOptions != null &&
+                _languageServices.SyntaxTreeFactory!.OptionsDifferOnlyByPreprocessorDirectives(options, ParseOptions);
+
             return With(
                 projectInfo: ProjectInfo.WithParseOptions(options).WithVersion(Version.GetNewerVersion()),
-                documentStates: DocumentStates.UpdateStates(static (state, options) => state.UpdateParseOptions(options), options));
+                documentStates: DocumentStates.UpdateStates((state, options) => state.UpdateParseOptions(options, onlyPreprocessorDirectiveChange), options));
         }
 
         public static bool IsSameLanguage(ProjectState project1, ProjectState project2)

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -741,6 +741,68 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public async Task ChangingLanguageVersionReparses()
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+
+            using var workspace = CreateWorkspace();
+            var document = workspace.CurrentSolution
+                            .AddProject(projectId, "proj1", "proj1.dll", LanguageNames.CSharp)
+                            .AddDocument(documentId, "Test.cs", "// File")
+                            .GetRequiredDocument(documentId);
+
+            var oldTree = await document.GetRequiredSyntaxTreeAsync(CancellationToken.None);
+
+            Assert.Equal(document.Project.ParseOptions, oldTree.Options);
+
+            document = document.Project.WithParseOptions(new CSharpParseOptions(languageVersion: CS.LanguageVersion.CSharp1)).GetRequiredDocument(documentId);
+
+            var newTree = await document.GetRequiredSyntaxTreeAsync(CancellationToken.None);
+
+            Assert.Equal(document.Project.ParseOptions, newTree.Options);
+
+            Assert.False(oldTree.GetRoot().IsIncrementallyIdenticalTo(newTree.GetRoot()));
+        }
+
+        [Theory]
+        [InlineData("#if DEBUG", false, LanguageNames.CSharp, false)]
+        [InlineData("#if DEBUG", false, LanguageNames.CSharp, true)]
+        [InlineData("// File", true, LanguageNames.CSharp, false)]
+        [InlineData("// File", true, LanguageNames.CSharp, true)]
+        [InlineData("#if DEBUG", false, LanguageNames.VisualBasic, false)]
+        [InlineData("#if DEBUG", false, LanguageNames.VisualBasic, true)]
+        [InlineData("' File", true, LanguageNames.VisualBasic, false)]
+        [InlineData("' File", true, LanguageNames.VisualBasic, true)]
+        public async Task ChangingPreprocessorDirectivesMayReparse(string source, bool expectReuse, string languageName, bool useRecoverableTrees)
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+
+            using var workspace = useRecoverableTrees ? CreateWorkspaceWithRecoverableSyntaxTreesAndWeakCompilations() : CreateWorkspace();
+            var document = workspace.CurrentSolution
+                            .AddProject(projectId, "proj1", "proj1.dll", languageName)
+                            .AddDocument(documentId, "Test", source)
+                            .GetRequiredDocument(documentId);
+
+            var oldTree = await document.GetRequiredSyntaxTreeAsync(CancellationToken.None);
+
+            Assert.Equal(document.Project.ParseOptions, oldTree.Options);
+
+            ParseOptions newOptions =
+                languageName == LanguageNames.CSharp ? new CSharpParseOptions(preprocessorSymbols: new[] { "DEBUG" })
+                                                     : new VisualBasicParseOptions(preprocessorSymbols: new KeyValuePair<string, object?>[] { new("DEBUG", null) });
+
+            document = document.Project.WithParseOptions(newOptions).GetRequiredDocument(documentId);
+
+            var newTree = await document.GetRequiredSyntaxTreeAsync(CancellationToken.None);
+
+            Assert.Equal(document.Project.ParseOptions, newTree.Options);
+
+            Assert.Equal(expectReuse, oldTree.GetRoot().IsIncrementallyIdenticalTo(newTree.GetRoot()));
+        }
+
+        [Fact]
         public void WithProjectReferences()
         {
             using var workspace = CreateWorkspaceWithProjectAndDocuments();

--- a/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicSyntaxTreeFactoryService.RecoverableSyntaxTree.vb
+++ b/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicSyntaxTreeFactoryService.RecoverableSyntaxTree.vb
@@ -61,7 +61,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             options,
                             text,
                             encoding,
-                            root.FullSpan.Length))
+                            root.FullSpan.Length,
+                            root.ContainsDirectives))
                 End Function
 
                 Public Overrides ReadOnly Property FilePath As String Implements IRecoverableSyntaxTree(Of CompilationUnitSyntax).FilePath
@@ -142,6 +143,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return CloneNodeAsRoot(root)
                 End Function
 
+                Public ReadOnly Property ContainsDirectives As Boolean Implements IRecoverableSyntaxTree.ContainsDirectives
+                    Get
+                        Return _info.ContainsDirectives
+                    End Get
+                End Property
+
                 Public Overrides Function WithRootAndOptions(root As SyntaxNode, options As ParseOptions) As SyntaxTree
                     Dim oldRoot As VisualBasicSyntaxNode = Nothing
                     If _info.Options Is options AndAlso TryGetRoot(oldRoot) AndAlso root Is oldRoot Then
@@ -157,6 +164,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     Return New RecoverableSyntaxTree(Me, _info.WithFilePath(path))
+                End Function
+
+                Public Function WithOptions(parseOptions As ParseOptions) As SyntaxTree Implements IRecoverableSyntaxTree.WithOptions
+                    If _info.Options Is parseOptions Then
+                        Return Me
+                    End If
+
+                    Return New RecoverableSyntaxTree(Me, _info.WithOptions(parseOptions))
                 End Function
             End Class
         End Class

--- a/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Workspace/LanguageServices/VisualBasicSyntaxTreeFactoryService.vb
@@ -63,6 +63,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return New VisualBasicParseOptions(languageVersion:=langVersion, preprocessorSymbols:=preprocessorSymbols)
             End Function
 
+            Public Overrides Function OptionsDifferOnlyByPreprocessorDirectives(options1 As ParseOptions, options2 As ParseOptions) As Boolean
+                Dim vbOptions1 = DirectCast(options1, VisualBasicParseOptions)
+                Dim vbOptions2 = DirectCast(options2, VisualBasicParseOptions)
+
+                ' The easy way to figure out if these only differ by a single field is to update one with the preprocessor symbols of the
+                ' other, and then do an equality check from there; this is future proofed if another value is ever added.
+                Return vbOptions1.WithPreprocessorSymbols(vbOptions2.PreprocessorSymbols) = vbOptions2
+            End Function
+
             Public Overloads Overrides Function GetDefaultParseOptionsWithLatestLanguageVersion() As ParseOptions
                 Return _parseOptionsWithLatestLanguageVersion
             End Function


### PR DESCRIPTION
If you change your solution configuration from debug to release or vice versa, this will usually trigger a reparse of the entire solution because the DEBUG directive is being defined or undefined. However, most source files out there probably don't have any #ifs in them anywhere, so in that case we can just reuse the tree.

This change aims for simple rather than fully optimal at this point; this is partly because right now this change is hard to measure the full benefits of -- CPS projects destroy and recreate new projects when there's a configuration change. Alongside this change the project system will be fixing that as a part of https://github.com/dotnet/project-system/issues/7541 which we hope will make this actually work well. But I don't want to invest in a bunch of fancy code that may not move the needle much in practice until we've got the end-to-end working first.

Possible improvements include:

1. Right now we don't try to differentiate between different types of directives in a tree; we'll reparse files containing #if, but    also will reparse files containing #nullable directives.
2. We don't make any attempt to determine if a preprocessor directive is changing, but won't impact the file in question. For example, if switching to debug means we're defining DEBUG, but the file is only doing something like #if NETCORE, we still don't need to reparse the file. But getting that fully right can be a bit tricky.
3. Right now we're only using the root to check for directives if we already have one in hand. That might not be available if the tree is a recoverable tree, but we could still cache the directive bit separately.

We can look at addressing some or all of these once we have the CPS issue fixed. Until then, I'm keeping this simple.