### PR TITLE
SyntaxWrappingOptions

### DIFF
--- a/src/EditorFeatures/CSharpTest/Wrapping/AbstractWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/AbstractWrappingTests.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
-using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.SymbolSearch;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
 {
@@ -18,17 +18,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
         protected sealed override ImmutableArray<CodeAction> MassageActions(ImmutableArray<CodeAction> actions)
             => FlattenActions(actions);
 
-        private protected OptionsCollection GetIndentionColumn(int column)
-            => new OptionsCollection(GetLanguage())
-               {
-                   { FormattingOptions2.PreferredWrappingColumn, column }
-               };
+        private protected static CodeActionOptions GetIndentionColumn(int column)
+            => new(SymbolSearchOptions.Default, WrappingColumn: column);
 
         protected Task TestAllWrappingCasesAsync(
             string input,
             params string[] outputs)
         {
-            return TestAllWrappingCasesAsync(input, options: null, outputs);
+            return TestAllWrappingCasesAsync(input, options: CodeActionOptions.Default, outputs);
+        }
+
+        private protected Task TestAllWrappingCasesAsync(
+            string input,
+            CodeActionOptions options,
+            params string[] outputs)
+        {
+            var parameters = new TestParameters(codeActionOptions: options);
+            return TestAllInRegularAndScriptAsync(input, parameters, outputs);
         }
 
         private protected Task TestAllWrappingCasesAsync(

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -49,28 +49,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         internal async Task<CodeRefactoring> GetCodeRefactoringAsync(
             TestWorkspace workspace, TestParameters parameters)
         {
-            return (await GetCodeRefactoringsAsync(workspace, parameters)).FirstOrDefault();
-        }
-
-        private async Task<IEnumerable<CodeRefactoring>> GetCodeRefactoringsAsync(
-            TestWorkspace workspace, TestParameters parameters)
-        {
             var provider = CreateCodeRefactoringProvider(workspace, parameters);
-            return SpecializedCollections.SingletonEnumerable(
-                await GetCodeRefactoringAsync(provider, workspace));
-        }
 
-        private static async Task<CodeRefactoring> GetCodeRefactoringAsync(
-            CodeRefactoringProvider provider,
-            TestWorkspace workspace)
-        {
             var documentsWithSelections = workspace.Documents.Where(d => !d.IsLinkFile && d.SelectedSpans.Count == 1);
             Debug.Assert(documentsWithSelections.Count() == 1, "One document must have a single span annotation");
             var span = documentsWithSelections.Single().SelectedSpans.Single();
             var actions = ArrayBuilder<(CodeAction, TextSpan?)>.GetInstance();
             var document = workspace.CurrentSolution.GetDocument(documentsWithSelections.Single().Id);
-            var options = CodeActionOptions.Default;
-            var context = new CodeRefactoringContext(document, span, (a, t) => actions.Add((a, t)), options, CancellationToken.None);
+            var context = new CodeRefactoringContext(document, span, (a, t) => actions.Add((a, t)), parameters.codeActionOptions, CancellationToken.None);
             await provider.ComputeRefactoringsAsync(context);
 
             var result = actions.Count > 0 ? new CodeRefactoring(provider, actions.ToImmutable()) : null;

--- a/src/EditorFeatures/VisualBasicTest/Wrapping/AbstractParameterWrappingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Wrapping/AbstractParameterWrappingTests.vb
@@ -6,7 +6,7 @@ Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
-Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.SymbolSearch
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Wrapping
     Public MustInherit Class AbstractWrappingTests
@@ -16,17 +16,24 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Wrapping
             Return FlattenActions(actions)
         End Function
 
-        Private Protected Function GetIndentionColumn(column As Integer) As OptionsCollection
-            Return New OptionsCollection(GetLanguage()) From {
-                   {FormattingOptions2.PreferredWrappingColumn, column}
-               }
+        Private Protected Shared Function GetIndentionColumn(column As Integer) As CodeActionOptions
+            Return New CodeActionOptions(SymbolSearchOptions.Default, WrappingColumn:=column)
         End Function
 
         Protected Function TestAllWrappingCasesAsync(
             input As String,
             ParamArray outputs As String()) As Task
 
-            Return TestAllWrappingCasesAsync(input, options:=Nothing, outputs)
+            Return TestAllWrappingCasesAsync(input, options:=CodeActionOptions.Default, outputs)
+        End Function
+
+        Private Protected Function TestAllWrappingCasesAsync(
+            input As String,
+            options As CodeActionOptions,
+            ParamArray outputs As String()) As Task
+
+            Dim parameters = New TestParameters(codeActionOptions:=options)
+            Return TestAllInRegularAndScriptAsync(input, parameters, outputs)
         End Function
 
         Private Protected Function TestAllWrappingCasesAsync(

--- a/src/Features/CSharp/Portable/Wrapping/CSharpSyntaxWrappingOptions.cs
+++ b/src/Features/CSharp/Portable/Wrapping/CSharpSyntaxWrappingOptions.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Wrapping;
+
+namespace Microsoft.CodeAnalysis.CSharp.Wrapping
+{
+    internal sealed class CSharpSyntaxWrappingOptions : SyntaxWrappingOptions
+    {
+        public readonly bool NewLinesForBracesInObjectCollectionArrayInitializers;
+
+        public CSharpSyntaxWrappingOptions(
+            bool useTabs,
+            int tabSize,
+            string newLine,
+            int wrappingColumn,
+            OperatorPlacementWhenWrappingPreference operatorPlacement,
+            bool newLinesForBracesInObjectCollectionArrayInitializers)
+            : base(useTabs, tabSize, newLine, wrappingColumn, operatorPlacement)
+        {
+            NewLinesForBracesInObjectCollectionArrayInitializers = newLinesForBracesInObjectCollectionArrayInitializers;
+        }
+
+        public static CSharpSyntaxWrappingOptions Create(AnalyzerConfigOptions options, CodeActionOptions ideOptions)
+            => new(
+                useTabs: options.GetOption(FormattingOptions2.UseTabs),
+                tabSize: options.GetOption(FormattingOptions2.TabSize),
+                newLine: options.GetOption(FormattingOptions2.NewLine),
+                operatorPlacement: options.GetOption(CodeStyleOptions2.OperatorPlacementWhenWrapping),
+                wrappingColumn: ideOptions.WrappingColumn,
+                newLinesForBracesInObjectCollectionArrayInitializers: options.GetOption(CSharpFormattingOptions2.NewLinesForBracesInObjectCollectionArrayInitializers));
+    }
+}

--- a/src/Features/CSharp/Portable/Wrapping/CSharpWrappingCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/Wrapping/CSharpWrappingCodeRefactoringProvider.cs
@@ -5,10 +5,12 @@
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Wrapping.BinaryExpression;
 using Microsoft.CodeAnalysis.CSharp.Wrapping.ChainedExpression;
 using Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Wrapping;
 
 namespace Microsoft.CodeAnalysis.CSharp.Wrapping
@@ -30,5 +32,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping
             : base(s_wrappers)
         {
         }
+
+        protected override SyntaxWrappingOptions GetWrappingOptions(AnalyzerConfigOptions options, CodeActionOptions ideOptions)
+            => CSharpSyntaxWrappingOptions.Create(options, ideOptions);
     }
 }

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpArgumentWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpArgumentWrapper.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Wrapping;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
@@ -28,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
         public override bool Supports_WrapEveryGroup_UnwrapFirst => true;
         public override bool Supports_WrapLongGroup_UnwrapFirst => true;
 
-        protected override bool ShouldMoveOpenBraceToNewLine(OptionSet options)
+        protected override bool ShouldMoveOpenBraceToNewLine(SyntaxWrappingOptions options)
             => false;
 
         protected override bool ShouldMoveCloseBraceToNewLine

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Wrapping;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
@@ -28,8 +27,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
         protected override string Indent_wrapped_items => throw ExceptionUtilities.Unreachable;
         protected override string Unwrap_and_indent_all_items => throw ExceptionUtilities.Unreachable;
 
-        protected override bool ShouldMoveOpenBraceToNewLine(OptionSet options)
-            => options.GetOption(CSharpFormattingOptions.NewLinesForBracesInObjectCollectionArrayInitializers);
+        protected override bool ShouldMoveOpenBraceToNewLine(SyntaxWrappingOptions options)
+            => ((CSharpSyntaxWrappingOptions)options).NewLinesForBracesInObjectCollectionArrayInitializers;
 
         protected override bool ShouldMoveCloseBraceToNewLine
             => true;

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpParameterWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpParameterWrapper.cs
@@ -5,11 +5,10 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Utilities;
+using Microsoft.CodeAnalysis.Wrapping;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
@@ -30,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
         public override bool Supports_WrapEveryGroup_UnwrapFirst => true;
         public override bool Supports_WrapLongGroup_UnwrapFirst => true;
 
-        protected override bool ShouldMoveOpenBraceToNewLine(OptionSet options)
+        protected override bool ShouldMoveOpenBraceToNewLine(SyntaxWrappingOptions options)
             => false;
 
         protected override bool ShouldMoveCloseBraceToNewLine

--- a/src/Features/Core/Portable/Wrapping/AbstractCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/AbstractCodeActionComputer.cs
@@ -50,11 +50,7 @@ namespace Microsoft.CodeAnalysis.Wrapping
             protected readonly Document OriginalDocument;
             protected readonly SourceText OriginalSourceText;
             protected readonly CancellationToken CancellationToken;
-
-            protected readonly bool UseTabs;
-            protected readonly int TabSize;
-            protected readonly string NewLine;
-            protected readonly int WrappingColumn;
+            protected readonly SyntaxWrappingOptions Options;
 
             protected readonly SyntaxTriviaList NewLineTrivia;
             protected readonly SyntaxTriviaList SingleWhitespaceTrivia;
@@ -70,22 +66,18 @@ namespace Microsoft.CodeAnalysis.Wrapping
                 TWrapper service,
                 Document document,
                 SourceText originalSourceText,
-                DocumentOptionSet options,
+                SyntaxWrappingOptions options,
                 CancellationToken cancellationToken)
             {
                 Wrapper = service;
                 OriginalDocument = document;
                 OriginalSourceText = originalSourceText;
                 CancellationToken = cancellationToken;
-
-                UseTabs = options.GetOption(FormattingOptions2.UseTabs);
-                TabSize = options.GetOption(FormattingOptions2.TabSize);
-                NewLine = options.GetOption(FormattingOptions2.NewLine);
-                WrappingColumn = options.GetOption(FormattingOptions2.PreferredWrappingColumn);
+                Options = options;
 
                 var generator = SyntaxGenerator.GetGenerator(document);
                 var generatorInternal = document.GetRequiredLanguageService<SyntaxGeneratorInternal>();
-                NewLineTrivia = new SyntaxTriviaList(generatorInternal.EndOfLine(NewLine));
+                NewLineTrivia = new SyntaxTriviaList(generatorInternal.EndOfLine(options.NewLine));
                 SingleWhitespaceTrivia = new SyntaxTriviaList(generator.Whitespace(" "));
             }
 
@@ -96,9 +88,9 @@ namespace Microsoft.CodeAnalysis.Wrapping
 
             protected string GetIndentationAfter(SyntaxNodeOrToken nodeOrToken, FormattingOptions.IndentStyle indentStyle)
             {
-                var newSourceText = OriginalSourceText.WithChanges(new TextChange(new TextSpan(nodeOrToken.Span.End, 0), NewLine));
+                var newSourceText = OriginalSourceText.WithChanges(new TextChange(new TextSpan(nodeOrToken.Span.End, 0), Options.NewLine));
                 newSourceText = newSourceText.WithChanges(
-                    new TextChange(TextSpan.FromBounds(nodeOrToken.Span.End + NewLine.Length, newSourceText.Length), ""));
+                    new TextChange(TextSpan.FromBounds(nodeOrToken.Span.End + Options.NewLine.Length, newSourceText.Length), ""));
                 var newDocument = OriginalDocument.WithText(newSourceText);
 
                 var indentationService = Wrapper.IndentationService;
@@ -108,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Wrapping
                     indentStyle,
                     CancellationToken);
 
