### PR TITLE
Revert "BackgroundAnalysisScope enhancements"

### DIFF
--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -1211,16 +1211,16 @@ class D { }
             var optionValue = solution.Options.GetOption(optionKey);
             Assert.Equal(BackgroundAnalysisScope.Default, optionValue);
 
-            var newOptions = solution.Options.WithChangedOption(optionKey, BackgroundAnalysisScope.FullSolution);
+            var newOptions = solution.Options.WithChangedOption(optionKey, BackgroundAnalysisScope.ActiveFile);
             var newSolution = solution.WithOptions(newOptions);
             var newOptionValue = newSolution.Options.GetOption(optionKey);
-            Assert.Equal(BackgroundAnalysisScope.FullSolution, newOptionValue);
+            Assert.Equal(BackgroundAnalysisScope.ActiveFile, newOptionValue);
 
             var applied = workspace.TryApplyChanges(newSolution);
             Assert.True(applied);
 
             var currentOptionValue = workspace.CurrentSolution.Options.GetOption(optionKey);
-            Assert.Equal(BackgroundAnalysisScope.FullSolution, currentOptionValue);
+            Assert.Equal(BackgroundAnalysisScope.ActiveFile, currentOptionValue);
         }
 
         [CombinatorialData]
@@ -1253,12 +1253,12 @@ class D { }
             if (testDeprecatedOptionsSetter)
             {
 #pragma warning disable CS0618 // Type or member is obsolete - this test ensures that deprecated "Workspace.set_Options" API's functionality is preserved.
-                primaryWorkspace.Options = primaryWorkspace.Options.WithChangedOption(optionKey, BackgroundAnalysisScope.FullSolution);
+                primaryWorkspace.Options = primaryWorkspace.Options.WithChangedOption(optionKey, BackgroundAnalysisScope.ActiveFile);
 #pragma warning restore CS0618 // Type or member is obsolete
             }
             else
             {
-                primaryWorkspace.SetOptions(primaryWorkspace.Options.WithChangedOption(optionKey, BackgroundAnalysisScope.FullSolution));
+                primaryWorkspace.SetOptions(primaryWorkspace.Options.WithChangedOption(optionKey, BackgroundAnalysisScope.ActiveFile));
             }
 
             // Verify current solution and option change for both workspaces.
@@ -1284,7 +1284,7 @@ class D { }
                 // Verify workspace.CurrentSolution has changed option.
                 var optionKey = new OptionKey2(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp);
                 Assert.Equal(BackgroundAnalysisScope.Default, beforeOptionChangedSolution.Options.GetOption(optionKey));
