### PR TITLE
Disable Auto-Open behavior for Stack Trace Explorer (#59785)

### DIFF
--- a/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerOptions.cs
+++ b/src/Features/Core/Portable/StackTraceExplorer/StackTraceExplorerOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.StackTraceExplorer
         public static readonly Option2<bool> OpenOnFocus = new(
             nameof(StackTraceExplorerOptions),
             nameof(OpenOnFocus),
-            true,
+            false,
             storageLocation: new RoamingProfileStorageLocation("StackTraceExplorer.Options.OpenOnFocus"));
     }
 }


### PR DESCRIPTION
Retrieving clipboard data on open is causing significant problems for some users. Until we solve this, disable that behavior by default

Fixes:

[AB#1467909](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1467909)
[AB#1487900](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1487900)
[AB#1487925](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1487925)
[AB#1488011](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1488011)
[AB#1488019](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1488019)
[AB#1488430](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1488430)
[AB#1488574](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1488574)
[AB#1487421](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1487421)
[AB#1463413](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1463413)