### PR TITLE
Improve PDB source document project handling

### DIFF
--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/AbstractPdbSourceDocumentTests.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/AbstractPdbSourceDocumentTests.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.PdbSourceDocument;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -158,6 +159,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PdbSourceDocument
                 var document = masWorkspace!.CurrentSolution.Projects.First().Documents.First();
 
                 Assert.Equal(document.FilePath, file.FilePath);
+
+                // Mapping the project from the generated document should map back to the original project
+                var exportProvider = (IMefHostExportProvider)project.Solution.Workspace.Services.HostServices;
+                var provider = exportProvider.GetExportedValues<IMetadataAsSourceFileProvider>().OfType<PdbSourceDocumentMetadataAsSourceFileProvider>().Single();
+                var mappedProject = provider.MapDocument(document);
+                Assert.NotNull(mappedProject);
+                Assert.Equal(project.Id, mappedProject!.Id);
 
                 var actual = await document.GetTextAsync();
                 var actualSpan = file!.IdentifierLocation.SourceSpan;

--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/AbstractPdbSourceDocumentTests.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/AbstractPdbSourceDocumentTests.cs
@@ -161,8 +161,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PdbSourceDocument
                 Assert.Equal(document.FilePath, file.FilePath);
 
                 // Mapping the project from the generated document should map back to the original project
-                var exportProvider = (IMefHostExportProvider)project.Solution.Workspace.Services.HostServices;
-                var provider = exportProvider.GetExportedValues<IMetadataAsSourceFileProvider>().OfType<PdbSourceDocumentMetadataAsSourceFileProvider>().Single();
+                var provider = workspace.ExportProvider.GetExportedValues<IMetadataAsSourceFileProvider>().OfType<PdbSourceDocumentMetadataAsSourceFileProvider>().Single();
                 var mappedProject = provider.MapDocument(document);
                 Assert.NotNull(mappedProject);
                 Assert.Equal(project.Id, mappedProject!.Id);

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -29,8 +29,6 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         /// </summary>
         private readonly SemaphoreSlim _gate = new(initialCount: 1);
 
-        private readonly Dictionary<string, IMetadataAsSourceFileProvider> _tempFileToProviderMap = new(StringComparer.OrdinalIgnoreCase);
-
         private MetadataAsSourceWorkspace? _workspace;
 
         /// <summary>
@@ -97,7 +95,6 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                     var result = await provider.GetGeneratedFileAsync(_workspace, project, symbol, signaturesOnly, allowDecompilation, providerTempPath, cancellationToken).ConfigureAwait(false);
                     if (result is not null)
                     {
-                        _tempFileToProviderMap[result.FilePath] = provider;
                         return result;
                     }
                 }
