### PR TITLE
Simple attempt to find implementation assembly

### DIFF
--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/AbstractPdbSourceDocumentTests.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/AbstractPdbSourceDocumentTests.cs
@@ -247,7 +247,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PdbSourceDocument
                 .AddReferences(project.MetadataReferences);
 
             IEnumerable<EmbeddedText>? embeddedTexts;
-            if (sourceLocation == Location.OnDisk)
+            if (buildReferenceAssembly)
+            {
+                embeddedTexts = null;
+            }
+            else if (sourceLocation == Location.OnDisk)
             {
                 embeddedTexts = null;
                 File.WriteAllText(sourceCodePath, source.ToString(), source.Encoding);

--- a/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             if (_openedDocumentIds.TryGetValue(fileInfo, out var openDocumentId))
             {
                 // Awesome, it's already open. Let's try to grab a document for it
-                var document = workspace.CurrentSolution.GetDocument(openDocumentId);
+                var document = workspace.CurrentSolution.GetRequiredDocument(openDocumentId);
 
                 return await MetadataAsSourceHelpers.GetLocationInGeneratedSourceAsync(symbolId, document, cancellationToken).ConfigureAwait(false);
             }
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             // Annoying case: the file is still on disk. Only real option here is to spin up a fake project to go and bind in.
             var temporaryProjectInfoAndDocumentId = fileInfo.GetProjectInfoAndDocumentId(workspace, loadFileFromDisk: true);
             var temporaryDocument = workspace.CurrentSolution.AddProject(temporaryProjectInfoAndDocumentId.Item1)
-                                                             .GetDocument(temporaryProjectInfoAndDocumentId.Item2);
+                                                             .GetRequiredDocument(temporaryProjectInfoAndDocumentId.Item2);
 
             return await MetadataAsSourceHelpers.GetLocationInGeneratedSourceAsync(symbolId, temporaryDocument, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
Part of https://github.com/dotnet/roslyn/issues/55834

If a user references a nuget package that has `ref/` and `lib/` folders, this will enable them to see embedded source/Source Link/decompiled source instead of just getting metadata. This might help 1% of 1% of users, but that's more than zero so I think its worth it.

Better handling for SDK and Nuget refs will come later.