-                Assert.Equal(BackgroundAnalysisScope.FullSolution, currentSolution.Options.GetOption(optionKey));
+                Assert.Equal(BackgroundAnalysisScope.ActiveFile, currentSolution.Options.GetOption(optionKey));
             }
         }
     }

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -78,9 +78,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(10, worker.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory, WorkItem(747226, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/747226")]
         internal async Task SolutionAdded_Simple(BackgroundAnalysisScope analysisScope)
@@ -106,9 +105,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.SyntaxDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
         internal async Task SolutionAdded_Complex(BackgroundAnalysisScope analysisScope)
@@ -122,9 +120,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.SyntaxDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
         internal async Task Solution_Remove(BackgroundAnalysisScope analysisScope)
@@ -138,9 +135,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(10, worker.InvalidateDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
         internal async Task Solution_Clear(BackgroundAnalysisScope analysisScope)
@@ -154,9 +150,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(10, worker.InvalidateDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
         internal async Task Solution_Reload(BackgroundAnalysisScope analysisScope)
@@ -174,9 +169,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedProjectEvents, worker.ProjectIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
         internal async Task Solution_Change(BackgroundAnalysisScope analysisScope)
@@ -198,9 +192,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.SyntaxDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
         internal async Task Project_Add(BackgroundAnalysisScope analysisScope)
@@ -225,9 +218,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.SyntaxDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
         internal async Task Project_Remove(BackgroundAnalysisScope analysisScope)
@@ -244,9 +236,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(5, worker.InvalidateDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
         internal async Task Project_Change(BackgroundAnalysisScope analysisScope)
@@ -265,10 +256,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(1, worker.InvalidateDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Project_AssemblyName_Change(BackgroundAnalysisScope analysisScope, bool firstDocumentActive)
@@ -293,10 +283,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Project_DefaultNamespace_Change(BackgroundAnalysisScope analysisScope, bool firstDocumentActive)
@@ -321,10 +310,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Project_AnalyzerOptions_Change(BackgroundAnalysisScope analysisScope, bool firstDocumentActive)
@@ -351,10 +339,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(1, worker.NonSourceDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Project_OutputFilePath_Change(BackgroundAnalysisScope analysisScope, bool firstDocumentActive)
@@ -379,10 +366,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Project_OutputRefFilePath_Change(BackgroundAnalysisScope analysisScope, bool firstDocumentActive)
@@ -407,10 +393,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Project_CompilationOutputInfo_Change(BackgroundAnalysisScope analysisScope, bool firstDocumentActive)
@@ -435,10 +420,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Project_RunAnalyzers_Change(BackgroundAnalysisScope analysisScope, bool firstDocumentActive)
@@ -484,7 +468,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
         }
 
         [Fact]
-        public async Task Test_BackgroundAnalysisScopeOptionChanged_OpenFiles()
+        public async Task Test_BackgroundAnalysisScopeOptionChanged_ActiveFile()
         {
             using var workspace = new WorkCoordinatorWorkspace(SolutionCrawlerWorkspaceKind, incrementalAnalyzer: typeof(AnalyzerProviderNoWaitNoBlock));
             var solutionInfo = GetInitialSolutionInfo_2Projects_10Documents();
@@ -492,9 +476,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             MakeFirstDocumentActive(workspace.CurrentSolution.Projects.First());
             await WaitWaiterAsync(workspace.ExportProvider);
 
-            Assert.Equal(BackgroundAnalysisScope.ActiveFile, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
+            Assert.Equal(BackgroundAnalysisScope.Default, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
 
-            var newAnalysisScope = BackgroundAnalysisScope.OpenFiles;
+            var newAnalysisScope = BackgroundAnalysisScope.ActiveFile;
             var worker = await ExecuteOperation(workspace, w => w.TryApplyChanges(w.CurrentSolution.WithOptions(w.CurrentSolution.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope))));
 
             Assert.Equal(newAnalysisScope, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
@@ -511,7 +495,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             workspace.OnSolutionAdded(solutionInfo);
             await WaitWaiterAsync(workspace.ExportProvider);
 
-            Assert.Equal(BackgroundAnalysisScope.ActiveFile, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
+            Assert.Equal(BackgroundAnalysisScope.Default, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
 
             var newAnalysisScope = BackgroundAnalysisScope.FullSolution;
             var worker = await ExecuteOperation(workspace, w => w.TryApplyChanges(w.CurrentSolution.WithOptions(w.CurrentSolution.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope))));
@@ -522,9 +506,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(2, worker.ProjectIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None)]
         [InlineData(BackgroundAnalysisScope.ActiveFile)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects)]
         [InlineData(BackgroundAnalysisScope.FullSolution)]
         [Theory]
         internal async Task Project_Reload(BackgroundAnalysisScope analysisScope)
@@ -543,10 +526,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedProjectEvents, worker.ProjectIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Document_Add(BackgroundAnalysisScope analysisScope, bool activeDocument)
@@ -577,10 +559,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentSemanticEvents, worker.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Document_Remove(BackgroundAnalysisScope analysisScope, bool removeActiveDocument)
@@ -607,10 +588,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentInvalidatedEvents, worker.InvalidateDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Document_Reload(BackgroundAnalysisScope analysisScope, bool reloadActiveDocument)
@@ -633,10 +613,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(0, worker.InvalidateDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Document_Reanalyze(BackgroundAnalysisScope analysisScope, bool reanalyzeActiveDocument)
@@ -679,10 +658,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedReanalyzeDocumentCount, worker.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem(670335, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
         internal async Task Document_Change(BackgroundAnalysisScope analysisScope, bool changeActiveDocument)
@@ -705,10 +683,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentEvents, worker.SyntaxDocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Document_AdditionalFileChange(BackgroundAnalysisScope analysisScope, bool firstDocumentActive)
@@ -748,10 +725,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Empty(worker.NonSourceDocumentIds);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory]
         internal async Task Document_AnalyzerConfigFileChange(BackgroundAnalysisScope analysisScope, bool firstDocumentActive)
@@ -788,10 +764,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentSemanticEvents, worker.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem(670335, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
         internal async Task Document_Cancellation(BackgroundAnalysisScope analysisScope, bool activeDocument)
@@ -843,10 +818,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(expectedDocumentSemanticEvents, analyzer.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem(670335, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
         internal async Task Document_Cancellation_MultipleTimes(BackgroundAnalysisScope analysisScope, bool activeDocument)
@@ -951,10 +925,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(5, analyzer.DocumentIds.Count);
         }
 
-        [InlineData(BackgroundAnalysisScope.None, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, false)]
         [InlineData(BackgroundAnalysisScope.ActiveFile, true)]
-        [InlineData(BackgroundAnalysisScope.OpenFiles, false)]
+        [InlineData(BackgroundAnalysisScope.OpenFilesAndProjects, false)]
         [InlineData(BackgroundAnalysisScope.FullSolution, false)]
         [Theory, WorkItem(670335, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/670335")]
         internal async Task Document_ActiveDocumentChanged(BackgroundAnalysisScope analysisScope, bool hasActiveDocumentBefore)
@@ -976,14 +949,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             var expectedSyntaxDocumentEvents = (analysisScope, hasActiveDocumentBefore) switch
             {
                 (BackgroundAnalysisScope.ActiveFile, _) => 1,
-                (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution or BackgroundAnalysisScope.None, _) => 0,
+                (BackgroundAnalysisScope.OpenFilesAndProjects or BackgroundAnalysisScope.FullSolution, _) => 0,
                 _ => throw ExceptionUtilities.Unreachable,
             };
 
             var expectedDocumentEvents = (analysisScope, hasActiveDocumentBefore) switch
             {
-                (BackgroundAnalysisScope.ActiveFile, _) => 1,
-                (BackgroundAnalysisScope.OpenFiles or BackgroundAnalysisScope.FullSolution or BackgroundAnalysisScope.None, _) => 0,
+                (BackgroundAnalysisScope.ActiveFile, _) => 5,
+                (BackgroundAnalysisScope.OpenFilesAndProjects or BackgroundAnalysisScope.FullSolution, _) => 0,
                 _ => throw ExceptionUtilities.Unreachable,
             };
 
@@ -1723,24 +1696,6 @@ class C
                 return Task.CompletedTask;
             }
 
-            public async Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken)
-            {
-                if (SolutionCrawlerOptions.GetBackgroundAnalysisScope(document.Project) != BackgroundAnalysisScope.ActiveFile)
-                {
-                    return;
-                }
-
-                if (document is Document sourceDocument)
-                {
-                    await AnalyzeSyntaxAsync(sourceDocument, InvocationReasons.ActiveDocumentSwitched, cancellationToken).ConfigureAwait(false);
-                    await AnalyzeDocumentAsync(sourceDocument, bodyOpt: null, InvocationReasons.ActiveDocumentSwitched, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    await AnalyzeNonSourceDocumentAsync(document, InvocationReasons.ActiveDocumentSwitched, cancellationToken).ConfigureAwait(false);
-                }
-            }
-
             public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
             {
                 InvalidateDocumentIds.Add(documentId);
@@ -1819,7 +1774,6 @@ class C
             public Task DocumentOpenAsync(Document document, CancellationToken cancellationToken) => Task.CompletedTask;
             public Task DocumentCloseAsync(Document document, CancellationToken cancellationToken) => Task.CompletedTask;
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken) => Task.CompletedTask;
-            public Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken) => Task.CompletedTask;
             public Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken) => Task.CompletedTask;
             public Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken) => Task.CompletedTask;
             public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
-Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Shared.Options
 Imports Microsoft.CodeAnalysis.SolutionCrawler
 Imports Microsoft.CodeAnalysis.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic
@@ -256,11 +256,6 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
 
         Private Shared Sub VerifyAllAvailableDiagnostics(test As XElement, diagnostics As XElement, Optional ordered As Boolean = True)
             Using workspace = TestWorkspace.CreateWorkspace(test, composition:=s_composition)
-                ' Ensure that diagnostic service computes diagnostics for all open files, not just the active file (default mode)
-                For Each language In workspace.Projects.Select(Function(p) p.Language).Distinct()
-                    Dim key = New OptionKey2(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, language)
-                    workspace.SetOptions(workspace.Options.WithChangedOption(key, BackgroundAnalysisScope.OpenFiles))
-                Next
 
                 Dim registrationService = workspace.Services.GetService(Of ISolutionCrawlerRegistrationService)()
                 registrationService.Register(workspace)

--- a/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/DiagnosticTaggerWrapper.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.InlineDiagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.Text.Tagging;
@@ -45,14 +44,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
             var analyzerReference = new TestAnalyzerReferenceByLanguage(analyzerMap ?? DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap());
             workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { analyzerReference }));
-
-            // Change the background analysis scope to OpenFiles instead of ActiveFile (default),
-            // so that every diagnostic tagger test does not need to mark test files as "active" file.
-            var csKey = new OptionKey2(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp);
-            var vbKey = new OptionKey2(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic);
-            workspace.SetOptions(workspace.Options
-                .WithChangedOption(csKey, BackgroundAnalysisScope.OpenFiles)
-                .WithChangedOption(vbKey, BackgroundAnalysisScope.OpenFiles));
 
             _workspace = workspace;
 

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -300,32 +299,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // given compilation must be from given project.
             Contract.ThrowIfFalse(project.TryGetCompilation(out var compilation2));
             Contract.ThrowIfFalse(compilation1 == compilation2);
-        }
-
-        /// <summary>
-        /// Return true if the given <paramref name="analyzer"/> is not suppressed for the given project.
-        /// NOTE: This API is intended to be used only for performance optimization.
-        /// </summary>
-        public static bool IsAnalyzerEnabledForProject(DiagnosticAnalyzer analyzer, Project project)
-        {
-            var options = project.CompilationOptions;
-            if (options == null || analyzer == FileContentLoadAnalyzer.Instance || analyzer.IsCompilerAnalyzer())
-            {
-                return true;
-            }
-
-            // Check if user has disabled analyzer execution for this project or via options.
-            if (!project.State.RunAnalyzers || SolutionCrawlerOptions.GetBackgroundAnalysisScope(project) == BackgroundAnalysisScope.None)
-            {
-                return false;
-            }
-
-            // NOTE: Previously we used to return "CompilationWithAnalyzers.IsDiagnosticAnalyzerSuppressed(options)"
-            //       on this code path, which returns true if analyzer is suppressed through compilation options.
-            //       However, this check is no longer correct as analyzers can be enabled/disabled for individual
-            //       documents through .editorconfig files. So we pessimistically assume analyzer is not suppressed
-            //       and let the core analyzer driver in the compiler layer handle skipping redundant analysis callbacks.
-            return true;
         }
 
         public static async Task<ImmutableArray<Diagnostic>> ComputeDocumentDiagnosticAnalyzerDiagnosticsAsync(

--- a/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DefaultDiagnosticAnalyzerService.cs
@@ -231,9 +231,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             public Task NonSourceDocumentOpenAsync(TextDocument textDocument, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 
-            public Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken)
-                => Task.CompletedTask;
-
             public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,17 +25,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         /// Also returns empty diagnostics for suppressed analyzer.
         /// Returns null if the diagnostics need to be computed.
         /// </summary>
-        private static DocumentAnalysisData? TryGetCachedDocumentAnalysisData(
-            TextDocument document, StateSet stateSet,
-            AnalysisKind kind, VersionStamp version,
-            BackgroundAnalysisScope analysisScope, bool isActiveDocument,
-            bool isOpenDocument, bool isGeneratedRazorDocument,
-            CancellationToken cancellationToken)
+        private async Task<DocumentAnalysisData?> TryGetCachedDocumentAnalysisDataAsync(
+            TextDocument document, StateSet stateSet, AnalysisKind kind, CancellationToken cancellationToken)
         {
-            Debug.Assert(isActiveDocument || isOpenDocument || isGeneratedRazorDocument);
-
             try
             {
+                var version = await GetDiagnosticVersionAsync(document.Project, cancellationToken).ConfigureAwait(false);
                 var state = stateSet.GetOrCreateActiveFileState(document.Id);
                 var existingData = state.GetAnalysisData(kind);
 
@@ -45,9 +39,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return existingData;
                 }
 
-                // Perf optimization: Check whether analyzer is suppressed for project or document and avoid getting diagnostics if suppressed.
-                if (!AnalyzerHelper.IsAnalyzerEnabledForProject(stateSet.Analyzer, document.Project) ||
-                    !IsAnalyzerEnabledForDocument(stateSet.Analyzer, analysisScope, isActiveDocument, isOpenDocument, isGeneratedRazorDocument))
+                // Perf optimization: Check whether analyzer is suppressed and avoid getting diagnostics if suppressed.
+                if (DiagnosticAnalyzerInfoCache.IsAnalyzerSuppressed(stateSet.Analyzer, document.Project))
                 {
                     return new DocumentAnalysisData(version, existingData.Items, ImmutableArray<DiagnosticData>.Empty);
                 }
@@ -57,49 +50,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {
                 throw ExceptionUtilities.Unreachable;
-            }
-
-            static bool IsAnalyzerEnabledForDocument(
-                DiagnosticAnalyzer analyzer,
-                BackgroundAnalysisScope analysisScope,
-                bool isActiveDocument,
-                bool isOpenDocument,
-                bool isGeneratedRazorDocument)
-            {
-                Debug.Assert(!isActiveDocument || isOpenDocument || isGeneratedRazorDocument);
-
-                if (isGeneratedRazorDocument)
-                {
-                    // This is a generated Razor document, and they always want all analyzer diagnostics.
-                    return true;
-                }
-
-                if (analyzer.IsCompilerAnalyzer())
-                {
-                    // Compiler analyzer is treated specially.
-                    // It is executed for all documents (open and closed) for 'BackgroundAnalysisScope.FullSolution'
-                    // and executed for just open documents for other analysis scopes.
-                    return analysisScope == BackgroundAnalysisScope.FullSolution || isOpenDocument;
-                }
-                else
-                {
-                    return analysisScope switch
-                    {
-                        // Analyzers are disabled for all documents.
-                        BackgroundAnalysisScope.None => false,
-
-                        // Analyzers are enabled for active document.
-                        BackgroundAnalysisScope.ActiveFile => isActiveDocument,
-
-                        // Analyzers are enabled for all open documents.
-                        BackgroundAnalysisScope.OpenFiles => isOpenDocument,
-
-                        // Analyzers are enabled for all documents.
-                        BackgroundAnalysisScope.FullSolution => true,
-
-                        _ => throw ExceptionUtilities.UnexpectedValue(analysisScope)
-                    };
-                }
             }
         }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -281,12 +281,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private bool ShouldIncludeStateSet(Project project, StateSet stateSet)
             {
-                if (!AnalyzerHelper.IsAnalyzerEnabledForProject(stateSet.Analyzer, project))
+                var infoCache = Owner.DiagnosticAnalyzerInfoCache;
+                if (infoCache.IsAnalyzerSuppressed(stateSet.Analyzer, project))
                 {
                     return false;
                 }
 
-                if (_diagnosticIds != null && Owner.DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(stateSet.Analyzer).All(d => !_diagnosticIds.Contains(d.Id)))
+                if (_diagnosticIds != null && infoCache.GetDiagnosticDescriptors(stateSet.Analyzer).All(d => !_diagnosticIds.Contains(d.Id)))
                 {
                     return false;
                 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                  CancellationToken cancellationToken)
             {
                 var stateSets = owner._stateManager
-                                     .GetOrCreateStateSets(document.Project).Where(s => AnalyzerHelper.IsAnalyzerEnabledForProject(s.Analyzer, document.Project));
+                                     .GetOrCreateStateSets(document.Project).Where(s => !owner.DiagnosticAnalyzerInfoCache.IsAnalyzerSuppressed(s.Analyzer, document.Project));
 
                 var compilationWithAnalyzers = await GetOrCreateCompilationWithAnalyzersAsync(document.Project, stateSets, includeSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -35,25 +35,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             try
             {
-                if (!document.SupportsDiagnostics())
+                if (!AnalysisEnabled(document, _documentTrackingService))
                 {
-                    return;
-                }
-
-                var isActiveDocument = _documentTrackingService.TryGetActiveDocument() == document.Id;
-                var isOpenDocument = document.IsOpen();
-                var isGeneratedRazorDocument = document.Services.GetService<DocumentPropertiesService>()?.DiagnosticsLspClientName != null;
-
-                // Only analyze open/active documents, unless it is a generated Razor document.
-                if (!isActiveDocument && !isOpenDocument && !isGeneratedRazorDocument)
-                {
+                    // to reduce allocations, here, we don't clear existing diagnostics since it is dealt by other entry point such as
+                    // DocumentReset or DocumentClosed.
                     return;
                 }
 
                 var stateSets = _stateManager.GetOrUpdateStateSets(document.Project);
                 var compilationWithAnalyzers = await GetOrCreateCompilationWithAnalyzersAsync(document.Project, stateSets, cancellationToken).ConfigureAwait(false);
-                var version = await GetDiagnosticVersionAsync(document.Project, cancellationToken).ConfigureAwait(false);
-                var backgroundAnalysisScope = SolutionCrawlerOptions.GetBackgroundAnalysisScope(document.Project);
 
                 // We split the diagnostic computation for document into following steps:
                 //  1. Try to get cached diagnostics for each analyzer, while computing the set of analyzers that do not have cached diagnostics.
@@ -66,8 +56,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 using var _ = ArrayBuilder<StateSet>.GetInstance(out var nonCachedStateSets);
                 foreach (var stateSet in stateSets)
                 {
-                    var data = TryGetCachedDocumentAnalysisData(document, stateSet, kind, version,
-                        backgroundAnalysisScope, isActiveDocument, isOpenDocument, isGeneratedRazorDocument, cancellationToken);
+                    var data = await TryGetCachedDocumentAnalysisDataAsync(document, stateSet, kind, cancellationToken).ConfigureAwait(false);
                     if (data.HasValue)
                     {
                         // We need to persist and raise diagnostics for suppressed analyzer.
@@ -143,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // this is perf optimization. we cache these result since we know the result. (no diagnostics)
                 var activeAnalyzers = stateSets
                                         .Select(s => s.Analyzer)
-                                        .Where(a => AnalyzerHelper.IsAnalyzerEnabledForProject(a, project) && !a.IsOpenFileOnly(options));
+                                        .Where(a => !DiagnosticAnalyzerInfoCache.IsAnalyzerSuppressed(a, project) && !a.IsOpenFileOnly(options));
 
                 // get driver only with active analyzers.
                 var compilationWithAnalyzers = await AnalyzerHelper.CreateCompilationWithAnalyzersAsync(project, activeAnalyzers, includeSuppressedDiagnostics: true, cancellationToken).ConfigureAwait(false);
@@ -267,28 +256,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             RaiseDiagnosticsRemovedForDocument(document.Id, stateSets);
         }
 
-        public async Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken)
-        {
-            // When the analysis scope is set to 'ActiveFile' and the active document is switched,
-            // we retrigger analysis of newly active document.
-            // For the remaining analysis scopes, we always analyze all the open files, so switching active
-            // documents between two open files doesn't require us to retrigger analysis of the newly active document.
-            if (SolutionCrawlerOptions.GetBackgroundAnalysisScope(document.Project) != BackgroundAnalysisScope.ActiveFile)
-            {
-                return;
-            }
-
-            // First reset the document states.
-            await TextDocumentResetAsync(document, cancellationToken).ConfigureAwait(false);
-
-            // Trigger syntax analysis.
-            await AnalyzeDocumentForKindAsync(document, AnalysisKind.Syntax, cancellationToken).ConfigureAwait(false);
-
-            // Trigger semantic analysis for source documents. Non-source documents do not support semantic analysis.
-            if (document is Document)
-                await AnalyzeDocumentForKindAsync(document, AnalysisKind.Semantic, cancellationToken).ConfigureAwait(false);
-        }
-
         public Task RemoveDocumentAsync(DocumentId documentId, CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.Diagnostics_RemoveDocument, GetRemoveLogMessage, documentId, CancellationToken.None))
@@ -361,6 +328,31 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             ClearCompilationsWithAnalyzersCache();
 
             return Task.CompletedTask;
+        }
+
+        private static bool AnalysisEnabled(TextDocument document, IDocumentTrackingService documentTrackingService)
+        {
+            if (document.Services.GetService<DocumentPropertiesService>()?.DiagnosticsLspClientName != null)
+            {
+                // This is a generated Razor document, and they want diagnostics, so let's report it
+                return true;
+            }
+
+            if (!document.SupportsDiagnostics())
+            {
+                return false;
+            }
+
+            // change it to check active file (or visible files), not open files if active file tracking is enabled.
+            // otherwise, use open file.
+            if (SolutionCrawlerOptions.GetBackgroundAnalysisScope(document.Project) == BackgroundAnalysisScope.ActiveFile)
+            {
+                return documentTrackingService.TryGetActiveDocument() == document.Id;
+            }
+            else
+            {
+                return document.IsOpen();
+            }
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptOptions.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             => options.WithChangedOption(
                     SolutionCrawlerOptions.BackgroundAnalysisScopeOption,
                     InternalLanguageNames.TypeScript,
-                    openFilesOnly ? BackgroundAnalysisScope.OpenFiles : BackgroundAnalysisScope.FullSolution)
+                    openFilesOnly ? BackgroundAnalysisScope.OpenFilesAndProjects : BackgroundAnalysisScope.FullSolution)
                 .WithChangedOption(
                     ServiceFeatureOnOffOptions.RemoveDocumentDiagnosticsOnDocumentClose,
                     InternalLanguageNames.TypeScript,

--- a/src/Features/Core/Portable/SolutionCrawler/AggregateIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/AggregateIncrementalAnalyzer.cs
@@ -61,14 +61,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
         }
 
-        public async Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken)
-        {
-            if (TryGetAnalyzer(document.Project, out var analyzer))
-            {
-                await analyzer.ActiveDocumentSwitchedAsync(document, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
         public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
         {
             // TODO: Is this correct?

--- a/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerBase.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IncrementalAnalyzerBase.cs
@@ -26,9 +26,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         public virtual Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             => Task.CompletedTask;
 
-        public Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken)
-            => Task.CompletedTask;
-
         public virtual bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
             => false;
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -164,18 +164,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 private async Task ProcessDocumentAnalyzersAsync(
                     TextDocument textDocument, ImmutableArray<IIncrementalAnalyzer> analyzers, WorkItem workItem, CancellationToken cancellationToken)
                 {
-                    // process special active document switched request, if any.
-                    if (await ProcessActiveDocumentSwitchedAsync(analyzers, workItem, textDocument, cancellationToken).ConfigureAwait(false))
-                    {
-                        return;
-                    }
-
                     // process all analyzers for each categories in this order - syntax, body, document
                     var reasons = workItem.InvocationReasons;
                     if (workItem.MustRefresh || reasons.Contains(PredefinedInvocationReasons.SyntaxChanged))
                     {
-                        await RunAnalyzersAsync(analyzers, textDocument, workItem, (analyzer, document, cancellationToken) =>
-                            AnalyzeSyntaxAsync(analyzer, document, reasons, cancellationToken), cancellationToken).ConfigureAwait(false);
+                        await RunAnalyzersAsync(analyzers, textDocument, workItem, (a, d, c) => AnalyzeSyntaxAsync(a, d, reasons, c), cancellationToken).ConfigureAwait(false);
                     }
 
                     if (textDocument is not Document document)
@@ -186,8 +179,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                     if (workItem.MustRefresh || reasons.Contains(PredefinedInvocationReasons.SemanticChanged))
                     {
-                        await RunAnalyzersAsync(analyzers, document, workItem, (analyzer, document, cancellationToken) =>
-                            analyzer.AnalyzeDocumentAsync(document, null, reasons, cancellationToken), cancellationToken).ConfigureAwait(false);
+                        await RunAnalyzersAsync(analyzers, document, workItem, (a, d, c) => a.AnalyzeDocumentAsync(d, null, reasons, c), cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -206,25 +198,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         else if (analyzer is IIncrementalAnalyzer2 analyzer2)
                         {
                             await analyzer2.AnalyzeNonSourceDocumentAsync(textDocument, reasons, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-
-                    async Task<bool> ProcessActiveDocumentSwitchedAsync(ImmutableArray<IIncrementalAnalyzer> analyzers, WorkItem workItem, TextDocument document, CancellationToken cancellationToken)
-                    {
-                        try
-                        {
-                            if (!workItem.InvocationReasons.Contains(PredefinedInvocationReasons.ActiveDocumentSwitched))
-                            {
-                                return false;
-                            }
-
-                            await RunAnalyzersAsync(analyzers, document, workItem, (analyzer, document, cancellationToken) =>
-                                analyzer.ActiveDocumentSwitchedAsync(document, cancellationToken), cancellationToken).ConfigureAwait(false);
-                            return true;
-                        }
-                        catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
-                        {
-                            throw ExceptionUtilities.Unreachable;
                         }
                     }
                 }
@@ -273,8 +246,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         if (root == null || syntaxFactsService == null)
                         {
                             // as a fallback mechanism, if we can't run one method body due to some missing service, run whole document analyzer.
-                            await RunAnalyzersAsync(analyzers, document, workItem, (analyzer, document, cancellationToken) =>
-                                analyzer.AnalyzeDocumentAsync(document, null, reasons, cancellationToken), cancellationToken).ConfigureAwait(false);
+                            await RunAnalyzersAsync(analyzers, document, workItem, (a, d, c) => a.AnalyzeDocumentAsync(d, null, reasons, c), cancellationToken).ConfigureAwait(false);
                             return;
                         }
 
@@ -285,14 +257,12 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         {
                             // no active member means, change is out side of a method body, but it didn't affect semantics (such as change in comment)
                             // in that case, we update whole document (just this document) so that we can have updated locations.
-                            await RunAnalyzersAsync(analyzers, document, workItem, (analyzer, document, cancellationToken) =>
-                                analyzer.AnalyzeDocumentAsync(document, null, reasons, cancellationToken), cancellationToken).ConfigureAwait(false);
+                            await RunAnalyzersAsync(analyzers, document, workItem, (a, d, c) => a.AnalyzeDocumentAsync(d, null, reasons, c), cancellationToken).ConfigureAwait(false);
                             return;
                         }
 
                         // re-run just the body
-                        await RunAnalyzersAsync(analyzers, document, workItem, (analyzer, document, cancellationToken) =>
-                            analyzer.AnalyzeDocumentAsync(document, activeMember, reasons, cancellationToken), cancellationToken).ConfigureAwait(false);
+                        await RunAnalyzersAsync(analyzers, document, workItem, (a, d, c) => a.AnalyzeDocumentAsync(d, activeMember, reasons, c), cancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
                     {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 _optionService.OptionChanged += OnOptionChanged;
 
                 // subscribe to active document changed event for active file background analysis scope.
-                _documentTrackingService.ActiveDocumentChanged += OnActiveDocumentSwitched;
+                _documentTrackingService.ActiveDocumentChanged += OnActiveDocumentChanged;
             }
 
             public int CorrelationId => _registration.CorrelationId;
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             public void Shutdown(bool blockingShutdown)
             {
                 _optionService.OptionChanged -= OnOptionChanged;
-                _documentTrackingService.ActiveDocumentChanged -= OnActiveDocumentSwitched;
+                _documentTrackingService.ActiveDocumentChanged -= OnActiveDocumentChanged;
 
                 // detach from the workspace
                 _registration.Workspace.WorkspaceChanged -= OnWorkspaceChanged;
@@ -205,13 +205,20 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
             }
 
-            private void OnActiveDocumentSwitched(object? sender, DocumentId? activeDocumentId)
+            private void OnActiveDocumentChanged(object? sender, DocumentId? activeDocumentId)
             {
-                if (activeDocumentId == null)
+                var solution = _registration.GetSolutionToAnalyze();
+                if (solution.GetProject(activeDocumentId?.ProjectId) is not { } activeProject)
                     return;
 
-                var solution = _registration.GetSolutionToAnalyze();
-                EnqueueFullDocumentEvent(solution, activeDocumentId, InvocationReasons.ActiveDocumentSwitched, eventName: nameof(OnActiveDocumentSwitched));
+                RoslynDebug.AssertNotNull(activeDocumentId);
+                var analysisScope = SolutionCrawlerOptions.GetBackgroundAnalysisScope(activeProject);
+                if (analysisScope == BackgroundAnalysisScope.ActiveFile)
+                {
+                    // When the active document changes and we are only analyzing the active file, trigger a document
+                    // changed event to reanalyze the newly-active file.
+                    EnqueueFullDocumentEvent(solution, activeDocumentId, InvocationReasons.DocumentChanged, nameof(OnActiveDocumentChanged));
+                }
             }
 
             private void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs args)

--- a/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Host
     internal sealed class BackgroundCompiler : IDisposable
     {
         private Workspace _workspace;
+        private readonly IDocumentTrackingService _documentTrackingService;
         private readonly TaskQueue _taskQueue;
 
         [SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Used to keep a strong reference to the built compilations so they are not GC'd")]
@@ -28,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Host
         public BackgroundCompiler(Workspace workspace)
         {
             _workspace = workspace;
+            _documentTrackingService = _workspace.Services.GetRequiredService<IDocumentTrackingService>();
 
             // make a scheduler that runs on the thread pool
             var listenerProvider = workspace.Services.GetRequiredService<IWorkspaceAsynchronousOperationListenerProvider>();
@@ -99,11 +101,12 @@ namespace Microsoft.CodeAnalysis.Host
                 CancelBuild(releasePreviousCompilations: false);
 
                 var allOpenProjects = _workspace.GetOpenDocumentIds().Select(d => d.ProjectId).ToSet();
+                var activeProject = _documentTrackingService.TryGetActiveDocument()?.ProjectId;
 
                 // don't even get started if there is nothing to do
                 if (allOpenProjects.Count > 0)
                 {
-                    _ = BuildCompilationsAsync(solution, initialProject, allOpenProjects);
+                    _ = BuildCompilationsAsync(solution, initialProject, allOpenProjects, activeProject);
                 }
             }
         }
@@ -124,12 +127,13 @@ namespace Microsoft.CodeAnalysis.Host
         private Task BuildCompilationsAsync(
             Solution solution,
             ProjectId? initialProject,
-            ISet<ProjectId> allOpenProjects)
+            ISet<ProjectId> allOpenProjects,
+            ProjectId? activeProject)
         {
             var cancellationToken = _cancellationSource.Token;
             return _taskQueue.ScheduleTask(
                 "BackgroundCompiler.BuildCompilationsAsync",
-                () => BuildCompilationsAsync(solution, initialProject, allOpenProjects, cancellationToken),
+                () => BuildCompilationsAsync(solution, initialProject, allOpenProjects, activeProject, cancellationToken),
                 cancellationToken);
         }
 
@@ -137,6 +141,7 @@ namespace Microsoft.CodeAnalysis.Host
             Solution solution,
             ProjectId? initialProject,
             ISet<ProjectId> projectsToBuild,
+            ProjectId? activeProject,
             CancellationToken cancellationToken)
         {
             var allProjectIds = new List<ProjectId>();
@@ -149,12 +154,22 @@ namespace Microsoft.CodeAnalysis.Host
 
             var logger = Logger.LogBlock(FunctionId.BackgroundCompiler_BuildCompilationsAsync, cancellationToken);
 
+            // Skip performing any background compilation for projects where user has explicitly
+            // set the background analysis scope to only analyze active files.
             var compilationTasks = allProjectIds
                 .Select(solution.GetProject)
                 .Select(async p =>
                 {
                     if (p is null)
                         return null;
+
+                    if (SolutionCrawlerOptions.GetBackgroundAnalysisScope(p) == BackgroundAnalysisScope.ActiveFile
+                        && p.Id != activeProject)
+                    {
+                        // For open files with Active File analysis scope, only build the compilation if the project is
+                        // active.
+                        return null;
+                    }
 
                     return await p.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 })

--- a/src/Features/Core/Portable/Workspace/BackgroundParser.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundParser.cs
@@ -208,6 +208,14 @@ namespace Microsoft.CodeAnalysis.Host
                 {
                     try
                     {
+                        if (SolutionCrawlerOptions.GetBackgroundAnalysisScope(document.Project) == BackgroundAnalysisScope.ActiveFile
+                            && _documentTrackingService?.TryGetActiveDocument() != document.Id)
+                        {
+                            // Active file analysis is enabled, but the document for parsing is not the current
+                            // document. Return immediately without parsing.
+                            return;
+                        }
+
                         await document.GetSyntaxTreeAsync(CancellationToken.None).ConfigureAwait(false);
                     }
                     finally

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects);
 
             var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
 
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects);
 
             // Calling GetTextBuffer will effectively open the file.
             testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles, pullDiagnostics: false);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects, pullDiagnostics: false);
 
             // Calling GetTextBuffer will effectively open the file.
             testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles, DiagnosticMode.Default);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects, DiagnosticMode.Default);
 
             // Calling GetTextBuffer will effectively open the file.
             testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles, DiagnosticMode.Default);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects, DiagnosticMode.Default);
 
             // Calling GetTextBuffer will effectively open the file.
             testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects);
             var workspace = testLspServer.TestWorkspace;
 
             // Calling GetTextBuffer will effectively open the file.
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects);
 
             // Calling GetTextBuffer will effectively open the file.
             testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects);
 
             // Calling GetTextBuffer will effectively open the file.
             var buffer = testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects);
 
             // Calling GetTextBuffer will effectively open the file.
             var buffer = testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             var markup =
 @"#line 1 ""test.txt""
 class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects);
 
             // Calling GetTextBuffer will effectively open the file.
             testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -275,7 +275,7 @@ class A {";
         {
             var markup =
 @"class A {";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects);
 
             // Calling GetTextBuffer will effectively open the file.
             testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -307,7 +307,7 @@ class B {";
     </Project>
 </Workspace>";
 
-            using var testLspServer = await CreateTestWorkspaceFromXmlAsync(workspaceXml, BackgroundAnalysisScope.OpenFiles);
+            using var testLspServer = await CreateTestWorkspaceFromXmlAsync(workspaceXml, BackgroundAnalysisScope.OpenFilesAndProjects);
 
             var csproj1Document = testLspServer.GetCurrentSolution().Projects.Where(p => p.Name == "CSProj1").Single().Documents.First();
             var csproj2Document = testLspServer.GetCurrentSolution().Projects.Where(p => p.Name == "CSProj2").Single().Documents.First();
@@ -434,7 +434,7 @@ class B {";
 @"class A {";
 
             // Turn off pull diagnostics by default, but send a request to the razor LSP server which is always pull.
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles, DiagnosticMode.Push, serverKind: WellKnownLspServerKinds.RazorLspServer);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects, DiagnosticMode.Push, serverKind: WellKnownLspServerKinds.RazorLspServer);
 
             // Calling GetTextBuffer will effectively open the file.
             testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -458,7 +458,7 @@ class B {";
 @"class A {";
 
             // Turn off pull diagnostics by default, but send a request to the razor LSP server which is always pull.
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles, DiagnosticMode.Push, serverKind: WellKnownLspServerKinds.LiveShareLspServer);
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFilesAndProjects, DiagnosticMode.Push, serverKind: WellKnownLspServerKinds.LiveShareLspServer);
 
             // Calling GetTextBuffer will effectively open the file.
             testLspServer.TestWorkspace.Documents.Single().GetTextBuffer();
@@ -486,7 +486,7 @@ class B {";
 @"class A {";
             var markup2 = "";
             using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(
-                new[] { markup1, markup2 }, BackgroundAnalysisScope.OpenFiles);
+                new[] { markup1, markup2 }, BackgroundAnalysisScope.OpenFilesAndProjects);
 
             var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
 

--- a/src/Tools/AnalyzerRunner/Options.cs
+++ b/src/Tools/AnalyzerRunner/Options.cs
@@ -40,7 +40,7 @@ namespace AnalyzerRunner
         internal readonly string ProfileRoot;
 
         internal BackgroundAnalysisScope AnalysisScope
-            => FullSolutionAnalysis ? BackgroundAnalysisScope.FullSolution : BackgroundAnalysisScope.OpenFiles;
+            => FullSolutionAnalysis ? BackgroundAnalysisScope.FullSolution : BackgroundAnalysisScope.Default;
 
         public Options(
             string analyzerPath,

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -15,14 +15,17 @@
             <GroupBox x:Uid="AnalysisGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Analysis}">
                 <StackPanel>
-                    <Label Content="{x:Static local:AdvancedOptionPageStrings.Option_Run_background_code_analysis_for}"/>
-                    <StackPanel>
-                        <ComboBox x:Name="Run_background_code_analysis_for" IsEditable="false" AutomationProperties.Name="{x:Static local:AdvancedOptionPageStrings.Option_Run_background_code_analysis_for}">
-                            <ComboBoxItem Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_None}" Tag="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_None_Tag}" />
-                            <ComboBoxItem Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Active_File}" Tag="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Active_File_Tag}" />
-                            <ComboBoxItem Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Open_Files}" Tag="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Open_Files_Tag}" />
-                            <ComboBoxItem Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Full_Solution}" Tag="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Full_Solution_Tag}" />
-                        </ComboBox>
+                    <Label Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_analysis_scope}"/>
+                    <StackPanel Margin="15, 0, 0, 0">
+                        <RadioButton  GroupName="Background_analysis_scope"
+                                              x:Name="Background_analysis_scope_active_file"
+                                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Active_File}"/>
+                        <RadioButton  GroupName="Background_analysis_scope"
+                                              x:Name="Background_analysis_scope_open_files"
+                                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Open_Files_And_Projects}"/>
+                        <RadioButton  GroupName="Background_analysis_scope"
+                                              x:Name="Background_analysis_scope_full_solution"
+                                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Full_Solution}"/>
                     </StackPanel>
                     <StackPanel>
                         <CheckBox x:Name="DisplayDiagnosticsInline"

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System;
 using System.Windows;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