@@ -111,11 +108,14 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         {
             using (_gate.DisposableWait())
             {
-                if (_tempFileToProviderMap.TryGetValue(filePath, out var provider))
-                {
-                    Contract.ThrowIfNull(_workspace);
+                Contract.ThrowIfNull(_workspace);
 
-                    return provider.TryAddDocumentToWorkspace(_workspace, filePath, sourceTextContainer);
+                foreach (var provider in _providers)
+                {
+                    if (!provider.IsValueCreated)
+                        continue;
+
+                    return provider.Value.TryAddDocumentToWorkspace(_workspace, filePath, sourceTextContainer);
                 }
             }
 
@@ -126,11 +126,14 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         {
             using (_gate.DisposableWait())
             {
-                if (_tempFileToProviderMap.TryGetValue(filePath, out var provider))
-                {
-                    Contract.ThrowIfNull(_workspace);
+                Contract.ThrowIfNull(_workspace);
 
-                    return provider.TryRemoveDocumentFromWorkspace(_workspace, filePath);
+                foreach (var provider in _providers)
+                {
+                    if (!provider.IsValueCreated)
+                        continue;
+
+                    return provider.Value.TryRemoveDocumentFromWorkspace(_workspace, filePath);
                 }
             }
 
@@ -149,16 +152,24 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         {
             Contract.ThrowIfNull(document.FilePath);
 
-            Project? project;
+            Project? project = null;
             using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                if (!_tempFileToProviderMap.TryGetValue(document.FilePath, out var provider))
-                    return null;
+                Contract.ThrowIfNull(_workspace);
 
-                project = provider.MapDocument(document);
-                if (project == null)
-                    return null;
+                foreach (var provider in _providers)
+                {
+                    if (!provider.IsValueCreated)
+                        continue;
+
+                    project = provider.Value.MapDocument(document);
+                    if (project is not null)
+                        break;
+                }
             }
+
+            if (project is null)
+                return null;
 
             var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
             var resolutionResult = symbolId.Resolve(compilation, ignoreAssemblyKey: true, cancellationToken: cancellationToken);
@@ -182,12 +193,13 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
                 // Only cleanup for providers that have actually generated a file. This keeps us from
                 // accidentally loading lazy providers on cleanup that weren't used
-                foreach (var provider in _tempFileToProviderMap.Values.Distinct())
+                foreach (var provider in _providers)
                 {
-                    provider.CleanupGeneratedFiles(_workspace);
-                }
+                    if (!provider.IsValueCreated)
+                        continue;
 
-                _tempFileToProviderMap.Clear();
+                    provider.Value.CleanupGeneratedFiles(_workspace);
+                }
 
                 try
                 {

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -108,12 +108,12 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         {
             using (_gate.DisposableWait())
             {
-                Contract.ThrowIfNull(_workspace);
-
                 foreach (var provider in _providers)
                 {
                     if (!provider.IsValueCreated)
                         continue;
+
+                    Contract.ThrowIfNull(_workspace);
 
                     if (provider.Value.TryAddDocumentToWorkspace(_workspace, filePath, sourceTextContainer))
                         return true;
@@ -127,12 +127,12 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         {
             using (_gate.DisposableWait())
             {
-                Contract.ThrowIfNull(_workspace);
-
                 foreach (var provider in _providers)
                 {
                     if (!provider.IsValueCreated)
                         continue;
+
+                    Contract.ThrowIfNull(_workspace);
 
                     if (provider.Value.TryRemoveDocumentFromWorkspace(_workspace, filePath))
                         return true;
@@ -157,12 +157,12 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             Project? project = null;
             using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                Contract.ThrowIfNull(_workspace);
-
                 foreach (var provider in _providers)
                 {
                     if (!provider.IsValueCreated)
                         continue;
+
+                    Contract.ThrowIfNull(_workspace);
 
                     project = provider.Value.MapDocument(document);
                     if (project is not null)

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -115,7 +115,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                     if (!provider.IsValueCreated)
                         continue;
 
-                    return provider.Value.TryAddDocumentToWorkspace(_workspace, filePath, sourceTextContainer);
+                    if (provider.Value.TryAddDocumentToWorkspace(_workspace, filePath, sourceTextContainer))
+                        return true;
                 }
             }
 
@@ -133,7 +134,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                     if (!provider.IsValueCreated)
                         continue;
 
-                    return provider.Value.TryRemoveDocumentFromWorkspace(_workspace, filePath);
+                    if (provider.Value.TryRemoveDocumentFromWorkspace(_workspace, filePath))
+                        return true;
                 }
             }
 

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
             var symbolId = SymbolKey.Create(symbol, cancellationToken);
             var navigateProject = workspace.CurrentSolution.GetRequiredProject(projectId);
 
-            var documentInfos = CreateDocumentInfos(sourceFileInfos, encoding, navigateProject);
+            var documentInfos = CreateDocumentInfos(sourceFileInfos, encoding, navigateProject.Id, project);
             if (documentInfos.Length > 0)
             {
                 workspace.OnDocumentsAdded(documentInfos);
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
                 metadataReferences: project.MetadataReferences.ToImmutableArray()); // TODO: Read references from PDB info: https://github.com/dotnet/roslyn/issues/55834
         }
 
-        private ImmutableArray<DocumentInfo> CreateDocumentInfos(SourceFileInfo?[] sourceFileInfos, Encoding encoding, Project project)
+        private ImmutableArray<DocumentInfo> CreateDocumentInfos(SourceFileInfo?[] sourceFileInfos, Encoding encoding, ProjectId projectId, Project sourceProject)
         {
             using var _ = ArrayBuilder<DocumentInfo>.GetInstance(out var documents);
 
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
                     continue;
                 }
 
-                var documentId = DocumentId.CreateNewId(project.Id);
+                var documentId = DocumentId.CreateNewId(projectId);
 
                 documents.Add(DocumentInfo.Create(
                     documentId,
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
                     loader: info.Loader));
 
                 // In order to open documents in VS we need to understand the link from temp file to document and its encoding etc.
-                _fileToDocumentMap[info.FilePath] = new(documentId, encoding, project.Id, project.Solution.Workspace);
+                _fileToDocumentMap[info.FilePath] = new(documentId, encoding, sourceProject.Id, sourceProject.Solution.Workspace);
             }
 
             return documents.ToImmutable();

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -57,6 +57,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
             using var telemetry = new TelemetryMessage(cancellationToken);
 
             var assemblyName = symbol.ContainingAssembly.Identity.Name;
+            var assemblyVersion = symbol.ContainingAssembly.Identity.Version.ToString();
 
             if (_logger is not null)
             {
@@ -122,7 +123,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
             if (!_assemblyToProjectMap.TryGetValue(assemblyName, out var projectId))
             {
                 // Get the project info now, so we can dispose the documentDebugInfoReader sooner
-                var projectInfo = CreateProjectInfo(workspace, project, pdbCompilationOptions, assemblyName);
+                var projectInfo = CreateProjectInfo(workspace, project, pdbCompilationOptions, assemblyName, assemblyVersion);
 
                 if (projectInfo is null)
                     return null;
@@ -186,7 +187,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
             return new MetadataAsSourceFile(documentPath, navigateLocation, documentName, sourceDocuments[0].FilePath);
         }
 
-        private ProjectInfo? CreateProjectInfo(Workspace workspace, Project project, ImmutableDictionary<string, string> pdbCompilationOptions, string assemblyName)
+        private ProjectInfo? CreateProjectInfo(Workspace workspace, Project project, ImmutableDictionary<string, string> pdbCompilationOptions, string assemblyName, string assemblyVersion)
         {
             // First we need the language name in order to get the services
             // TODO: Find language another way for non portable PDBs: https://github.com/dotnet/roslyn/issues/55834
@@ -206,7 +207,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
             return ProjectInfo.Create(
                 projectId,
                 VersionStamp.Default,
-                name: assemblyName + ProviderName, // Distinguish this project from any decompilation projects that might be created
+                name: $"{assemblyName} ({assemblyVersion})",
                 assemblyName: assemblyName,
                 language: languageName,
                 compilationOptions: compilationOptions,

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToBase.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToBase.cs
@@ -36,7 +36,7 @@ class C
 }", HangMitigatingCancellationToken);
             await TestServices.Editor.PlaceCaretAsync("ToString", charsOffset: -1, HangMitigatingCancellationToken);
             await TestServices.Editor.GoToBaseAsync(HangMitigatingCancellationToken);
-            Assert.Equal("Object [from metadata] [Read Only]", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));
+            Assert.Equal("Object [from metadata]", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));
 
             await TestServices.EditorVerifier.TextContainsAsync(@"public virtual string ToString$$()", assertCaretPosition: true);
         }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToBase.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToBase.cs
@@ -36,7 +36,7 @@ class C
 }", HangMitigatingCancellationToken);
             await TestServices.Editor.PlaceCaretAsync("ToString", charsOffset: -1, HangMitigatingCancellationToken);
             await TestServices.Editor.GoToBaseAsync(HangMitigatingCancellationToken);
-            Assert.Equal("Object [from metadata]", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));
+            Assert.Equal("Object [from metadata] [Read Only]", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));
 
             await TestServices.EditorVerifier.TextContainsAsync(@"public virtual string ToString$$()", assertCaretPosition: true);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59138
Part of https://github.com/dotnet/roslyn/issues/55834

The main thing this does is ensure that additional documents found via Source Link are shown in the right project context. The affect is seen when opening a Source Link file other than the first one the user navigated to.

Before:
File is in Misc Files, classification is broken (eg constructer parameters)
<img width="444" alt="image" src="https://user-images.githubusercontent.com/754264/154661635-5d95ea42-d7ff-4465-a485-8e0b16ea339f.png">

After:
Show in the right project, with a nice name, and full classification (and in dark mode apparently 😛)
<img width="467" alt="image" src="https://user-images.githubusercontent.com/754264/154668115-f19ade99-b53e-47a8-ae7d-22f9d5c3f877.png">
