### PR TITLE
Allow exception local to be used in filter prologue in async methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -587,13 +587,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var prologueBuilder = ArrayBuilder<BoundStatement>.GetInstance();
                 var sourceOpt = node.ExceptionSourceOpt;
-                if (sourceOpt == null)
+                prologueBuilder.Add(_F.ExpressionStatement(storePending));
+                if (sourceOpt is not null)
                 {
-                    prologueBuilder.Add(_F.ExpressionStatement(storePending));
-                }
-                else
-                {
-                    prologueBuilder.Add(_F.ExpressionStatement(storePending));
                     prologueBuilder.Add(_F.ExpressionStatement(AssignCatchSource((BoundExpression)this.Visit(sourceOpt), currentAwaitCatchFrame)));
                 }
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncExceptionHandlerRewriter.cs
@@ -582,25 +582,35 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // store pending exception 
-                // as the first expression in a filter
-                var sourceOpt = node.ExceptionSourceOpt;
+                // as the first expression in a filter prologue
                 var rewrittenPrologue = (BoundStatementList)this.Visit(filterPrologueOpt);
+
+                var prologueBuilder = ArrayBuilder<BoundStatement>.GetInstance();
+                var sourceOpt = node.ExceptionSourceOpt;
+                if (sourceOpt == null)
+                {
+                    prologueBuilder.Add(_F.ExpressionStatement(storePending));
+                }
+                else
+                {
+                    prologueBuilder.Add(_F.ExpressionStatement(storePending));
+                    prologueBuilder.Add(_F.ExpressionStatement(AssignCatchSource((BoundExpression)this.Visit(sourceOpt), currentAwaitCatchFrame)));
+                }
+
+                if (rewrittenPrologue != null)
+                {
+                    prologueBuilder.Add(rewrittenPrologue);
+                }
+                var newPrologue = _F.StatementList(prologueBuilder.ToImmutableAndFree());
+
                 var rewrittenFilter = (BoundExpression)this.Visit(filterOpt);
