### PR TITLE
View call hierarchy fix (#57856)

### DIFF
--- a/src/VisualStudio/CSharp/Test/CallHierarchy/CSharpCallHierarchyTests.cs
+++ b/src/VisualStudio/CSharp/Test/CallHierarchy/CSharpCallHierarchyTests.cs
@@ -475,7 +475,7 @@ namespace N
         {
         }
 
-        void Foo()
+        void M()
         {   
             Goo();
         }
@@ -487,7 +487,29 @@ namespace N
             testState.Workspace.Documents.Single().GetTextBuffer().Insert(0, "/* hello */");
 
             testState.VerifyRoot(root, "N.C.Goo()", new[] { string.Format(EditorFeaturesResources.Calls_To_0, "Goo"), });
-            testState.VerifyResult(root, string.Format(EditorFeaturesResources.Calls_To_0, "Goo"), expectedCallers: new[] { "N.C.Foo()" });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.Calls_To_0, "Goo"), expectedCallers: new[] { "N.C.M()" });
+        }
+
+        [WorkItem(57856, "https://github.com/dotnet/roslyn/issues/57856")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CallHierarchy)]
+        public void PropertySet()
+        {
+            var code = @"
+namespace N
+{
+    class C
+    {
+        public int Property { get; s$$et; }
+        void M()
+        {
+            Property = 2;
+        }
+    }
+}";
+            using var testState = CallHierarchyTestState.Create(code);
+            var root = testState.GetRoot();
+            testState.VerifyRoot(root, "N.C.Property.set", new[] { string.Format(EditorFeaturesResources.Calls_To_0, "set_Property") });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.Calls_To_0, "set_Property"), new[] { "N.C.M()" });
         }
     }
 }

--- a/src/VisualStudio/CSharp/Test/CallHierarchy/CSharpCallHierarchyTests.cs
+++ b/src/VisualStudio/CSharp/Test/CallHierarchy/CSharpCallHierarchyTests.cs
@@ -237,9 +237,9 @@ namespace N
 {
     class C
     {
-        public int g$$oo = Goo();
+        public int g$$oo;
 
-        protected int Goo() { goo = 3; }
+        protected void Goo() { goo = 3; }
     }
 }";
             using var testState = CallHierarchyTestState.Create(text);
@@ -367,7 +367,7 @@ namespace N
 
     class C : I
     {
-        public async Task Goo()
+        public void Goo()
         {
         }
     }
@@ -474,6 +474,11 @@ namespace N
         void G$$oo()
         {
         }
+
+        void Foo()
+        {   
+            Goo();
+        }
     }
 }";
             using var testState = CallHierarchyTestState.Create(text);
@@ -482,7 +487,7 @@ namespace N
             testState.Workspace.Documents.Single().GetTextBuffer().Insert(0, "/* hello */");
 
             testState.VerifyRoot(root, "N.C.Goo()", new[] { string.Format(EditorFeaturesResources.Calls_To_0, "Goo"), });
-            testState.VerifyResult(root, string.Format(EditorFeaturesResources.Calls_To_0, "Goo"), expectedCallers: new[] { "N.C.Goo()" });
+            testState.VerifyResult(root, string.Format(EditorFeaturesResources.Calls_To_0, "Goo"), expectedCallers: new[] { "N.C.Foo()" });
         }
     }
 }

--- a/src/VisualStudio/Core/Test/CallHierarchy/CallHierarchyTests.vb
+++ b/src/VisualStudio/Core/Test/CallHierarchy/CallHierarchyTests.vb
@@ -140,7 +140,7 @@ namespace C
 
     public class C : I
     {
-        void goo() { }
+        public void goo() { }
     }
 }
         </Document>
@@ -148,7 +148,7 @@ namespace C
 using C;
 namespace G
 {
-    public Class G : I
+    public class G : I
     {
         public void goo()
         {

--- a/src/VisualStudio/TestUtilities2/CallHierarchy/CallHierarchyTestState.vb
+++ b/src/VisualStudio/TestUtilities2/CallHierarchy/CallHierarchyTestState.vb
@@ -179,6 +179,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
                 scope,
                 documents)
 
+            Assert.Equal(callers.Count, expectedCallers.Length)
             For Each expected In expectedCallers
                 Assert.Contains(expected, callers)
             Next
@@ -192,6 +193,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
                 scope,
                 documents)
 
+            Assert.Equal(callers.Count, expectedCallers.Length)
             For Each expected In expectedCallers
                 Assert.Contains(expected, callers)
             Next

--- a/src/VisualStudio/TestUtilities2/CallHierarchy/CallHierarchyTestState.vb
+++ b/src/VisualStudio/TestUtilities2/CallHierarchy/CallHierarchyTestState.vb
@@ -172,19 +172,30 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.CallHierarchy
         End Sub
 
         Friend Sub VerifyResultName(root As CallHierarchyItem, searchCategory As String, expectedCallers As String(), Optional scope As CallHierarchySearchScope = CallHierarchySearchScope.EntireSolution, Optional documents As IImmutableSet(Of Document) = Nothing)
+            Dim callers = New List(Of String)
             SearchRoot(root, searchCategory, Sub(c As ICallHierarchyNameItem)
-                                                 Assert.Contains(ConvertToName(c), expectedCallers)
+                                                 callers.Add(ConvertToName(c))
                                              End Sub,
                 scope,
                 documents)
+
+            For Each expected In expectedCallers
+                Assert.Contains(expected, callers)
+            Next
         End Sub
 
         Friend Sub VerifyResult(root As CallHierarchyItem, searchCategory As String, expectedCallers As String(), Optional scope As CallHierarchySearchScope = CallHierarchySearchScope.EntireSolution, Optional documents As IImmutableSet(Of Document) = Nothing)
+            Dim callers = New List(Of String)
             SearchRoot(root, searchCategory, Sub(c As CallHierarchyItem)
-                                                 Assert.Contains(ConvertToName(c), expectedCallers)
+                                                 callers.Add(ConvertToName(c))
                                              End Sub,
                 scope,
                 documents)
+
+            For Each expected In expectedCallers
+                Assert.Contains(expected, callers)
+            Next
+
         End Sub
 
         Friend Sub Navigate(root As CallHierarchyItem, searchCategory As String, callSite As String, Optional scope As CallHierarchySearchScope = CallHierarchySearchScope.EntireSolution, Optional documents As IImmutableSet(Of Document) = Nothing)

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Callers.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Callers.cs
@@ -80,12 +80,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             if (symbol.Kind is SymbolKind.Event or
                 SymbolKind.Method or
-                SymbolKind.Property)
+                SymbolKind.Property or
+                SymbolKind.Field)
             {
                 var collector = new StreamingProgressCollector();
+                var options = FindReferencesSearchOptions.GetFeatureOptionsForStartingSymbol(symbol);
                 await FindReferencesAsync(
                     symbol, solution, collector, documents,
-                    FindReferencesSearchOptions.Default, cancellationToken).ConfigureAwait(false);
+                    options, cancellationToken).ConfigureAwait(false);
                 return collector.GetReferencedSymbols();
             }
 


### PR DESCRIPTION
Fix #57856

Fix view call hierarchy tests. Assertions in methods 'VerifyResult' and 'VerifyResultName' weren't reached, if the specified root had no callers. 