### PR TITLE
Backport "Remove handling of certain BCL binaries from our build" to 17.0

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -26,9 +26,6 @@
     <FileSignInfo Include="Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ResultProvider.dll" PublicKeyToken="31bf3856ad364e35" TargetFramework=".NETFramework,Version=v2.0" CertificateName="MicrosoftWin8WinBlue"/>
     <FileSignInfo Include="Microsoft.CodeAnalysis.ExpressionEvaluator.FunctionResolver.dll" PublicKeyToken="31bf3856ad364e35" TargetFramework=".NETFramework,Version=v4.5" CertificateName="MicrosoftWin8WinBlue"/>
 
-    <FileSignInfo Include="System.Collections.Immutable.dll" CertificateName="Microsoft101240624"/>
-    <FileSignInfo Include="System.Reflection.Metadata.dll" CertificateName="Microsoft101240624"/>
-
     <!-- Sign 3rd party dlls with 3rd party cert -->
     <FileSignInfo Include="ICSharpCode.Decompiler.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="e_sqlite3.dll" CertificateName="3PartySHA2" />

--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -253,10 +253,6 @@
           "container": "TeamEng",
           "filteredTestCases": [
             {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Threading.Tasks.Extensions.dll",
-              "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
-            },
-            {
               "filename": "/Contents/MSBuild/Current/Bin/Roslyn/Microsoft.CodeAnalysis.CSharp.dll",
               "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
             },
@@ -269,19 +265,7 @@
               "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
             },
             {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Memory.dll",
-              "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
-            },
-            {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Collections.Immutable.dll",
-              "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
-            },
-            {
               "filename": "/Contents/MSBuild/Current/Bin/Roslyn/VBCSCompiler.exe",
-              "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
-            },
-            {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Runtime.CompilerServices.Unsafe.dll",
               "testCases":[ "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble" ]
             }
           ]
@@ -290,10 +274,6 @@
           "container": "VSPE",
           "filteredTestCases": [
             {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Threading.Tasks.Extensions.dll",
-              "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
-            },
-            {
               "filename": "/Contents/MSBuild/Current/Bin/Roslyn/Microsoft.CodeAnalysis.CSharp.dll",
               "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
             },
@@ -302,125 +282,18 @@
               "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
             },
             {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Text.Encoding.CodePages.dll",
-              "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
-            },
-            {
               "filename": "/Contents/MSBuild/Current/Bin/Roslyn/Microsoft.CodeAnalysis.VisualBasic.dll",
               "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
             },
             {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Memory.dll",
-              "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
-            },
-            {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Collections.Immutable.dll",
-              "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
-            },
-            {
               "filename": "/Contents/MSBuild/Current/Bin/Roslyn/VBCSCompiler.exe",
               "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
-            },
-            {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Runtime.CompilerServices.Unsafe.dll",
-              "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
-            },
-            {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Reflection.Metadata.dll",
-              "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
             }
           ]
         }
       ]
     }
   ],
