### PR TITLE
Disable Auto-Open behavior for Stack Trace Explorer

### DIFF
--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerOptions.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.StackTraceExplorer
         /// Used to determine if a user focusing VS should look at the clipboard for a callstack and automatically
         /// open the tool window with the callstack inserted
         /// </summary>
-        public static readonly Option2<bool> OpenOnFocus = new(FeatureName, "OpenOnFocus", defaultValue: true,
+        public static readonly Option2<bool> OpenOnFocus = new(FeatureName, "OpenOnFocus", defaultValue: false,
             storageLocation: new RoamingProfileStorageLocation("StackTraceExplorer.Options.OpenOnFocus"));
     }
 }


### PR DESCRIPTION
Retrieving clipboard data on open is causing significant problems for some users. Until we solve this, disable that behavior by default

Fixes:

[AB#1467909](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1467909)
[AB#1487900](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1487900)
[AB#1487925](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1487925)
[AB#1488011](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1488011)
[AB#1488019](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1488019)
[AB#1488430](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1488430)
[AB#1488574](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1488574)
[AB#1487421](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1487421)
[AB#1463413](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1463413)
