### PR TITLE
allow third party codfixers to be run in code cleanup

### DIFF
--- a/src/Analyzers/Core/Analyzers/IDEDiagnosticIdToOptionMappingHelper.cs
+++ b/src/Analyzers/Core/Analyzers/IDEDiagnosticIdToOptionMappingHelper.cs
@@ -27,6 +27,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                (s_diagnosticIdToLanguageSpecificOptionsMap.TryGetValue(language, out var map) &&
                 map.TryGetValue(diagnosticId, out options));
 
+        public static bool IsKnownIDEDiagnosticId(string diagnosticId)
+            => s_diagnosticIdToOptionMap.ContainsKey(diagnosticId) ||
+               s_diagnosticIdToLanguageSpecificOptionsMap.Values.Any(map => map.ContainsKey(diagnosticId));
+
         public static void AddOptionMapping(string diagnosticId, ImmutableHashSet<IPerLanguageOption> perLanguageOptions)
         {
             diagnosticId = diagnosticId ?? throw new ArgumentNullException(nameof(diagnosticId));

--- a/src/EditorFeatures/CSharp/CodeCleanup/CSharpCodeCleanupService.cs
+++ b/src/EditorFeatures/CSharp/CodeCleanup/CSharpCodeCleanupService.cs
@@ -267,8 +267,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeCleanup
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpCodeCleanupService(ICodeFixService codeFixService)
-            : base(codeFixService)
+        public CSharpCodeCleanupService(ICodeFixService codeFixService, IDiagnosticAnalyzerService diagnosticAnalyzerService)
+            : base(codeFixService, diagnosticAnalyzerService)
         {
         }
 

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.TestFixers.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.TestFixers.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
             }
         }
 
