### PR TITLE
Create attribute default arguments during binding

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -121,14 +121,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics)
         {
             beforeAttributePartBound?.Invoke(node);
-            var boundAttribute = new ExecutableCodeBinder(node, this.ContainingMemberOrLambda, this).BindAttribute(node, boundAttributeType, diagnostics, (this as ContextualAttributeBinder)?.AttributedMember);
+            var boundAttribute = new ExecutableCodeBinder(node, this.ContainingMemberOrLambda, this).BindAttribute(node, boundAttributeType, (this as ContextualAttributeBinder)?.AttributedMember, diagnostics);
             afterAttributePartBound?.Invoke(node);
             return (GetAttribute(boundAttribute, diagnostics), boundAttribute);
         }
 
-        internal BoundAttribute BindAttribute(AttributeSyntax node, NamedTypeSymbol attributeType, BindingDiagnosticBag diagnostics, Symbol? attributedMember = null)
+        internal BoundAttribute BindAttribute(AttributeSyntax node, NamedTypeSymbol attributeType, Symbol? attributedMember, BindingDiagnosticBag diagnostics)
         {
-            return this.GetRequiredBinder(node).BindAttributeCore(node, attributeType, diagnostics, attributedMember);
+            return this.GetRequiredBinder(node).BindAttributeCore(node, attributeType, attributedMember, diagnostics);
         }
 
         private Binder SkipSemanticModelBinder()
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private BoundAttribute BindAttributeCore(AttributeSyntax node, NamedTypeSymbol attributeType, BindingDiagnosticBag diagnostics, Symbol? attributedMember)
+        private BoundAttribute BindAttributeCore(AttributeSyntax node, NamedTypeSymbol attributeType, Symbol? attributedMember, BindingDiagnosticBag diagnostics)
         {
             Debug.Assert(this.SkipSemanticModelBinder() == this.GetRequiredBinder(node).SkipSemanticModelBinder());
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -299,6 +299,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics,
                     boundAttribute.ConstructorExpanded,
                     ref hasErrors);
+                // Arguments and parameters length are only required to match when the attribute doesn't have errors.
+                Debug.Assert(rewrittenArguments.Length == attributeConstructor.ParameterCount);
             }
 
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
@@ -317,7 +319,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ImmutableArray<int> makeSourceIndices()
             {
-                Debug.Assert(attributeConstructor.ParameterCount == rewrittenArguments.Length || hasErrors);
                 var lengthAfterRewriting = rewrittenArguments.Length;
                 if (lengthAfterRewriting == 0 || hasErrors)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -121,14 +121,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics)
         {
             beforeAttributePartBound?.Invoke(node);
-            var boundAttribute = new ExecutableCodeBinder(node, this.ContainingMemberOrLambda, this).BindAttribute(node, boundAttributeType, diagnostics);
+            var boundAttribute = new ExecutableCodeBinder(node, this.ContainingMemberOrLambda, this).BindAttribute(node, boundAttributeType, diagnostics, (this as ContextualAttributeBinder)?.AttributedMember);
             afterAttributePartBound?.Invoke(node);
             return (GetAttribute(boundAttribute, diagnostics), boundAttribute);
         }
 