-                return desiredIndentation.GetIndentationString(newSourceText, UseTabs, TabSize);
+                return desiredIndentation.GetIndentationString(newSourceText, Options.UseTabs, Options.TabSize);
             }
 
             /// <summary>

--- a/src/Features/Core/Portable/Wrapping/AbstractWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/AbstractWrapper.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
+using Microsoft.CodeAnalysis.Indentation;
+using Microsoft.CodeAnalysis.Text;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,9 +12,6 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Wrapping
 {
-    using System.Linq;
-    using Microsoft.CodeAnalysis.Indentation;
-    using Microsoft.CodeAnalysis.Text;
 
     /// <summary>
     /// Common implementation of all <see cref="ISyntaxWrapper"/>.  This type takes care of a lot of common logic for
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Wrapping
             => IndentationService = indentationService;
 
         public abstract Task<ICodeActionComputer?> TryCreateComputerAsync(
-            Document document, int position, SyntaxNode node, bool containsSyntaxError, CancellationToken cancellationToken);
+            Document document, int position, SyntaxNode node, SyntaxWrappingOptions options, bool containsSyntaxError, CancellationToken cancellationToken);
 
         protected static async Task<bool> ContainsUnformattableContentAsync(
             Document document, IEnumerable<SyntaxNodeOrToken> nodesAndTokens, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Wrapping/BinaryExpression/AbstractBinaryExpressionWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/BinaryExpression/AbstractBinaryExpressionWrapper.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.BinaryExpression
         protected abstract SyntaxTriviaList GetNewLineBeforeOperatorTrivia(SyntaxTriviaList newLine);
 
         public sealed override async Task<ICodeActionComputer?> TryCreateComputerAsync(
-            Document document, int position, SyntaxNode node, bool containsSyntaxError, CancellationToken cancellationToken)
+            Document document, int position, SyntaxNode node, SyntaxWrappingOptions options, bool containsSyntaxError, CancellationToken cancellationToken)
         {
             if (containsSyntaxError)
                 return null;
@@ -87,7 +87,6 @@ namespace Microsoft.CodeAnalysis.Wrapping.BinaryExpression
                 return null;
 
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             return new BinaryExpressionCodeActionComputer(
                 this, document, sourceText, options, binaryExpr,
                 exprsAndOperators, cancellationToken);

--- a/src/Features/Core/Portable/Wrapping/BinaryExpression/BinaryExpressionCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/BinaryExpression/BinaryExpressionCodeActionComputer.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.Wrapping.BinaryExpression
             AbstractCodeActionComputer<AbstractBinaryExpressionWrapper<TBinaryExpressionSyntax>>
         {
             private readonly ImmutableArray<SyntaxNodeOrToken> _exprsAndOperators;
-            private readonly OperatorPlacementWhenWrappingPreference _preference;
 
             /// <summary>
             /// trivia to place at the end of a node prior to a chunk that is wrapped.
@@ -48,14 +47,13 @@ namespace Microsoft.CodeAnalysis.Wrapping.BinaryExpression
                 AbstractBinaryExpressionWrapper<TBinaryExpressionSyntax> service,
                 Document document,
                 SourceText originalSourceText,
-                DocumentOptionSet options,
+                SyntaxWrappingOptions options,
                 TBinaryExpressionSyntax binaryExpression,
                 ImmutableArray<SyntaxNodeOrToken> exprsAndOperators,
                 CancellationToken cancellationToken)
                 : base(service, document, originalSourceText, options, cancellationToken)
             {
                 _exprsAndOperators = exprsAndOperators;
-                _preference = options.GetOption(CodeStyleOptions2.OperatorPlacementWhenWrapping);
 
                 var generator = SyntaxGenerator.GetGenerator(document);
 
@@ -63,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.BinaryExpression
 
                 _indentAndAlignTrivia = new SyntaxTriviaList(generator.Whitespace(
                     OriginalSourceText.GetOffset(binaryExpression.Span.Start)
-                                      .CreateIndentationString(UseTabs, TabSize)));
+                                      .CreateIndentationString(options.UseTabs, options.TabSize)));
 
                 _smartIndentTrivia = new SyntaxTriviaList(generator.Whitespace(
                     GetSmartIndentationAfter(_exprsAndOperators[1])));