-        [PartNotDiscoverable, Shared, ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        [PartNotDiscoverable, Shared, ExportCodeFixProvider(LanguageNames.CSharp)]
         private class TestThirdPartyCodeFixWithFixAll : TestThirdPartyCodeFix
         {
             [ImportingConstructor]
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
             public override FixAllProvider GetFixAllProvider() => BatchFixAllProvider.Instance;
         }
 
-        [PartNotDiscoverable, Shared, ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        [PartNotDiscoverable, Shared, ExportCodeFixProvider(LanguageNames.CSharp)]
         private class TestThirdPartyCodeFixWithOutFixAll : TestThirdPartyCodeFix
         {
             [ImportingConstructor]

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.TestFixers.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.TestFixers.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
             }
         }
 
-        [Shared, ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        [PartNotDiscoverable, Shared, ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic)]
         private class TestThirdPartyCodeFixWithFixAll : TestThirdPartyCodeFix
         {
             [ImportingConstructor]
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
             public override FixAllProvider GetFixAllProvider() => BatchFixAllProvider.Instance;
         }
 
-        [Shared, ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        [PartNotDiscoverable, Shared, ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic)]
         private class TestThirdPartyCodeFixWithOutFixAll : TestThirdPartyCodeFix
         {
             [ImportingConstructor]

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.TestFixers.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.TestFixers.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
+{
+    public partial class CodeCleanupTests
+    {
+        private abstract class TestThirdPartyCodeFix : CodeFixProvider
+        {
+            public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create("HasDefaultCase");
+
+            public override Task RegisterCodeFixesAsync(CodeFixContext context)
+            {
+                foreach (var diagnostic in context.Diagnostics)
+                {
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            "Remove default case",
+                            async cancellationToken =>
+                            {
+                                var root = await context.Document.GetSyntaxRootAsync(cancellationToken);
+                                var node = (await diagnostic.Location.SourceTree.GetRootAsync(cancellationToken)).FindNode(diagnostic.Location.SourceSpan);
+                                return context.Document.WithSyntaxRoot(root.RemoveNode(node.Parent, SyntaxRemoveOptions.KeepNoTrivia));
+                            },
+                            nameof(TestThirdPartyCodeFix)),
+                        diagnostic);
+                }
+
+                return Task.CompletedTask;
+            }
+        }
+
+        [Shared, ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        private class TestThirdPartyCodeFixWithFixAll : TestThirdPartyCodeFix
+        {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public TestThirdPartyCodeFixWithFixAll()
+            {
+            }
+
+            public override FixAllProvider GetFixAllProvider() => BatchFixAllProvider.Instance;
+        }
+
+        [Shared, ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        private class TestThirdPartyCodeFixWithOutFixAll : TestThirdPartyCodeFix
+        {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public TestThirdPartyCodeFixWithOutFixAll()
+            {
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.TestFixers.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.TestFixers.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading.Tasks;
-using System.Windows.Documents;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -33,8 +30,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
                             async cancellationToken =>
                             {
                                 var root = await context.Document.GetSyntaxRootAsync(cancellationToken);
-                                var node = (await diagnostic.Location.SourceTree.GetRootAsync(cancellationToken)).FindNode(diagnostic.Location.SourceSpan);
-                                return context.Document.WithSyntaxRoot(root.RemoveNode(node.Parent, SyntaxRemoveOptions.KeepNoTrivia));
+                                Assumes.NotNull(root);
+                                var sourceTree = diagnostic.Location.SourceTree;
+                                Assumes.NotNull(sourceTree);
+                                var node = (await sourceTree.GetRootAsync(cancellationToken)).FindNode(diagnostic.Location.SourceSpan);
+                                Assumes.NotNull(node?.Parent);
+                                var newRoot = root.RemoveNode(node.Parent, SyntaxRemoveOptions.KeepNoTrivia);
+                                Assumes.NotNull(newRoot);
+                                return context.Document.WithSyntaxRoot(newRoot);
                             },
                             nameof(TestThirdPartyCodeFix)),
                         diagnostic);
@@ -79,30 +82,37 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
 
             private class ModifySolutionFixAll : FixAllProvider
             {
-                public override Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+                public override Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
                 {
                     var solution = fixAllContext.Solution;
-                    return Task.FromResult(CodeAction.Create(
+                    return Task.FromResult<CodeAction?>(CodeAction.Create(
                             "Remove default case",
                             async cancellationToken =>
                             {
                                 var toFix = await fixAllContext.GetDocumentDiagnosticsToFixAsync();
-                                Project project = null;
+                                Project? project = null;
                                 foreach (var kvp in toFix)
                                 {
                                     var document = kvp.Key;
                                     project ??= document.Project;
                                     var diagnostics = kvp.Value;
                                     var root = await document.GetSyntaxRootAsync(cancellationToken);
+                                    Assumes.NotNull(root);
                                     foreach (var diagnostic in diagnostics)
                                     {
-                                        var node = (await diagnostic.Location.SourceTree.GetRootAsync(cancellationToken)).FindNode(diagnostic.Location.SourceSpan);
-                                        document = document.WithSyntaxRoot(root.RemoveNode(node.Parent, SyntaxRemoveOptions.KeepNoTrivia));
+                                        var sourceTree = diagnostic.Location.SourceTree;
+                                        Assumes.NotNull(sourceTree);
+                                        var node = (await sourceTree.GetRootAsync(cancellationToken)).FindNode(diagnostic.Location.SourceSpan);
+                                        Assumes.NotNull(node?.Parent);
+                                        var newRoot = root.RemoveNode(node.Parent, SyntaxRemoveOptions.KeepNoTrivia);
+                                        Assumes.NotNull(newRoot);
+                                        document = document.WithSyntaxRoot(newRoot);
                                     }
 
                                     solution = solution.WithDocumentText(document.Id, await document.GetTextAsync());
                                 }
 
+                                Assumes.NotNull(project);
                                 return solution.AddDocument(DocumentId.CreateNewId(project.Id), "new.cs", SourceText.From(""));
                             },
                             nameof(TestThirdPartyCodeFix)));
@@ -128,30 +138,37 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
                     return new[] { FixAllScope.Project, FixAllScope.Solution, FixAllScope.Custom };
                 }
 
-                public override Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+                public override Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
                 {
                     var solution = fixAllContext.Solution;
-                    return Task.FromResult(CodeAction.Create(
+                    return Task.FromResult<CodeAction?>(CodeAction.Create(
                             "Remove default case",
                             async cancellationToken =>
                             {
                                 var toFix = await fixAllContext.GetDocumentDiagnosticsToFixAsync();
-                                Project project = null;
+                                Project? project = null;
                                 foreach (var kvp in toFix)
                                 {
                                     var document = kvp.Key;
                                     project ??= document.Project;
                                     var diagnostics = kvp.Value;
                                     var root = await document.GetSyntaxRootAsync(cancellationToken);
+                                    Assumes.NotNull(root);
                                     foreach (var diagnostic in diagnostics)
                                     {
-                                        var node = (await diagnostic.Location.SourceTree.GetRootAsync(cancellationToken)).FindNode(diagnostic.Location.SourceSpan);
-                                        document = document.WithSyntaxRoot(root.RemoveNode(node.Parent, SyntaxRemoveOptions.KeepNoTrivia));
+                                        var sourceTree = diagnostic.Location.SourceTree;
+                                        Assumes.NotNull(sourceTree);
+                                        var node = (await sourceTree.GetRootAsync(cancellationToken)).FindNode(diagnostic.Location.SourceSpan);
+                                        Assumes.NotNull(node?.Parent);
+                                        var newRoot = root.RemoveNode(node.Parent, SyntaxRemoveOptions.KeepNoTrivia);
+                                        Assumes.NotNull(newRoot);
+                                        document = document.WithSyntaxRoot(newRoot);
                                     }
 
                                     solution = solution.WithDocumentText(document.Id, await document.GetTextAsync());
                                 }
 
+                                Assumes.NotNull(project);
                                 return solution.AddDocument(DocumentId.CreateNewId(project.Id), "new.cs", SourceText.From(""));
                             },
                             nameof(TestThirdPartyCodeFix)));

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -996,7 +996,7 @@ End Class
 
             using var workspace = GetTestWorkspaceForLanguage(code, language);
 
-            var options = CodeActionOptions.Default;
+            var options = CodeActionOptions.DefaultProvider;
 
             var project = workspace.CurrentSolution.Projects.Single();
 

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -672,14 +672,14 @@ class C
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
         public async Task RunThirdPartyFixer()
         {
-            await TestThirdPartyCodeFixer<TestThirdPartyCodeFixWithFixAll, CaseTestAnalyzer>(_code, _fixed);
+            await TestThirdPartyCodeFixerApplied<TestThirdPartyCodeFixWithFixAll, CaseTestAnalyzer>(_code, _fixed);
         }
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
         public async Task DoNotRunThirdPartyFixerWithNoFixAll()
         {
-            await TestThirdPartyCodeFixer<TestThirdPartyCodeFixWithOutFixAll, CaseTestAnalyzer>(_code, _code);
+            await TestThirdPartyCodeFixerNoChanges<TestThirdPartyCodeFixWithOutFixAll, CaseTestAnalyzer>(_code);
         }
 
         [Theory]
@@ -688,7 +688,7 @@ class C
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
         public async Task RunThirdPartyFixerWithSeverityOfWarningOrHigher(DiagnosticSeverity severity)
         {
-            await TestThirdPartyCodeFixer<TestThirdPartyCodeFixWithFixAll, CaseTestAnalyzer>(_code, _fixed, severity);
+            await TestThirdPartyCodeFixerApplied<TestThirdPartyCodeFixWithFixAll, CaseTestAnalyzer>(_code, _fixed, severity);
         }
 
         [Theory]
@@ -697,24 +697,38 @@ class C
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
         public async Task DoNotRunThirdPartyFixerWithSeverityLessThanWarning(DiagnosticSeverity severity)
         {
-            await TestThirdPartyCodeFixer<TestThirdPartyCodeFixWithOutFixAll, CaseTestAnalyzer>(_code, _code, severity);
+            await TestThirdPartyCodeFixerNoChanges<TestThirdPartyCodeFixWithOutFixAll, CaseTestAnalyzer>(_code, severity);
         }
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
         public async Task DoNotRunThirdPartyFixerIfItDoesNotSupportDocumentScope()
         {
-            await TestThirdPartyCodeFixer<TestThirdPartyCodeFixDoesNotSupportDocumentScope, CaseTestAnalyzer>(_code, _code);
+            await TestThirdPartyCodeFixerNoChanges<TestThirdPartyCodeFixDoesNotSupportDocumentScope, CaseTestAnalyzer>(_code);
         }
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
         public async Task DoNotApplyFixerIfChangesAreMadeOutsideDocument()
         {
-            await TestThirdPartyCodeFixer<TestThirdPartyCodeFixModifiesSolution, CaseTestAnalyzer>(_code, _code);
+            await TestThirdPartyCodeFixerNoChanges<TestThirdPartyCodeFixModifiesSolution, CaseTestAnalyzer>(_code);
         }
 
-        private static async Task TestThirdPartyCodeFixer<TCodefix, TAnalyzer>(string code, string expected, DiagnosticSeverity severity = DiagnosticSeverity.Warning)
+        private static Task TestThirdPartyCodeFixerNoChanges<TCodefix, TAnalyzer>(string code, DiagnosticSeverity severity = DiagnosticSeverity.Warning)
+            where TAnalyzer : DiagnosticAnalyzer, new()
+            where TCodefix : CodeFixProvider, new()
+        {
+            return TestThirdPartyCodeFixer<TCodefix, TAnalyzer>(code, code, severity);
+        }
+
+        private static Task TestThirdPartyCodeFixerApplied<TCodefix, TAnalyzer>(string code, string expected, DiagnosticSeverity severity = DiagnosticSeverity.Warning)
+            where TAnalyzer : DiagnosticAnalyzer, new()
+            where TCodefix : CodeFixProvider, new()
+        {
+            return TestThirdPartyCodeFixer<TCodefix, TAnalyzer>(code, expected, severity);
+        }
+
+        private static async Task TestThirdPartyCodeFixer<TCodefix, TAnalyzer>(string code = null, string expected = null, DiagnosticSeverity severity = DiagnosticSeverity.Warning)
             where TAnalyzer : DiagnosticAnalyzer, new()
             where TCodefix : CodeFixProvider, new()
         {

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -109,7 +109,7 @@ global using System.Collections.Generic;
 global using System;
 class Program
 {
-    static async Task Main(string[] args)
+    static Task Main(string[] args)
     {
         Barrier b = new Barrier(0);
         var list = new List<int>();
@@ -126,7 +126,7 @@ using System.Threading.Tasks;
 
 internal class Program
 {
-    private static async Task Main(string[] args)
+    private static Task Main(string[] args)
     {
         Barrier b = new(0);
         List<int> list = new();

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -7,7 +7,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;
@@ -578,7 +577,7 @@ namespace A
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
-        public async Task RunThirdPartyFixerCSharp()
+        public async Task RunThirdPartyFixer()
         {
             const string code = @"
 class C
@@ -670,170 +669,12 @@ class C
     }
 }
 ";
-            await TestThirdPartyCodeFixerCSharp<TestThirdPartyCodeFixWithFixAll, CaseTestAnalyzer>(code, expected);
+            await TestThirdPartyCodeFixer<TestThirdPartyCodeFixWithFixAll, CaseTestAnalyzer>(code, expected);
         }
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
-        public async Task RunThirdPartyFixerVisualBasic()
-        {
-            const string code = @"
-Class C
-    Public Sub M1(x As Integer)
-        Select Case x
-            Case 1, 2
-                Exit Select
-            Case = 10
-                Exit Select
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case = 1000
-                Exit Select
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 10 To 500
-                Exit Select
-            Case = 1000
-                Exit Select
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1, 980 To 985
-                Exit Select
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1 to 3, 980 To 985
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case > 100000
-                Exit Select
-        End Select
-
-        Select Case x
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case =
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case 2 to
-                Exit Select
-        End Select
-    End Sub
-End Class
-";
-
-            const string expected = @"
-Class C
-    Public Sub M1(x As Integer)
-        Select Case x
-            Case 1, 2
-                Exit Select
-            Case = 10
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case = 1000
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 10 To 500
-                Exit Select
-            Case = 1000
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1, 980 To 985
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1 to 3, 980 To 985
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case > 100000
-                Exit Select
-        End Select
-
-        Select Case x
-        End Select
-
-        Select Case x
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case =
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case 2 to
-                Exit Select
-        End Select
-    End Sub
-End Class
-";
-            await TestThirdPartyCodeFixerVisualBasic<TestThirdPartyCodeFixWithFixAll, CaseTestAnalyzer>(code, expected);
-        }
-
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
-        public async Task DoNotRunThirdPartyFixerWithNoFixAllCSharp()
+        public async Task DoNotRunThirdPartyFixerWithNoFixAll()
         {
             const string code = @"
 class C
@@ -884,124 +725,22 @@ class C
 }
 ";
 
-            await TestThirdPartyCodeFixerCSharp<TestThirdPartyCodeFixWithOutFixAll, CaseTestAnalyzer>(code, code);
+            await TestThirdPartyCodeFixer<TestThirdPartyCodeFixWithOutFixAll, CaseTestAnalyzer>(code, code);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
-        public async Task DoNotRunThirdPartyFixerWithNoFixAllVisualBasic()
-        {
-            const string code = @"
-Class C
-    Public Sub M1(x As Integer)
-        Select Case x
-            Case 1, 2
-                Exit Select
-            Case = 10
-                Exit Select
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case = 1000
-                Exit Select
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 10 To 500
-                Exit Select
-            Case = 1000
-                Exit Select
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1, 980 To 985
-                Exit Select
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1 to 3, 980 To 985
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case > 100000
-                Exit Select
-        End Select
-
-        Select Case x
-            Case Else
-                Exit Select
-        End Select
-
-        Select Case x
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case =
-                Exit Select
-        End Select
-
-        Select Case x
-            Case 1
-                Exit Select
-            Case 2 to
-                Exit Select
-        End Select
-    End Sub
-End Class
-";
-
-            await TestThirdPartyCodeFixerVisualBasic<TestThirdPartyCodeFixWithOutFixAll, CaseTestAnalyzer>(code, code);
-        }
-
-        private static Task TestThirdPartyCodeFixerCSharp<TCodefix, TAnalyzer>(string code, string expected)
-            where TAnalyzer : DiagnosticAnalyzer, new()
-            where TCodefix : CodeFixProvider, new()
-        {
-            return TestThirdPartyCodeFixer<TCodefix, TAnalyzer>(code, expected, LanguageNames.CSharp);
-        }
-
-        private static Task TestThirdPartyCodeFixerVisualBasic<TCodefix, TAnalyzer>(string code, string expected)
-            where TAnalyzer : DiagnosticAnalyzer, new()
-            where TCodefix : CodeFixProvider, new()
-        {
-            return TestThirdPartyCodeFixer<TCodefix, TAnalyzer>(code, expected, LanguageNames.VisualBasic);
-        }
-
-        private static async Task TestThirdPartyCodeFixer<TCodefix, TAnalyzer>(string code, string expected, string language)
+        private static async Task TestThirdPartyCodeFixer<TCodefix, TAnalyzer>(string code, string expected)
             where TAnalyzer : DiagnosticAnalyzer, new()
             where TCodefix : CodeFixProvider, new()
         {
 
-            using var workspace = GetTestWorkspaceForLanguage(code, language);
+            using var workspace = TestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf.AddParts(typeof(TCodefix)));
 
             var options = CodeActionOptions.DefaultProvider;
 
             var project = workspace.CurrentSolution.Projects.Single();
 
             var map = new Dictionary<string, ImmutableArray<DiagnosticAnalyzer>>{
-                { language, ImmutableArray.Create((DiagnosticAnalyzer)new  TAnalyzer()) }
+                { LanguageNames.CSharp, ImmutableArray.Create((DiagnosticAnalyzer)new  TAnalyzer()) }
             };
 
             project = project.AddAnalyzerReference(new TestAnalyzerReferenceByLanguage(map));
@@ -1024,21 +763,6 @@ End Class
 
             var actual = await newDoc.GetTextAsync();
             Assert.Equal(expected, actual.ToString());
-
-            static TestWorkspace GetTestWorkspaceForLanguage(string code, string language)
-            {
-                if (language == LanguageNames.CSharp)
-                {
-                    return TestWorkspace.CreateCSharp(code, composition: EditorTestCompositions.EditorFeaturesWpf.AddParts(typeof(TCodefix)));
-                }
-
-                if (language == LanguageNames.VisualBasic)
-                {
-                    return TestWorkspace.CreateVisualBasic(code, composition: EditorTestCompositions.EditorFeaturesWpf.AddParts(typeof(TCodefix)));
-                }
-
-                return null;
-            }
         }
 
         private static string[] GetSupportedDiagnosticIdsForCodeCleanupService(string language)

--- a/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, DocumentId? documentId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, bool includeCompilerDiagnostics = true, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)

--- a/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/Helpers/MockDiagnosticAnalyzerService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, DocumentId? documentId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, bool includeCompilerDiagnostics = true, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeCompilerDiagnostics, bool includeSuppressedDiagnostics = true, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)

--- a/src/EditorFeatures/VisualBasic/CodeCleanup/VisualBasicCodeCleanupService.vb
+++ b/src/EditorFeatures/VisualBasic/CodeCleanup/VisualBasicCodeCleanupService.vb
@@ -82,8 +82,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeCleanup
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
-        Public Sub New(codeFixService As ICodeFixService)
-            MyBase.New(codeFixService)
+        Public Sub New(codeFixService As ICodeFixService, diagnosticAnalyzerService As IDiagnosticAnalyzerService)
+            MyBase.New(codeFixService, diagnosticAnalyzerService)
         End Sub
 
         Protected Overrides ReadOnly Property OrganizeImportsDescription As String = VBFeaturesResources.Organize_Imports

--- a/src/Features/Core/Portable/CodeFixes/DiagnosticExtensions.cs
+++ b/src/Features/Core/Portable/CodeFixes/DiagnosticExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CodeFixes.Suppression;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CodeFixes
+{
+    internal static class DiagnosticExtensions
+    {
+        public static bool GreaterThanOrEqualTo(this DiagnosticSeverity left, DiagnosticSeverity right)
+        {
+            var leftInt = (int)left;
+            var rightInt = (int)right;
+            return leftInt >= rightInt;
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeFixes/DiagnosticExtensions.cs
+++ b/src/Features/Core/Portable/CodeFixes/DiagnosticExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 {
     internal static class DiagnosticExtensions
     {
-        public static bool GreaterThanOrEqualTo(this DiagnosticSeverity left, DiagnosticSeverity right)
+        public static bool IsMoreSevereThanOrEqualTo(this DiagnosticSeverity left, DiagnosticSeverity right)
         {
             var leftInt = (int)left;
             var rightInt = (int)right;

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// This API will only force complete analyzers that support span based analysis, i.e. compiler analyzer and
         /// <see cref="IBuiltInAnalyzer"/>s that support <see cref="DiagnosticAnalyzerCategory.SemanticSpanAnalysis"/>.
         /// For the rest of the analyzers, it will only return diagnostics if the analyzer has already been executed.
-        /// Use <see cref="GetDiagnosticsForSpanAsync(Document, TextSpan?, Func{string, bool}?, bool, CodeActionRequestPriority, Func{string, IDisposable?}?, CancellationToken)"/>
+        /// Use <see cref="GetDiagnosticsForSpanAsync(Document, TextSpan?, Func{string, bool}?, bool, bool, CodeActionRequestPriority, Func{string, IDisposable?}?, CancellationToken)"/>
         /// if you want to force complete all analyzers and get up-to-date diagnostics for all analyzers for the given span.
         /// </summary>
         Task<(ImmutableArray<DiagnosticData> diagnostics, bool upToDate)> TryGetDiagnosticsForSpanAsync(Document document, TextSpan range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, CancellationToken cancellationToken = default);
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// none of its reported diagnostics should be included in the result.
         /// </para>
         /// </summary>
-        Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, bool includeCompilerDiagnostics = true, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default);
+        Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeCompilerDiagnostics, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default);
     }
 
     internal static class IDiagnosticAnalyzerServiceExtensions
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             Func<string, bool>? shouldIncludeDiagnostic = diagnosticId != null ? id => id == diagnosticId : null;
             return service.GetDiagnosticsForSpanAsync(document, range, shouldIncludeDiagnostic,
-                includeSuppressedDiagnostics, true, priority, addOperationScope, cancellationToken);
+                includeCompilerDiagnostics: true, includeSuppressedDiagnostics: true, priority: priority, addOperationScope: addOperationScope, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             Func<string, bool>? shouldIncludeDiagnostic = diagnosticId != null ? id => id == diagnosticId : null;
             return service.GetDiagnosticsForSpanAsync(document, range, shouldIncludeDiagnostic,
-                includeCompilerDiagnostics: true, includeSuppressedDiagnostics: true, priority: priority, addOperationScope: addOperationScope, cancellationToken: cancellationToken);
+                includeCompilerDiagnostics: true, includeSuppressedDiagnostics, priority: priority, addOperationScope: addOperationScope, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// none of its reported diagnostics should be included in the result.
         /// </para>
         /// </summary>
-        Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default);
+        Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, bool includeCompilerDiagnostics = true, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default);
     }
 
     internal static class IDiagnosticAnalyzerServiceExtensions
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             Func<string, bool>? shouldIncludeDiagnostic = diagnosticId != null ? id => id == diagnosticId : null;
             return service.GetDiagnosticsForSpanAsync(document, range, shouldIncludeDiagnostic,
-                includeSuppressedDiagnostics, priority, addOperationScope, cancellationToken);
+                includeSuppressedDiagnostics, true, priority, addOperationScope, cancellationToken);
         }
     }
 }

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -3141,4 +3141,7 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="Replace_conditional_expression_with_statements" xml:space="preserve">
     <value>Replace conditional expression with statements</value>
   </data>
+  <data name="Fixing_0" xml:space="preserve">
+    <value>Fixing '{0}'</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -730,6 +730,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Opravit překlep {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">Formátuje se dokument.</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -730,6 +730,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Tippfehler "{0}" korrigieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">Dokument wird formatiert</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -730,6 +730,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Corregir error de escritura "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">Aplicando formato al documento</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -730,6 +730,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">Corriger la faute de frappe '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">Mise en forme du document</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -730,6 +730,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Correggi l'errore di ortografia '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">Formattazione del documento</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -730,6 +730,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">'{0}' の入力ミスを修正します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">ドキュメントの書式設定</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -730,6 +730,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">오타 '{0}' 수정</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">문서 서식을 지정하는 중</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -730,6 +730,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Popraw błąd pisowni „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">Trwa formatowanie dokumentu...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -730,6 +730,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Corrigir erro de digitação '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">Formatando documento</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -730,6 +730,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Исправьте опечатку "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">Форматирование документа</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -730,6 +730,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">'{0}' yazım hatasını düzeltin</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">Belge biçimlendiriliyor</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -730,6 +730,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">修正笔误“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">设置文档格式</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -730,6 +730,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">修正錯字 '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fixing_0">
+        <source>Fixing '{0}'</source>
+        <target state="new">Fixing '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatting_document">
         <source>Formatting document</source>
         <target state="translated">正在將文件格式化</target>

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
 
             // Compute diagnostics for everything that is not an IDE analyzer
             var allDiagnostics = (await _diagnosticService.GetDiagnosticsForSpanAsync(document, range,
-                shouldIncludeDiagnostic: static diagnosticId => !(IDEDiagnosticIdToOptionMappingHelper.IsKnownIDEDiagnosticId(diagnosticId)),
+                shouldIncludeDiagnostic: static diagnosticId => !IDEDiagnosticIdToOptionMappingHelper.IsKnownIDEDiagnosticId(diagnosticId),
                 includeSuppressedDiagnostics: false,
                 cancellationToken: cancellationToken).ConfigureAwait(false));
 

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -190,8 +190,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             // Compute diagnostics for everything that is not an IDE analyzer
             var diagnostics = (await _diagnosticService.GetDiagnosticsForSpanAsync(document, range,
                 shouldIncludeDiagnostic: static diagnosticId => !(IDEDiagnosticIdToOptionMappingHelper.IsKnownIDEDiagnosticId(diagnosticId)),
-                includeCompilerDiagnostics: false,
-                includeSuppressedDiagnostics: false,
+                includeCompilerDiagnostics: true, includeSuppressedDiagnostics: false,
                 cancellationToken: cancellationToken).ConfigureAwait(false));
 
             // ensure more than just known diagnostics were returned

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -240,7 +240,8 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             static bool ChangesMadeOutsideDocument(Document currentDocument, Document updatedDocument)
             {
                 var solutionChanges = updatedDocument.Project.Solution.GetChanges(currentDocument.Project.Solution);
-                if (solutionChanges.GetAddedProjects().Any() ||
+                return
+                    solutionChanges.GetAddedProjects().Any() ||
                     solutionChanges.GetRemovedProjects().Any() ||
                     solutionChanges.GetAddedAnalyzerReferences().Any() ||
                     solutionChanges.GetRemovedAnalyzerReferences().Any() ||
@@ -256,12 +257,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
                                           projectChanges.GetAddedAnalyzerConfigDocuments().Any() ||
                                           projectChanges.GetChangedDocuments().Any(documentId => documentId != updatedDocument.Id) ||
                                           projectChanges.GetChangedAdditionalDocuments().Any(documentId => documentId != updatedDocument.Id) ||
-                                          projectChanges.GetChangedAnalyzerConfigDocuments().Any(documentId => documentId != updatedDocument.Id)))
-                {
-                    return true;
-                }
-
-                return false;
+                                          projectChanges.GetChangedAnalyzerConfigDocuments().Any(documentId => documentId != updatedDocument.Id));
             }
         }
         public EnabledDiagnosticOptions GetAllDiagnostics()

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -263,6 +263,6 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             }
         }
         public EnabledDiagnosticOptions GetAllDiagnostics()
-            => new EnabledDiagnosticOptions(formatDocument: true, runThirdPartyFixers: true, GetDiagnosticSets(), new OrganizeUsingsSet(isRemoveUnusedImportEnabled: true, isSortImportsEnabled: true));
+            => new(FormatDocument: true, RunThirdPartyFixers: true, Diagnostics: GetDiagnosticSets(), OrganizeUsings: new OrganizeUsingsSet(isRemoveUnusedImportEnabled: true, isSortImportsEnabled: true));
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -186,13 +186,12 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             var range = new TextSpan(0, tree.Length);
 
             // Compute diagnostics for everything that is not an IDE analyzer
-            var allDiagnostics = (await _diagnosticService.GetDiagnosticsForSpanAsync(document, range,
-                shouldIncludeDiagnostic: static diagnosticId => !IDEDiagnosticIdToOptionMappingHelper.IsKnownIDEDiagnosticId(diagnosticId),
+            var diagnostics = (await _diagnosticService.GetDiagnosticsForSpanAsync(document, range,
+                shouldIncludeDiagnostic: static diagnosticId => !(IDEDiagnosticIdToOptionMappingHelper.IsKnownIDEDiagnosticId(diagnosticId) || IsCompilerDiagnostic(diagnosticId)),
                 includeSuppressedDiagnostics: false,
                 cancellationToken: cancellationToken).ConfigureAwait(false));
 
             // ensure more than just compiler diagnostics were returned
-            var diagnostics = allDiagnostics.WhereAsArray(d => !IsCompilerDiagnostic(d.Id));
             if (!diagnostics.Any())
             {
                 return document;

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -189,7 +189,8 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
 
             // Compute diagnostics for everything that is not an IDE analyzer
             var diagnostics = (await _diagnosticService.GetDiagnosticsForSpanAsync(document, range,
-                shouldIncludeDiagnostic: static diagnosticId => !(IDEDiagnosticIdToOptionMappingHelper.IsKnownIDEDiagnosticId(diagnosticId) || IsCompilerDiagnostic(diagnosticId)),
+                shouldIncludeDiagnostic: static diagnosticId => !(IDEDiagnosticIdToOptionMappingHelper.IsKnownIDEDiagnosticId(diagnosticId)),
+                includeCompilerDiagnostics: false,
                 includeSuppressedDiagnostics: false,
                 cancellationToken: cancellationToken).ConfigureAwait(false));
 
@@ -200,21 +201,6 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             }
 
             return diagnostics.SelectAsArray(static d => (d.Id, d.Title)).Distinct();
-
-            static bool IsCompilerDiagnostic(string errorId)
-            {
-                if (!string.IsNullOrEmpty(errorId) && errorId.Length > 2)
-                {
-                    var prefix = errorId[..2];
-                    if (prefix.Equals("CS", StringComparison.OrdinalIgnoreCase) || prefix.Equals("BC", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var suffix = errorId[2..];
-                        return int.TryParse(suffix, out _);
-                    }
-                }
-
-                return false;
-            }
         }
 
         private async Task<Document> ApplyThirdPartyCodeFixesAsync(

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             if (enabledDiagnostics.RunThirdPartyFixers)
             {
                 document = await ApplyThirdPartyCodeFixesAsync(
-                    document, thirdPartyDiagnosticIdsAndTitles, progressTracker, options, cancellationToken).ConfigureAwait(false);
+                    document, thirdPartyDiagnosticIdsAndTitles, progressTracker, fallbackOptions, cancellationToken).ConfigureAwait(false);
             }
 
             // do the remove usings after code fix, as code fix might remove some code which can results in unused usings.

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/EnabledDiagnosticOptions.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/EnabledDiagnosticOptions.cs
@@ -14,14 +14,15 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
     internal sealed class EnabledDiagnosticOptions
     {
         public bool FormatDocument { get; }
-
+        public bool RunThirdPartyFixers { get; }
         public ImmutableArray<DiagnosticSet> Diagnostics { get; }
 
         public OrganizeUsingsSet OrganizeUsings { get; }
 
-        public EnabledDiagnosticOptions(bool formatDocument, ImmutableArray<DiagnosticSet> diagnostics, OrganizeUsingsSet organizeUsings)
+        public EnabledDiagnosticOptions(bool formatDocument, bool runThirdPartyFixers, ImmutableArray<DiagnosticSet> diagnostics, OrganizeUsingsSet organizeUsings)
         {
             FormatDocument = formatDocument;
+            RunThirdPartyFixers = runThirdPartyFixers;
             Diagnostics = diagnostics;
             OrganizeUsings = organizeUsings;
         }

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/EnabledDiagnosticOptions.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/EnabledDiagnosticOptions.cs
@@ -11,20 +11,5 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
     /// <summary>
     /// Indicates which features are enabled for a code cleanup operation.
     /// </summary>
-    internal sealed class EnabledDiagnosticOptions
-    {
-        public bool FormatDocument { get; }
-        public bool RunThirdPartyFixers { get; }
-        public ImmutableArray<DiagnosticSet> Diagnostics { get; }
-
-        public OrganizeUsingsSet OrganizeUsings { get; }
-
-        public EnabledDiagnosticOptions(bool formatDocument, bool runThirdPartyFixers, ImmutableArray<DiagnosticSet> diagnostics, OrganizeUsingsSet organizeUsings)
-        {
-            FormatDocument = formatDocument;
-            RunThirdPartyFixers = runThirdPartyFixers;
-            Diagnostics = diagnostics;
-            OrganizeUsings = organizeUsings;
-        }
-    }
+    internal sealed record EnabledDiagnosticOptions(bool FormatDocument, bool RunThirdPartyFixers, ImmutableArray<DiagnosticSet> Diagnostics, OrganizeUsingsSet OrganizeUsings);
 }

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -230,31 +230,70 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             return spanToDiagnostics;
         }
 
-        public async Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(
+        public Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(
             Document document, TextSpan range, string diagnosticId, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
+            => GetDocumentFixAllForIdInSpanAsync(document, range, diagnosticId, DiagnosticSeverity.Hidden, fallbackOptions, cancellationToken);
+
+        public async Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(
+            Document document, TextSpan range, string diagnosticId, DiagnosticSeverity severity, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var diagnostics = (await _diagnosticService.GetDiagnosticsForSpanAsync(document, range, diagnosticId, includeSuppressedDiagnostics: false, cancellationToken: cancellationToken).ConfigureAwait(false)).ToList();
-            if (diagnostics.Count == 0)
+            var diagnostics = (await _diagnosticService.GetDiagnosticsForSpanAsync(document, range, diagnosticId, includeSuppressedDiagnostics: false, cancellationToken: cancellationToken).ConfigureAwait(false));
+            diagnostics = diagnostics.WhereAsArray(d => d.Severity.GreaterThanOrEqualTo(severity));
+            if (!diagnostics.Any())
                 return null;
 
             using var resultDisposer = ArrayBuilder<CodeFixCollection>.GetInstance(out var result);
             var spanToDiagnostics = new SortedDictionary<TextSpan, List<DiagnosticData>>
             {
-                { range, diagnostics },
+                { range, diagnostics.ToList() },
             };
 
             await foreach (var collection in StreamFixesAsync(
                 document, spanToDiagnostics, fixAllForInSpan: true, CodeActionRequestPriority.None,
                 fallbackOptions, isBlocking: false, addOperationScope: static _ => null, cancellationToken).ConfigureAwait(false))
             {
-                // TODO: Just get the first fix for now until we have a way to config user's preferred fix
-                // https://github.com/dotnet/roslyn/issues/27066
-                return collection;
+                if (collection.FixAllState is not null && collection.SupportedScopes.Contains(FixAllScope.Document))
+                {
+                    // TODO: Just get the first fix for now until we have a way to config user's preferred fix
+                    // https://github.com/dotnet/roslyn/issues/27066
+                    return collection;
+                }
             }
 
             return null;
+        }
+
+        public Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, IProgressTracker progressTracker, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
+            => ApplyCodeFixesForSpecificDiagnosticIdAsync(document, diagnosticId, DiagnosticSeverity.Hidden, progressTracker, fallbackOptions, cancellationToken);
+
+        public async Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(
+            Document document,
+            string diagnosticId,
+            DiagnosticSeverity severity,
+            IProgressTracker progressTracker,
+            CodeActionOptionsProvider fallbackOptions,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var textSpan = new TextSpan(0, tree.Length);
+
+            var fixCollection = await GetDocumentFixAllForIdInSpanAsync(
+                document, textSpan, diagnosticId, severity, fallbackOptions, cancellationToken).ConfigureAwait(false);
+            if (fixCollection == null)
+            {
+                return document;
+            }
+
+            var fixAllService = document.Project.Solution.Workspace.Services.GetRequiredService<IFixAllGetFixesService>();
+
+            var solution = await fixAllService.GetFixAllChangedSolutionAsync(
+                new FixAllContext(fixCollection.FixAllState, progressTracker, cancellationToken)).ConfigureAwait(false);
+
+            return solution.GetDocument(document.Id) ?? throw new NotSupportedException(FeaturesResources.Removal_of_document_not_supported);
         }
 
         private bool TryGetWorkspaceFixersMap(Document document, [NotNullWhen(true)] out Lazy<ImmutableDictionary<DiagnosticId, ImmutableArray<CodeFixProvider>>>? fixerMap)

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
             var diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
                 document, range, diagnosticId, includeSuppressedDiagnostics: false, cancellationToken: cancellationToken).ConfigureAwait(false);
-            diagnostics = diagnostics.WhereAsArray(d => d.Severity.GreaterThanOrEqualTo(minimumSeverity));
+            diagnostics = diagnostics.WhereAsArray(d => d.Severity.IsMoreSevereThanOrEqualTo(minimumSeverity));
             if (!diagnostics.Any())
                 return null;
 

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -173,7 +173,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
             var diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
                 document, range, GetShouldIncludeDiagnosticPredicate(document, priority),
-                includeSuppressionFixes, true, priority, addOperationScope, cancellationToken).ConfigureAwait(false);
+                includeCompilerDiagnostics: true, includeSuppressedDiagnostics: includeSuppressionFixes, priority: priority,
+                addOperationScope: addOperationScope, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (diagnostics.IsEmpty)
                 yield break;

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -239,7 +239,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var diagnostics = (await _diagnosticService.GetDiagnosticsForSpanAsync(document, range, diagnosticId, includeSuppressedDiagnostics: false, cancellationToken: cancellationToken).ConfigureAwait(false));
+            var diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
+                document, range, diagnosticId, includeSuppressedDiagnostics: false, cancellationToken: cancellationToken).ConfigureAwait(false);
             diagnostics = diagnostics.WhereAsArray(d => d.Severity.GreaterThanOrEqualTo(severity));
             if (!diagnostics.Any())
                 return null;

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
             var diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
                 document, range, GetShouldIncludeDiagnosticPredicate(document, priority),
-                includeSuppressionFixes, priority, addOperationScope, cancellationToken).ConfigureAwait(false);
+                includeSuppressionFixes, true, priority, addOperationScope, cancellationToken).ConfigureAwait(false);
 
             if (diagnostics.IsEmpty)
                 yield break;

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -235,13 +235,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             => GetDocumentFixAllForIdInSpanAsync(document, range, diagnosticId, DiagnosticSeverity.Hidden, fallbackOptions, cancellationToken);
 
         public async Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(
-            Document document, TextSpan range, string diagnosticId, DiagnosticSeverity severity, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
+            Document document, TextSpan range, string diagnosticId, DiagnosticSeverity minimumSeverity, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
                 document, range, diagnosticId, includeSuppressedDiagnostics: false, cancellationToken: cancellationToken).ConfigureAwait(false);