@@ -48,7 +47,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
             InitializeComponent();
 
-            BindToOption(Run_background_code_analysis_for, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp);
+            BindToOption(Background_analysis_scope_active_file, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.ActiveFile, LanguageNames.CSharp);
+            BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects, LanguageNames.CSharp);
+            BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution, LanguageNames.CSharp);
             BindToOption(DisplayDiagnosticsInline, InlineDiagnosticsOptions.EnableInlineDiagnostics, LanguageNames.CSharp);
             BindToOption(at_the_end_of_the_line_of_code, InlineDiagnosticsOptions.Location, InlineDiagnosticsLocations.PlacedAtEndOfCode, LanguageNames.CSharp);
             BindToOption(on_the_right_edge_of_the_editor_window, InlineDiagnosticsOptions.Location, InlineDiagnosticsLocations.PlacedAtEndOfEditor, LanguageNames.CSharp);

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Editor.ColorSchemes;
-using Microsoft.CodeAnalysis.SolutionCrawler;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 {
@@ -12,32 +11,17 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         public static string Option_Analysis
             => ServicesVSResources.Analysis;
 
-        public static string Option_Run_background_code_analysis_for
-            => ServicesVSResources.Run_background_code_analysis_for_colon;
-
-        public static string Option_Background_Analysis_Scope_None
-            => ServicesVSResources.None;
+        public static string Option_Background_analysis_scope
+            => ServicesVSResources.Background_analysis_scope_colon;
 
         public static string Option_Background_Analysis_Scope_Active_File
             => ServicesVSResources.Current_document;
 
-        public static string Option_Background_Analysis_Scope_Open_Files
+        public static string Option_Background_Analysis_Scope_Open_Files_And_Projects
             => ServicesVSResources.Open_documents;
 
         public static string Option_Background_Analysis_Scope_Full_Solution
             => ServicesVSResources.Entire_solution;
-
-        public static BackgroundAnalysisScope Option_Background_Analysis_Scope_None_Tag
-            => BackgroundAnalysisScope.None;
-
-        public static BackgroundAnalysisScope Option_Background_Analysis_Scope_Active_File_Tag
-            => BackgroundAnalysisScope.ActiveFile;
-
-        public static BackgroundAnalysisScope Option_Background_Analysis_Scope_Open_Files_Tag
-            => BackgroundAnalysisScope.OpenFiles;
-
-        public static BackgroundAnalysisScope Option_Background_Analysis_Scope_Full_Solution_Tag
-            => BackgroundAnalysisScope.FullSolution;
 
         public static string Option_Enable_navigation_to_decompiled_sources
             => ServicesVSResources.Enable_navigation_to_decompiled_sources;

--- a/src/VisualStudio/Core/Def/Commands.vsct
+++ b/src/VisualStudio/Core/Def/Commands.vsct
@@ -322,16 +322,6 @@
           <CommandName>AnalysisScopeEntireSolution</CommandName>
         </Strings>
       </Button>
-      <Button guid="guidRoslynGrpId" id="cmdidAnalysisScopeNone" priority="500" type="Button">
-        <Parent guid="guidRoslynGrpId" id="grpAnalysisScopeItems" />
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <ButtonText>&amp;None</ButtonText>
-          <CanonicalName>None</CanonicalName>
-          <LocCanonicalName>None</LocCanonicalName>
-          <CommandName>AnalysisScopeNone</CommandName>
-        </Strings>
-      </Button>
       <!-- Button to open the diagnostic help link -->
       <Button guid="guidRoslynGrpId" id="cmdidOpenDiagnosticHelpLink" priority="100" type="Button">
         <Parent guid="guidRoslynGrpId" id="grpDiagnosticProperties" />
@@ -720,7 +710,6 @@
       <IDSymbol name="cmdidAnalysisScopeEntireSolution" value="0x0134" />
       <IDSymbol name="grpAnalysisScope" value="0x0135" />
       <IDSymbol name="grpAnalysisScopeItems" value="0x0136" />
-      <IDSymbol name="cmdidAnalysisScopeNone" value="0x0137" />
 
       <IDSymbol name="cmdidGoToImplementation"        value="0x0200" />
 

--- a/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
+++ b/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
@@ -49,7 +49,6 @@ namespace Microsoft.VisualStudio.LanguageServices
             public const int AnalysisScopeCurrentDocument = 0x0132;
             public const int AnalysisScopeOpenDocuments = 0x0133;
             public const int AnalysisScopeEntireSolution = 0x0134;
-            public const int AnalysisScopeNone = 0x0137;
 
             public const int GoToImplementation = 0x0200;
 

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -75,7 +75,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 VisualStudioCommandHandlerHelpers.AddCommand(menuCommandService, ID.RoslynCommands.AnalysisScopeCurrentDocument, Guids.RoslynGroupId, OnSetAnalysisScopeCurrentDocument, OnSetAnalysisScopeCurrentDocumentStatus);
                 VisualStudioCommandHandlerHelpers.AddCommand(menuCommandService, ID.RoslynCommands.AnalysisScopeOpenDocuments, Guids.RoslynGroupId, OnSetAnalysisScopeOpenDocuments, OnSetAnalysisScopeOpenDocumentsStatus);
                 VisualStudioCommandHandlerHelpers.AddCommand(menuCommandService, ID.RoslynCommands.AnalysisScopeEntireSolution, Guids.RoslynGroupId, OnSetAnalysisScopeEntireSolution, OnSetAnalysisScopeEntireSolutionStatus);
-                VisualStudioCommandHandlerHelpers.AddCommand(menuCommandService, ID.RoslynCommands.AnalysisScopeNone, Guids.RoslynGroupId, OnSetAnalysisScopeNone, OnSetAnalysisScopeNoneStatus);
             }
         }
 
