### PR TITLE
Produce specific error for misplaced 'record' keyword

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6990,6 +6990,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Line contains different whitespace than the closing line of the raw string literal: '{0}' versus '{1}'</value>
   </data>
   <data name="ERR_MisplacedRecord" xml:space="preserve">
-    <value>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</value>
+    <value>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6989,4 +6989,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_LineContainsDifferentWhitespace" xml:space="preserve">
     <value>Line contains different whitespace than the closing line of the raw string literal: '{0}' versus '{1}'</value>
   </data>
+  <data name="ERR_MisplacedRecord" xml:space="preserve">
+    <value>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2046,6 +2046,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_IllegalAtSequence = 9008,
         ERR_StringMustStartWithQuoteCharacter = 9009,
 
+        ERR_MisplacedRecord = 9012,
+
         #endregion
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7,16 +7,16 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
-    using System.Diagnostics.CodeAnalysis;
-    using Microsoft.CodeAnalysis.PooledObjects;
     using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 
     internal partial class LanguageParser : SyntaxParser

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1559,6 +1559,15 @@ tryAgain:
                 _termState |= TerminatorState.IsEndOfRecordSignature;
                 recordModifier = eatRecordModifierIfAvailable();
             }
+            else if (keyword.Kind is SyntaxKind.StructKeyword or SyntaxKind.ClassKeyword &&
+                    CurrentToken.ContextualKind == SyntaxKind.RecordKeyword &&
+                    IsFeatureEnabled(MessageID.IDS_FeatureRecordStructs) &&
+                    PeekToken(1).Kind is not (SyntaxKind.LessThanToken or SyntaxKind.OpenBraceToken))
+            {
+                // Provide a specific diagnostic on `struct record` or `class record`
+                var misplacedRecord = this.AddError(this.EatToken(), ErrorCode.ERR_MisplacedRecord);
+                keyword = AddTrailingSkippedSyntax(keyword, misplacedRecord);
+            }
 
             var saveTerm = _termState;
             _termState |= TerminatorState.IsPossibleAggregateClauseStartOrStop;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1562,9 +1562,9 @@ tryAgain:
             else if (keyword.Kind is SyntaxKind.StructKeyword or SyntaxKind.ClassKeyword &&
                     CurrentToken.ContextualKind == SyntaxKind.RecordKeyword &&
                     IsFeatureEnabled(MessageID.IDS_FeatureRecordStructs) &&
-                    PeekToken(1).Kind is not (SyntaxKind.LessThanToken or SyntaxKind.OpenBraceToken))
+                    PeekToken(1).Kind is SyntaxKind.IdentifierToken)
             {
-                // Provide a specific diagnostic on `struct record` or `class record`
+                // Provide a specific diagnostic on `struct record S` or `class record C`
                 var misplacedRecord = this.AddError(this.EatToken(), ErrorCode.ERR_MisplacedRecord);
                 keyword = AddTrailingSkippedSyntax(keyword, misplacedRecord);
             }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -817,6 +817,11 @@
         <target state="translated">Žádná přetížená metoda {0} neodpovídá ukazateli na funkci {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">Vzory řezů se dají použít jenom jednou a přímo uvnitř vzoru seznamu.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -817,6 +817,11 @@
         <target state="translated">Keine Überladung für "{0}" stimmt mit dem Funktionszeiger "{1}" überein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">Segmentmuster dürfen nur einmal und direkt innerhalb eines Listenmusters verwendet werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -817,6 +817,11 @@
         <target state="translated">Ninguna sobrecarga correspondiente a "{0}" coincide con el puntero de función "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">Los patrones de segmento solo se pueden utilizar una vez directamente dentro de un patrón de lista.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -817,6 +817,11 @@
         <target state="translated">Aucune surcharge pour '{0}' ne correspond au pointeur de fonction '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">Les modèles de tranche ne peuvent être utilisés qu'une seule fois et directement à l'intérieur d'un modèle de liste.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -817,6 +817,11 @@
         <target state="translated">Nessun overload per '{0}' corrisponde al puntatore a funzione '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">I modelli di sezione possono essere usati solo una volta e direttamente all'interno di un modello di elenco.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -817,6 +817,11 @@
         <target state="translated">関数ポインター '{1}' に一致する '{0}' のオーバーロードはありません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">スライス パターンは、1 回限り、リスト パターン内で直接使用される可能性があります。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -817,6 +817,11 @@
         <target state="translated">함수 포인터 '{1}'과(와) 일치하는 '{0}'에 대한 오버로드가 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">조각 패턴은 목록 패턴 내에서 바로 한 번만 사용할 수 있습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -817,6 +817,11 @@
         <target state="translated">Żadne z przeciążeń dla elementu „{0}” nie pasuje do wskaźnika funkcji „{1}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">Wzorce wycinków mogą być używane tylko raz i bezpośrednio wewnątrz wzorca listy.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -817,6 +817,11 @@
         <target state="translated">Nenhuma sobrecarga de '{0}' corresponde ao ponteiro de função '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">Os padrões de fatia somente podem ser usados uma vez e diretamente dentro de um padrão de lista.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -817,6 +817,11 @@
         <target state="translated">Нет перегруженного метода для "{0}", который соответствует указателю на функцию "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">Шаблоны среза можно использовать только один раз и непосредственно внутри шаблона списка.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -817,6 +817,11 @@
         <target state="translated">'{0}' için aşırı yüklemelerin hiçbiri '{1}' işlev işaretçisiyle eşleşmiyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">Dilim desenleri yalnızca bir kez ve doğrudan bir liste deseninin içinde kullanılabilir.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -817,6 +817,11 @@
         <target state="translated">“{0}”没有与函数指针“{1}”匹配的重载</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">切片模式只能使用一次，并且直接在列表模式内使用。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -817,6 +817,11 @@
         <target state="translated">'{0}' 沒有任何多載符合函式指標 '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_MisplacedRecord">
+        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">
         <source>Slice patterns may only be used once and directly inside a list pattern.</source>
         <target state="translated">切片模式只能在清單模式中使用一次且直接使用。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -818,8 +818,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedRecord">
-        <source>Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</source>
-        <target state="new">Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?</target>
+        <source>Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</source>
+        <target state="new">Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_MisplacedSlicePattern">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -11211,5 +11211,34 @@ record struct S3(char A)
                 Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(1, 8)
                 );
         }