-            diagnostics = diagnostics.WhereAsArray(d => d.Severity.GreaterThanOrEqualTo(severity));
+            diagnostics = diagnostics.WhereAsArray(d => d.Severity.GreaterThanOrEqualTo(minimumSeverity));
             if (!diagnostics.Any())
                 return null;
 

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
@@ -25,9 +25,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// </summary>
         Task<FirstFixResult> GetMostSevereFixAsync(Document document, TextSpan range, CodeActionRequestPriority priority, CodeActionOptionsProvider fallbackOptions, bool isBlocking, CancellationToken cancellationToken);
 
-        Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
         Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, DiagnosticSeverity severity, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
-        Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, IProgressTracker progressTracker, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
         Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, DiagnosticSeverity severity, IProgressTracker progressTracker, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
         CodeFixProvider? GetSuppressionFixer(string language, IEnumerable<string> diagnosticIds);
     }
@@ -42,5 +40,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
         public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider fallbackOptions, bool isBlocking, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken)
             => service.StreamFixesAsync(document, textSpan, priority, fallbackOptions, isBlocking, addOperationScope, cancellationToken).ToImmutableArrayAsync(cancellationToken);
+
+        public static Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(this ICodeFixService service, Document document, TextSpan range, string diagnosticId, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
+            => service.GetDocumentFixAllForIdInSpanAsync(document, range, diagnosticId, DiagnosticSeverity.Hidden, fallbackOptions, cancellationToken);
+
+        public static Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(this ICodeFixService service, Document document, string diagnosticId, IProgressTracker progressTracker, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
+            => service.ApplyCodeFixesForSpecificDiagnosticIdAsync(document, diagnosticId, DiagnosticSeverity.Hidden, progressTracker, fallbackOptions, cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
@@ -26,6 +26,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         Task<FirstFixResult> GetMostSevereFixAsync(Document document, TextSpan range, CodeActionRequestPriority priority, CodeActionOptionsProvider fallbackOptions, bool isBlocking, CancellationToken cancellationToken);
 
         Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
+        Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, DiagnosticSeverity severity, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
+        Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, IProgressTracker progressTracker, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
+        Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, DiagnosticSeverity severity, IProgressTracker progressTracker, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
         CodeFixProvider? GetSuppressionFixer(string language, IEnumerable<string> diagnosticIds);
     }
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
@@ -96,8 +96,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Document document,
             TextSpan? range,
             Func<string, bool>? shouldIncludeDiagnostic,
-            bool includeSuppressedDiagnostics,
             bool includeCompilerDiagnostics,
+            bool includeSuppressedDiagnostics,
             CodeActionRequestPriority priority,
             Func<string, IDisposable?>? addOperationScope,
             CancellationToken cancellationToken)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var diagnostics);
                     var upToDate = await analyzer.TryAppendDiagnosticsForSpanAsync(
                         document, range, diagnostics, shouldIncludeDiagnostic,
-                        includeSuppressedDiagnostics, priority, blockForData: false,
+                        includeSuppressedDiagnostics, true, priority, blockForData: false,
                         addOperationScope: null, cancellationToken).ConfigureAwait(false);
                     return (diagnostics.ToImmutable(), upToDate);
                 }, cancellationToken);
