### PR TITLE
Fix flaky test

### DIFF
--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -787,6 +787,11 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var oldTree = await document.GetRequiredSyntaxTreeAsync(CancellationToken.None);
 
+            // Hold onto the old root, so we don't actually release the root; if the root were to fall away
+            // we're unable to use IsIncrementallyIdenticalTo to see if we didn't reparse, since asking for
+            // the old root will recover the tree and produce a new green node.
+            var oldRoot = oldTree.GetRoot();
+
             Assert.Equal(document.Project.ParseOptions, oldTree.Options);
 
             ParseOptions newOptions =
@@ -799,7 +804,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Equal(document.Project.ParseOptions, newTree.Options);
 
-            Assert.Equal(expectReuse, oldTree.GetRoot().IsIncrementallyIdenticalTo(newTree.GetRoot()));
+            Assert.Equal(expectReuse, oldRoot.IsIncrementallyIdenticalTo(newTree.GetRoot()));
         }
 
         [Fact]


### PR DESCRIPTION
This test was trying to assert that we didn't do a reparse by comparing the green nodes of the two trees. We didn't hold onto the root of the old tree, so it was possible for the root to fall away if we were testing recoverable trees. If the root had fallen away, it meant that asking for the old root would recover it as well, which would result in deserializing the roots twice and the green nodes being different.

The fix is to ensure the root doesn't fall away.