+
+        [Fact]
+        public void StructNamedRecord_WithBaseList()
+        {
+            var source = @"
+interface I { }
+struct record<T> : I { }
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (3,8): warning CS8981: The type name 'record' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // struct record<T> : I { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "record").WithArguments("record").WithLocation(3, 8)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (3,8): warning CS8860: Types and aliases should not be named 'record'.
+                // struct record<T> : I { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(3, 8)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (3,8): warning CS8860: Types and aliases should not be named 'record'.
+                // struct record<T> : I { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(3, 8)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -11187,6 +11187,32 @@ record struct S3(char A)
         }
 
         [Fact]
+        public void ClassNamedRecord()
+        {
+            var source = "class record { } ";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (1,7): warning CS8981: The type name 'record' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // class record { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "record").WithArguments("record").WithLocation(1, 7)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (1,7): warning CS8860: Types and aliases should not be named 'record'.
+                // class record { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(1, 7)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (1,7): warning CS8860: Types and aliases should not be named 'record'.
+                // class record { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(1, 7)
+                );
+        }
+
+        [Fact]
         public void StructNamedRecord_WithTypeParameters()
         {
             var source = "struct record<T> { } ";
@@ -11213,7 +11239,62 @@ record struct S3(char A)
         }
 
         [Fact]