@@ -97,6 +97,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             TextSpan? range,
             Func<string, bool>? shouldIncludeDiagnostic,
             bool includeSuppressedDiagnostics,
+            bool includeCompilerDiagnostics,
             CodeActionRequestPriority priority,
             Func<string, IDisposable?>? addOperationScope,
             CancellationToken cancellationToken)
@@ -105,8 +106,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // always make sure that analyzer is called on background thread.
                 return Task.Run(() => analyzer.GetDiagnosticsForSpanAsync(
-                    document, range, shouldIncludeDiagnostic, includeSuppressedDiagnostics, priority,
-                    blockForData: true, addOperationScope, cancellationToken), cancellationToken);
+                    document, range, shouldIncludeDiagnostic, includeSuppressedDiagnostics, includeCompilerDiagnostics,
+                    priority, blockForData: true, addOperationScope, cancellationToken), cancellationToken);
             }
 
             return SpecializedTasks.EmptyImmutableArray<DiagnosticData>();

--- a/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
@@ -341,7 +341,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
                     {
                         if (enabledFixIds.IsFixIdEnabled(diagnosticId))
                         {
-                            enabedDiagnosticSets.Add(diagnostic);
+                            enabledDiagnosticSets.Add(diagnostic);
                             break;
                         }
                     }
