### PR TITLE
Add missing API to IVSTypeScriptDiagnosticService

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/IVSTypeScriptDiagnosticService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/IVSTypeScriptDiagnosticService.cs
@@ -2,14 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
     internal interface IVSTypeScriptDiagnosticService
     {
         Task<ImmutableArray<VSTypeScriptDiagnosticData>> GetPushDiagnosticsAsync(Workspace workspace, ProjectId projectId, DocumentId documentId, object id, bool includeSuppressedDiagnostics, CancellationToken cancellationToken);
+
+        IDisposable RegisterDiagnosticsUpdatedEventHandler(Action<VSTypeScriptDiagnosticsUpdatedArgsWrapper> action);
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticsUpdatedArgsWrapper.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticsUpdatedArgsWrapper.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
+{
+    internal readonly struct VSTypeScriptDiagnosticsUpdatedArgsWrapper
+    {
+        internal readonly DiagnosticsUpdatedArgs UnderlyingObject;
+
+        public VSTypeScriptDiagnosticsUpdatedArgsWrapper(DiagnosticsUpdatedArgs underlyingObject)
+            => UnderlyingObject = underlyingObject;
+
+        public Solution? Solution
+            => UnderlyingObject.Solution;
+
+        public DocumentId? DocumentId
+            => UnderlyingObject.DocumentId;
+    }
+}


### PR DESCRIPTION
TypeScript needs to hook up DiagnosticUpdated event

Corresponding TypeScript PR: https://devdiv.visualstudio.com/DevDiv/_git/TypeScript-VS/pullrequest/382162