-  "assemblies": [
-    {
-      "assembly": "System.Collections.Immutable.dll",
-      "instrumentationArguments": [
-        {
-          "relativeInstallationFolder": "Common7/IDE/PrivateAssemblies",
-          "instrumentationExecutable": "Common7/IDE/vsn.exe"
-        }
-      ],
-      "tests": [
-        {
-          "container": "TeamEng",
-          "testCases": [
-            "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble"
-          ]
-        },
-        {
-          "container": "VSPE",
-          "testCases": [
-            "VSPE.OptProfTests.vs_asl_cs_scenario",
-            "VSPE.OptProfTests.vs_asl_vb_scenario",
-            "VSPE.OptProfTests.vs_ddbvtqa_vbwin",
-            "VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs",
-            "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest",
-            "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment",
-            "VSPE.OptProfTests.vs_perf_DesignTime_solution_loadclose_cs_picasso",
-            "VSPE.OptProfTests.vs_perf_designtime_solution_loadclose_vb_australiangovernment",
-            "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing",
-            "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug"
-          ]
-        },
-        {
-          "container": "WinForms",
-          "testCases": [
-            "WinForms.OptProfTests.winforms_largeform_vb"
-          ]
-        },
-        {
-          "container": "XamlOptProf",
-          "testCases": [
-            "Microsoft.Test.Performance.XamlOptProfCreateTests.UwpCreateProject_SurfaceIsolated"
-          ]
-        }
-      ]
-    },
-    {
-      "assembly": "System.Reflection.Metadata.dll",
-      "instrumentationArguments": [
-        {
-          "relativeInstallationFolder": "Common7/IDE/PrivateAssemblies",
-          "instrumentationExecutable": "Common7/IDE/vsn.exe"
-        }
-      ],
-      "tests": [
-        {
-          "container": "TeamEng",
-          "testCases": [
-            "TeamEng.OptProfTest.vs_debugger_start_no_build_cs_scribble"
-          ]
-        },
-        {
-          "container": "VSPE",
-          "testCases": [
-            "VSPE.OptProfTests.vs_asl_cs_scenario",
-            "VSPE.OptProfTests.vs_asl_vb_scenario",
-            "VSPE.OptProfTests.vs_ddbvtqa_vbwin",
-            "VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs",
-            "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest",
-            "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment",
-            "VSPE.OptProfTests.vs_perf_designtime_solution_loadclose_vb_australiangovernment",
-            "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing",
-            "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug"
-          ]
-        },
-        {
-          "container": "WinForms",
-          "testCases": [
-            "WinForms.OptProfTests.winforms_largeform_vb"
-          ]
-        },
-        {
-          "container": "XamlOptProf",
-          "testCases": [
-            "Microsoft.Test.Performance.XamlOptProfCreateTests.UwpCreateProject_SurfaceIsolated"
-          ]
-        }
-      ]
-    }
+  "assemblies": [    
   ]
 }

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/DesktopCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/DesktopCompilerArtifacts.targets
@@ -56,23 +56,21 @@
         
         We don't currently collect optimization data for the following assemblies.
       -->
-      <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Threading.Tasks.Extensions.dll"/>
       <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Buffers.dll"/>
+      <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Collections.Immutable.dll"/>
       <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Memory.dll"/>
       <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Numerics.Vectors.dll"/>      
-      <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Text.Encoding.CodePages.dll"/>
+      <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Reflection.Metadata.dll"/>
+      <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Runtime.CompilerServices.Unsafe.dll"/> 
+      <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Text.Encoding.CodePages.dll"/>   
+      <_NoOptimizationData Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Threading.Tasks.Extensions.dll"/>  
       
       <!--
         System.Numerics.Vector requires JIT, since its size is dynamic and based on the underlying CPU support.
       -->
       <_NoNGen Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Numerics.Vectors.dll"/>
       