@@ -354,7 +354,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
                 enabledDiagnostics = new EnabledDiagnosticOptions(
                     isFormatDocumentEnabled,
                     isApplyThirdPartyFixersEnabled,
-                    enabedDiagnosticSets.ToImmutableArray(),
+                    enabledDiagnosticSets.ToImmutableArray(),
                     new OrganizeUsingsSet(isRemoveUnusedUsingsEnabled, isSortUsingsEnabled));
             }
 

--- a/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
@@ -333,7 +333,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
             var enabledDiagnostics = codeCleanupService.GetAllDiagnostics();
             if (!enabledFixIds.IsFixIdEnabled(ApplyAllAnalyzerFixersId))
             {
-                var enabedDiagnosticSets = ArrayBuilder<DiagnosticSet>.GetInstance();
+                var enabledDiagnosticSets = ArrayBuilder<DiagnosticSet>.GetInstance();
 
                 foreach (var diagnostic in enabledDiagnostics.Diagnostics)
                 {

--- a/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
         protected internal const string FormatDocumentFixId = nameof(FormatDocumentFixId);
         protected internal const string RemoveUnusedImportsFixId = nameof(RemoveUnusedImportsFixId);
         protected internal const string SortImportsFixId = nameof(SortImportsFixId);
+        protected internal const string ApplyThirdPartyFixersId = nameof(ApplyThirdPartyFixersId);
 
         private readonly IThreadingContext _threadingContext;
         private readonly VisualStudioWorkspaceImpl _workspace;
@@ -347,8 +348,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
             var isFormatDocumentEnabled = enabledFixIds.IsFixIdEnabled(FormatDocumentFixId);
             var isRemoveUnusedUsingsEnabled = enabledFixIds.IsFixIdEnabled(RemoveUnusedImportsFixId);
             var isSortUsingsEnabled = enabledFixIds.IsFixIdEnabled(SortImportsFixId);
+            var isApplyThirdPartyFixersEnabled = enabledFixIds.IsFixIdEnabled(ApplyThirdPartyFixersId);
             var enabledDiagnostics = new EnabledDiagnosticOptions(
                 isFormatDocumentEnabled,
+                isApplyThirdPartyFixersEnabled,
                 enabedDiagnosticSets.ToImmutableArray(),
                 new OrganizeUsingsSet(isRemoveUnusedUsingsEnabled, isSortUsingsEnabled));
 

--- a/src/VisualStudio/Core/Def/CodeCleanup/CommonCodeCleanUpFixerDiagnosticIds.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/CommonCodeCleanUpFixerDiagnosticIds.cs
@@ -338,5 +338,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
         [HelpLink($"https://microsoft.com/")]
         [LocalizedName(typeof(ServicesVSResources), nameof(ServicesVSResources.Fix_analyzer_warnings_and_errors_set_in_EditorConfig))]
         public static readonly FixIdDefinition? ThirdPartyAnalyzers;
+
+        [Export]
+        [FixId(AbstractCodeCleanUpFixer.ApplyAllAnalyzerFixersId)]
+        [Name(AbstractCodeCleanUpFixer.ApplyAllAnalyzerFixersId)]
+        [Order(After = IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink($"https://microsoft.com/")]
+        [LocalizedName(typeof(ServicesVSResources), nameof(ServicesVSResources.Fix_all_warnings_and_errors_set_in_EditorConfig))]
+        public static readonly FixIdDefinition? AllAnalyzers;
     }
 }

--- a/src/VisualStudio/Core/Def/CodeCleanup/CommonCodeCleanUpFixerDiagnosticIds.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/CommonCodeCleanUpFixerDiagnosticIds.cs
@@ -336,7 +336,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
         [Order(After = IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId)]
         [ConfigurationKey("unused")]
         [HelpLink($"https://microsoft.com/")]
-        [LocalizedName(typeof(ServicesVSResources), nameof(ServicesVSResources.Fix_analyzer_warnings_and_errors))]
+        [LocalizedName(typeof(ServicesVSResources), nameof(ServicesVSResources.Fix_analyzer_warnings_and_errors_set_in_EditorConfig))]
         public static readonly FixIdDefinition? ThirdPartyAnalyzers;
     }
 }

