### PR TITLE
Add feature to fixup code when user transposes 'record' in a declaration

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
+++ b/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
@@ -44,6 +44,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SimplifyInterpolation\CSharpSimplifyInterpolationCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SimplifyLinqExpression\CSharpSimplifyLinqExpressionCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SimplifyPropertyPattern\CSharpSimplifyPropertyPatternCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TransposeRecordKeyword\CSharpTransposeRecordKeywordCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCollectionInitializer\CSharpUseCollectionInitializerCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\CSharpUseCompoundAssignmentCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseCompoundAssignment\CSharpUseCompoundCoalesceAssignmentCodeFixProvider.cs" />
@@ -78,8 +79,5 @@
   </ItemGroup>
   <ItemGroup Condition="'$(DefaultLanguageSourceExtension)' != '' AND '$(BuildingInsideVisualStudio)' != 'true'">
     <ExpectedCompile Include="$(MSBuildThisFileDirectory)**\*$(DefaultLanguageSourceExtension)" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="$(MSBuildThisFileDirectory)ConvertNamespace\" />
   </ItemGroup>
 </Project>

--- a/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixesResources.resx
+++ b/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixesResources.resx
@@ -144,4 +144,7 @@
   <data name="Place_colon_on_following_line" xml:space="preserve">
     <value>Place colon on following line</value>
   </data>
+  <data name="Fix_token_placement" xml:space="preserve">
+    <value>Fix token placement</value>
+  </data>
 </root>

--- a/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixesResources.resx
+++ b/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixesResources.resx
@@ -144,7 +144,7 @@
   <data name="Place_colon_on_following_line" xml:space="preserve">
     <value>Place colon on following line</value>
   </data>
-  <data name="Fix_token_placement" xml:space="preserve">
-    <value>Fix token placement</value>
+  <data name="Fix_record_declaration" xml:space="preserve">
+    <value>Fix_record_declaration</value>
   </data>
 </root>