-      <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.*.dll" Exclude="@(_NoOptimizationData)" NgenArchitecture="all" NgenApplication="VBCSCompiler.exe" OverwriteNgenOptimizationData="true"/>
-      
-      <!-- Note: do not use Update attribute (see https://github.com/microsoft/msbuild/issues/1124) -->
-      <DesktopCompilerArtifact NgenPriority="1" Condition="'%(Identity)' == '$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Collections.Immutable.dll'" />
-      <DesktopCompilerArtifact NgenPriority="1" Condition="'%(Identity)' == '$(ArtifactsBinDir)csi\$(Configuration)\net472\System.Reflection.Metadata.dll'" />
-      
+      <DesktopCompilerArtifact Include="$(ArtifactsBinDir)csi\$(Configuration)\net472\System.*.dll" Exclude="@(_NoOptimizationData)" NgenArchitecture="all" NgenApplication="VBCSCompiler.exe" OverwriteNgenOptimizationData="true"/>            
       <DesktopCompilerArtifact Include="@(_NoOptimizationData)" Exclude="@(_NoNGen)" NgenArchitecture="all" NgenApplication="VBCSCompiler.exe" OverwriteNgenOptimizationData="false"/>
       <DesktopCompilerArtifact Include="@(_NoNGen)" />
 

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -51,21 +51,10 @@
     <ExpectedDependency Include="Microsoft.DiaSymReader"/>
     <ExpectedDependency Include="Microsoft.CodeAnalysis.Elfie"/>
     <ExpectedDependency Include="System.Buffers" />
-    <ExpectedDependency Include="System.Collections.Immutable" OptimizeAssemblies="lib/netstandard2.0/System.Collections.Immutable.dll" UnsignAssemblies="lib/netstandard1.0/System.Collections.Immutable.dll" />
-    <ExpectedDependency Include="System.Reflection.Metadata" OptimizeAssemblies="lib/netstandard2.0/System.Reflection.Metadata.dll" UnsignAssemblies="lib/netstandard1.1/System.Reflection.Metadata.dll" />
     <ExpectedDependency Include="System.Memory"/>
-    <ExpectedDependency Include="System.Runtime.CompilerServices.Unsafe" OptimizeAssemblies="lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.dll" />
     <!-- We do not have a training scenario that covers lib/netstandard2.0/System.Text.Encoding.CodePages.dll  -->
     <ExpectedDependency Include="System.Text.Encoding.CodePages" />
     <ExpectedDependency Include="System.Numerics.Vectors"/>
-    <!--
-      Do not overwrite optimization data for this binary for now.
-      This assembly is signed by Open key in CoreFX and MicroBuild does not support this key.
-      Arcade SignTool doesn't support signing directly at this point either.
-      https://github.com/dotnet/arcade/issues/1204
-      TODO: add OptimizeAssemblies="lib/netstandard2.0/System.Threading.Tasks.Extensions.dll"
-    -->
-    <ExpectedDependency Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
   <Target Name="_CalculateDependenciesToInsert" DependsOnTargets="ResolveAssemblyReferences;GetAssemblyVersion">
@@ -136,14 +125,18 @@
       <_Dependency Remove="NuGet.VisualStudio.Contracts"/>
       <_Dependency Remove="stdole"/>
       <_Dependency Remove="StreamJsonRpc"/>
+      <_Dependency Remove="System.Collections.Immutable"/>
       <_Dependency Remove="System.Diagnostics.DiagnosticSource"/>
       <_Dependency Remove="System.IO.Pipelines"/>
+      <_Dependency Remove="System.Reflection.Metadata"/>
       <_Dependency Remove="System.Reflection.TypeExtensions"/>
+      <_Dependency Remove="System.Runtime.CompilerServices.Unsafe"/>
       <_Dependency Remove="System.ValueTuple"/>
       <_Dependency Remove="System.Security.AccessControl"/>
       <_Dependency Remove="System.Security.Principal.Windows"/>
       <_Dependency Remove="System.Threading.AccessControl"/>
       <_Dependency Remove="System.Threading.Tasks.Dataflow"/>
+      <_Dependency Remove="System.Threading.Tasks.Extensions" />
       <_Dependency Remove="VSLangProj"/>
       <_Dependency Remove="VSLangProj2"/>
       <_Dependency Remove="VSLangProj80"/>
@@ -261,14 +254,15 @@
     <MakeDir Directories="$(VisualStudioBuildPackagesDir)"/>
 
     <!-- Unsign assemblies that need to be unsigned but not optimized. -->
-    <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_UnsignAssembly.Identity)" />
+    <Microsoft.DotNet.Arcade.Sdk.Unsign FilePath="%(_UnsignAssembly.Identity)" Condition="'@(_UnsignAssembly)' != ''"/>
 
     <!-- Repack optimized dependencies -->
     <Microsoft.DotNet.Tools.ReplacePackageParts SourcePackage="%(_PackageToRepack.Identity)"
                                                 DestinationFolder="$(VisualStudioBuildPackagesDir)"
                                                 NewVersionSuffix="$(_OptimizedNuGetPackageVersionSuffix)"
                                                 Parts="%(_PackageToRepack.Parts)"
-                                                ReplacementFiles="%(_PackageToRepack.ReplacementFiles)">
+                                                ReplacementFiles="%(_PackageToRepack.ReplacementFiles)"
+                                                Condition="'@(_PackageToRepack)' != ''">
       <Output TaskParameter="NewPackage" ItemName="FileWrites" />
     </Microsoft.DotNet.Tools.ReplacePackageParts>
 


### PR DESCRIPTION
Backporting #57832 to 17.0 branch. This fixes an issue where auto insertions specify [bad package versions](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/379949?_a=files&path=/src/ConfigData/Packages/Microsoft.VisualStudio.MinShell/corefx.props) for S.C.I and S.R.M.

This PR was produced using `git cherry-pick -m 1 ac09ff70edae5ebbc301538e055ae93c0cf86549` (ac09ff70edae5ebbc301538e055ae93c0cf86549). Hopefully that is right.

Validation insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/382721