### PR TITLE
Add the fix all provider for fixing all naming violation to feature branch

### DIFF
--- a/src/Analyzers/Core/Analyzers/NamingStyle/NamingStyleDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/NamingStyle/NamingStyleDiagnosticAnalyzerBase.cs
@@ -163,6 +163,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             builder[nameof(NamingStyle)] = applicableRule.NamingStyle.CreateXElement().ToString();
             builder["OptionName"] = nameof(NamingStyleOptions.NamingPreferences);
             builder["OptionLanguage"] = compilation.Language;
+            builder["SymbolSpecificationID"] = applicableRule.SymbolSpecification.ID.ToString();
 
             return DiagnosticHelper.Create(Descriptor, symbol.Locations.First(), applicableRule.EnforcementLevel, additionalLocations: null, builder.ToImmutable(), failureReason);
         }

--- a/src/Analyzers/Core/CodeFixes/CodeFixes.projitems
+++ b/src/Analyzers/Core/CodeFixes/CodeFixes.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MatchFolderAndNamespace\AbstractChangeNamespaceToMatchFolderCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MatchFolderAndNamespace\AbstractChangeNamespaceToMatchFolderCodeFixProvider.CustomFixAllProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NamingStyle\NamingStyleCodeFixProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NamingStyle\NamingStyleFixAllProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NewLines\ConsecutiveStatementPlacement\ConsecutiveStatementPlacementCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NewLines\MultipleBlankLines\AbstractMultipleBlankLinesCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OrderModifiers\AbstractOrderModifiersCodeFixProvider.cs" />

--- a/src/Analyzers/Core/CodeFixes/CodeFixesResources.resx
+++ b/src/Analyzers/Core/CodeFixes/CodeFixesResources.resx
@@ -120,8 +120,8 @@
   <data name="Add_file_header" xml:space="preserve">
     <value>Add file header</value>
   </data>
-  <data name="Fix_Name_Violation_colon_0" xml:space="preserve">
-    <value>Fix Name Violation: {0}</value>
+  <data name="Fix_name_violation_colon_0" xml:space="preserve">
+    <value>Fix name violation: {0}</value>
   </data>
   <data name="Add_both" xml:space="preserve">
     <value>Add both</value>
@@ -152,5 +152,8 @@
   </data>
   <data name="Add_blank_line_after_block" xml:space="preserve">
     <value>Add blank line after block</value>
+  </data>
+  <data name="Fix_all_name_violations" xml:space="preserve">
+    <value>Fix all name violations</value>
   </data>
 </root>

--- a/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleCodeFixProvider.cs
@@ -57,6 +57,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
             var model = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var symbol = GetSymbol(root, span, syntaxFactsService, model, cancellationToken);
+
+            // TODO: We should always be able to find the symbol that generated this diagnostic,
+            // but this cannot always be done by simply asking for the declared symbol on the node 
+            // from the symbol's declaration location.
+            // See https://github.com/dotnet/roslyn/issues/16588
             if (symbol == null)
             {
                 return;
@@ -110,13 +115,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
             if (node == null)
                 return null;
 
-            var symbol = semanticModel.GetDeclaredSymbol(node, cancellationToken);
-
-            // TODO: We should always be able to find the symbol that generated this diagnostic,
-            // but this cannot always be done by simply asking for the declared symbol on the node 
-            // from the symbol's declaration location.
-            // See https://github.com/dotnet/roslyn/issues/16588
-            return symbol;
+            return semanticModel.GetDeclaredSymbol(node, cancellationToken);
         }
 
         private class FixNameCodeAction : CodeAction

--- a/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleCodeFixProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
     [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic,
         Name = PredefinedCodeFixProviderNames.ApplyNamingStyle), Shared]
 #endif