@@ -146,13 +145,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.ActiveFile);
 
         private void OnSetAnalysisScopeOpenDocumentsStatus(object sender, EventArgs e)
-            => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.OpenFiles);
+            => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.OpenFilesAndProjects);
 
         private void OnSetAnalysisScopeEntireSolutionStatus(object sender, EventArgs e)
             => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.FullSolution);
-
-        private void OnSetAnalysisScopeNoneStatus(object sender, EventArgs e)
-            => OnSetAnalysisScopeStatus((OleMenuCommand)sender, BackgroundAnalysisScope.None);
 
         private void OnSetAnalysisScopeStatus(OleMenuCommand command, BackgroundAnalysisScope? scope)
         {
@@ -185,9 +181,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 command.Text = GetBackgroundAnalysisScope(_workspace) switch
                 {
                     BackgroundAnalysisScope.ActiveFile => ServicesVSResources.Default_Current_Document,
-                    BackgroundAnalysisScope.OpenFiles => ServicesVSResources.Default_Open_Documents,
+                    BackgroundAnalysisScope.OpenFilesAndProjects => ServicesVSResources.Default_Open_Documents,
                     BackgroundAnalysisScope.FullSolution => ServicesVSResources.Default_Entire_Solution,
-                    BackgroundAnalysisScope.None => ServicesVSResources.Default_None,
                     _ => ServicesVSResources.Default_,
                 };
             }