-        internal BoundAttribute BindAttribute(AttributeSyntax node, NamedTypeSymbol attributeType, BindingDiagnosticBag diagnostics)
+        internal BoundAttribute BindAttribute(AttributeSyntax node, NamedTypeSymbol attributeType, BindingDiagnosticBag diagnostics, Symbol? attributedMember = null)
         {
-            return this.GetRequiredBinder(node).BindAttributeCore(node, attributeType, diagnostics);
+            return this.GetRequiredBinder(node).BindAttributeCore(node, attributeType, diagnostics, attributedMember);
         }
 
         private Binder SkipSemanticModelBinder()
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private BoundAttribute BindAttributeCore(AttributeSyntax node, NamedTypeSymbol attributeType, BindingDiagnosticBag diagnostics)
+        private BoundAttribute BindAttributeCore(AttributeSyntax node, NamedTypeSymbol attributeType, BindingDiagnosticBag diagnostics, Symbol? attributedMember)
         {
             Debug.Assert(this.SkipSemanticModelBinder() == this.GetRequiredBinder(node).SkipSemanticModelBinder());
 
@@ -175,41 +175,64 @@ namespace Microsoft.CodeAnalysis.CSharp
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             ImmutableArray<int> argsToParamsOpt = default;
             bool expanded = false;
+            BitVector defaultArguments = default;
             MethodSymbol? attributeConstructor = null;
-
-            // Bind attributeType's constructor based on the bound constructor arguments
             ImmutableArray<BoundExpression> boundConstructorArguments;
-            if (!attributeTypeForBinding.IsErrorType())
-            {
-                attributeConstructor = BindAttributeConstructor(node,
-                                                                attributeTypeForBinding,
-                                                                analyzedArguments.ConstructorArguments,
-                                                                diagnostics,
-                                                                ref resultKind,
-                                                                suppressErrors: attributeType.IsErrorType(),
-                                                                ref argsToParamsOpt,
-                                                                ref expanded,
-                                                                ref useSiteInfo,
-                                                                out boundConstructorArguments);
-            }
-            else
+            if (attributeTypeForBinding.IsErrorType())
             {
                 boundConstructorArguments = analyzedArguments.ConstructorArguments.Arguments.SelectAsArray(
                     static (arg, attributeArgumentBinder) => attributeArgumentBinder.BindToTypeForErrorRecovery(arg),
                     attributeArgumentBinder);
             }
-            Debug.Assert(boundConstructorArguments.All(a => !a.NeedsToBeConverted()));
-            diagnostics.Add(node, useSiteInfo);
-
-            if (attributeConstructor is object)
+            else
             {
-                ReportDiagnosticsIfObsolete(diagnostics, attributeConstructor, node, hasBaseReceiver: false);
+                bool found = TryPerformConstructorOverloadResolution(
+                    attributeTypeForBinding,
+                    analyzedArguments.ConstructorArguments,
+                    attributeTypeForBinding.Name,
+                    node.Location,
+                    attributeType.IsErrorType(),
+                    diagnostics,
+                    out var memberResolutionResult,
+                    out var candidateConstructors,
+                    allowProtectedConstructorsOfBaseType: true);
+                attributeConstructor = memberResolutionResult.Member;
+                expanded = memberResolutionResult.Resolution == MemberResolutionKind.ApplicableInExpandedForm;
+                argsToParamsOpt = memberResolutionResult.Result.ArgsToParamsOpt;
 
-                if (attributeConstructor.Parameters.Any(p => p.RefKind == RefKind.In))
+                if (!found)
                 {
-                    Error(diagnostics, ErrorCode.ERR_AttributeCtorInParameter, node, attributeConstructor.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+                    resultKind = resultKind.WorseResultKind(
+                        memberResolutionResult.IsValid && !IsConstructorAccessible(memberResolutionResult.Member, ref useSiteInfo) ?
+                            LookupResultKind.Inaccessible :
+                            LookupResultKind.OverloadResolutionFailure);
+                    boundConstructorArguments = BuildArgumentsForErrorRecovery(analyzedArguments.ConstructorArguments, candidateConstructors);
+                }
+                else
+                {
+                    attributeArgumentBinder.BindDefaultArguments(
+                        node,
+                        attributeConstructor.Parameters,
+                        analyzedArguments.ConstructorArguments.Arguments,
+                        argumentRefKindsBuilder: null,
+                        ref argsToParamsOpt,
+                        out defaultArguments,
+                        expanded,
+                        enableCallerInfo: !IsEarlyAttributeBinder,
+                        diagnostics,
+                        attributedMember: attributedMember);
+                    boundConstructorArguments = analyzedArguments.ConstructorArguments.Arguments.ToImmutable();
+                    ReportDiagnosticsIfObsolete(diagnostics, attributeConstructor, node, hasBaseReceiver: false);
+
+                    if (attributeConstructor.Parameters.Any(p => p.RefKind == RefKind.In))
+                    {
+                        Error(diagnostics, ErrorCode.ERR_AttributeCtorInParameter, node, attributeConstructor.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+                    }
                 }
             }
+
+            Debug.Assert(boundConstructorArguments.All(a => !a.NeedsToBeConverted()));
+            diagnostics.Add(node, useSiteInfo);
 
             ImmutableArray<string?> boundConstructorArgumentNamesOpt = analyzedArguments.ConstructorArguments.GetNames();
             ImmutableArray<BoundAssignmentOperator> boundNamedArguments = analyzedArguments.NamedArguments?.ToImmutableAndFree() ?? ImmutableArray<BoundAssignmentOperator>.Empty;
@@ -217,8 +240,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             analyzedArguments.ConstructorArguments.Free();
 
-            return new BoundAttribute(node, attributeConstructor, boundConstructorArguments, boundConstructorArgumentNamesOpt, argsToParamsOpt, expanded,
-                boundNamedArguments, resultKind, attributeType, hasErrors: resultKind != LookupResultKind.Viable);
+            return new BoundAttribute(
+                node,
+                attributeConstructor,
+                boundConstructorArguments,
+                boundConstructorArgumentNamesOpt,
+                argsToParamsOpt,
+                expanded,
+                defaultArguments,
+                boundNamedArguments,
+                resultKind,
+                attributeType,
+                hasErrors: resultKind != LookupResultKind.Viable);
         }
 
         private CSharpAttributeData GetAttribute(BoundAttribute boundAttribute, BindingDiagnosticBag diagnostics)
@@ -249,24 +282,81 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(!constructorArgsArray.IsDefault, "Property of VisitArguments");
 
-            ImmutableArray<int> constructorArgumentsSourceIndices;
-            ImmutableArray<TypedConstant> constructorArguments;
+            ImmutableArray<int> argsToParamsOpt = boundAttribute.ConstructorArgumentsToParamsOpt;
+            ImmutableArray<TypedConstant> rewrittenArguments;
             if (hasErrors || attributeConstructor.ParameterCount == 0)
             {
-                constructorArgumentsSourceIndices = default(ImmutableArray<int>);
-                constructorArguments = constructorArgsArray;
+                rewrittenArguments = constructorArgsArray;
             }
             else
             {
-                constructorArguments = GetRewrittenAttributeConstructorArguments(out constructorArgumentsSourceIndices, attributeConstructor,
-                    constructorArgsArray, boundAttribute.ConstructorArgumentNamesOpt, (AttributeSyntax)boundAttribute.Syntax, boundAttribute.ConstructorArgumentsToParamsOpt, diagnostics, ref hasErrors);
+                rewrittenArguments = GetRewrittenAttributeConstructorArguments(
+                    attributeConstructor,
+                    constructorArgsArray,
+                    boundAttribute.ConstructorArgumentNamesOpt,
+                    (AttributeSyntax)boundAttribute.Syntax,
+                    argsToParamsOpt,
+                    diagnostics,
+                    boundAttribute.ConstructorExpanded,
+                    ref hasErrors);
             }
 
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             bool isConditionallyOmitted = IsAttributeConditionallyOmitted(attributeType, boundAttribute.SyntaxTree, ref useSiteInfo);
             diagnostics.Add(boundAttribute.Syntax, useSiteInfo);
 
-            return new SourceAttributeData(boundAttribute.Syntax.GetReference(), attributeType, attributeConstructor, constructorArguments, constructorArgumentsSourceIndices, namedArguments, hasErrors, isConditionallyOmitted);
+            return new SourceAttributeData(
+                boundAttribute.Syntax.GetReference(),
+                attributeType,
+                attributeConstructor,
+                rewrittenArguments,
+                makeSourceIndices(),
+                namedArguments,
+                hasErrors,
+                isConditionallyOmitted);
+
+            ImmutableArray<int> makeSourceIndices()
+            {
+                Debug.Assert(attributeConstructor.ParameterCount == rewrittenArguments.Length || hasErrors);
+                var lengthAfterRewriting = rewrittenArguments.Length;
+                if (lengthAfterRewriting == 0)
+                {
+                    return default;
+                }
+
+                // make source indices if we have anything that doesn't map 1:1 from arguments to parameters:
+                // 1. implicit default arguments
+                // 2. reordered labeled arguments
+                // 3. expanded params calls
+                var defaultArguments = boundAttribute.ConstructorDefaultArguments;
+                if (argsToParamsOpt.IsDefault && !boundAttribute.ConstructorExpanded)
+                {
+                    var hasDefaultArgument = false;
+                    var lengthBeforeRewriting = arguments.Length;
+                    for (var i = 0; i < lengthBeforeRewriting; i++)
+                    {
+                        if (defaultArguments[i])
+                        {
+                            hasDefaultArgument = true;
+                            break;
+                        }
+                    }
+                    if (!hasDefaultArgument)
+                    {
+                        return default;
+                    }
+                }
+
+                var constructorArgumentSourceIndices = ImmutableArray.CreateBuilder<int>(initialCapacity: lengthAfterRewriting);
+                for (int i = 0; i < lengthAfterRewriting; i++)
+                {
+                    constructorArgumentSourceIndices.Add(
+                        defaultArguments[i] ? -1 :
+                        argsToParamsOpt.IsDefault ? i :
+                        argsToParamsOpt[i]);
+                }
+                return constructorArgumentSourceIndices.MoveToImmutable();
+            }
         }
 
         private void ValidateTypeForAttributeParameters(ImmutableArray<ParameterSymbol> parameters, CSharpSyntaxNode syntax, BindingDiagnosticBag diagnostics, ref bool hasErrors)
@@ -549,46 +639,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return namedArgumentType;
         }
 
