### PR TITLE
Check forbidden zone for typed deconstruction variables

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1810,7 +1810,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 this.Compilation, name: "var", arity: 0, errorInfo: null, variableUsedBeforeDeclaration: true);
                             isNullableUnknown = true;
                         }
-                        else if ((localSymbol as SourceLocalSymbol)?.IsVar == true && localSymbol.ForbiddenZone?.Contains(node) == true)
+                        else if ((localSymbol.DeclarationKind == LocalDeclarationKind.DeconstructionVariable ||
+                                  localSymbol is SourceLocalSymbol { IsVar: true }) &&
+                                 localSymbol.ForbiddenZone?.Contains(node) == true)
                         {
                             // A var (type-inferred) local variable has been used in its own initialization (the "forbidden zone").
                             // There are many cases where this occurs, including:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -149,9 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(nodeBinder != null);
 
             Debug.Assert(closestTypeSyntax.Kind() != SyntaxKind.RefType);
-            return closestTypeSyntax.IsVar
-                ? new DeconstructionLocalSymbol(containingSymbol, scopeBinder, nodeBinder, closestTypeSyntax, identifierToken, kind, deconstruction)
-                : new SourceLocalSymbol(containingSymbol, scopeBinder, false, closestTypeSyntax, identifierToken, kind);
+            return new DeconstructionLocalSymbol(containingSymbol, scopeBinder, nodeBinder, closestTypeSyntax, identifierToken, kind, deconstruction);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -9723,6 +9723,27 @@ class C
         }
 
         [Fact]
+        public void MixedDeclarationAndAssignmentForbiddenZone()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        (int x1, (x1, int x2), x2) = (1, (2, 3), 4);
+    }
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+                // (6,19): error CS0841: Cannot use local variable 'x1' before it is declared
+                //         (int x1, (x1, int x2), x2) = (1, (2, 3), 4);
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x1").WithArguments("x1").WithLocation(6, 19),
+                // (6,32): error CS0841: Cannot use local variable 'x2' before it is declared
+                //         (int x1, (x1, int x2), x2) = (1, (2, 3), 4);
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x2").WithArguments("x2").WithLocation(6, 32));
+        }
+        
+        [Fact]
         public void MixedDeclarationAndAssignmentInForInitialization()
         {
             string source = @"


### PR DESCRIPTION
Fixes https://twitter.com/controlflow/status/1487757301461266434

Sounds like a bug. This probably needs approval as it's a breaking change.