@@ -227,13 +222,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             => OnSetAnalysisScope(BackgroundAnalysisScope.ActiveFile);
 
         private void OnSetAnalysisScopeOpenDocuments(object sender, EventArgs args)
-            => OnSetAnalysisScope(BackgroundAnalysisScope.OpenFiles);
+            => OnSetAnalysisScope(BackgroundAnalysisScope.OpenFilesAndProjects);
 
         private void OnSetAnalysisScopeEntireSolution(object sender, EventArgs args)
             => OnSetAnalysisScope(BackgroundAnalysisScope.FullSolution);
-
-        private void OnSetAnalysisScopeNone(object sender, EventArgs args)
-            => OnSetAnalysisScope(BackgroundAnalysisScope.None);
 
         private void OnSetAnalysisScope(BackgroundAnalysisScope? scope)
         {
@@ -300,7 +292,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             var project = GetProject(hierarchy);
             var solution = _workspace.CurrentSolution;
             var projectOrSolutionName = project?.Name ?? PathUtilities.GetFileName(solution.FilePath);
-            var analysisScope = project != null ? SolutionCrawlerOptions.GetBackgroundAnalysisScope(project) : SolutionCrawlerOptions.BackgroundAnalysisScopeOption.DefaultValue;
 
             // Add a message to VS status bar that we are running code analysis.
             var statusBar = _serviceProvider?.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
@@ -343,9 +334,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 }
 
                 // Now compute the new host diagostics for all projects with disabled analysis.