-        protected MethodSymbol BindAttributeConstructor(
-            AttributeSyntax node,
-            NamedTypeSymbol attributeType,
-            AnalyzedArguments boundConstructorArguments,
-            BindingDiagnosticBag diagnostics,
-            ref LookupResultKind resultKind,
-            bool suppressErrors,
-            ref ImmutableArray<int> argsToParamsOpt,
-            ref bool expanded,
-            ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo,
-            out ImmutableArray<BoundExpression> constructorArguments)
-        {
-            MemberResolutionResult<MethodSymbol> memberResolutionResult;
-            ImmutableArray<MethodSymbol> candidateConstructors;
-            if (!TryPerformConstructorOverloadResolution(
-                attributeType,
-                boundConstructorArguments,
-                attributeType.Name,
-                node.Location,
-                suppressErrors, //don't cascade in these cases
-                diagnostics,
-                out memberResolutionResult,
-                out candidateConstructors,
-                allowProtectedConstructorsOfBaseType: true))
-            {
-                resultKind = resultKind.WorseResultKind(
-                    memberResolutionResult.IsValid && !IsConstructorAccessible(memberResolutionResult.Member, ref useSiteInfo) ?
-                        LookupResultKind.Inaccessible :
-                        LookupResultKind.OverloadResolutionFailure);
-                constructorArguments = BuildArgumentsForErrorRecovery(boundConstructorArguments, candidateConstructors);
-            }
-            else
-            {
-                constructorArguments = boundConstructorArguments.Arguments.ToImmutable();
-            }
-            argsToParamsOpt = memberResolutionResult.Result.ArgsToParamsOpt;
-            expanded = memberResolutionResult.Result.Kind == MemberResolutionKind.ApplicableInExpandedForm;
-            return memberResolutionResult.Member;
-        }
-
         /// <summary>
         /// Gets the rewritten attribute constructor arguments, i.e. the arguments
         /// are in the order of parameters, which may differ from the source
@@ -606,13 +656,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// CONSIDER: Can we share some code will call rewriting in the local rewriter?
         /// </remarks>
         private ImmutableArray<TypedConstant> GetRewrittenAttributeConstructorArguments(
-            out ImmutableArray<int> constructorArgumentsSourceIndices,
             MethodSymbol attributeConstructor,
             ImmutableArray<TypedConstant> constructorArgsArray,
             ImmutableArray<string?> constructorArgumentNamesOpt,
             AttributeSyntax syntax,
             ImmutableArray<int> argumentsToParams,
             BindingDiagnosticBag diagnostics,
+            bool expanded,
             ref bool hasErrors)
         {
             RoslynDebug.Assert((object)attributeConstructor != null);
@@ -621,66 +671,30 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             int argumentsCount = constructorArgsArray.Length;
 
-            // argsConsumedCount keeps track of the number of constructor arguments
-            // consumed from this.ConstructorArguments array
-            int argsConsumedCount = 0;
-
-            bool hasNamedCtorArguments = !constructorArgumentNamesOpt.IsDefault;
-            Debug.Assert(!hasNamedCtorArguments ||
-                constructorArgumentNamesOpt.Length == argumentsCount);
-
             ImmutableArray<ParameterSymbol> parameters = attributeConstructor.Parameters;
             int parameterCount = parameters.Length;
 
             var reorderedArguments = new TypedConstant[parameterCount];
-            int[]? sourceIndices = null;
-
-            for (int i = 0; i < parameterCount; i++)
+            for (int i = 0; i < argumentsCount; i++)
             {
-                Debug.Assert(argsConsumedCount <= argumentsCount);
+                var paramIndex = argumentsToParams.IsDefault ? i : argumentsToParams[i];
+                ParameterSymbol parameter = parameters[paramIndex];
 
-                ParameterSymbol parameter = parameters[i];
                 TypedConstant reorderedArgument;
-
-                if (parameter.IsParams && parameter.Type.IsSZArray() && i + 1 == parameterCount)
+                if (parameter.IsParams && parameter.Type.IsSZArray())
                 {
-                    reorderedArgument = GetParamArrayArgument(parameter, constructorArgsArray, constructorArgumentNamesOpt, argumentsCount,
-                        argsConsumedCount, this.Conversions, out bool foundNamed);
-                    if (!foundNamed)
-                    {
-                        sourceIndices = sourceIndices ?? CreateSourceIndicesArray(i, parameterCount);
-                    }
-                }
-                else if (argsConsumedCount < argumentsCount)
-                {
-                    if (!hasNamedCtorArguments ||
-                        constructorArgumentNamesOpt[argsConsumedCount] == null)
-                    {
-                        // positional constructor argument
-                        reorderedArgument = constructorArgsArray[argsConsumedCount];
-                        if (sourceIndices != null)
-                        {
-                            sourceIndices[i] = argsConsumedCount;
-                        }
-                        argsConsumedCount++;
-                    }
-                    else
-                    {
-                        // Current parameter must either have a matching named argument or a default value
-                        // For the former case, argsConsumedCount must be incremented to note that we have
-                        // consumed a named argument. For the latter case, argsConsumedCount stays same.
-                        int matchingArgumentIndex;
-                        reorderedArgument = getMatchingNamedOrOptionalConstructorArgument(out matchingArgumentIndex, constructorArgsArray,
-                            parameter, argumentsCount, ref argsConsumedCount, syntax, argumentsToParams, diagnostics);
-
-                        sourceIndices = sourceIndices ?? CreateSourceIndicesArray(i, parameterCount);
-                        sourceIndices[i] = matchingArgumentIndex;
-                    }
+                    reorderedArgument = GetParamArrayArgument(
+                        parameter,
+                        constructorArgsArray,
+                        constructorArgumentNamesOpt,
+                        argumentsCount,
+                        currentArgumentIndex: i,
+                        this.Conversions,
+                        endOfParamsArrayIndex: out i);
                 }
                 else
                 {
-                    reorderedArgument = GetDefaultValueArgument(parameter, syntax, argumentsToParams, argumentsCount, diagnostics);
-                    sourceIndices = sourceIndices ?? CreateSourceIndicesArray(i, parameterCount);
+                    reorderedArgument = constructorArgsArray[i];
                 }
 
                 if (!hasErrors)
@@ -700,256 +714,77 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                reorderedArguments[i] = reorderedArgument;
+                reorderedArguments[paramIndex] = reorderedArgument;
             }
 
-            constructorArgumentsSourceIndices = sourceIndices != null ? sourceIndices.AsImmutableOrNull() : default(ImmutableArray<int>);
+            // If we are in expanded form and no explicit argument was provided for the params array, then create the empty params array now.
+            if (expanded && reorderedArguments[^1].Kind == TypedConstantKind.Error)
+            {
+                var paramArray = parameters[^1];
+                Debug.Assert(paramArray.IsParams);
+                reorderedArguments[^1] = GetParamArrayArgument(paramArray, constructorArgsArray, constructorArgumentNamesOpt, argumentsCount, currentArgumentIndex: argumentsCount, this.Conversions, endOfParamsArrayIndex: out _);
+            }
+
+            Debug.Assert(hasErrors || reorderedArguments.All(arg => arg.Kind != TypedConstantKind.Error));
             return reorderedArguments.AsImmutableOrNull();
-
-            // Local functions
-            TypedConstant getMatchingNamedOrOptionalConstructorArgument(
-                out int matchingArgumentIndex,
-                ImmutableArray<TypedConstant> constructorArgsArray,
-                ParameterSymbol parameter,
-                int argumentsCount,
-                ref int argsConsumedCount,
-                AttributeSyntax syntax,
-                ImmutableArray<int> argumentsToParams,
-                BindingDiagnosticBag diagnostics)
-            {
-                matchingArgumentIndex = argumentsToParams.IsDefaultOrEmpty
-                    ? parameter.Ordinal
-                    : argumentsToParams.IndexOf(parameter.Ordinal);
-
-                if (matchingArgumentIndex > -1)
-                {
-                    // found a matching named argument
-                    Debug.Assert(matchingArgumentIndex < argumentsCount);
-
-                    // increment argsConsumedCount
-                    argsConsumedCount++;
-                    return constructorArgsArray[matchingArgumentIndex];
-                }
-                else
-                {
-                    return GetDefaultValueArgument(parameter, syntax, argumentsToParams, argumentsCount, diagnostics);
-                }
-            }
         }
 
