### PR TITLE
Include record primary constructor props in nav-to when not backed by a corresponding field/prop.

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -1526,6 +1526,7 @@ testHost, composition, @"class Goo
 
         [Theory]
         [CombinatorialData]
+        [WorkItem(57873, "https://github.com/dotnet/roslyn/issues/57873")]
         public async Task FindRecordMember1(TestHost testHost, Composition composition)
         {
             await TestAsync(
@@ -1540,6 +1541,7 @@ testHost, composition, @"record Goo(int Member)
 
         [Theory]
         [CombinatorialData]
+        [WorkItem(57873, "https://github.com/dotnet/roslyn/issues/57873")]
         public async Task FindRecordMember2(TestHost testHost, Composition composition)
         {
             await TestAsync(
@@ -1555,6 +1557,7 @@ testHost, composition, @"record Goo(int Member)
 
         [Theory]
         [CombinatorialData]
+        [WorkItem(57873, "https://github.com/dotnet/roslyn/issues/57873")]
         public async Task FindRecordMember3(TestHost testHost, Composition composition)
         {
             await TestAsync(

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -1523,6 +1523,50 @@ testHost, composition, @"class Goo
     VerifyNavigateToResultItem(item, "Method", "[|Method|]((int x, Dictionary<int,string> y), (bool b, global::System.Int32 c))", PatternMatchKind.Exact, NavigateToItemKind.Method, Glyph.MethodPublic, string.Format(FeaturesResources.in_0_project_1, "Goo", "Test"));
 });
         }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task FindRecordMember1(TestHost testHost, Composition composition)
+        {
+            await TestAsync(
+testHost, composition, @"record Goo(int Member)
+{
+}", async w =>
+{
+    var item = (await _aggregator.GetItemsAsync("Member")).Single(x => x.Kind == NavigateToItemKind.Property);
+    VerifyNavigateToResultItem(item, "Member", "[|Member|]", PatternMatchKind.Exact, NavigateToItemKind.Property, Glyph.PropertyPublic);
+});
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task FindRecordMember2(TestHost testHost, Composition composition)
+        {
+            await TestAsync(
+testHost, composition, @"record Goo(int Member)
+{
+    public int Member { get; } = Member;
+}", async w =>
+{
+    var item = (await _aggregator.GetItemsAsync("Member")).Single(x => x.Kind == NavigateToItemKind.Property);
+    VerifyNavigateToResultItem(item, "Member", "[|Member|]", PatternMatchKind.Exact, NavigateToItemKind.Property, Glyph.PropertyPublic);
+});
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task FindRecordMember3(TestHost testHost, Composition composition)
+        {
+            await TestAsync(
+testHost, composition, @"record Goo(int Member)
+{
+    public int Member = Member;
+}", async w =>
+{
+    var item = (await _aggregator.GetItemsAsync("Member")).Single(x => x.Kind == NavigateToItemKind.Field);
+    VerifyNavigateToResultItem(item, "Member", "[|Member|]", PatternMatchKind.Exact, NavigateToItemKind.Field, Glyph.FieldPublic);
+});
+        }
     }
 }
 #pragma warning restore CS0618 // MatchKind is obsolete

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -209,6 +209,20 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                         GetInheritanceNames(stringTable, typeDecl.BaseList),
                         IsNestedType(typeDecl)));
                     return;
+                case SyntaxKind.EnumDeclaration:
+                    var enumDecl = (EnumDeclarationSyntax)node;
+                    declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
+                        stringTable,
+                        enumDecl.Identifier.ValueText, null,
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
+                        enumDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
+                        DeclaredSymbolInfoKind.Enum,
+                        GetAccessibility(container, enumDecl.Modifiers),
+                        enumDecl.Identifier.Span,
+                        inheritanceNames: ImmutableArray<string>.Empty,
+                        isNestedType: IsNestedType(enumDecl)));
+                    return;
                 case SyntaxKind.ConstructorDeclaration:
                     var ctorDecl = (ConstructorDeclarationSyntax)node;
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -360,8 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
         {
             // Add synthesized properties for record primary constructors that are not backed by an existing field
             // or property.
-            if (memberDeclaration is RecordDeclarationSyntax { ParameterList: { } parameterList } recordDeclaration &&
-                parameterList.Parameters.Count > 0)
+            if (memberDeclaration is RecordDeclarationSyntax { ParameterList: { Parameters.Count: > 0 } parameterList } recordDeclaration)
             {
                 using var _ = PooledHashSet<string>.GetInstance(out var existingFieldPropNames);
 

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -375,7 +375,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                             containerDisplayName,
                             fullyQualifiedContainerName,
                             isPartial: false,
-                            DeclaredSymbolInfoKind.Parameter,
+                            DeclaredSymbolInfoKind.Property,
                             Accessibility.Public,
                             parameter.Identifier.Span,
                             inheritanceNames: ImmutableArray<string>.Empty));

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                             SyntaxKind.RecordStructDeclaration => DeclaredSymbolInfoKind.RecordStruct,
                             _ => throw ExceptionUtilities.UnexpectedValue(node.Kind()),
                         },
