### PR TITLE
Revert "Move workspace file removal to BG to avoid UI delay"

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -214,7 +214,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var solutionClosingContext = UIContext.FromUIContextGuid(VSConstants.UICONTEXT.SolutionClosing_guid);
             solutionClosingContext.UIContextChanged += (_, e) => _solutionClosing = e.Activated;
 
-            var openFileTracker = await OpenFileTracker.CreateAsync(this, _threadingContext, asyncServiceProvider).ConfigureAwait(true);
+            var openFileTracker = await OpenFileTracker.CreateAsync(this, asyncServiceProvider).ConfigureAwait(true);
             var memoryListener = await VirtualMemoryNotificationListener.CreateAsync(this, _threadingContext, asyncServiceProvider, _globalOptions, _threadingContext.DisposalToken).ConfigureAwait(true);
 
             // Update our fields first, so any asynchronous work that needs to use these is able to see the service.
@@ -1565,9 +1565,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// <summary>
         /// Applies a single operation to the workspace. <paramref name="action"/> should be a call to one of the protected Workspace.On* methods.
         /// </summary>
-        public async ValueTask ApplyChangeToWorkspaceMaybeAsync(bool useAsync, Action<Workspace> action, CancellationToken cancellationToken = default)
+        public async ValueTask ApplyChangeToWorkspaceMaybeAsync(bool useAsync, Action<Workspace> action)
         {
-            using (useAsync ? await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false) : _gate.DisposableWait(cancellationToken))
+            using (useAsync ? await _gate.DisposableWaitAsync().ConfigureAwait(false) : _gate.DisposableWait())
             {
                 action(this);
             }


### PR DESCRIPTION
Reverts dotnet/roslyn#59211.

This is causing regressions in DDRITs. When we are applying file edits as a part of code model or other features like code fixes, we in rapid succession open the file in an invisible editor, make changes in that editor, and then close it again. Because the open/close is now happening asynchronously, we end up with workspace changes from the background thread in places that don't expect it. I've seen a few odd behaviors under the debugger such as:

1. Places in CodeModel that grab CurrentSolution more than once, assuming the documents are the same and thus have the same trees. Since the snapshot changes underneath them, we throw exceptions.
2. Places where we are calling TryApplyChanges, but the intervening open/close means we are failing those (silently), resulting in later things throwing exceptions.

I think we can salvage the PR, but it's going to take some more work to ensure we don't break other things, and also to clean up some of the other issues discovered while debugging this. That won't happen quickly, so let's revert since we're breaking divisional tests here.