-        private static int[] CreateSourceIndicesArray(int paramIndex, int parameterCount)
+        // This should eventually be moved to initial binding.
+        // https://github.com/dotnet/roslyn/issues/49602
+        private static TypedConstant GetParamArrayArgument(
+            ParameterSymbol parameter,
+            ImmutableArray<TypedConstant> constructorArgsArray,
+            ImmutableArray<string?> constructorArgumentNamesOpt,
+            int argumentsCount,
+            int currentArgumentIndex,
+            Conversions conversions,
+            out int endOfParamsArrayIndex)
         {
-            Debug.Assert(paramIndex >= 0);
-            Debug.Assert(paramIndex < parameterCount);
-
-            var sourceIndices = new int[parameterCount];
-            for (int i = 0; i < paramIndex; i++)
-            {
-                sourceIndices[i] = i;
-            }
-
-            for (int i = paramIndex; i < parameterCount; i++)
-            {
-                sourceIndices[i] = -1;
-            }
-
-            return sourceIndices;
-        }
-
-        private static int GetMatchingNamedConstructorArgumentIndex(string parameterName, ImmutableArray<string?> argumentNamesOpt, int startIndex, int argumentsCount)
-        {
-            RoslynDebug.Assert(parameterName != null);
-            Debug.Assert(startIndex >= 0 && startIndex < argumentsCount);
-
-            if (parameterName.IsEmpty() || !argumentNamesOpt.Any())
-            {
-                return argumentsCount;
-            }
-
-            // get the matching named (constructor) argument
-            int argIndex = startIndex;
-            while (argIndex < argumentsCount)
-            {
-                var name = argumentNamesOpt[argIndex];
-
-                if (string.Equals(name, parameterName, StringComparison.Ordinal))
-                {
-                    break;
-                }
-
-                argIndex++;
-            }
-
-            return argIndex;
-        }
-
-        private TypedConstant GetDefaultValueArgument(ParameterSymbol parameter, AttributeSyntax syntax, ImmutableArray<int> argumentsToParams, int argumentsCount, BindingDiagnosticBag diagnostics)
-        {
-            var parameterType = parameter.Type;
-            ConstantValue? defaultConstantValue = parameter.IsOptional ? parameter.ExplicitDefaultConstantValue : ConstantValue.NotAvailable;
-
-            TypedConstantKind kind;
-            object? defaultValue = null;
-
-            if (!IsEarlyAttributeBinder && parameter.IsCallerLineNumber)
-            {
-                int line = syntax.SyntaxTree.GetDisplayLineNumber(syntax.Name.Span);
-                kind = TypedConstantKind.Primitive;
-
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-                var conversion = Conversions.GetCallerLineNumberConversion(parameterType, ref useSiteInfo);
-                diagnostics.Add(syntax, useSiteInfo);
-
-                if (conversion.IsNumeric || conversion.IsConstantExpression)
-                {
-                    // DoUncheckedConversion() keeps "single" floats as doubles internally to maintain higher
-                    // precision, so make sure they get cast to floats here.
-                    defaultValue = (parameterType.SpecialType == SpecialType.System_Single)
-                        ? (float)line
-                        : Binder.DoUncheckedConversion(parameterType.SpecialType, ConstantValue.Create(line));
-                }
-                else
-                {
-                    // Boxing or identity conversion:
-                    parameterType = GetSpecialType(SpecialType.System_Int32, diagnostics, syntax);
-                    defaultValue = line;
-                }
-            }
-            else if (!IsEarlyAttributeBinder && parameter.IsCallerFilePath)
-            {
-                parameterType = GetSpecialType(SpecialType.System_String, diagnostics, syntax);
-                kind = TypedConstantKind.Primitive;
-                defaultValue = syntax.SyntaxTree.GetDisplayPath(syntax.Name.Span, Compilation.Options.SourceReferenceResolver);
-            }
-            else if (!IsEarlyAttributeBinder && parameter.IsCallerMemberName && (object)((ContextualAttributeBinder)this).AttributedMember != null)
-            {
-                parameterType = GetSpecialType(SpecialType.System_String, diagnostics, syntax);
-                kind = TypedConstantKind.Primitive;
-                defaultValue = ((ContextualAttributeBinder)this).AttributedMember.GetMemberCallerName();
-            }
-            // We check IsCallerMemberName here since the above if can be reached with AttributedMember == null, in which case,
-            // We shouldn't be checking CallerArgumentExpression
-            else if (!IsEarlyAttributeBinder && syntax.ArgumentList is not null && !parameter.IsCallerMemberName &&
-                getCallerArgumentArgumentIndex(parameter, argumentsToParams) is int argumentIndex && argumentIndex > -1 && argumentIndex < argumentsCount)
-            {
-                Debug.Assert(argumentsCount <= syntax.ArgumentList.Arguments.Count);
-                parameterType = GetSpecialType(SpecialType.System_String, diagnostics, syntax);
-                kind = TypedConstantKind.Primitive;
-                defaultValue = syntax.ArgumentList.Arguments[argumentIndex].Expression.ToString();
-            }
-            else if (defaultConstantValue == ConstantValue.NotAvailable)
-            {
-                // There is no constant value given for the parameter in source/metadata.
-                // For example, the attribute constructor with signature: M([Optional] int x), has no default value from syntax or attributes.
-                // Default value for these cases is "default(parameterType)".
-
-                // Optional parameter of System.Object type is treated specially though.
-                // Native compiler treats "M([Optional] object x)" equivalent to "M(object x)" for attributes if parameter type is System.Object.
-                // We generate a better diagnostic for this case by treating "x" in the above case as optional, but generating CS7067 instead.
-                if (parameterType.SpecialType == SpecialType.System_Object)
-                {
-                    // CS7067: Attribute constructor parameter '{0}' is optional, but no default parameter value was specified.
-                    diagnostics.Add(ErrorCode.ERR_BadAttributeParamDefaultArgument, syntax.Name.Location, parameter.Name);
-                    kind = TypedConstantKind.Error;
-                }
-                else
-                {
-                    kind = TypedConstant.GetTypedConstantKind(parameterType, this.Compilation);
-                    Debug.Assert(kind != TypedConstantKind.Error);
-
-                    defaultConstantValue = parameterType.GetDefaultValue();
-                    if (defaultConstantValue != null)
-                    {
-                        defaultValue = defaultConstantValue.Value;
-                    }
-                }
-            }
-            else if (defaultConstantValue.IsBad)
-            {
-                // Constant value through syntax had errors, don't generate cascading diagnostics.
-                kind = TypedConstantKind.Error;
-            }
-            else if (parameterType.SpecialType == SpecialType.System_Object && !defaultConstantValue.IsNull)
-            {
-                // error CS1763: '{0}' is of type '{1}'. A default parameter value of a reference type other than string can only be initialized with null
-                diagnostics.Add(ErrorCode.ERR_NotNullRefDefaultParameter, syntax.Location, parameter.Name, parameterType);
-                kind = TypedConstantKind.Error;
-            }
-            else
-            {
-                kind = TypedConstant.GetTypedConstantKind(parameterType, this.Compilation);
-                Debug.Assert(kind != TypedConstantKind.Error);
-
-                defaultValue = defaultConstantValue.Value;
-            }
-
-            if (kind == TypedConstantKind.Array)
-            {
-                Debug.Assert(defaultValue == null);
-                return new TypedConstant(parameterType, default(ImmutableArray<TypedConstant>));
-            }
-            else
-            {
-                return new TypedConstant(parameterType, kind, defaultValue);
-            }
-
-            static int getCallerArgumentArgumentIndex(ParameterSymbol parameter, ImmutableArray<int> argumentsToParams)
-            {
-                return argumentsToParams.IsDefault || parameter.CallerArgumentExpressionParameterIndex == -1
-                        ? parameter.CallerArgumentExpressionParameterIndex
-                        : argumentsToParams.IndexOf(parameter.CallerArgumentExpressionParameterIndex);
-            }
-        }
-
-        private static TypedConstant GetParamArrayArgument(ParameterSymbol parameter, ImmutableArray<TypedConstant> constructorArgsArray,
-            ImmutableArray<string?> constructorArgumentNamesOpt, int argumentsCount, int argsConsumedCount, Conversions conversions, out bool foundNamed)
-        {
-            Debug.Assert(argsConsumedCount <= argumentsCount);
+            Debug.Assert(currentArgumentIndex <= argumentsCount);
 
             // If there's a named argument, we'll use that
-            if (!constructorArgumentNamesOpt.IsDefault)
+            if (!constructorArgumentNamesOpt.IsDefault && constructorArgumentNamesOpt.Contains(parameter.Name))
             {
-                int argIndex = constructorArgumentNamesOpt.IndexOf(parameter.Name);
-                if (argIndex >= 0)
+                Debug.Assert(constructorArgumentNamesOpt.IndexOf(parameter.Name) == currentArgumentIndex);
+                endOfParamsArrayIndex = currentArgumentIndex;
+                if (TryGetNormalParamValue(parameter, constructorArgsArray, currentArgumentIndex, conversions, out var namedValue))
                 {
-                    foundNamed = true;
-                    if (TryGetNormalParamValue(parameter, constructorArgsArray, argIndex, conversions, out var namedValue))
-                    {
-                        return namedValue;
-                    }
-
-                    // A named argument for a params parameter is necessarily the only one for that parameter
-                    return new TypedConstant(parameter.Type, ImmutableArray.Create(constructorArgsArray[argIndex]));
+                    return namedValue;
                 }
+
+                // A named argument for a params parameter is necessarily the only one for that parameter
+                return new TypedConstant(parameter.Type, ImmutableArray.Create(constructorArgsArray[currentArgumentIndex]));
             }
 
-            int paramArrayArgCount = argumentsCount - argsConsumedCount;
-            foundNamed = false;
+            int paramArrayArgCount = argumentsCount - currentArgumentIndex;
 
             // If there are zero arguments left
             if (paramArrayArgCount == 0)
             {
+                endOfParamsArrayIndex = argumentsCount - 1;
                 return new TypedConstant(parameter.Type, ImmutableArray<TypedConstant>.Empty);
             }
 
             // If there's exactly one argument left, we'll try to use it in normal form
             if (paramArrayArgCount == 1 &&
-                TryGetNormalParamValue(parameter, constructorArgsArray, argsConsumedCount, conversions, out var lastValue))
+                TryGetNormalParamValue(parameter, constructorArgsArray, currentArgumentIndex, conversions, out var lastValue))
             {
+                endOfParamsArrayIndex = argumentsCount - 1;
                 return lastValue;
             }
 
             Debug.Assert(!constructorArgsArray.IsDefault);