-                        GetAccessibility(container, node.Modifiers),
+                        GetAccessibility(container, typeDecl.Modifiers),
                         typeDecl.Identifier.Span,
                         GetInheritanceNames(stringTable, typeDecl.BaseList),
                         IsNestedType(typeDecl)));

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -183,10 +183,10 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
             switch (node.Kind())
             {
                 case SyntaxKind.ClassDeclaration:
-                case SyntaxKind.RecordDeclaration:
-                case SyntaxKind.RecordStructDeclaration:
                 case SyntaxKind.InterfaceDeclaration:
                 case SyntaxKind.StructDeclaration:
+                case SyntaxKind.RecordDeclaration:
+                case SyntaxKind.RecordStructDeclaration:
                     var typeDecl = (TypeDeclarationSyntax)node;
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                         stringTable,
@@ -198,30 +198,16 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                         node.Kind() switch
                         {
                             SyntaxKind.ClassDeclaration => DeclaredSymbolInfoKind.Class,
-                            SyntaxKind.RecordDeclaration => DeclaredSymbolInfoKind.Record,
                             SyntaxKind.InterfaceDeclaration => DeclaredSymbolInfoKind.Interface,
                             SyntaxKind.StructDeclaration => DeclaredSymbolInfoKind.Struct,
+                            SyntaxKind.RecordDeclaration => DeclaredSymbolInfoKind.Record,
                             SyntaxKind.RecordStructDeclaration => DeclaredSymbolInfoKind.RecordStruct,
                             _ => throw ExceptionUtilities.UnexpectedValue(node.Kind()),
                         },
-                        GetAccessibility(container, typeDecl.Modifiers),
+                        GetAccessibility(container, node.Modifiers),
                         typeDecl.Identifier.Span,
                         GetInheritanceNames(stringTable, typeDecl.BaseList),
                         IsNestedType(typeDecl)));
-                    return;
-                case SyntaxKind.EnumDeclaration:
-                    var enumDecl = (EnumDeclarationSyntax)node;
-                    declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
-                        stringTable,
-                        enumDecl.Identifier.ValueText, null,
-                        containerDisplayName,
-                        fullyQualifiedContainerName,
-                        enumDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
-                        DeclaredSymbolInfoKind.Enum,
-                        GetAccessibility(container, enumDecl.Modifiers),
-                        enumDecl.Identifier.Span,
-                        inheritanceNames: ImmutableArray<string>.Empty,
-                        isNestedType: IsNestedType(enumDecl)));
                     return;
                 case SyntaxKind.ConstructorDeclaration:
                     var ctorDecl = (ConstructorDeclarationSyntax)node;
@@ -346,6 +332,55 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                     }
 
                     return;