--- a/src/VisualStudio/Core/Def/CodeCleanup/CommonCodeCleanUpFixerDiagnosticIds.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/CommonCodeCleanUpFixerDiagnosticIds.cs
@@ -329,5 +329,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
         [HelpLink($"https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/{IDEDiagnosticIds.ValueAssignedIsUnusedDiagnosticId}")]
         [LocalizedName(typeof(FeaturesResources), nameof(FeaturesResources.Apply_unused_value_preferences))]
         public static readonly FixIdDefinition? ValueAssignedIsUnusedDiagnosticId;
+
+        [Export]
+        [FixId(AbstractCodeCleanUpFixer.ApplyThirdPartyFixersId)]
+        [Name(AbstractCodeCleanUpFixer.ApplyThirdPartyFixersId)]
+        [Order(After = IDEDiagnosticIds.RemoveUnnecessaryCastDiagnosticId)]
+        [ConfigurationKey("unused")]
+        [HelpLink($"https://microsoft.com/")]
+        [LocalizedName(typeof(ServicesVSResources), nameof(ServicesVSResources.Fix_analyzer_warnings_and_errors))]
+        public static readonly FixIdDefinition? ThirdPartyAnalyzers;
     }
 }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1971,4 +1971,7 @@ Additional information: {1}</value>
   <data name="Rename_asynchronously_experimental" xml:space="preserve">
     <value>Rename asynchronously experimental</value>
   </data>