--- a/src/Analyzers/CSharp/CodeFixes/TransposeRecordKeyword/CSharpTransposeRecordKeywordCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/TransposeRecordKeyword/CSharpTransposeRecordKeywordCodeFixProvider.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.TransposeRecordKeyword
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    internal class CSharpTransposeRecordKeywordCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+    {
+        private const string CS9012 = nameof(CS9012); // Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpTransposeRecordKeywordCodeFixProvider()
+        {
+        }
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(CS9012);
+
+        internal override CodeFixCategory CodeFixCategory
+            => CodeFixCategory.Compile;
+
+        private static bool TryGetRecordDeclaration(
+            Diagnostic diagnostic, CancellationToken cancellationToken, [NotNullWhen(true)] out RecordDeclarationSyntax? recordDeclaration)
+        {
+            recordDeclaration = diagnostic.Location.FindNode(cancellationToken) as RecordDeclarationSyntax;
+            return recordDeclaration != null;
+        }
+
+        private static bool TryGetTokens(
+            RecordDeclarationSyntax recordDeclaration,
+            out SyntaxToken recordKeyword,
+            out SyntaxToken classOrStructKeyword,
+            out SyntaxTrivia whitespaceTrivia)
+        {
+            recordKeyword = recordDeclaration.Keyword;
+            if (!recordKeyword.IsMissing)
+            {
+                var leadingTrivia = recordKeyword.LeadingTrivia;
+                if (leadingTrivia.Count >= 2)
+                {
+                    var skippedTrivia = leadingTrivia[^2];
+                    whitespaceTrivia = leadingTrivia[^1];
+                    if (skippedTrivia.Kind() == SyntaxKind.SkippedTokensTrivia &&
+                        whitespaceTrivia.Kind() == SyntaxKind.WhitespaceTrivia)
+                    {
+                        var structure = (SkippedTokensTriviaSyntax)skippedTrivia.GetStructure()!;
+                        var tokens = structure.Tokens;
+                        if (tokens.Count == 1)
+                        {
+                            var lastSkippedToken = tokens.Single();
+                            if (lastSkippedToken.Kind() is SyntaxKind.ClassKeyword or SyntaxKind.StructKeyword)
+                            {
+                                classOrStructKeyword = lastSkippedToken;
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            classOrStructKeyword = default;
+            whitespaceTrivia = default;
+            return false;
+        }
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var document = context.Document;
+            var cancellationToken = context.CancellationToken;
+
+            var diagnostic = context.Diagnostics.First();
+            if (TryGetRecordDeclaration(diagnostic, cancellationToken, out var recordDeclaration) &&
+                TryGetTokens(recordDeclaration, out _, out _, out _))
+            {
+                context.RegisterCodeFix(
+                    new MyCodeAction(c => this.FixAsync(document, diagnostic, c)),
+                    diagnostic);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        protected override Task FixAllAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics,
+            SyntaxEditor editor, CancellationToken cancellationToken)
+        {
+            foreach (var diagnostic in diagnostics)
+            {
+                if (TryGetRecordDeclaration(diagnostic, cancellationToken, out var recordDeclaration))
+                {
+                    editor.ReplaceNode(
+                        recordDeclaration,
+                        (current, _) =>
+                        {
+                            var currentRecordDeclaration = (RecordDeclarationSyntax)current;
+                            if (!TryGetTokens(currentRecordDeclaration, out var recordKeyword, out var classOrStructKeyword, out var whitespace))
+                                return currentRecordDeclaration;
+
+                            return currentRecordDeclaration
+                                .WithClassOrStructKeyword(classOrStructKeyword.WithAppendedTrailingTrivia(whitespace))
+                                .WithKeyword(recordKeyword.WithLeadingTrivia(
+                                    recordKeyword.LeadingTrivia.Take(recordKeyword.LeadingTrivia.Count - 2)));
+                        });
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private class MyCodeAction : CustomCodeActions.DocumentChangeAction
+        {
+            public MyCodeAction(
+                Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpCodeFixesResources.Fix_token_placement, createChangedDocument, nameof(CSharpTransposeRecordKeywordCodeFixProvider))
+            {
+            }
+        }
+    }
+}

--- a/src/Analyzers/CSharp/CodeFixes/TransposeRecordKeyword/CSharpTransposeRecordKeywordCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/TransposeRecordKeyword/CSharpTransposeRecordKeywordCodeFixProvider.cs
@@ -44,9 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.TransposeRecordKeyword
 
         private static bool TryGetTokens(
             RecordDeclarationSyntax recordDeclaration,
-            out SyntaxToken recordKeyword,
             out SyntaxToken classOrStructKeyword,
-            out SyntaxTrivia whitespaceTrivia)
+            out SyntaxToken recordKeyword)
         {
             recordKeyword = recordDeclaration.Keyword;
             if (!recordKeyword.IsMissing)
@@ -113,9 +112,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.TransposeRecordKeyword
                                 return currentRecordDeclaration;
 
                             return currentRecordDeclaration
-                                .WithClassOrStructKeyword(classOrStructKeyword.WithAppendedTrailingTrivia(whitespace))
-                                .WithKeyword(recordKeyword.WithLeadingTrivia(
-                                    recordKeyword.LeadingTrivia.Take(recordKeyword.LeadingTrivia.Count - 2)));
+                                .WithClassOrStructKeyword(classOrStructKeyword)
+                                .WithKeyword(recordKeyword);
                         });
                 }
             }

--- a/src/Analyzers/CSharp/CodeFixes/TransposeRecordKeyword/CSharpTransposeRecordKeywordCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/TransposeRecordKeyword/CSharpTransposeRecordKeywordCodeFixProvider.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.TransposeRecordKeyword
         {
             public MyCodeAction(
                 Func<CancellationToken, Task<Document>> createChangedDocument)
-                : base(CSharpCodeFixesResources.Fix_token_placement, createChangedDocument, nameof(CSharpTransposeRecordKeywordCodeFixProvider))
+                : base(CSharpCodeFixesResources.Fix_record_declaration, createChangedDocument, nameof(CSharpTransposeRecordKeywordCodeFixProvider))
             {
             }
         }

--- a/src/Analyzers/CSharp/CodeFixes/TransposeRecordKeyword/CSharpTransposeRecordKeywordCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/TransposeRecordKeyword/CSharpTransposeRecordKeywordCodeFixProvider.cs
@@ -18,7 +18,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.TransposeRecordKeyword
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.TransposeRecordKeyword), Shared]
     internal class CSharpTransposeRecordKeywordCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
         private const string CS9012 = nameof(CS9012); // Unexpected keyword 'record'. Did you mean 'record struct' or 'record class'?

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.cs.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Převést typeof na nameof</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">Předat zachycené proměnné jako argumenty</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.cs.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.cs.xlf
@@ -12,9 +12,9 @@
         <target state="translated">Převést typeof na nameof</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.de.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.de.xlf
@@ -12,9 +12,9 @@
         <target state="translated">"typeof" in "nameof" konvertieren</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.de.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">"typeof" in "nameof" konvertieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">Erfasste Variablen als Argumente übergeben</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.es.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.es.xlf
@@ -12,9 +12,9 @@
         <target state="translated">Convertir "typeof" en "nameof"</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.es.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Convertir "typeof" en "nameof"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">Pasar variables capturadas como argumentos</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.fr.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.fr.xlf
@@ -12,9 +12,9 @@
         <target state="translated">Convertir 'typeof' en 'nameof'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.fr.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Convertir 'typeof' en 'nameof'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">Passer les variables capturées en tant qu'arguments</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.it.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Convertire 'typeof' in 'nameof'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">Passa le variabili catturate come argomenti</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.it.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.it.xlf
@@ -12,9 +12,9 @@
         <target state="translated">Convertire 'typeof' in 'nameof'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ja.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ja.xlf
@@ -12,9 +12,9 @@
         <target state="translated">'typeof' を 'nameof' に変換します</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ja.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">'typeof' を 'nameof' に変換します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">キャプチャした変数を引数として渡す</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ko.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ko.xlf
@@ -12,9 +12,9 @@
         <target state="translated">'typeof'를 'nameof'로 변환</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ko.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">'typeof'를 'nameof'로 변환</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">캡처된 변수를 인수로 전달</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.pl.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.pl.xlf
@@ -12,9 +12,9 @@
         <target state="translated">Konwertuj element „typeof” na element „nameof”</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.pl.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Konwertuj element „typeof” na element „nameof”</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">Przekaż przechwycone zmienne jako argumenty</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.pt-BR.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Converter 'typeof' em 'nameof'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">Passar variáveis capturadas como argumentos</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.pt-BR.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.pt-BR.xlf
@@ -12,9 +12,9 @@
         <target state="translated">Converter 'typeof' em 'nameof'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ru.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ru.xlf
@@ -12,9 +12,9 @@
         <target state="translated">Преобразовать "typeof" в "nameof"</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ru.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Преобразовать "typeof" в "nameof"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">Передача зафиксированных переменных в качестве аргументов</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.tr.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">'Typeof' metodunu 'nameof' metoduna dönüştürün</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">Yakalanan değişkenleri bağımsız değişken olarak geçir</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.tr.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.tr.xlf
@@ -12,9 +12,9 @@
         <target state="translated">'Typeof' metodunu 'nameof' metoduna dönüştürün</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.zh-Hans.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">将 "typeof" 转换为 "nameof"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">以参数形式传入捕获的变量</target>

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.zh-Hans.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.zh-Hans.xlf
@@ -12,9 +12,9 @@
         <target state="translated">将 "typeof" 转换为 "nameof"</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.zh-Hant.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.zh-Hant.xlf
@@ -12,9 +12,9 @@
         <target state="translated">將 'typeof' 轉換為 'nameof'</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_token_placement">
-        <source>Fix token placement</source>
-        <target state="new">Fix token placement</target>
+      <trans-unit id="Fix_record_declaration">
+        <source>Fix_record_declaration</source>
+        <target state="new">Fix_record_declaration</target>
         <note />
       </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">

--- a/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.zh-Hant.xlf
+++ b/src/Analyzers/CSharp/CodeFixes/xlf/CSharpCodeFixesResources.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">將 'typeof' 轉換為 'nameof'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_token_placement">
+        <source>Fix token placement</source>
+        <target state="new">Fix token placement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Pass_in_captured_variables_as_arguments">
         <source>Pass in captured variables as arguments</source>
         <target state="translated">以引數形式傳入擷取到的變數</target>

--- a/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -109,6 +109,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string SimplifyPropertyPattern = nameof(SimplifyPropertyPattern);
         public const string SimplifyThisOrMe = nameof(SimplifyThisOrMe);
         public const string SpellCheck = nameof(SpellCheck);
+        public const string TransposeRecordKeyword = nameof(TransposeRecordKeyword);
         public const string UnsealClass = nameof(UnsealClass);
         public const string UpdateLegacySuppressions = nameof(UpdateLegacySuppressions);
         public const string UpdateProjectToAllowUnsafe = nameof(UpdateProjectToAllowUnsafe);

--- a/src/EditorFeatures/CSharpTest/TransposeRecordKeyword/TransposeRecordKeywordTests.cs
+++ b/src/EditorFeatures/CSharpTest/TransposeRecordKeyword/TransposeRecordKeywordTests.cs
@@ -149,5 +149,24 @@ record class C
                 LanguageVersion = LanguageVersion.CSharp10
             }.RunAsync();
         }