-                var projectsWithDisabledAnalysis = analysisScope == BackgroundAnalysisScope.None
-                    ? projects.ToImmutableArray()
-                    : projects.Where(p => !p.State.RunAnalyzers).ToImmutableArrayOrEmpty();
+                var projectsWithDisabledAnalysis = projects.Where(p => !p.State.RunAnalyzers).ToImmutableArrayOrEmpty();
                 if (!projectsWithDisabledAnalysis.IsEmpty)
                 {
                     // Compute diagnostics by overidding project's RunCodeAnalysis flag to true.

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1321,8 +1321,8 @@ Additional information: {1}</value>
   <data name="Code_analysis_terminated_before_completion_for_Solution" xml:space="preserve">
     <value>Code analysis terminated before completion for Solution.</value>
   </data>
-  <data name="Run_background_code_analysis_for_colon" xml:space="preserve">
-    <value>Run background code analysis for:</value>
+  <data name="Background_analysis_scope_colon" xml:space="preserve">
+    <value>Background analysis scope:</value>
   </data>
   <data name="Current_document" xml:space="preserve">
     <value>Current document</value>
@@ -1830,10 +1830,6 @@ Additional information: {1}</value>
   </data>
   <data name="Default_Open_Documents" xml:space="preserve">
     <value>Default (Open Documents)</value>
-    <comment>This text is a menu command</comment>
-  </data>
-  <data name="Default_None" xml:space="preserve">
-    <value>Default (None)</value>
     <comment>This text is a menu command</comment>
   </data>
   <data name="Suppress_hints_when_argument_matches_parameter_name" xml:space="preserve">

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.cs.xlf
@@ -67,21 +67,6 @@
         <target state="translated">Celé řešení</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">&amp;Otevřít dokumenty</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.de.xlf
@@ -67,21 +67,6 @@
         <target state="translated">Gesamte Projektmappe</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">&amp;Dokumente öffnen</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.es.xlf
@@ -67,21 +67,6 @@
         <target state="translated">Toda la solución</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">&amp;Documentos abiertos</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.fr.xlf
@@ -67,21 +67,6 @@
         <target state="translated">Solution complète</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">Documents &amp;ouverts</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.it.xlf
@@ -67,21 +67,6 @@
         <target state="translated">Intera soluzione</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">D&amp;ocumenti aperti</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.ja.xlf
@@ -67,21 +67,6 @@
         <target state="translated">ソリューション全体</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">開かれているドキュメント(&amp;O)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.ko.xlf
@@ -67,21 +67,6 @@
         <target state="translated">전체 솔루션</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">열린 문서(&amp;O)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.pl.xlf
@@ -67,21 +67,6 @@
         <target state="translated">Całe rozwiązanie</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">&amp;Otwórz dokumenty</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.pt-BR.xlf
@@ -67,21 +67,6 @@
         <target state="translated">Solução Inteira</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">&amp;Abrir Documentos</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.ru.xlf
@@ -67,21 +67,6 @@
         <target state="translated">Все решение</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">Открыть документы</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.tr.xlf
@@ -67,21 +67,6 @@
         <target state="translated">Tüm Çözüm</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">&amp;Belge Aç</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hans.xlf
@@ -67,21 +67,6 @@
         <target state="translated">整个解决方案</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">打开文档(&amp;O)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hant.xlf
@@ -67,21 +67,6 @@
         <target state="translated">整個解決方案</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|ButtonText">
-        <source>&amp;None</source>
-        <target state="new">&amp;None</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|CommandName">
-        <source>AnalysisScopeNone</source>
-        <target state="new">AnalysisScopeNone</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidAnalysisScopeNone|LocCanonicalName">
-        <source>None</source>
-        <target state="new">None</target>
-        <note />
-      </trans-unit>
       <trans-unit id="cmdidAnalysisScopeOpenFiles|ButtonText">
         <source>&amp;Open Documents</source>
         <target state="translated">開啟文件(&amp;O)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Zpět</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">Obor analýzy na pozadí:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">Začátek řádku</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">Výchozí (celé řešení)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">Spustit analýzu kódu {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Zurück</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">Bereich für Hintergrundanalyse:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">Zeilenanfang</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">Standard (gesamte Lösung)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">Code Analysis ausführen für "{0}"</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Atrás</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">Ámbito de análisis en segundo plano:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">Principio de línea</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">Valor predeterminado (Toda la solución)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">Ejecutar análisis de código en {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Précédent</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">Étendue de l'analyse en arrière-plan :</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">Début de ligne</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">Par défaut (solution entière)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">Exécuter une analyse du code sur {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Indietro</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">Ambito di analisi in background:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">Inizio riga</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">Impostazione predefinita (Intera soluzione)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">Esegui Code Analysis su {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -132,6 +132,11 @@
         <target state="translated">戻る</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">バックグラウンドの分析スコープ:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">行の先頭</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">既定値 (ソリューション全体)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">{0} で Code Analysis を実行</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -132,6 +132,11 @@
         <target state="translated">뒤로</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">백그라운드 분석 범위:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">줄의 시작</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">기본값(전체 솔루션)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">{0}에서 코드 분석 실행</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Wstecz</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">Zakres analizy w tle:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">Początek wiersza</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">Domyślne (całe rozwiązanie)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">Uruchom analizę kodu dla: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Voltar</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">Escopo da análise em segundo plano:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">Início da linha</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">Padrão (solução inteira)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">Executar Análise de Código em {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Назад</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">Область фонового анализа:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">Начало строки</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">По умолчанию (все решение)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">Запустить Code Analysis для {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Geri</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">Arka plan çözümleme kapsamı:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">Satır başlangıcı</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">Varsayılan (Tüm Çözüm)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">{0} Öğesinde Code Analysis Çalıştır</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -132,6 +132,11 @@
         <target state="translated">后退</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">后台分析范围:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">行首</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">默认(整个解决方案)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">对 {0} 运行 Code Analysis</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -132,6 +132,11 @@
         <target state="translated">返回</target>
         <note />
       </trans-unit>
+      <trans-unit id="Background_analysis_scope_colon">
+        <source>Background analysis scope:</source>
+        <target state="translated">背景分析範圍:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Beginning_of_line">
         <source>Beginning of line</source>
         <target state="translated">行首</target>
@@ -290,11 +295,6 @@
       <trans-unit id="Default_Entire_Solution">
         <source>Default (Entire Solution)</source>
         <target state="translated">預設 (整個解決方案)</target>
-        <note>This text is a menu command</note>
-      </trans-unit>
-      <trans-unit id="Default_None">
-        <source>Default (None)</source>
-        <target state="new">Default (None)</target>
         <note>This text is a menu command</note>
       </trans-unit>
       <trans-unit id="Default_Open_Documents">
@@ -1155,11 +1155,6 @@
       <trans-unit id="Run_Code_Analysis_on_0">
         <source>Run Code Analysis on {0}</source>
         <target state="translated">對 {0} 執行 Code Analysis</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Run_background_code_analysis_for_colon">
-        <source>Run background code analysis for:</source>
-        <target state="new">Run background code analysis for:</target>
         <note />
       </trans-unit>
       <trans-unit id="Run_code_analysis_in_separate_process_requires_restart">

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -16,14 +16,17 @@
             <GroupBox x:Uid="AnalysisGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Analysis}">
                 <StackPanel>
-                    <Label Content="{x:Static local:AdvancedOptionPageStrings.Option_Run_background_code_analysis_for}"/>
-                    <StackPanel>
-                        <ComboBox x:Name="Run_background_code_analysis_for" IsEditable="false" AutomationProperties.Name="{x:Static local:AdvancedOptionPageStrings.Option_Run_background_code_analysis_for}">
-                            <ComboBoxItem Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_None}" Tag="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_None_Tag}" />
-                            <ComboBoxItem Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Active_File}" Tag="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Active_File_Tag}" />
-                            <ComboBoxItem Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Open_Files}" Tag="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Open_Files_Tag}" />
-                            <ComboBoxItem Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Full_Solution}" Tag="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Full_Solution_Tag}" />
-                        </ComboBox>
+                    <Label Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_analysis_scope}"/>
+                    <StackPanel Margin="15, 0, 0, 0">
+                        <RadioButton  GroupName="Background_analysis_scope"
+                                              x:Name="Background_analysis_scope_active_file"
+                                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Active_File}"/>
+                        <RadioButton  GroupName="Background_analysis_scope"
+                                              x:Name="Background_analysis_scope_open_files"
+                                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Open_Files_And_Projects}"/>
+                        <RadioButton  GroupName="Background_analysis_scope"
+                                              x:Name="Background_analysis_scope_full_solution"
+                                              Content="{x:Static local:AdvancedOptionPageStrings.Option_Background_Analysis_Scope_Full_Solution}"/>
                     </StackPanel>
                     <StackPanel>
                         <CheckBox x:Name="DisplayDiagnosticsInline"

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -46,7 +46,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             ' Keep this code in sync with the actual order options appear in Tools | Options
 
             ' Analysis