-            Debug.Assert(argsConsumedCount <= constructorArgsArray.Length);
+            Debug.Assert(currentArgumentIndex <= constructorArgsArray.Length);
 
             // Take the trailing arguments as an array for expanded form
             var values = new TypedConstant[paramArrayArgCount];
 
             for (int i = 0; i < paramArrayArgCount; i++)
             {
-                values[i] = constructorArgsArray[argsConsumedCount++];
+                values[i] = constructorArgsArray[currentArgumentIndex++];
             }
 
+            endOfParamsArrayIndex = currentArgumentIndex + paramArrayArgCount - 1;
             return new TypedConstant(parameter.Type, values.AsImmutableOrNull());
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -347,15 +347,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                var constructorArgumentSourceIndices = ImmutableArray.CreateBuilder<int>(initialCapacity: lengthAfterRewriting);
-                for (int i = 0; i < lengthAfterRewriting; i++)
+                var constructorArgumentSourceIndices = ArrayBuilder<int>.GetInstance(lengthAfterRewriting);
+                constructorArgumentSourceIndices.Count = lengthAfterRewriting;
+                for (int argIndex = 0; argIndex < lengthAfterRewriting; argIndex++)
                 {
-                    constructorArgumentSourceIndices.Add(
-                        defaultArguments[i] ? -1 :
-                        argsToParamsOpt.IsDefault ? i :
-                        argsToParamsOpt[i]);
+                    int paramIndex = argsToParamsOpt.IsDefault ? argIndex : argsToParamsOpt[argIndex];
+                    constructorArgumentSourceIndices[paramIndex] = defaultArguments[argIndex] ? -1 : argIndex;
                 }