-    internal class NamingStyleCodeFixProvider : CodeFixProvider
+    internal partial class NamingStyleCodeFixProvider : CodeFixProvider
     {
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
@@ -40,11 +40,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
         public override ImmutableArray<string> FixableDiagnosticIds { get; }
             = ImmutableArray.Create(IDEDiagnosticIds.NamingRuleId);
 
-        public override FixAllProvider? GetFixAllProvider()
-        {
-            // Currently Fix All is not supported for naming style violations.
-            return null;
-        }
+        public override FixAllProvider? GetFixAllProvider() => NamingStyleCodeFixAllProvider.Instance;
 
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleFixAllProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleFixAllProvider.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
+{
+    internal partial class NamingStyleCodeFixProvider
+    {
+        private class NamingStyleCodeFixAllProvider : FixAllProvider
+        {
+            public static readonly NamingStyleCodeFixAllProvider Instance = new();
+
+            private NamingStyleCodeFixAllProvider() { }
+
+            public override async Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
+            {
+                var diagnostics = fixAllContext.Scope switch
+                {
+                    FixAllScope.Document when fixAllContext.Document is not null => await fixAllContext.GetDocumentDiagnosticsAsync(fixAllContext.Document).ConfigureAwait(false),
+                    FixAllScope.Project => await fixAllContext.GetAllDiagnosticsAsync(fixAllContext.Project).ConfigureAwait(false),
+                    FixAllScope.Solution => await GetSolutionDiagnosticsAsync(fixAllContext).ConfigureAwait(false),
+                    _ => default
+                };
+
+                if (diagnostics.IsDefaultOrEmpty)
+                {
+                    return null;
+                }
+            }
+
+            private static async Task<ImmutableArray<Diagnostic>> GetSolutionDiagnosticsAsync(FixAllContext fixAllContext)
+            {
+                using var _ = ArrayBuilder<Diagnostic>.GetInstance(out var diagnostics);
+                foreach (var project in fixAllContext.Solution.Projects)
+                {
+                    var projectDiagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+                    diagnostics.AddRange(projectDiagnostics);
+                }
+
+                return diagnostics.ToImmutable();
+            }
+        }
+    }
+}

--- a/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleFixAllProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/NamingStyle/NamingStyleFixAllProvider.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -31,22 +35,22 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
                     _ => default
                 };
 
-                var keys = fixAllContext.CodeActionEquivalenceKey!.Split("|");
+                var keys = fixAllContext.CodeActionEquivalenceKey!.Split('|');
                 RoslynDebug.Assert(keys.Length == 2);
                 RoslynDebug.Assert(Guid.TryParse(keys[0], out _));
                 RoslynDebug.Assert(int.TryParse(keys[1], out _));
 
-                var symbolSpecificationID = keys[0];
-                var complaintNameIndex = int.Parse(keys[1]);
+                var symbolSpecificationId = keys[0];
                 var diagnosticsToFix = diagnostics.WhereAsArray(
-                    d => d.Location.IsInSource && d.Properties["SymbolSpecificationID"] == symbolSpecificationID);
-                if (diagnostics.IsDefaultOrEmpty)
+                    d => d.Location.IsInSource && d.Properties["SymbolSpecificationID"] == symbolSpecificationId);
+                if (diagnosticsToFix.IsDefaultOrEmpty)
                 {
                     return null;
                 }
 
+                var complaintNameIndex = int.Parse(keys[1]);
                 var symbolsToRename = await GetSymbolsToRenameAsync(
-                    fixAllContext.Solution, diagnostics, complaintNameIndex, fixAllContext.CancellationToken).ConfigureAwait(false);
+                    fixAllContext.Solution, diagnosticsToFix, complaintNameIndex, fixAllContext.CancellationToken).ConfigureAwait(false);
                 if (symbolsToRename.IsEmpty)
                 {
                     return null;
@@ -58,11 +62,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
                     fixAllContext.CodeActionEquivalenceKey);
             }
 