-                var newFilter = sourceOpt == null ?
-                                _F.MakeSequence(
-                                    storePending,
-                                    rewrittenFilter) :
-                                _F.MakeSequence(
-                                    storePending,
-                                    AssignCatchSource((BoundExpression)this.Visit(sourceOpt), currentAwaitCatchFrame),
-                                    rewrittenFilter);
 
                 catchAndPend = node.Update(
                     ImmutableArray.Create(catchTemp),
                     _F.Local(catchTemp),
                     catchType,
-                    exceptionFilterPrologueOpt: rewrittenPrologue,
-                    exceptionFilterOpt: newFilter,
+                    exceptionFilterPrologueOpt: newPrologue,
+                    exceptionFilterOpt: rewrittenFilter,
                     body: _F.Block(
                         _F.HiddenSequencePoint(),
                         setPendingCatchNum),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -7885,34 +7885,34 @@ static class C
       IL_00df:  br.s       IL_013c
       IL_00e1:  stloc.s    V_9
       IL_00e3:  ldarg.0
-      IL_00e4:  ldfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
-      IL_00e9:  callvirt   ""System.Exception System.Exception.InnerException.get""
-      IL_00ee:  stloc.s    V_6
-      IL_00f0:  ldloc.s    V_6
-      IL_00f2:  brfalse.s  IL_0120
-      IL_00f4:  ldloc.s    V_6
-      IL_00f6:  callvirt   ""string System.Exception.Message.get""
-      IL_00fb:  stloc.s    V_7
-      IL_00fd:  ldloc.s    V_7
-      IL_00ff:  ldstr      ""bad dog""
-      IL_0104:  call       ""bool string.op_Equality(string, string)""
-      IL_0109:  brtrue.s   IL_011b
-      IL_010b:  ldloc.s    V_7
-      IL_010d:  ldstr      ""dog bad""
-      IL_0112:  call       ""bool string.op_Equality(string, string)""
-      IL_0117:  brtrue.s   IL_011b
-      IL_0119:  br.s       IL_0120
-      IL_011b:  ldc.i4.1
-      IL_011c:  stloc.s    V_8
-      IL_011e:  br.s       IL_0123
-      IL_0120:  ldc.i4.0
-      IL_0121:  stloc.s    V_8
-      IL_0123:  ldarg.0
-      IL_0124:  ldloc.s    V_8
-      IL_0126:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__6""
+      IL_00e4:  ldloc.s    V_9
+      IL_00e6:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__4""
+      IL_00eb:  ldarg.0
+      IL_00ec:  ldfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3""
+      IL_00f1:  callvirt   ""System.Exception System.Exception.InnerException.get""
+      IL_00f6:  stloc.s    V_6
+      IL_00f8:  ldloc.s    V_6
+      IL_00fa:  brfalse.s  IL_0128
+      IL_00fc:  ldloc.s    V_6
+      IL_00fe:  callvirt   ""string System.Exception.Message.get""
+      IL_0103:  stloc.s    V_7
+      IL_0105:  ldloc.s    V_7
+      IL_0107:  ldstr      ""bad dog""
+      IL_010c:  call       ""bool string.op_Equality(string, string)""
+      IL_0111:  brtrue.s   IL_0123
+      IL_0113:  ldloc.s    V_7
+      IL_0115:  ldstr      ""dog bad""
+      IL_011a:  call       ""bool string.op_Equality(string, string)""
+      IL_011f:  brtrue.s   IL_0123
+      IL_0121:  br.s       IL_0128
+      IL_0123:  ldc.i4.1
+      IL_0124:  stloc.s    V_8
+      IL_0126:  br.s       IL_012b
+      IL_0128:  ldc.i4.0
+      IL_0129:  stloc.s    V_8
       IL_012b:  ldarg.0
-      IL_012c:  ldloc.s    V_9
-      IL_012e:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__4""
+      IL_012c:  ldloc.s    V_8
+      IL_012e:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__6""
       IL_0133:  ldarg.0
       IL_0134:  ldfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__6""
       IL_0139:  ldc.i4.0


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59050

Some background:
1. Some patterns involve spilling (ie. creation of statements)
2. Filter prologue holds spilled statements from exception filter: When a `BoundSpillSequence` appears in an exception filter, we take the statements out and put them in the filter prologue. The filter prologue (`BoundCatchBlock.ExceptionFilterPrologueOpt`) is just a collection of statements to be evaluated before the filter (`BoundCatchBlock.ExceptionFilterOpt`, an expression).  
This was introduced in https://github.com/dotnet/roslyn/pull/46054
3. Catch blocks are rewritten for async methods: When a `catch` block (or `finally`) contains an `await`, we rewrite the block to just save the exception and we move the original logic from the `catch` block after the `try` statement. This is done by `AsyncExceptionHandlerRewriter`. Generally, it rewrites `catch (Exception ex) { ... catch block ...}` to something like `catch (Exception temp) { ex = temp; } /* extracted  catch block */`.  
I copied a short write-up on this below.

The problem is that `AsyncExceptionHandlerRewriter` did not properly account for filter prologues. It uses a different local for the caught exception (`temp`), so it adds an assignment into the local (`ex`) used by the filter prologue and the filter. It was doing so before the filter, but *after* the filter prologue. So the filter prologue would see an uninitialized value for `ex`.

The IL snippets below show the before and after for `catch (Exception ex) when (ex.InnerException is { Message: ""bad dog"" or ""dog bad"" })` (from test `IsPatternInExceptionFilterInAsyncMethod_Spilled` in this PR):

<details><summary>IL before fix</summary>

```
    filter
    {
      IL_0094:  isinst     ""System.Exception""
      IL_0099:  dup
      IL_009a:  brtrue.s   IL_00a0
      IL_009c:  pop
      IL_009d:  ldc.i4.0
      IL_009e:  br.s       IL_0106
      IL_00a0:  stloc.s    V_7
      IL_00a2:  ldarg.0
      IL_00a3:  ldfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"" // notice we read here
      IL_00a8:  callvirt   ""System.Exception System.Exception.InnerException.get""
      IL_00ad:  stloc.2
      IL_00ae:  ldloc.2
      IL_00af:  brfalse.s  IL_00d9
      IL_00b1:  ldloc.2
      IL_00b2:  callvirt   ""string System.Exception.Message.get""
      IL_00b7:  stloc.3
      IL_00b8:  ldloc.3
      IL_00b9:  ldstr      ""bad dog""
      IL_00be:  call       ""bool string.op_Equality(string, string)""
      IL_00c3:  brtrue.s   IL_00d4
      IL_00c5:  ldloc.3
      IL_00c6:  ldstr      ""dog bad""
      IL_00cb:  call       ""bool string.op_Equality(string, string)""
      IL_00d0:  brtrue.s   IL_00d4
      IL_00d2:  br.s       IL_00d9
      IL_00d4:  ldc.i4.1
      IL_00d5:  stloc.s    V_4
      IL_00d7:  br.s       IL_00dc
      IL_00d9:  ldc.i4.0
      IL_00da:  stloc.s    V_4
      IL_00dc:  ldarg.0
      IL_00dd:  ldloc.s    V_4
      IL_00df:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__4""
      IL_00e4:  ldarg.0
      IL_00e5:  ldloc.s    V_7
      IL_00e7:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
      IL_00ec:  ldarg.0
      IL_00ed:  ldarg.0
      IL_00ee:  ldfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
      IL_00f3:  castclass  ""System.Exception""
      IL_00f8:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"" // notice we initialize later
      IL_00fd:  ldarg.0
      IL_00fe:  ldfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__4""
      IL_0103:  ldc.i4.0
      IL_0104:  cgt.un
      IL_0106:  endfilter
    }  // end filter
```

</details>

<details><summary>IL after fix</summary>

```
    filter
    {
      IL_0094:  isinst     ""System.Exception""
      IL_0099:  dup
      IL_009a:  brtrue.s   IL_00a0
      IL_009c:  pop
      IL_009d:  ldc.i4.0
      IL_009e:  br.s       IL_0106
      IL_00a0:  stloc.s    V_7
      IL_00a2:  ldarg.0
      IL_00a3:  ldloc.s    V_7
      IL_00a5:  stfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
      IL_00aa:  ldarg.0
      IL_00ab:  ldarg.0
      IL_00ac:  ldfld      ""object C.<ExceptionFilterBroken>d__1.<>s__1""
      IL_00b1:  castclass  ""System.Exception""
      IL_00b6:  stfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"" // notice we now initialize first
      IL_00bb:  ldarg.0
      IL_00bc:  ldfld      ""System.Exception C.<ExceptionFilterBroken>d__1.<ex>5__3"" // before reading the value here
      IL_00c1:  callvirt   ""System.Exception System.Exception.InnerException.get""
      IL_00c6:  stloc.2
      IL_00c7:  ldloc.2
      IL_00c8:  brfalse.s  IL_00f2
      IL_00ca:  ldloc.2
      IL_00cb:  callvirt   ""string System.Exception.Message.get""
      IL_00d0:  stloc.3
      IL_00d1:  ldloc.3
      IL_00d2:  ldstr      ""bad dog""
      IL_00d7:  call       ""bool string.op_Equality(string, string)""
      IL_00dc:  brtrue.s   IL_00ed
      IL_00de:  ldloc.3
      IL_00df:  ldstr      ""dog bad""
      IL_00e4:  call       ""bool string.op_Equality(string, string)""
      IL_00e9:  brtrue.s   IL_00ed
      IL_00eb:  br.s       IL_00f2
      IL_00ed:  ldc.i4.1
      IL_00ee:  stloc.s    V_4
      IL_00f0:  br.s       IL_00f5
      IL_00f2:  ldc.i4.0
      IL_00f3:  stloc.s    V_4
      IL_00f5:  ldarg.0
      IL_00f6:  ldloc.s    V_4
      IL_00f8:  stfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__4""
      IL_00fd:  ldarg.0
      IL_00fe:  ldfld      ""bool C.<ExceptionFilterBroken>d__1.<>s__4""
      IL_0103:  ldc.i4.0
      IL_0104:  cgt.un
      IL_0106:  endfilter
    }  // end filter
```
</details>

<details><summary>Short-write up on catch/finally rewriting for async methods</summary>

(from an [async-streams post](https://github.com/jcouv/roslyn/pull/1/files) I'm working on)

#### `await` in `catch` and `finally` blocks (optional)

The nested dispatching allows us to resume execution at a label inside a `try` block.
But that strategy doesn't allow us to resume from a label inside a `catch` block which is only entered when an exception is thrown.
This is solved by yet another lowering pass which extracts any `catch` or `finally` blocks containing awaits and turns them into regular blocks.

Consider a `finally`:
```C#
try
{
    ... body ...
}
finally
{
    ... some await ...
}
```
We can extract it into a regular block:
```C#
Exception exceptionLocal = null;
try
{
     ... body ...
    goto extractedFinallyLabel;
}
catch (Exception e)
{
    exceptionLocal = e;
}
// extracted finally block
extractedFinallyLabel:
{
    ... some await ...
    if (exceptionLocal != null)
    {
        throw exceptionLocal;
    }
}
```

This pattern can be expanded to extract `catch` handlers: each `catch` block is replaced with logic to pend the exception (save the exception into a local, remember which exception handler we were in) and the original handlers are moved out into the extracted block.

</details>