-                return constructorArgumentSourceIndices.MoveToImmutable();
+                return constructorArgumentSourceIndices.ToImmutableAndFree();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1182,6 +1182,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We have a call to a method M([Optional] object x) which omits the argument. The value we generate
             // for the argument depends on the presence or absence of other attributes. The rules are:
             //
+            // * If we're generating a default argument for an attribute, it's a compile error.
             // * If the parameter is marked as [MarshalAs(Interface)], [MarshalAs(IUnknown)] or [MarshalAs(IDispatch)]
             //   then the argument is null.
             // * Otherwise, if the parameter is marked as [IUnknownConstant] then the argument is
@@ -1191,7 +1192,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // * Otherwise, the argument is Type.Missing.
 
             BoundExpression? defaultValue = null;
-            if (parameter.IsMarshalAsObject)
+            if (InAttributeArgument)
+            {
+                // CS7067: Attribute constructor parameter '{0}' is optional, but no default parameter value was specified.
+                diagnostics.Add(ErrorCode.ERR_BadAttributeParamDefaultArgument, syntax.Location, parameter.Name);
+                defaultValue = BadExpression(syntax).MakeCompilerGenerated();
+            }
+            else if (parameter.IsMarshalAsObject)
             {
                 // default(object)
                 defaultValue = new BoundDefaultExpression(syntax, parameterType) { WasCompilerGenerated = true };
@@ -1278,7 +1285,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool expanded,
             bool enableCallerInfo,
             BindingDiagnosticBag diagnostics,
-            bool assertMissingParametersAreOptional = true)
+            bool assertMissingParametersAreOptional = true,
+            Symbol? attributedMember = null)
         {
 
             var visitedParameters = BitVector.Create(parameters.Length);
@@ -1300,11 +1308,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // In a scenario like `string Prop { get; } = M();`, the containing symbol could be the synthesized field.
             // We want to use the associated user-declared symbol instead where possible.
-            var containingMember = ContainingMember() switch
+            var containingMember = InAttributeArgument ? attributedMember : ContainingMember() switch
             {
                 FieldSymbol { AssociatedSymbol: { } symbol } => symbol,
                 var c => c
             };
+            Debug.Assert(InAttributeArgument || (attributedMember is null && containingMember is not null));
 
             defaultArguments = BitVector.Create(parameters.Length);
             ArrayBuilder<int>? argsToParamsBuilder = null;
@@ -1348,7 +1357,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argsToParamsBuilder.Free();
             }
 
-            BoundExpression bindDefaultArgument(SyntaxNode syntax, ParameterSymbol parameter, Symbol containingMember, bool enableCallerInfo, BindingDiagnosticBag diagnostics, ArrayBuilder<BoundExpression> argumentsBuilder, int argumentsCount, ImmutableArray<int> argsToParamsOpt)
+            BoundExpression bindDefaultArgument(SyntaxNode syntax, ParameterSymbol parameter, Symbol? containingMember, bool enableCallerInfo, BindingDiagnosticBag diagnostics, ArrayBuilder<BoundExpression> argumentsBuilder, int argumentsCount, ImmutableArray<int> argsToParamsOpt)
             {
                 TypeSymbol parameterType = parameter.Type;
                 if (Flags.Includes(BinderFlags.ParameterDefaultValue))
@@ -1358,7 +1367,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return new BoundDefaultExpression(syntax, parameterType) { WasCompilerGenerated = true };
                 }
 
-                var defaultConstantValue = parameter.ExplicitDefaultConstantValue switch
+                var parameterDefaultValue = parameter.ExplicitDefaultConstantValue;
+                if (InAttributeArgument && parameterDefaultValue?.IsBad == true)
+                {
+                    diagnostics.Add(ErrorCode.ERR_BadAttributeArgument, syntax.Location);
+                    return BadExpression(syntax).MakeCompilerGenerated();
+                }
+
+                var defaultConstantValue = parameterDefaultValue switch
                 {
                     // Bad default values are implicitly replaced with default(T) at call sites.
                     { IsBad: true } => ConstantValue.Null,
@@ -1366,6 +1382,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 };
                 Debug.Assert((object?)defaultConstantValue != ConstantValue.Unset);
 
+                var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
                 var callerSourceLocation = enableCallerInfo ? GetCallerLocation(syntax) : null;
                 BoundExpression defaultValue;
                 if (callerSourceLocation is object && parameter.IsCallerLineNumber)
@@ -1378,13 +1395,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     string path = callerSourceLocation.SourceTree.GetDisplayPath(callerSourceLocation.SourceSpan, Compilation.Options.SourceReferenceResolver);
                     defaultValue = new BoundLiteral(syntax, ConstantValue.Create(path), Compilation.GetSpecialType(SpecialType.System_String)) { WasCompilerGenerated = true };
                 }
