### PR TITLE
Catch more exceptions

### DIFF
--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
 
                         new FileInfo(filePath).IsReadOnly = true;
                     }
-                    catch (IOException ex)
+                    catch (Exception ex) when (IOUtilities.IsNormalIOException(ex))
                     {
                         _logger?.Log(FeaturesResources._0_found_in_embedded_PDB_but_could_not_write_file_1, sourceDocument.FilePath, ex.Message);
                         return null;


### PR DESCRIPTION
Trust Tomas to find the one spot I forgot to use IOUtilities

```
>System.UnauthorizedAccessException: Access to the path &apos;C:\Users\tomat\AppData\Local\Temp\MetadataAsSource\299ccf8761144445b4e0c0e582509103\PdbSourceDocumentMetadataAsSourceFileProvider\d12bdc6b-e248-49bc-a21d-d774c9351c8a\CodeFixTest`1.cs&apos; is denied.\r
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)\r
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)\r
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)\r
   at Microsoft.CodeAnalysis.PdbSourceDocument.PdbSourceDocumentLoaderService.TryGetEmbeddedSourceFile(String tempFilePath, SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry)\r
   at Microsoft.CodeAnalysis.PdbSourceDocument.PdbSourceDocumentLoaderService.&lt;LoadSourceDocumentAsync&gt;d__4.MoveNext()\r
```