### PR TITLE
Filter to exact test class names in RunTests

### DIFF
--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -47,9 +47,8 @@ namespace RunTests
                 {
                     MaybeAddSeparator();
                     // https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest#syntax
-                    builder.Append("(FullyQualifiedName=");
                     builder.Append(typeInfo.FullName);
-                    builder.Append(')');
+                    builder.Append('.');
                 }
                 builder.Append(sep);
 

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -46,6 +46,8 @@ namespace RunTests
                 foreach (var typeInfo in typeInfoList)
                 {
                     MaybeAddSeparator();
+                    // https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest#syntax
+                    builder.Append("FullyQualifiedName=");
                     builder.Append(typeInfo.FullName);
                 }
                 builder.Append(sep);

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -47,6 +47,9 @@ namespace RunTests
                 {
                     MaybeAddSeparator();
                     // https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest#syntax
+                    // We want to avoid matching other test classes whose names are prefixed with this test class's name.
+                    // For example, avoid running 'AttributeTests_WellKnownMember', when the request here is to run 'AttributeTests'.
+                    // We append a '.', assuming that all test methods in the class *will* match it, but not methods in other classes.
                     builder.Append(typeInfo.FullName);
                     builder.Append('.');
                 }

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -47,8 +47,9 @@ namespace RunTests
                 {
                     MaybeAddSeparator();
                     // https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=mstest#syntax
-                    builder.Append("FullyQualifiedName=");
+                    builder.Append("(FullyQualifiedName=");
                     builder.Append(typeInfo.FullName);
+                    builder.Append(')');
                 }
                 builder.Append(sep);
 


### PR DESCRIPTION
I observed that when the filter contains `Microsoft.CodeAnalysis.CSharp.UnitTests.AttributeTests`, we would also run tests in `Microsoft.CodeAnalysis.CSharp.UnitTests.AttributeTests_WellKnownAttributes`, which we don't want. 

https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-roslyn-refs-pull-59750-merge-8edd16eeb0de436da3/Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests.dll.1/1/console.5d56e696.log?sv=2019-07-07&se=2022-03-16T21%3A40%3A07Z&sr=c&sp=rl&sig=HxhVtmQTizibmnuJ3rjrZLqe9OfUkU1%2FODO9NeOue2g%3D

Before this PR, roslyn-ci runs about [680,586 tests](https://github.com/dotnet/roslyn/pull/59755/checks?check_run_id=5327504323).
After this PR, roslyn-ci runs about [649,537 tests](https://github.com/dotnet/roslyn/pull/59752/checks?check_run_id=5327602857).