@@ -94,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.BinaryExpression
                     var opToken = _exprsAndOperators[i].AsToken();
                     var right = _exprsAndOperators[i + 1].AsNode();
 
-                    if (_preference == OperatorPlacementWhenWrappingPreference.BeginningOfLine)
+                    if (Options.OperatorPlacement == OperatorPlacementWhenWrappingPreference.BeginningOfLine)
                     {
                         // convert: 
                         //      (a == b) && (c == d) to

--- a/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
         protected abstract SyntaxTriviaList GetNewLineBeforeOperatorTrivia(SyntaxTriviaList newLine);
 
         public sealed override async Task<ICodeActionComputer?> TryCreateComputerAsync(
-            Document document, int position, SyntaxNode node, bool containsSyntaxError, CancellationToken cancellationToken)
+            Document document, int position, SyntaxNode node, SyntaxWrappingOptions options, bool containsSyntaxError, CancellationToken cancellationToken)
         {
             if (containsSyntaxError)
                 return null;
@@ -108,7 +108,6 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
             // Looks good.  Create the action computer which will actually determine
             // the set of wrapping options to provide.
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             return new CallExpressionCodeActionComputer(
                 this, document, sourceText, options, chunks, cancellationToken);
         }

--- a/src/Features/Core/Portable/Wrapping/ChainedExpression/ChainedExpressionCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/ChainedExpression/ChainedExpressionCodeActionComputer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
                 AbstractChainedExpressionWrapper<TNameSyntax, TBaseArgumentListSyntax> service,
                 Document document,
                 SourceText originalSourceText,