+
+        [Fact]
+        public async Task TestTriviaBeforeAfter()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+/*1*/
+class /**/
+/*3*/
+{|CS9012:record|} /*4*/ C { }",
+                FixedCode = @"
+/*1*/
+record /**/
+/*3*/
+class /*4*/ C { }",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/TransposeRecordKeyword/TransposeRecordKeywordTests.cs
+++ b/src/EditorFeatures/CSharpTest/TransposeRecordKeyword/TransposeRecordKeywordTests.cs
@@ -1,0 +1,153 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.TransposeRecordKeyword;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TransposeRecordKeyword
+{
+    using VerifyCS = CSharpCodeFixVerifier<
+        EmptyDiagnosticAnalyzer,
+        CSharpTransposeRecordKeywordCodeFixProvider>;
+
+    public class TransposeRecordKeywordTests
+    {
+        [Fact]
+        public async Task TestStructRecord()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"struct {|CS9012:record|} C { }",
+                FixedCode = @"record struct C { }",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestClassRecord()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"class {|CS9012:record|} C { }",
+                FixedCode = @"record class C { }",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestWithModifiers()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"public struct {|CS9012:record|} C { }",
+                FixedCode = @"public record struct C { }",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestWithComment()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+// my struct
+public struct {|CS9012:record|} C { }",
+                FixedCode = @"
+// my struct
+public record struct C { }",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestWithDocComment()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+/// <summary></summary>
+public struct {|CS9012:record|} C { }",
+                FixedCode = @"
+/// <summary></summary>
+public record struct C { }",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestWithAttributes1()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+[System.CLSCompliant(false)]
+struct {|CS9012:record|} C { }",
+                FixedCode = @"
+[System.CLSCompliant(false)]
+record struct C { }",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestWithAttributes2()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+[System.CLSCompliant(false)] struct {|CS9012:record|} C { }",
+                FixedCode = @"
+[System.CLSCompliant(false)] record struct C { }",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNestedRecord()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+class {|CS9012:record|} C
+{
+    struct {|CS9012:record|} D { }
+}",
+                FixedCode = @"
+record class C
+{
+    record struct D { }
+}",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNestedRecordWithComments()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+// my class
+class {|CS9012:record|} C
+{
+    // my struct
+    struct {|CS9012:record|} D { }
+}",
+                FixedCode = @"
+// my class
+record class C
+{
+    // my struct
+    record struct D { }
+}",
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
+        }
+    }
+}


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/59622

Looks like:

![image](https://user-images.githubusercontent.com/4564579/154758919-43941a0f-48f3-4e15-954b-82660c18e9e8.png)
