### PR TITLE
Disable additional text comparer in generator driver (#59776)

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SharedInputNodes.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SharedInputNodes.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis
 
         public static readonly InputNode<ParseOptions> ParseOptions = new InputNode<ParseOptions>(b => ImmutableArray.Create(b.DriverState.ParseOptions));
 
-        public static readonly InputNode<AdditionalText> AdditionalTexts = new InputNode<AdditionalText>(b => b.DriverState.AdditionalTexts, AdditionalTextComparer.Instance);
+        public static readonly InputNode<AdditionalText> AdditionalTexts = new InputNode<AdditionalText>(b => b.DriverState.AdditionalTexts);
 
         public static readonly InputNode<SyntaxTree> SyntaxTrees = new InputNode<SyntaxTree>(b => b.Compilation.SyntaxTrees.ToImmutableArray());
 


### PR DESCRIPTION
Cherry pick of https://github.com/dotnet/roslyn/pull/59776 to backport to 17.1