-            BindToOption(Run_background_code_analysis_for, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic)
+            BindToOption(Background_analysis_scope_active_file, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.ActiveFile, LanguageNames.VisualBasic)
+            BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects, LanguageNames.VisualBasic)
+            BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution, LanguageNames.VisualBasic)
             BindToOption(DisplayDiagnosticsInline, InlineDiagnosticsOptions.EnableInlineDiagnostics, LanguageNames.VisualBasic)
             BindToOption(at_the_end_of_the_line_of_code, InlineDiagnosticsOptions.Location, InlineDiagnosticsLocations.PlacedAtEndOfCode, LanguageNames.VisualBasic)
             BindToOption(on_the_right_edge_of_the_editor_window, InlineDiagnosticsOptions.Location, InlineDiagnosticsLocations.PlacedAtEndOfEditor, LanguageNames.VisualBasic)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageStrings.vb
@@ -3,7 +3,6 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Editor.ColorSchemes
-Imports Microsoft.CodeAnalysis.SolutionCrawler
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
     Friend Module AdvancedOptionPageStrings
@@ -16,32 +15,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         Public ReadOnly Property Option_Analysis As String =
             ServicesVSResources.Analysis
 
-        Public ReadOnly Property Option_Run_background_code_analysis_for As String =
-            ServicesVSResources.Run_background_code_analysis_for_colon
-
-        Public ReadOnly Property Option_Background_Analysis_Scope_None As String =
-            ServicesVSResources.None
+        Public ReadOnly Property Option_Background_analysis_scope As String =
+            ServicesVSResources.Background_analysis_scope_colon
 
         Public ReadOnly Property Option_Background_Analysis_Scope_Active_File As String =
             ServicesVSResources.Current_document
 