+  <data name="Fix_analyzer_warnings_and_errors" xml:space="preserve">
+    <value>Fix analyzer warnings and errors</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1974,4 +1974,7 @@ Additional information: {1}</value>
   <data name="Fix_analyzer_warnings_and_errors" xml:space="preserve">
     <value>Fix analyzer warnings and errors</value>
   </data>
+  <data name="Fix_analyzer_warnings_and_errors_set_in_EditorConfig" xml:space="preserve">
+    <value>Fix analyzer warnings and errors set in EditorConfig</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1977,4 +1977,7 @@ Additional information: {1}</value>
   <data name="Fix_analyzer_warnings_and_errors_set_in_EditorConfig" xml:space="preserve">
     <value>Fix analyzer warnings and errors set in EditorConfig</value>
   </data>
+  <data name="Fix_all_warnings_and_errors_set_in_EditorConfig" xml:space="preserve">
+    <value>Fix all warnings and errors set in EditorConfig</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">Pro členy mimo rozhraní</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">Für Nichtschnittstellenmember</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">Para miembros que no son de interfaz</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">Pour les membres non d’interface</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">Per i membri non di interfaccia</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">非インターフェイスメンバーの場合</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">비 인터페이스 멤버의 경우</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">Dla elementów innych niż składowe interfejsu</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">Para membros sem interface</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">Для элементов без интерфейса</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">Arabirim olmayan üyeler için</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">对于非接口成员</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -467,6 +467,11 @@
         <target state="new">Fix text pasted into string literals (experimental)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors">