+            }
+        }
+
+        protected override void AddSynthesizedDeclaredSymbolInfos(
+            SyntaxNode container,
+            MemberDeclarationSyntax memberDeclaration,
+            StringTable stringTable,
+            ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos,
+            string containerDisplayName,
+            string fullyQualifiedContainerName,
+            CancellationToken cancellationToken)
+        {
+            // Add synthesized properties for record primary constructors that are not backed by an existing field
+            // or property.
+            if (memberDeclaration is RecordDeclarationSyntax { ParameterList: { } parameterList } recordDeclaration &&
+                parameterList.Parameters.Count > 0)
+            {
+                using var _ = PooledHashSet<string>.GetInstance(out var existingFieldPropNames);
+
+                foreach (var member in recordDeclaration.Members)
+                {
+                    switch (member)
+                    {
+                        case PropertyDeclarationSyntax property:
+                            existingFieldPropNames.Add(property.Identifier.ValueText);
+                            continue;
+                        case FieldDeclarationSyntax fieldDeclaration:
+                            foreach (var variable in fieldDeclaration.Declaration.Variables)
+                                existingFieldPropNames.Add(variable.Identifier.ValueText);
+                            continue;
+                    }
+                }
+
+                foreach (var parameter in parameterList.Parameters)
+                {
+                    if (!existingFieldPropNames.Contains(parameter.Identifier.ValueText))
+                    {
+                        declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
+                            stringTable,
+                            parameter.Identifier.ValueText, null,
+                            containerDisplayName,
+                            fullyQualifiedContainerName,
+                            isPartial: false,
+                            DeclaredSymbolInfoKind.Parameter,
+                            Accessibility.Public,
+                            parameter.Identifier.Span,
+                            inheritanceNames: ImmutableArray<string>.Empty));
+                    }
+                }
             }
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class AbstractSyntaxIndex<TIndex> : IObjectWritable
     {
         private static readonly string s_persistenceName = typeof(TIndex).Name;
-        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("28");
+        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("29");
 
         public readonly Checksum? Checksum;
 

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -64,6 +64,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         protected abstract void AddDeclaredSymbolInfosWorker(
             SyntaxNode container, TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, string?> aliases, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, string containerDisplayName, string fullyQualifiedContainerName, CancellationToken cancellationToken);
+        protected abstract void AddSynthesizedDeclaredSymbolInfos(
+            SyntaxNode container, TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, string containerDisplayName, string fullyQualifiedContainerName, CancellationToken cancellationToken);
+
         /// <summary>
         /// Get the name of the target type of specified extension method declaration. The node provided must be an
         /// extension method declaration,  i.e. calling `TryGetDeclaredSymbolInfo()` on `node` should return a
@@ -205,6 +208,15 @@ namespace Microsoft.CodeAnalysis.LanguageServices
                         memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo,
                         innerContainerDisplayName, innerFullyQualifiedContainerName, cancellationToken);
                 }
+
+                AddSynthesizedDeclaredSymbolInfos(
+                    container,
+                    memberDeclaration,
+                    stringTable,
+                    declaredSymbolInfos,
+                    innerContainerDisplayName,
+                    innerFullyQualifiedContainerName,
+                    cancellationToken);
             }
             else if (memberDeclaration is TEnumDeclarationSyntax enumDeclaration)
             {

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -126,6 +126,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             Return VisualBasicSyntaxFacts.Instance.GetDisplayName(node, DisplayNameOptions.IncludeNamespaces, rootNamespace)
         End Function
 
+        Protected Overrides Sub AddSynthesizedDeclaredSymbolInfos(container As SyntaxNode, memberDeclaration As StatementSyntax, stringTable As StringTable, declaredSymbolInfos As ArrayBuilder(Of DeclaredSymbolInfo), containerDisplayName As String, fullyQualifiedContainerName As String, cancellationToken As CancellationToken)
+            ' Nothing to do in VB.
+        End Sub
+
         Protected Overrides Sub AddDeclaredSymbolInfosWorker(
                 container As SyntaxNode,
                 node As StatementSyntax,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/57873