### PR TITLE
Move cancellation catch up out of the navigate to searcher

### DIFF
--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -112,7 +113,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 kinds,
                 _threadingContext.DisposalToken);
 
-            _ = searcher.SearchAsync(searchCurrentDocument, _cancellationTokenSource.Token);
+            _ = SearchAsync(searcher, searchCurrentDocument, _cancellationTokenSource.Token);
+        }
+
+        private async Task SearchAsync(NavigateToSearcher searcher, bool searchCurrentDocument, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await searcher.SearchAsync(searchCurrentDocument, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -114,21 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 kinds,
                 _threadingContext.DisposalToken);
 
-            _ = SearchAsync(searcher, searchCurrentDocument, _cancellationTokenSource.Token);
-        }
-
-        private async Task SearchAsync(NavigateToSearcher searcher, bool searchCurrentDocument, CancellationToken cancellationToken)
-        {
-            try
-            {
-                await searcher.SearchAsync(searchCurrentDocument, cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (Exception e) when (FatalError.ReportAndCatch(e, ErrorSeverity.General))
-            {
-            }
+            _ = searcher.SearchAsync(searchCurrentDocument, _cancellationTokenSource.Token).ReportNonFatalErrorUnlessCancelledAsync(_cancellationTokenSource.Token);
         }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -123,7 +123,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             {
                 await searcher.SearchAsync(searchCurrentDocument, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, ErrorSeverity.General))
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception e) when (FatalError.ReportAndCatch(e, ErrorSeverity.General))
             {
             }
         }

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -122,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             {
                 await searcher.SearchAsync(searchCurrentDocument, cancellationToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, ErrorSeverity.General))
             {
             }
         }

--- a/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToSearcher.cs
@@ -129,9 +129,6 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                     await SearchAllProjectsAsync(isFullyLoaded, scope, cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (OperationCanceledException)
-            {
-            }
             finally
             {
                 // Ensure that we actually complete all our remaining progress items so that the progress bar completes.


### PR DESCRIPTION
Telemetry for lsp workspace/symbols was missing cancellations because the navigate to searcher caught cancellation exceptions internally.

This removes the catch from the navigate to searcher so that exceptions can bubble up to the caller.  In LSP cancellation will be recorded by the queue.  In Navto the cancellation is now caught where we send the fire and forget request.

Verified in telemetry monitor that we now report cancellations in the lsp case.