-                else if (callerSourceLocation is object && parameter.IsCallerMemberName)
+                else if (callerSourceLocation is object && parameter.IsCallerMemberName && containingMember is not null)
                 {
                     var memberName = containingMember.GetMemberCallerName();
                     defaultValue = new BoundLiteral(syntax, ConstantValue.Create(memberName), Compilation.GetSpecialType(SpecialType.System_String)) { WasCompilerGenerated = true };
                 }
-                else if (callerSourceLocation is object && getArgumentIndex(parameter.CallerArgumentExpressionParameterIndex, argsToParamsOpt) is int argumentIndex &&
-                    argumentIndex > -1 && argumentIndex < argumentsCount)
+                else if (callerSourceLocation is object
+                    && !parameter.IsCallerMemberName
+                    && Conversions.ClassifyBuiltInConversion(Compilation.GetSpecialType(SpecialType.System_String), parameterType, ref discardedUseSiteInfo).Exists
+                    && getArgumentIndex(parameter.CallerArgumentExpressionParameterIndex, argsToParamsOpt) is int argumentIndex
+                    && argumentIndex > -1 && argumentIndex < argumentsCount)
                 {
                     var argument = argumentsBuilder[argumentIndex];
                     defaultValue = new BoundLiteral(syntax, ConstantValue.Create(argument.Syntax.ToString()), Compilation.GetSpecialType(SpecialType.System_String)) { WasCompilerGenerated = true };
@@ -1411,6 +1431,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     TypeSymbol constantType = Compilation.GetSpecialType(defaultConstantValue.SpecialType);
                     defaultValue = new BoundLiteral(syntax, defaultConstantValue, constantType) { WasCompilerGenerated = true };
+
+                    if (InAttributeArgument && parameterType.SpecialType == SpecialType.System_Object)
+                    {
+                        // error CS1763: '{0}' is of type '{1}'. A default parameter value of a reference type other than string can only be initialized with null
+                        diagnostics.Add(ErrorCode.ERR_NotNullRefDefaultParameter, syntax.Location, parameter.Name, parameterType);
+                    }
                 }
 
                 CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1196,7 +1196,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // CS7067: Attribute constructor parameter '{0}' is optional, but no default parameter value was specified.
                 diagnostics.Add(ErrorCode.ERR_BadAttributeParamDefaultArgument, syntax.Location, parameter.Name);
-                defaultValue = BadExpression(syntax).MakeCompilerGenerated();
             }
             else if (parameter.IsMarshalAsObject)
             {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1755,6 +1755,7 @@
     <Field Name="ConstructorArgumentNamesOpt" Type="ImmutableArray&lt;string?&gt;" Null="allow"/>
     <Field Name="ConstructorArgumentsToParamsOpt" Type="ImmutableArray&lt;int&gt;" Null="allow"/>
     <Field Name="ConstructorExpanded" Type="bool" />
+    <Field Name="ConstructorDefaultArguments" Type="BitVector"/>
     <Field Name="NamedArguments" Type ="ImmutableArray&lt;BoundAssignmentOperator&gt;"/>
     <Field Name="ResultKind" PropertyOverrides="true" Type="LookupResultKind"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
@@ -89,7 +89,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.Kind() == SyntaxKind.Attribute)
             {
                 var attribute = (AttributeSyntax)node;
-                return binder.BindAttribute(attribute, AttributeType, diagnostics);
+                // note: we should find the attributed member before binding the attribute as part of https://github.com/dotnet/roslyn/issues/53618
+                return binder.BindAttribute(attribute, AttributeType, attributedMember: null, diagnostics);
             }
             else if (SyntaxFacts.IsAttributeName(node))
             {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -411,7 +411,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             AliasSymbol aliasOpt; // not needed.
             NamedTypeSymbol attributeType = (NamedTypeSymbol)binder.BindType(attribute.Name, BindingDiagnosticBag.Discarded, out aliasOpt).Type;
-            var boundNode = new ExecutableCodeBinder(attribute, binder.ContainingMemberOrLambda, binder).BindAttribute(attribute, attributeType, BindingDiagnosticBag.Discarded);
+            // note: we don't need to pass an 'attributedMember' here because we only need symbolInfo from this node
+            var boundNode = new ExecutableCodeBinder(attribute, binder.ContainingMemberOrLambda, binder).BindAttribute(attribute, attributeType, attributedMember: null, BindingDiagnosticBag.Discarded);
 
             return boundNode;
         }

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
@@ -598,17 +598,17 @@ static class Program
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestComplexOrderedAttributeArguments()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 
 sealed class MarkAttribute : Attribute
 {
-    public MarkAttribute(bool a, bool b, bool c)
+    public MarkAttribute(int a, int b, int c)
     {
     }
 }
 
