### PR TITLE
Add GlobalOptions.SetBackgroundAnalysisScope and PythiaGlobalOptions External Access API

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptGlobalOptions.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptGlobalOptions.cs
@@ -7,6 +7,8 @@ using System.Composition;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Options;
+using Microsoft.CodeAnalysis.SolutionCrawler;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
@@ -26,6 +28,22 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         {
             get => _globalOptions.GetOption(CompletionViewOptions.BlockForCompletionItems, InternalLanguageNames.TypeScript);
             set => _globalOptions.SetGlobalOption(new OptionKey(CompletionViewOptions.BlockForCompletionItems, InternalLanguageNames.TypeScript), value);
+        }
+
+#pragma warning disable CA1822 // Mark members as static - TODO: will set global options in future
+        public void SetBackgroundAnalysisScope(Workspace workspace, bool openFilesOnly)
+#pragma warning restore
+        {
+            var solution = workspace.CurrentSolution;
+            workspace.TryApplyChanges(solution.WithOptions(solution.Options
+                .WithChangedOption(
+                    SolutionCrawlerOptions.BackgroundAnalysisScopeOption,
+                    InternalLanguageNames.TypeScript,
+                    openFilesOnly ? BackgroundAnalysisScope.OpenFiles : BackgroundAnalysisScope.FullSolution)
+                .WithChangedOption(
+                    ServiceFeatureOnOffOptions.RemoveDocumentDiagnosticsOnDocumentClose,
+                    InternalLanguageNames.TypeScript,
+                    openFilesOnly)));
         }
 
         internal IGlobalOptionService Service => _globalOptions;

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptOptions.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptOptions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.Completion;
+using System;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
     internal static class VSTypeScriptOptions
     {
+        [Obsolete("Use VSTypeScriptGlobalOptions.SetBackgroundAnalysisScope instead")]
         public static OptionSet WithBackgroundAnalysisScope(this OptionSet options, bool openFilesOnly)
             => options.WithChangedOption(
                     SolutionCrawlerOptions.BackgroundAnalysisScopeOption,

--- a/src/Tools/ExternalAccess/FSharp/Editor/AutoFormattingOptionsWrapper.cs
+++ b/src/Tools/ExternalAccess/FSharp/Editor/AutoFormattingOptionsWrapper.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
+{
+    internal readonly struct AutoFormattingOptionsWrapper
+    {
+        internal readonly AutoFormattingOptions UnderlyingObject;
+
+        public AutoFormattingOptionsWrapper(AutoFormattingOptions underlyingObject)
+            => UnderlyingObject = underlyingObject;
+
+        public FormattingOptions.IndentStyle IndentStyle
+            => UnderlyingObject.IndentStyle;
+    }
+}

--- a/src/Tools/ExternalAccess/FSharp/Editor/IFSharpEditorFormattingService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Editor/IFSharpEditorFormattingService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Tools/ExternalAccess/FSharp/Editor/IFSharpEditorFormattingServiceWithOptions.cs
+++ b/src/Tools/ExternalAccess/FSharp/Editor/IFSharpEditorFormattingServiceWithOptions.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor
+{
+    internal interface IFSharpEditorFormattingServiceWithOptions : IFSharpEditorFormattingService
+    {
+        /// <summary>
+        /// True if this service would like to format the document based on the user typing the
+        /// provided character.
+        /// </summary>
+        bool SupportsFormattingOnTypedCharacter(Document document, AutoFormattingOptionsWrapper options, char ch);
+    }
+}

--- a/src/Tools/ExternalAccess/FSharp/FSharpGlobalOptions.cs
+++ b/src/Tools/ExternalAccess/FSharp/FSharpGlobalOptions.cs
@@ -7,6 +7,8 @@ using System.Composition;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.SolutionCrawler;
+using Microsoft.VisualStudio.LanguageServices;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
 {
@@ -14,18 +16,33 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
     internal sealed class FSharpGlobalOptions
     {
         private readonly IGlobalOptionService _globalOptions;
+        private readonly VisualStudioWorkspace _workspace;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public FSharpGlobalOptions(IGlobalOptionService globalOptions)
+        public FSharpGlobalOptions(IGlobalOptionService globalOptions, VisualStudioWorkspace workspace)
         {
             _globalOptions = globalOptions;
+            _workspace = workspace;
         }
 
         public bool BlockForCompletionItems
         {
             get => _globalOptions.GetOption(CompletionViewOptions.BlockForCompletionItems, LanguageNames.FSharp);
             set => _globalOptions.SetGlobalOption(new OptionKey(CompletionViewOptions.BlockForCompletionItems, LanguageNames.FSharp), value);
+        }
+
+        public void SetBackgroundAnalysisScope(bool openFilesOnly)
+        {
+            var solution = _workspace.CurrentSolution;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            _workspace.TryApplyChanges(solution.WithOptions(solution.Options
+                .WithChangedOption(
+                    SolutionCrawlerOptions.ClosedFileDiagnostic,
+                    LanguageNames.FSharp,
+                    !openFilesOnly)));
+#pragma warning restore
         }
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/FSharpGlobalOptions.cs
+++ b/src/Tools/ExternalAccess/FSharp/FSharpGlobalOptions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorFormattingService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorFormattingService.cs
@@ -59,7 +59,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 
         public bool SupportsFormattingOnTypedCharacter(Document document, AutoFormattingOptions options, char ch)
         {
-            return _service.SupportsFormattingOnTypedCharacter(document, ch);
+            return _service is IFSharpEditorFormattingServiceWithOptions serviceWithOptions ?
+                serviceWithOptions.SupportsFormattingOnTypedCharacter(document, new AutoFormattingOptionsWrapper(options), ch) :
+                _service.SupportsFormattingOnTypedCharacter(document, ch);
         }
 
         async Task<ImmutableArray<TextChange>> IFormattingInteractionService.GetFormattingChangesAsync(Document document, TextSpan? textSpan, DocumentOptionSet? documentOptions, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/ExternalAccess/Pythia/PythiaGlobalOptions.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/Pythia/PythiaGlobalOptions.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
+{
+    [Export(typeof(PythiaGlobalOptions)), Shared]
+    internal sealed class PythiaGlobalOptions
+    {
+        private readonly IGlobalOptionService _globalOptions;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public PythiaGlobalOptions(IGlobalOptionService globalOptions)
+        {
+            _globalOptions = globalOptions;
+        }
+
+        public bool ShowDebugInfo
+        {
+            get => _globalOptions.GetOption(s_showDebugInfoOption);
+            set => _globalOptions.SetGlobalOption(new OptionKey(s_showDebugInfoOption), value);
+        }
+
+        public bool RemoveRecommendationLimit
+        {
+            get => _globalOptions.GetOption(s_removeRecommendationLimitOption);
+            set => _globalOptions.SetGlobalOption(new OptionKey(s_removeRecommendationLimitOption), value);
+        }
+
+        public const string LocalRegistryPath = @"Roslyn\Internal\OnOff\Features\";
+
+        private static readonly Option2<bool> s_showDebugInfoOption = new(
+            "InternalFeatureOnOffOptions", "ShowDebugInfo", defaultValue: false,
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "ShowDebugInfo"));
+
+        private static readonly Option2<bool> s_removeRecommendationLimitOption = new(
+            "InternalFeatureOnOffOptions", "RemoveRecommendationLimit", defaultValue: false,
+            storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + "RemoveRecommendationLimit"));
+    }
+}

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -75,6 +75,8 @@
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.LiveUnitTesting.BuildManager.Core" Partner="UnitTesting" Key="$(UnitTestingKey)" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.UnitTesting.SourceBasedTestDiscovery" Partner="UnitTesting" Key="$(UnitTestingKey)" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.UnitTesting.SourceBasedTestDiscovery.Core" Partner="UnitTesting" Key="$(UnitTestingKey)" />
+    <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.IntelliCode.CSharp" Partner="Pythia" Key="$(IntelliCodeCSharpKey)" />
+    <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.IntelliCode.CSharp.Extraction" Partner="Pythia" Key="$(IntelliCodeCSharpKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CodeLens" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CSharp" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Implementation" />

--- a/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaOptions.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaOptions.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Options.Providers;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
 {
+    [Obsolete("Use PythiaGlobalOptions instead")]
     internal static class PythiaOptions
     {
         public const string LocalRegistryPath = @"Roslyn\Internal\OnOff\Features\";
@@ -26,6 +27,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
             storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(RemoveRecommendationLimit)));
     }
 
+    [Obsolete("Use PythiaGlobalOptions instead")]
     [ExportSolutionOptionProvider, Shared]
     internal class PythiaOptionsProvider : IOptionProvider
     {


### PR DESCRIPTION
Preparation for making solution crawler and Pythia options global.

Follow-up changes:
- Pythia: https://devdiv.visualstudio.com/DevDiv/_git/Pythia/pullrequest/382547
- F#: https://github.com/dotnet/fsharp/pull/12771
- TypeScript: https://devdiv.visualstudio.com/DevDiv/_git/TypeScript-VS/pullrequest/382548