-                DocumentOptionSet options,
+                SyntaxWrappingOptions options,
                 ImmutableArray<ImmutableArray<SyntaxNodeOrToken>> chunks,
                 CancellationToken cancellationToken)
                 : base(service, document, originalSourceText, options, cancellationToken)
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
                 var firstPeriod = chunks[0][0];
 
                 _firstPeriodIndentationTrivia = new SyntaxTriviaList(generator.Whitespace(
-                    OriginalSourceText.GetOffset(firstPeriod.SpanStart).CreateIndentationString(UseTabs, TabSize)));
+                    OriginalSourceText.GetOffset(firstPeriod.SpanStart).CreateIndentationString(options.UseTabs, options.TabSize)));
 
                 _smartIndentTrivia = new SyntaxTriviaList(generator.Whitespace(
                     GetSmartIndentationAfter(firstPeriod)));
@@ -116,8 +116,8 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
 
             private async Task AddWrapLongCodeActionAsync(ArrayBuilder<WrapItemsAction> actions)
             {
-                actions.Add(await TryCreateCodeActionAsync(GetWrapEdits(WrappingColumn, align: false), FeaturesResources.Wrapping, FeaturesResources.Wrap_long_call_chain).ConfigureAwait(false));
-                actions.Add(await TryCreateCodeActionAsync(GetWrapEdits(WrappingColumn, align: true), FeaturesResources.Wrapping, FeaturesResources.Wrap_and_align_long_call_chain).ConfigureAwait(false));
+                actions.Add(await TryCreateCodeActionAsync(GetWrapEdits(Options.WrappingColumn, align: false), FeaturesResources.Wrapping, FeaturesResources.Wrap_long_call_chain).ConfigureAwait(false));
+                actions.Add(await TryCreateCodeActionAsync(GetWrapEdits(Options.WrappingColumn, align: true), FeaturesResources.Wrapping, FeaturesResources.Wrap_and_align_long_call_chain).ConfigureAwait(false));
             }
 
             private ImmutableArray<Edit> GetWrapEdits(int wrappingColumn, bool align)

