### PR TITLE
Do not use 'var' when fixing the return type of method

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/FixReturnType/FixReturnTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FixReturnType/FixReturnTypeTests.cs
@@ -311,5 +311,47 @@ class C
     }
 }");
         }
+
+        [Fact]
+        [WorkItem(53574, "https://github.com/dotnet/roslyn/issues/53574")]
+        public async Task TestAnonymousTypeTopLevel()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    public void Method()
+    {
+        [|return|] new { A = 0, B = 1 };
+    }
+}",
+@"class C
+{
+    public object Method()
+    {
+        return new { A = 0, B = 1 };
+    }
+}");
+        }
+
+        [Fact]
+        [WorkItem(53574, "https://github.com/dotnet/roslyn/issues/53574")]
+        public async Task TestAnonymousTypeTopNested()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    public void Method()
+    {
+        [|return|] new[] { new { A = 0, B = 1 } };
+    }
+}",
+@"class C
+{
+    public object Method()
+    {
+        return new[] { new { A = 0, B = 1 } };
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     SyntaxFactory.TypeArgumentList(SyntaxFactory.SeparatedList(typeArguments)));
             }
 
-            private static QualifiedNameSyntax CreateSystemObject()
+            public static QualifiedNameSyntax CreateSystemObject()
             {
                 return SyntaxFactory.QualifiedName(
                     SyntaxFactory.AliasQualifiedName(


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/53574