+        <source>Fix analyzer warnings and errors</source>
+        <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
       <trans-unit id="For_non_interface_members">
         <source>For non interface members</source>
         <target state="translated">對於非介面成員</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -470,6 +470,10 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+      </trans-unit>
+      <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix analyzer warnings and errors set in EditorConfig</source>
+        <target state="new">Fix analyzer warnings and errors set in EditorConfig</target>
         <note />
       </trans-unit>
       <trans-unit id="For_non_interface_members">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -470,6 +470,12 @@
       <trans-unit id="Fix_analyzer_warnings_and_errors">
         <source>Fix analyzer warnings and errors</source>
         <target state="new">Fix analyzer warnings and errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_all_warnings_and_errors_set_in_EditorConfig">
+        <source>Fix all warnings and errors set in EditorConfig</source>
+        <target state="new">Fix all warnings and errors set in EditorConfig</target>
+        <note />
       </trans-unit>
       <trans-unit id="Fix_analyzer_warnings_and_errors_set_in_EditorConfig">
         <source>Fix analyzer warnings and errors set in EditorConfig</source>

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -521,7 +521,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Public Sub Reanalyze(workspace As Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing, Optional highPriority As Boolean = False) Implements IDiagnosticAnalyzerService.Reanalyze
             End Sub
 
-            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), Optional includeSuppressedDiagnostics As Boolean = False, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional addOperationScope As Func(Of String, IDisposable) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
+            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), Optional includeSuppressedDiagnostics As Boolean = False, Optional includeCompilerDiagnostics As Boolean = True, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional addOperationScope As Func(Of String, IDisposable) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
                 Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)
             End Function
 

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -521,7 +521,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Public Sub Reanalyze(workspace As Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing, Optional highPriority As Boolean = False) Implements IDiagnosticAnalyzerService.Reanalyze
             End Sub
 
-            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), Optional includeSuppressedDiagnostics As Boolean = False, Optional includeCompilerDiagnostics As Boolean = True, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional addOperationScope As Func(Of String, IDisposable) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
+            Public Function GetDiagnosticsForSpanAsync(document As Document, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), includeCompilerDiagnostics As Boolean, Optional includeSuppressedDiagnostics As Boolean = False, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional addOperationScope As Func(Of String, IDisposable) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
                 Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)
             End Function
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58089

This options looks like this in the UI:

<img width="516" alt="image" src="https://user-images.githubusercontent.com/9797472/155629840-416774db-234e-4eea-bc5a-9612dc51b821.png">

To enable this functionality the user needs to

0. have set a specific set of analyzer diagnostics as warning or error
1. Go to the "configure code cleanup" menu
<img width="305" alt="image" src="https://user-images.githubusercontent.com/9797472/155630001-15826776-2f55-4003-ad2e-4c7a539cfc0b.png">

2. Explicitly opt into this setting
<img width="510" alt="image" src="https://user-images.githubusercontent.com/9797472/155630068-b0222095-610e-440a-8026-9fa5bf23a865.png">
3. Run the code cleanup profile where they modified that setting
<img width="298" alt="image" src="https://user-images.githubusercontent.com/9797472/155630263-35099b49-1fdd-4a51-9ddb-40946f0778c2.png">

4. Or run the code cleanup profile on their project/solution
<img width="441" alt="image" src="https://user-images.githubusercontent.com/9797472/155630218-89b07624-a965-4f1d-912c-6a5c3970f926.png">

5. Or have configured the profile to run on save

<img width="449" alt="image" src="https://user-images.githubusercontent.com/9797472/155630347-50627ca8-1269-43fa-b95d-ec1eb49f7f0a.png">


Rules for whether we apply a code fix with this option are as follows:
1. The diagnostic is a warning or error
1. The code fix for this diagnostic supports fix-all in document scope
1. When applying the fix-all in document scope nothing outside the document changes 

____

TODO:

- [x] Add a new option that is a superset of this option that allows you to "fix all warnings and errors set in editorconfig" that included formatting, code-style, and third-party analyzers.