-            private static Task<Solution> FixAllAsync(Solution solution, ImmutableHashSet<(ISymbol symbol, string newName)> symbolsToRename, CancellationToken cancellationToken)
+            private static Task<Solution> FixAllAsync(Solution solution, ImmutableHashSet<(ISymbol symbol, string newName)> _1, CancellationToken _2)
             {
                 // TODO:
-                // Renamer needs a multiple renaming API which
-                // renaming multiple symbols using the same solution snapshot
+                // Renamer needs a new API which could rename multiple symbols using the same solution snapshot
                 // and calculate the changed documents for each symbol so that we could notify IRefactorNotifyService
                 return Task.FromResult(solution);
             }

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.cs.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.cs.xlf
@@ -22,14 +22,19 @@
         <target state="translated">Přidat hlavičku souboru</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">Opravit porušení názvu: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">Opravit všechny výskyty v</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.de.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.de.xlf
@@ -22,14 +22,19 @@
         <target state="translated">Dateiheader hinzufügen</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">Namensverletzung beheben: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">Alle Vorkommen korrigieren in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.es.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.es.xlf
@@ -22,14 +22,19 @@
         <target state="translated">Agregar encabezado de archivo</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">Corregir infracción de nombre: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">Corregir todas las repeticiones de</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.fr.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.fr.xlf
@@ -22,14 +22,19 @@
         <target state="translated">Ajouter un en-tête de fichier</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">Corrigez la violation de nom : {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">Corriger toutes les occurrences dans</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.it.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.it.xlf
@@ -22,14 +22,19 @@
         <target state="translated">Aggiungi intestazione del file</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">Correggi violazione del nome: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">Correggi tutte le occorrenze in</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.ja.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.ja.xlf
@@ -22,14 +22,19 @@
         <target state="translated">ファイル ヘッダーの追加</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">名前の違反を修正します: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">次の場所のすべての出現箇所を修正します</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.ko.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.ko.xlf
@@ -22,14 +22,19 @@
         <target state="translated">파일 헤더 추가</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">이름 위반 수정: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">다음 위치에서 모든 발생 수정</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.pl.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.pl.xlf
@@ -22,14 +22,19 @@
         <target state="translated">Dodaj nagłówek pliku</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">Napraw naruszenie nazwy: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">Popraw wszystkie wystąpienia w</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.pt-BR.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.pt-BR.xlf
@@ -22,14 +22,19 @@
         <target state="translated">Adicionar cabeçalho de arquivo</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">Corrigir Violação de Nome: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">Corrigir todas as ocorrências em</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.ru.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.ru.xlf
@@ -22,14 +22,19 @@
         <target state="translated">Добавить заголовок файла</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">Устраните нарушение имени: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">Исправить все случаи в</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.tr.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.tr.xlf
@@ -22,14 +22,19 @@
         <target state="translated">Dosya üst bilgisi ekle</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">Ad İhlalini Düzelt: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">Tüm oluşumları şurada düzelt:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.zh-Hans.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.zh-Hans.xlf
@@ -22,14 +22,19 @@
         <target state="translated">添加文件头</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">解决名称冲突: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">修复以下对象中的所有实例:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">

--- a/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.zh-Hant.xlf
+++ b/src/Analyzers/Core/CodeFixes/xlf/CodeFixesResources.zh-Hant.xlf
@@ -22,14 +22,19 @@
         <target state="translated">新增檔案標頭</target>
         <note />
       </trans-unit>
-      <trans-unit id="Fix_Name_Violation_colon_0">
-        <source>Fix Name Violation: {0}</source>
-        <target state="translated">修正名稱違規: {0}</target>
+      <trans-unit id="Fix_all_name_violations">
+        <source>Fix all name violations</source>
+        <target state="new">Fix all name violations</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_all_occurrences_in">
         <source>Fix all occurrences in</source>
         <target state="translated">修正所有出現之處於</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_name_violation_colon_0">
+        <source>Fix name violation: {0}</source>
+        <target state="new">Fix name violation: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Remove_extra_blank_lines">


### PR DESCRIPTION
As we discussed offline, the fix-all fixer would be
1. Only fix all symbols for a rule.
2. Create a new renamer API to rename many symbols using the one solution snapshot.

I would like to split it into 2 separate PRs which address the two issues.