-        Public ReadOnly Property Option_Background_Analysis_Scope_Open_Files As String =
+        Public ReadOnly Property Option_Background_Analysis_Scope_Open_Files_And_Projects As String =
             ServicesVSResources.Open_documents
 
         Public ReadOnly Property Option_Background_Analysis_Scope_Full_Solution As String =
             ServicesVSResources.Entire_solution
-
-        Public ReadOnly Property Option_Background_Analysis_Scope_None_Tag As BackgroundAnalysisScope =
-            BackgroundAnalysisScope.None
-
-        Public ReadOnly Property Option_Background_Analysis_Scope_Active_File_Tag As BackgroundAnalysisScope =
-            BackgroundAnalysisScope.ActiveFile
-
-        Public ReadOnly Property Option_Background_Analysis_Scope_Open_Files_Tag As BackgroundAnalysisScope =
-            BackgroundAnalysisScope.OpenFiles
-
-        Public ReadOnly Property Option_Background_Analysis_Scope_Full_Solution_Tag As BackgroundAnalysisScope =
-            BackgroundAnalysisScope.FullSolution
 
         Public ReadOnly Property Option_run_code_analysis_in_separate_process As String =
             ServicesVSResources.Run_code_analysis_in_separate_process_requires_restart

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.SolutionCrawler;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
@@ -109,5 +108,33 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             => analyzer.IsCompilerAnalyzer() ||
                analyzer is IBuiltInAnalyzer ||
                descriptors.Length > 0 && descriptors[0].ImmutableCustomTags().Any(t => t == WellKnownDiagnosticTags.Telemetry);
+
+        /// <summary>
+        /// Return true if the given <paramref name="analyzer"/> is suppressed for the given project.
+        /// NOTE: This API is intended to be used only for performance optimization.
+        /// </summary>
+        public bool IsAnalyzerSuppressed(DiagnosticAnalyzer analyzer, Project project)
+        {
+            var options = project.CompilationOptions;
+            if (options == null || analyzer == FileContentLoadAnalyzer.Instance || analyzer.IsCompilerAnalyzer())
+            {
+                return false;
+            }
+
+            // If user has disabled analyzer execution for this project, we only want to execute required analyzers
+            // that report diagnostics with category "Compiler".
+            if (!project.State.RunAnalyzers &&
+                GetDiagnosticDescriptors(analyzer).All(d => d.Category != DiagnosticCategory.Compiler))
+            {
+                return true;
+            }
+
+            // NOTE: Previously we used to return "CompilationWithAnalyzers.IsDiagnosticAnalyzerSuppressed(options)"
+            //       on this code path, which returns true if analyzer is suppressed through compilation options.
+            //       However, this check is no longer correct as analyzers can be enabled/disabled for individual
+            //       documents through .editorconfig files. So we pessimistically assume analyzer is not suppressed
+            //       and let the core analyzer driver in the compiler layer handle skipping redundant analysis callbacks.
+            return false;
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/UnitTestingIncrementalAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/UnitTesting/UnitTestingIncrementalAnalyzer.cs
@@ -37,9 +37,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting
         public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
             => _implementation.DocumentResetAsync(document, cancellationToken);
 
-        public Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken)
-            => Task.CompletedTask;
-
         public bool NeedsReanalysisOnOptionChanged(object sender, OptionChangedEventArgs e)
             => _implementation.NeedsReanalysisOnOptionChanged(sender, new UnitTestingOptionChangedEventArgsWrapper(e));
 

--- a/src/Workspaces/Core/Portable/SolutionCrawler/BackgroundAnalysisScope.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/BackgroundAnalysisScope.cs
@@ -6,30 +6,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
     internal enum BackgroundAnalysisScope
     {
-        // NOTE: Do not change existing field ordering/values as this scope is saved as a user option,
-        //       and that would break users who have saved a non-default scope for the option.
+        ActiveFile,
+        OpenFilesAndProjects,
+        FullSolution,
 
-        /// <summary>
-        /// Analyzers are executed only for currently active document.
-        /// </summary>
-        ActiveFile = 0,
-
-        /// <summary>
-        /// Analyzers are executed for all open documents.
-        /// </summary>
-        OpenFiles = 1,
-
-        /// <summary>
-        /// Analyzers are executed for all documents in the current solution.
-        /// </summary>
-        FullSolution = 2,
-
-        /// <summary>
-        /// Analyzers are disabled for all documents.
-        /// </summary>
-        None = 3,
-
-        Minimal = None,
-        Default = ActiveFile,
+        Minimal = ActiveFile,
+        Default = OpenFilesAndProjects,
     }
 }

--- a/src/Workspaces/Core/Portable/SolutionCrawler/IIncrementalAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/IIncrementalAnalyzer.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         Task DocumentOpenAsync(Document document, CancellationToken cancellationToken);
         Task DocumentCloseAsync(Document document, CancellationToken cancellationToken);
-        Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken);
 
         /// <summary>
         /// Resets all the document state cached by the analyzer.

--- a/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
@@ -84,8 +84,5 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public static readonly InvocationReasons ReanalyzeHighPriority =
             Reanalyze.With(PredefinedInvocationReasons.HighPriority);
-
-        public static readonly InvocationReasons ActiveDocumentSwitched =
-            new(PredefinedInvocationReasons.ActiveDocumentSwitched);
     }
 }

--- a/src/Workspaces/Core/Portable/SolutionCrawler/PredefinedInvocationReasons.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/PredefinedInvocationReasons.cs
@@ -23,6 +23,5 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         public const string SemanticChanged = nameof(SemanticChanged);
 
         public const string Reanalyze = nameof(Reanalyze);
-        public const string ActiveDocumentSwitched = nameof(ActiveDocumentSwitched);
     }
 }

--- a/src/Workspaces/Core/Portable/SolutionCrawler/SolutionCrawlerOptions.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/SolutionCrawlerOptions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return BackgroundAnalysisScope.FullSolution;
                     }
 
-                    return BackgroundAnalysisScope.OpenFiles;
+                    return BackgroundAnalysisScope.Default;
 
                 default:
                     return options.GetOption(BackgroundAnalysisScopeOption, language);

--- a/src/Workspaces/Remote/ServiceHub/Services/ProjectTelemetry/ApiUsageIncrementalAnalyzerProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProjectTelemetry/ApiUsageIncrementalAnalyzerProvider.cs
@@ -192,9 +192,6 @@ namespace Microsoft.CodeAnalysis.Remote.Telemetry
             public Task DocumentResetAsync(Document document, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 
-            public Task ActiveDocumentSwitchedAsync(TextDocument document, CancellationToken cancellationToken)
-                => Task.CompletedTask;
-
             public Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 


### PR DESCRIPTION
Reverts dotnet/roslyn#57172

This PR is suspected of introducing RPS regressions.

Last known good: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/379422
First known bad: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/379438
Revert validation: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/379561

Regressed counters:
- UWP64.ProjectManagement - RegressedBeyondThreshold / 0200.Xaml Designer Load / RefSet_Image_Delta_devenv / Regressed: 6668288.00 Bytes (8.10%)
- WebToolsVS64.Debugging - RegressedBeyondThreshold / 0300.Stop Debugging / CLR_BytesAllocated_Total_devenv / Regressed: 193326051.20 Bytes (19.17%)
- WinformsVS64.Designer - RegressedBeyondThreshold / 0200.Open Existing WinForm - Async / RefSet_Image_Delta_devenv / Regressed: 12410880.00 Bytes (620.27%)

Please advise whether the failures are plausibly connected with this PR, and if so, whether we should revert, or take a follow-up PR to fix, or seek an exception. @genlu @mavasani @CyrusNajmabadi @sharwell.
