### PR TITLE
Produce reference assembly in out directory

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -22,6 +22,7 @@
 
     <Features>strict</Features>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <ProduceReferenceAssemblyInOutDir>true<ProduceReferenceAssemblyInOutDir>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateFullPaths>true</GenerateFullPaths>
 

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -22,7 +22,7 @@
 
     <Features>strict</Features>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <ProduceReferenceAssemblyInOutDir>true<ProduceReferenceAssemblyInOutDir>
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateFullPaths>true</GenerateFullPaths>
 


### PR DESCRIPTION
Fixes the CI build. In the future we can discuss removing this flag and updating the tooling (e.g. BuildValidator) to account for the difference.