--- a/src/Features/Core/Portable/Wrapping/ISyntaxWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/ISyntaxWrapper.cs
@@ -26,6 +26,6 @@ namespace Microsoft.CodeAnalysis.Wrapping
         /// node passed in.  Returns <see langword="null"/> if this Wrapper cannot wrap this node.
         /// </summary>
         Task<ICodeActionComputer> TryCreateComputerAsync(
-            Document document, int position, SyntaxNode node, bool containsSyntaxError, CancellationToken cancellationToken);
+            Document document, int position, SyntaxNode node, SyntaxWrappingOptions options, bool containsSyntaxError, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Wrapping/SeparatedSyntaxList/AbstractSeparatedSyntaxListWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/SeparatedSyntaxList/AbstractSeparatedSyntaxListWrapper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList
         }
 
         protected abstract bool ShouldMoveCloseBraceToNewLine { get; }
-        protected abstract bool ShouldMoveOpenBraceToNewLine(OptionSet options);
+        protected abstract bool ShouldMoveOpenBraceToNewLine(SyntaxWrappingOptions options);
 
         protected abstract TListSyntax? TryGetApplicableList(SyntaxNode node);
         protected abstract SeparatedSyntaxList<TListItemSyntax> GetListItems(TListSyntax listSyntax);
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList
             SyntaxNode root, int position, SyntaxNode declaration, bool containsSyntaxError, TListSyntax listSyntax);
 
         public override async Task<ICodeActionComputer?> TryCreateComputerAsync(
-            Document document, int position, SyntaxNode declaration, bool containsSyntaxError, CancellationToken cancellationToken)
+            Document document, int position, SyntaxNode declaration, SyntaxWrappingOptions options, bool containsSyntaxError, CancellationToken cancellationToken)
         {
             var listSyntax = TryGetApplicableList(declaration);
             if (listSyntax == null)
@@ -74,7 +74,6 @@ namespace Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList
             if (containsUnformattableContent)
                 return null;
 
-            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             return new SeparatedSyntaxListCodeActionComputer(
                 this, document, sourceText, options, listSyntax, listItems, cancellationToken);

--- a/src/Features/Core/Portable/Wrapping/SeparatedSyntaxList/SeparatedSyntaxListCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/SeparatedSyntaxList/SeparatedSyntaxListCodeActionComputer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList
                 AbstractSeparatedSyntaxListWrapper<TListSyntax, TListItemSyntax> service,
                 Document document,
                 SourceText sourceText,
-                DocumentOptionSet options,
+                SyntaxWrappingOptions options,
                 TListSyntax listSyntax,
                 SeparatedSyntaxList<TListItemSyntax> listItems,
                 CancellationToken cancellationToken)
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList
                 var openToken = _listSyntax.GetFirstToken();
                 var afterOpenTokenOffset = OriginalSourceText.GetOffset(openToken.Span.End);
 