+        public void ClassNamedRecord_WithTypeParameters()
+        {
+            var source = "class record<T> { } ";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (1,7): warning CS8981: The type name 'record' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // class record<T> { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "record").WithArguments("record").WithLocation(1, 7)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (1,7): warning CS8860: Types and aliases should not be named 'record'.
+                // class record<T> { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(1, 7)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (1,7): warning CS8860: Types and aliases should not be named 'record'.
+                // class record<T> { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(1, 7)
+                );
+        }
+
+        [Fact]
         public void StructNamedRecord_WithBaseList()
+        {
+            var source = @"
+interface I { }
+struct record : I { }
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (3,8): warning CS8981: The type name 'record' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // struct record : I { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "record").WithArguments("record").WithLocation(3, 8)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (3,8): warning CS8860: Types and aliases should not be named 'record'.
+                // struct record : I { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(3, 8)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (3,8): warning CS8860: Types and aliases should not be named 'record'.
+                // struct record : I { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(3, 8)
+                );
+        }
+
+        [Fact]
+        public void StructNamedRecord_WithBaseList_Generic()
         {
             var source = @"
 interface I { }
@@ -11238,6 +11319,35 @@ struct record<T> : I { }
                 // (3,8): warning CS8860: Types and aliases should not be named 'record'.
                 // struct record<T> : I { }
                 Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(3, 8)
+                );
+        }
+
+        [Fact]
+        public void ClassNamedRecord_WithBaseList_Generic()
+        {
+            var source = @"
+interface I { }
+class record<T> : I { }
+";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (3,7): warning CS8981: The type name 'record' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // class record<T> : I { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "record").WithArguments("record").WithLocation(3, 7)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (3,7): warning CS8860: Types and aliases should not be named 'record'.
+                // class record<T> : I { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(3, 7)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (3,7): warning CS8860: Types and aliases should not be named 'record'.
+                // class record<T> : I { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(3, 7)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -11159,5 +11159,57 @@ record struct S3(char A)
                 //     static S() : this() { }
                 Diagnostic(ErrorCode.ERR_StaticConstructorWithExplicitConstructorCall, "this").WithArguments("S").WithLocation(4, 18));
         }
