### PR TITLE
Handle binary files in AdditionalTextComparer.GetHashCode

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/AdditionalTextComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/AdditionalTextComparer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis
         public int GetHashCode(AdditionalText obj)
         {
             return Hash.Combine(PathUtilities.Comparer.GetHashCode(obj.Path),
-                                ByteSequenceComparer.GetHashCode(obj.GetText()?.GetChecksum() ?? ImmutableArray<byte>.Empty));
+                                ByteSequenceComparer.GetHashCode(GetTextOrNullIfBinary(obj)?.GetChecksum() ?? ImmutableArray<byte>.Empty));
         }
 
         private static SourceText? GetTextOrNullIfBinary(AdditionalText text)

--- a/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
+++ b/src/Compilers/Test/Core/SourceGeneration/TestGenerators.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -94,6 +95,12 @@ namespace Roslyn.Test.Utilities.TestGenerators
 
         public override SourceText GetText(CancellationToken cancellationToken = default) => _content;
 
+        internal class BinaryText : InMemoryAdditionalText
+        {
+            public BinaryText(string path) : base(path, string.Empty) { }
+
+            public override SourceText GetText(CancellationToken cancellationToken = default) => throw new InvalidDataException("Binary content not supported");
+        }
     }
 
     internal sealed class PipelineCallbackGenerator : IIncrementalGenerator


### PR DESCRIPTION
This is a follow up to https://github.com/dotnet/roslyn/pull/59578, which missed the `GetHashCode` case.

cc: @sharwell @chsienki @jaredpar 

Fixes https://github.com/dotnet/roslyn/issues/59209