-                var indentString = afterOpenTokenOffset.CreateIndentationString(UseTabs, TabSize);
+                var indentString = afterOpenTokenOffset.CreateIndentationString(Options.UseTabs, Options.TabSize);
                 return indentString;
             }
 
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList
 
                     if (i > 0)
                     {
-                        if (currentOffset < WrappingColumn)
+                        if (currentOffset < Options.WrappingColumn)
                         {
                             // this item would not make us go pass our preferred wrapping column. So
                             // keep it on this line, making sure there's a space between the previous

--- a/src/Features/Core/Portable/Wrapping/SyntaxWrappingOptions.cs
+++ b/src/Features/Core/Portable/Wrapping/SyntaxWrappingOptions.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Microsoft.CodeAnalysis.Wrapping
+{
+    internal abstract class SyntaxWrappingOptions
+    {
+        public readonly bool UseTabs;
+        public readonly int TabSize;
+        public readonly string NewLine;
+        public readonly int WrappingColumn;
+        public readonly OperatorPlacementWhenWrappingPreference OperatorPlacement;
+
+        protected SyntaxWrappingOptions(
+            bool useTabs,
+            int tabSize,
+            string newLine,
+            int wrappingColumn,
+            OperatorPlacementWhenWrappingPreference operatorPlacement)
+        {
+            UseTabs = useTabs;
+            TabSize = tabSize;
+            NewLine = newLine;
+            WrappingColumn = wrappingColumn;
+            OperatorPlacement = operatorPlacement;
+        }
+    }
+}

--- a/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/AbstractVisualBasicSeparatedSyntaxListWrapper.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/AbstractVisualBasicSeparatedSyntaxListWrapper.vb
@@ -2,8 +2,8 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.VisualBasic.Indentation
+Imports Microsoft.CodeAnalysis.Wrapping
 Imports Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping.SeparatedSyntaxList
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping.SeparatedSyntaxList
 
         ' The visual basic language always requires the open brace to be on the same line as the collection
         ' being initialized.
-        Protected NotOverridable Overrides Function ShouldMoveOpenBraceToNewLine(options As OptionSet) As Boolean
+        Protected NotOverridable Overrides Function ShouldMoveOpenBraceToNewLine(options As SyntaxWrappingOptions) As Boolean
             Return False
         End Function
     End Class

--- a/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicArgumentWrapper.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicArgumentWrapper.vb
@@ -2,7 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax

--- a/src/Features/VisualBasic/Portable/Wrapping/VisualBasicSyntaxWrappingOptions.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/VisualBasicSyntaxWrappingOptions.vb
@@ -1,0 +1,35 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.CodeActions
+Imports Microsoft.CodeAnalysis.CodeStyle
+Imports Microsoft.CodeAnalysis.Wrapping
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Formatting
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping
+
+    Friend NotInheritable Class VisualBasicSyntaxWrappingOptions
+        Inherits SyntaxWrappingOptions
+
+        Public Sub New(
+            useTabs As Boolean,
+            tabSize As Integer,
+            newLine As String,
+            wrappingColumn As Integer,
+            operatorPlacement As OperatorPlacementWhenWrappingPreference)
+
+            MyBase.New(useTabs, tabSize, newLine, wrappingColumn, operatorPlacement)
+        End Sub
+
+        Public Shared Function Create(options As AnalyzerConfigOptions, ideOptions As CodeActionOptions) As VisualBasicSyntaxWrappingOptions
+            Return New VisualBasicSyntaxWrappingOptions(
+                useTabs:=options.GetOption(FormattingOptions2.UseTabs),
+                tabSize:=options.GetOption(FormattingOptions2.TabSize),
+                newLine:=options.GetOption(FormattingOptions2.NewLine),
+                operatorPlacement:=options.GetOption(CodeStyleOptions2.OperatorPlacementWhenWrapping),
+                wrappingColumn:=ideOptions.WrappingColumn)
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/Wrapping/VisualBasicWrappingCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/VisualBasicWrappingCodeRefactoringProvider.vb
@@ -5,7 +5,9 @@
 Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Diagnostics.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic.Wrapping.BinaryExpression
 Imports Microsoft.CodeAnalysis.VisualBasic.Wrapping.ChainedExpression
 Imports Microsoft.CodeAnalysis.VisualBasic.Wrapping.SeparatedSyntaxList
@@ -29,5 +31,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping
         Public Sub New()
             MyBase.New(s_wrappers)
         End Sub
+
+        Protected Overrides Function GetWrappingOptions(options As AnalyzerConfigOptions, ideOptions As CodeActionOptions) As SyntaxWrappingOptions
+            Return VisualBasicSyntaxWrappingOptions.Create(options, ideOptions)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -494,6 +494,13 @@ namespace Microsoft.CodeAnalysis
             return _cachedOptions.GetValueAsync(cancellationToken);
         }
 
+        internal async ValueTask<AnalyzerConfigOptions> GetAnalyzerConfigOptionsAsync(CancellationToken cancellationToken)
+        {
+            var optionService = Project.Solution.Workspace.Services.GetRequiredService<IOptionService>();
+            var documentOptions = await GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            return documentOptions.AsAnalyzerConfigOptions(optionService, Project.Language);
+        }
+
         private void InitializeCachedOptions(OptionSet solutionOptions)
         {
             var newAsyncLazy = new AsyncLazy<DocumentOptionSet>(async c =>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
@@ -76,19 +76,6 @@ namespace Microsoft.CodeAnalysis.Formatting
             new(FeatureName, FormattingOptionGroups.NewLine, nameof(InsertFinalNewLine), defaultValue: false,
             storageLocation: EditorConfigStorageLocation.ForBoolOption("insert_final_newline"));
 
-        /// <summary>
-        /// Default value of 120 was picked based on the amount of code in a github.com diff at 1080p.
-        /// That resolution is the most common value as per the last DevDiv survey as well as the latest
-        /// Steam hardware survey.  This also seems to a reasonable length default in that shorter
-        /// lengths can often feel too cramped for .NET languages, which are often starting with a
-        /// default indentation of at least 16 (for namespace, class, member, plus the final construct
-        /// indentation).
-        /// 
-        /// TODO: Currently the option has no storage and always has its default value. See https://github.com/dotnet/roslyn/pull/30422#issuecomment-436118696.
-        /// </summary>
-        internal static Option2<int> PreferredWrappingColumn { get; } =
-            new(FeatureName, FormattingOptionGroups.NewLine, nameof(PreferredWrappingColumn), defaultValue: 120);
-
 #if !CODE_STYLE
         internal static readonly ImmutableArray<IOption> Options = ImmutableArray.Create<IOption>(
             UseTabs,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CodeActionOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CodeActionOptions.cs
@@ -22,8 +22,21 @@ namespace Microsoft.CodeAnalysis.CodeActions
     internal readonly record struct CodeActionOptions(
         [property: DataMember(Order = 0)] SymbolSearchOptions SearchOptions,
         [property: DataMember(Order = 1)] bool HideAdvancedMembers = false,
-        [property: DataMember(Order = 2)] bool IsBlocking = false)
+        [property: DataMember(Order = 2)] bool IsBlocking = false,
+        [property: DataMember(Order = 3)] int WrappingColumn = CodeActionOptions.DefaultWrappingColumn)
     {
+        /// <summary>
+        /// Default value of 120 was picked based on the amount of code in a github.com diff at 1080p.
+        /// That resolution is the most common value as per the last DevDiv survey as well as the latest
+        /// Steam hardware survey.  This also seems to a reasonable length default in that shorter
+        /// lengths can often feel too cramped for .NET languages, which are often starting with a
+        /// default indentation of at least 16 (for namespace, class, member, plus the final construct
+        /// indentation).
+        /// 
+        /// TODO: Currently the option has no storage and always has its default value. See https://github.com/dotnet/roslyn/pull/30422#issuecomment-436118696.
+        /// </summary>
+        public const int DefaultWrappingColumn = 120;
+
         public CodeActionOptions()
             : this(SearchOptions: SymbolSearchOptions.Default)
         {


### PR DESCRIPTION
Group options used in syntax wrappers and pass them around instead of OptionSet.