+
+        [Fact]
+        public void StructNamedRecord()
+        {
+            var source = "struct record { } ";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (1,8): warning CS8981: The type name 'record' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // struct record { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "record").WithArguments("record").WithLocation(1, 8)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (1,8): warning CS8860: Types and aliases should not be named 'record'.
+                // struct record { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(1, 8)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (1,8): warning CS8860: Types and aliases should not be named 'record'.
+                // struct record { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(1, 8)
+                );
+        }
+
+        [Fact]
+        public void StructNamedRecord_WithTypeParameters()
+        {
+            var source = "struct record<T> { } ";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics(
+                // (1,8): warning CS8981: The type name 'record' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // struct record { }
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "record").WithArguments("record").WithLocation(1, 8)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular9);
+            comp.VerifyDiagnostics(
+                // (1,8): warning CS8860: Types and aliases should not be named 'record'.
+                // struct record { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(1, 8)
+                );
+
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (1,8): warning CS8860: Types and aliases should not be named 'record'.
+                // struct record<T> { }
+                Diagnostic(ErrorCode.WRN_RecordNamedDisallowed, "record").WithLocation(1, 8)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RecordParsing.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RecordParsing.cs
@@ -3355,21 +3355,14 @@ class C(int X, int Y)
         public void StructNamedRecord_CSharp10()
         {
             var text = "struct record { }";
-            UsingTree(text, options: TestOptions.Regular10,
-                // (1,8): error CS9012: Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?
-                // struct record { }
-                Diagnostic(ErrorCode.ERR_MisplacedRecord, "record").WithLocation(1, 8),
-                // (1,15): error CS1001: Identifier expected
-                // struct record { }
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(1, 15)
-                );
+            UsingTree(text, options: TestOptions.Regular10);
 
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.StructDeclaration);
                 {
                     N(SyntaxKind.StructKeyword);
-                    M(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "record");
                     N(SyntaxKind.OpenBraceToken);
                     N(SyntaxKind.CloseBraceToken);
                 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RecordParsing.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RecordParsing.cs
@@ -3150,7 +3150,7 @@ class C(int X, int Y)
         {
             var text = "struct record C(int X, int Y);";
             UsingTree(text, options: TestOptions.Regular10,
-                // (1,8): error CS9012: Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?
+                // (1,8): error CS9012: Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?
                 // struct record C(int X, int Y);
                 Diagnostic(ErrorCode.ERR_MisplacedRecord, "record").WithLocation(1, 8),
                 // (1,16): error CS1514: { expected
@@ -3356,7 +3356,7 @@ class C(int X, int Y)
         {
             var text = "struct record { }";
             UsingTree(text, options: TestOptions.Regular10,
-                // (1,8): error CS9012: Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?
+                // (1,8): error CS9012: Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?
                 // struct record { }
                 Diagnostic(ErrorCode.ERR_MisplacedRecord, "record").WithLocation(1, 8),
                 // (1,15): error CS1001: Identifier expected
@@ -3383,7 +3383,7 @@ class C(int X, int Y)
         {
             var text = "class record C(int X, int Y);";
             UsingTree(text, options: TestOptions.Regular10,
-                // (1,7): error CS9012: Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?
+                // (1,7): error CS9012: Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?
                 // class record C(int X, int Y);
                 Diagnostic(ErrorCode.ERR_MisplacedRecord, "record").WithLocation(1, 7),
                 // (1,15): error CS1514: { expected

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RecordParsing.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RecordParsing.cs
@@ -3145,11 +3145,85 @@ class C(int X, int Y)
             EOF();
         }
 
-        [Fact, CompilerTrait(CompilerFeature.RecordStructs)]
-        public void RecordStructParsing_WrongOrder()
+        [Fact, CompilerTrait(CompilerFeature.RecordStructs), WorkItem(59534, "https://github.com/dotnet/roslyn/issues/59534")]
+        public void RecordStructParsing_WrongOrder_CSharp10()
         {
             var text = "struct record C(int X, int Y);";
-            UsingTree(text, options: TestOptions.RegularPreview,
+            UsingTree(text, options: TestOptions.Regular10,
+                // (1,8): error CS9012: Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?
+                // struct record C(int X, int Y);
+                Diagnostic(ErrorCode.ERR_MisplacedRecord, "record").WithLocation(1, 8),
+                // (1,16): error CS1514: { expected
+                // struct record C(int X, int Y);
+                Diagnostic(ErrorCode.ERR_LbraceExpected, "(").WithLocation(1, 16),
+                // (1,16): error CS1513: } expected
+                // struct record C(int X, int Y);
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "(").WithLocation(1, 16),
+                // (1,16): error CS8803: Top-level statements must precede namespace and type declarations.
+                // struct record C(int X, int Y);
+                Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, "(int X, int Y);").WithLocation(1, 16)
+                );
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.StructDeclaration);
+                {
+                    N(SyntaxKind.StructKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    M(SyntaxKind.OpenBraceToken);
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.ExpressionStatement);
+                    {
+                        N(SyntaxKind.TupleExpression);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.DeclarationExpression);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.SingleVariableDesignation);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "X");
+                                    }
+                                }
+                            }
+                            N(SyntaxKind.CommaToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.DeclarationExpression);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.SingleVariableDesignation);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "Y");
+                                    }
+                                }
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact, CompilerTrait(CompilerFeature.RecordStructs), WorkItem(59534, "https://github.com/dotnet/roslyn/issues/59534")]
+        public void RecordStructParsing_WrongOrder_CSharp9()
+        {
+            var text = "struct record C(int X, int Y);";
+            UsingTree(text, options: TestOptions.Regular9,
                 // (1,15): error CS1514: { expected
                 // struct record C(int X, int Y);
                 Diagnostic(ErrorCode.ERR_LbraceExpected, "C").WithLocation(1, 15),
@@ -3237,11 +3311,152 @@ class C(int X, int Y)
             EOF();
         }
 
+        [Fact, CompilerTrait(CompilerFeature.RecordStructs), WorkItem(59534, "https://github.com/dotnet/roslyn/issues/59534")]
+        public void StructNamedRecord_CSharp8()
+        {
+            var text = "struct record { }";
+            UsingTree(text, options: TestOptions.Regular8);
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.StructDeclaration);
+                {
+                    N(SyntaxKind.StructKeyword);
+                    N(SyntaxKind.IdentifierToken, "record");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact, CompilerTrait(CompilerFeature.RecordStructs), WorkItem(59534, "https://github.com/dotnet/roslyn/issues/59534")]
+        public void StructNamedRecord_CSharp9()
+        {
+            var text = "struct record { }";
+            UsingTree(text, options: TestOptions.Regular9);
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.StructDeclaration);
+                {
+                    N(SyntaxKind.StructKeyword);
+                    N(SyntaxKind.IdentifierToken, "record");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact, CompilerTrait(CompilerFeature.RecordStructs), WorkItem(59534, "https://github.com/dotnet/roslyn/issues/59534")]
+        public void StructNamedRecord_CSharp10()
+        {
+            var text = "struct record { }";
+            UsingTree(text, options: TestOptions.Regular10,
+                // (1,8): error CS9012: Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?
+                // struct record { }
+                Diagnostic(ErrorCode.ERR_MisplacedRecord, "record").WithLocation(1, 8),
+                // (1,15): error CS1001: Identifier expected
+                // struct record { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(1, 15)
+                );
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.StructDeclaration);
+                {
+                    N(SyntaxKind.StructKeyword);
+                    M(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
         [Fact, CompilerTrait(CompilerFeature.RecordStructs)]
-        public void RecordClassParsing_WrongOrder()
+        public void RecordClassParsing_WrongOrder_CSharp10()
         {
             var text = "class record C(int X, int Y);";
-            UsingTree(text, options: TestOptions.RegularPreview,
+            UsingTree(text, options: TestOptions.Regular10,
+                // (1,7): error CS9012: Unexpected keyword 'record'. Did you mean 'struct record' or 'class record'?
+                // class record C(int X, int Y);
+                Diagnostic(ErrorCode.ERR_MisplacedRecord, "record").WithLocation(1, 7),
+                // (1,15): error CS1514: { expected
+                // class record C(int X, int Y);
+                Diagnostic(ErrorCode.ERR_LbraceExpected, "(").WithLocation(1, 15),
+                // (1,15): error CS1513: } expected
+                // class record C(int X, int Y);
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "(").WithLocation(1, 15),
+                // (1,15): error CS8803: Top-level statements must precede namespace and type declarations.
+                // class record C(int X, int Y);
+                Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, "(int X, int Y);").WithLocation(1, 15)
+                );
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    M(SyntaxKind.OpenBraceToken);
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.ExpressionStatement);
+                    {
+                        N(SyntaxKind.TupleExpression);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.DeclarationExpression);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.SingleVariableDesignation);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "X");
+                                    }
+                                }
+                            }
+                            N(SyntaxKind.CommaToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.DeclarationExpression);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.SingleVariableDesignation);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "Y");
+                                    }
+                                }
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact, CompilerTrait(CompilerFeature.RecordStructs)]
+        public void RecordClassParsing_WrongOrder_CSharp9()
+        {
+            var text = "class record C(int X, int Y);";
+            UsingTree(text, options: TestOptions.Regular9,
                 // (1,14): error CS1514: { expected
                 // class record C(int X, int Y);
                 Diagnostic(ErrorCode.ERR_LbraceExpected, "C").WithLocation(1, 14),


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59534