### PR TITLE
Add a few asserts/throws to our CodeModel implementation

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -1075,6 +1075,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             var newContainerNode = insertNodeIntoContainer(insertionIndex, node, containerNode);
             var newRoot = root.ReplaceNode(containerNode, newContainerNode);
+
+            Contract.ThrowIfTrue(object.ReferenceEquals(root, newRoot), $"We failed to insert the node into the tree; this might be if {nameof(containerNode)} came from a different snapshot.");
+
             document = document.WithSyntaxRoot(newRoot);
 
             if (!batchMode)

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -374,7 +375,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
             else
             {
-                workspace.TryApplyChanges(document.Project.Solution);
+                var applied = workspace.TryApplyChanges(document.Project.Solution);
+                if (!applied)
+                {
+                    FatalError.ReportAndPropagate(new Exception("Failed to apply the workspace changes."), ErrorSeverity.Critical);
+                }
             }
         }
 


### PR DESCRIPTION
While debugging some CodeModel issues yesterday, these would have greatly simplified the investigation. Just adding these now before I forget them and while we figure out how to properly fix the issues.