-[Mark(b: true, c: true, a: false)]
+[Mark(b: 0, c: 1, a: 2)]
 static class Program
 {
     public static void Main()
@@ -622,15 +622,15 @@ static class Program
             Assert.Equal(new[] { 2, 0, 1 }, attributeData.ConstructorArgumentsSourceIndices);
 
             var attributeSyntax = (AttributeSyntax)attributeData.ApplicationSyntaxReference.GetSyntax();
-            Assert.Equal("a: false", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
-            Assert.Equal("b: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
-            Assert.Equal("c: true", attributeData.GetAttributeArgumentSyntax(parameterIndex: 2, attributeSyntax).ToString());
+            Assert.Equal("a: 2", attributeData.GetAttributeArgumentSyntax(parameterIndex: 0, attributeSyntax).ToString());
+            Assert.Equal("b: 0", attributeData.GetAttributeArgumentSyntax(parameterIndex: 1, attributeSyntax).ToString());
+            Assert.Equal("c: 1", attributeData.GetAttributeArgumentSyntax(parameterIndex: 2, attributeSyntax).ToString());
         }
 
         [Fact]
         public void TestBadParamsCtor()
         {
-            var comp = CreateCompilationWithMscorlib46(@"
+            var comp = CreateCompilation(@"
 using System;
 
 class AAttribute : Attribute
@@ -655,12 +655,7 @@ class Program
             Assert.Equal("AAttribute..ctor(params System.Int32[] args)", attributeData.AttributeConstructor.ToTestDisplayString());
             Assert.Equal(1, attributeData.AttributeConstructor.ParameterCount);
             Assert.Equal(new object[] { 1, 2, 3 }, attributeData.ConstructorArguments.Select(arg => arg.Value));
-#if DEBUG
-            var root = comp.SyntaxTrees.Single().GetRoot();
-            var attrSyntax = root.DescendantNodes().OfType<AttributeSyntax>().Single();
-            // Asserts in debug mode.
-            Assert.Throws<InvalidOperationException>(() => attributeData.GetAttributeArgumentSyntax(0, attrSyntax));
-#endif
+            // `SourceAttributeData.GetAttributeArgumentSyntax` asserts in debug mode when the attributeData has errors, so we don't test it here.
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -1794,40 +1794,52 @@ class C
             CreateCompilation(source).VerifyDiagnostics(
                 // (63,65): error CS1763: 'x' is of type 'object'. A default parameter value of a reference type other than string can only be initialized with null
                 //     public MyPermission5Attribute(SecurityAction action, object x = SecurityAction.Demand) : base(SecurityAction.Demand)
-                Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "x").WithArguments("x", "object"),
+                Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "x").WithArguments("x", "object").WithLocation(63, 65),
                 // (76,42): error CS1763: 'x' is of type 'object'. A default parameter value of a reference type other than string can only be initialized with null
                 //     public MyPermission6Attribute(object x = SecurityAction.Demand) : base(SecurityAction.Demand)
-                Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "x").WithArguments("x", "object"),
+                Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "x").WithArguments("x", "object").WithLocation(76, 42),
                 // (101,46): error CS1908: The type of the argument to the DefaultParameterValue attribute must match the parameter type
                 //     public MyPermission8Attribute([Optional][DefaultParameterValueAttribute(null)]SecurityAction x) : base(SecurityAction.Demand)
-                Diagnostic(ErrorCode.ERR_DefaultValueTypeMustMatch, "DefaultParameterValueAttribute"),
+                Diagnostic(ErrorCode.ERR_DefaultValueTypeMustMatch, "DefaultParameterValueAttribute").WithLocation(101, 46),
                 // (113,46): error CS1908: The type of the argument to the DefaultParameterValue attribute must match the parameter type
                 //     public MyPermission9Attribute([Optional][DefaultParameterValueAttribute(-1)]SecurityAction x) : base(SecurityAction.Demand)
-                Diagnostic(ErrorCode.ERR_DefaultValueTypeMustMatch, "DefaultParameterValueAttribute"),
+                Diagnostic(ErrorCode.ERR_DefaultValueTypeMustMatch, "DefaultParameterValueAttribute").WithLocation(113, 46),
                 // (137,2): error CS7067: Attribute constructor parameter 'x' is optional, but no default parameter value was specified.
                 // [MyPermission(SecurityAction.Demand)]
-                Diagnostic(ErrorCode.ERR_BadAttributeParamDefaultArgument, "MyPermission").WithArguments("x"),
+                Diagnostic(ErrorCode.ERR_BadAttributeParamDefaultArgument, "MyPermission(SecurityAction.Demand)").WithArguments("x").WithLocation(137, 2),
                 // (140,2): error CS7067: Attribute constructor parameter 'x' is optional, but no default parameter value was specified.
                 // [MyPermission2(SecurityAction.Demand)]
-                Diagnostic(ErrorCode.ERR_BadAttributeParamDefaultArgument, "MyPermission2").WithArguments("x"),
+                Diagnostic(ErrorCode.ERR_BadAttributeParamDefaultArgument, "MyPermission2(SecurityAction.Demand)").WithArguments("x").WithLocation(140, 2),
                 // (143,2): error CS7067: Attribute constructor parameter 'x' is optional, but no default parameter value was specified.
                 // [MyPermission3()]
-                Diagnostic(ErrorCode.ERR_BadAttributeParamDefaultArgument, "MyPermission3").WithArguments("x"),
-                // (149,16): error CS1503: Argument 1: cannot convert from '<null>' to 'System.Security.Permissions.SecurityAction'
+                Diagnostic(ErrorCode.ERR_BadAttributeParamDefaultArgument, "MyPermission3()").WithArguments("x").WithLocation(143, 2),
+                // (149,16): error CS1503: Argument 1: cannot convert from '<null>' to 'SecurityAction'
                 // [MyPermission4(null)]
-                Diagnostic(ErrorCode.ERR_BadArgType, "null").WithArguments("1", "<null>", "System.Security.Permissions.SecurityAction"),
+                Diagnostic(ErrorCode.ERR_BadArgType, "null").WithArguments("1", "<null>", "System.Security.Permissions.SecurityAction").WithLocation(149, 16),
+                // (151,2): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                // [MyPermission5(SecurityAction.Demand)]
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "MyPermission5(SecurityAction.Demand)").WithLocation(151, 2),
+                // (154,2): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                // [MyPermission6()]
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "MyPermission6()").WithLocation(154, 2),
+                // (161,2): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                // [MyPermission8()]
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "MyPermission8()").WithLocation(161, 2),
+                // (164,2): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
+                // [MyPermission9()]
+                Diagnostic(ErrorCode.ERR_BadAttributeArgument, "MyPermission9()").WithLocation(164, 2),
                 // (167,2): error CS1763: 'y' is of type 'object'. A default parameter value of a reference type other than string can only be initialized with null
                 // [MyPermission10(SecurityAction.Demand)]
-                Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "MyPermission10(SecurityAction.Demand)").WithArguments("y", "object"),
+                Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "MyPermission10(SecurityAction.Demand)").WithArguments("y", "object").WithLocation(167, 2),
                 // (145,2): error CS7048: First argument to a security attribute must be a valid SecurityAction
                 // [MyPermission3(null)]
-                Diagnostic(ErrorCode.ERR_SecurityAttributeMissingAction, "MyPermission3"),
+                Diagnostic(ErrorCode.ERR_SecurityAttributeMissingAction, "MyPermission3").WithLocation(145, 2),
                 // (147,2): error CS7049: Security attribute 'MyPermission4' has an invalid SecurityAction value '0'
                 // [MyPermission4()]
-                Diagnostic(ErrorCode.ERR_SecurityAttributeInvalidAction, "MyPermission4()").WithArguments("MyPermission4", "0"),
+                Diagnostic(ErrorCode.ERR_SecurityAttributeInvalidAction, "MyPermission4()").WithArguments("MyPermission4", "0").WithLocation(147, 2),
                 // (156,2): error CS7048: First argument to a security attribute must be a valid SecurityAction
                 // [MyPermission6(null)]
-                Diagnostic(ErrorCode.ERR_SecurityAttributeMissingAction, "MyPermission6"));
+                Diagnostic(ErrorCode.ERR_SecurityAttributeMissingAction, "MyPermission6").WithLocation(156, 2));
         }
 
         [Fact]


### PR DESCRIPTION
Related to #47352

Before this change we had a dedicated code path for creating default arguments in attributes, separate from the path that creates default arguments everywhere else. This change consolidates us to the single path which creates BoundExpressions instead of TypedConstants.

#53618 becomes a lot simpler to implement and more similar to operation creation for calls after this change.