### PR TITLE
Detect ref assemblies in rebuild

### DIFF
--- a/src/Tools/BuildValidator/BuildValidator.csproj
+++ b/src/Tools/BuildValidator/BuildValidator.csproj
@@ -4,7 +4,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Tools/BuildValidator/BuildValidator.csproj
+++ b/src/Tools/BuildValidator/BuildValidator.csproj
@@ -4,7 +4,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsShipping>false</IsShipping>

--- a/src/Tools/BuildValidator/Program.cs
+++ b/src/Tools/BuildValidator/Program.cs
@@ -71,8 +71,6 @@ namespace BuildValidator
 
             var excludes = new List<string>(exclude ?? Array.Empty<string>());
             excludes.Add(Path.DirectorySeparatorChar + "runtimes" + Path.DirectorySeparatorChar);
-            excludes.Add(Path.DirectorySeparatorChar + "ref" + Path.DirectorySeparatorChar);
-            excludes.Add(Path.DirectorySeparatorChar + "refint" + Path.DirectorySeparatorChar);
             excludes.Add(@".resources.dll");
 
             var options = new Options(assembliesPath, referencesPath, excludes.ToArray(), sourcePath, verbose, quiet, debug, debugPath);
@@ -159,13 +157,19 @@ namespace BuildValidator
 
                     if (Util.GetPortableExecutableInfo(filePath) is not { } peInfo)
                     {
-                        logger.LogError($"Skipping non-pe file {filePath}");
+                        logger.LogInformation($"Skipping non-pe file {filePath}");
                         continue;
                     }
 
                     if (peInfo.IsReadyToRun)
                     {
-                        logger.LogError($"Skipping ReadyToRun file {filePath}");
+                        logger.LogInformation($"Skipping ReadyToRun file {filePath}");
+                        continue;
+                    }
+
+                    if (peInfo.IsReferenceAssembly)
+                    {
+                        logger.LogInformation($"Skipping reference assembly {filePath}");
                         continue;
                     }
 

--- a/src/Tools/BuildValidator/Records.cs
+++ b/src/Tools/BuildValidator/Records.cs
@@ -17,7 +17,7 @@ namespace BuildValidator
         internal string TargetFramework => Path.GetFileName(Path.GetDirectoryName(FilePath))!;
     }
 
-    internal sealed record PortableExecutableInfo(string FilePath, Guid Mvid, bool IsReadyToRun);
+    internal sealed record PortableExecutableInfo(string FilePath, Guid Mvid, bool IsReadyToRun, bool IsReferenceAssembly);
 
     internal record Options(
         string[] AssembliesPaths,

--- a/src/Tools/BuildValidator/Util.cs
+++ b/src/Tools/BuildValidator/Util.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using Microsoft.CodeAnalysis.VisualBasic;
 
 namespace BuildValidator
 {
@@ -18,7 +20,8 @@ namespace BuildValidator
             if (GetMvid(peReader) is { } mvid)
             {
                 var isReadyToRun = IsReadyToRunImage(peReader);
-                return new PortableExecutableInfo(filePath, mvid, isReadyToRun);
+                var isRefAssembly = IsReferenceAssembly(peReader);
+                return new PortableExecutableInfo(filePath, mvid, isReadyToRun, isRefAssembly);
             }
 
             return null;
@@ -36,6 +39,49 @@ namespace BuildValidator
             {
                 return null;
             }
+        }
+
+        internal static bool IsReferenceAssembly(this PEReader peReader)
+        {
+            var reader = peReader.GetMetadataReader();
+            foreach (var attributeHandle in reader.GetCustomAttributes(Handle.AssemblyDefinition))
+            {
+                var attribute = reader.GetCustomAttribute(attributeHandle);
+                if (GetAttributeFullName(reader, attribute) == "System.Runtime.CompilerServices.ReferenceAssemblyAttribute")
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal static string GetAttributeFullName(MetadataReader reader, CustomAttribute attribute)
+        {
+            switch (attribute.Constructor.Kind)
+            {
+                case HandleKind.MethodDefinition:
+                    {
+                        var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                        var declaringTypeHandle = methodDef.GetDeclaringType();
+                        var typeDefinition = reader.GetTypeDefinition(declaringTypeHandle);
+                        var @namespace = reader.GetString(typeDefinition.Namespace);
+                        var name = reader.GetString(typeDefinition.Name);
+                        return $"{@namespace}.{name}";
+                    }
+                case HandleKind.MemberReference:
+                    {
+                        var memberRef = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                        Debug.Assert(memberRef.Parent.Kind == HandleKind.TypeReference);
+                        var typeRef = reader.GetTypeReference((TypeReferenceHandle)memberRef.Parent);
+                        var @namespace = reader.GetString(typeRef.Namespace);
+                        var name = reader.GetString(typeRef.Name);
+                        return $"{@namespace}.{name}";
+                    }
+                default:
+                    throw new InvalidOperationException();
+            }
+
         }
 
         internal static bool IsReadyToRunImage(PEReader peReader)

--- a/src/Tools/BuildValidator/Util.cs
+++ b/src/Tools/BuildValidator/Util.cs
@@ -81,7 +81,6 @@ namespace BuildValidator
                 default:
                     throw new InvalidOperationException();
             }
-
         }
 
         internal static bool IsReadyToRunImage(PEReader peReader)


### PR DESCRIPTION
Rather than relying on directory name detection, which is a hueristic,
look for reference assemblies by identifying them in metadata.