### PR TITLE
Fix IDE0051 not working when using nameof() (#54972)

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -2654,6 +2654,19 @@ public class MyClass
             await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
         }
 
+        [Fact, WorkItem(54972, "https://github.com/dotnet/roslyn/issues/54972")]
+        public async Task FieldIsNotRead_NameOfIsUsed()
+        {
+            var code = @"
+public class C
+{
+    private string {|IDE0052:_field|};
+    public void M() => _field = nameof(C);
+}";
+
+            await VerifyCS.VerifyCodeFixAsync(code, code);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         [WorkItem(54972, "https://github.com/dotnet/roslyn/issues/54972")]
         public async Task RangesIsUsed()

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -1104,7 +1104,7 @@ class MyClass
             var code = @"class MyClass
 {
     private void M() { }
-    private string _goo = nameof(M);
+    public string _goo = nameof(M);
 }";
 
             await VerifyCS.VerifyCodeFixAsync(code, code);
@@ -1117,7 +1117,7 @@ class MyClass
             var code = @"class MyClass<T>
 {
     private void M() { }
-    private string _goo2 = nameof(MyClass<int>.M);
+    public string _goo2 = nameof(MyClass<int>.M);
 }
 ";
 
@@ -2628,6 +2628,59 @@ public class MyClass
 }";
 
             await VerifyCS.VerifyCodeFixAsync(code, code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(54972, "https://github.com/dotnet/roslyn/issues/54972")]
+        public async Task NameOfIsUsed()
+        {
+            var source =
+@"public class C
+{
+    private int [|i|];
+    public string M()
+    {
+        return nameof(C);
+    }
+}";
+            var fixedSource =
+@"public class C
+{
+    public string M()
+    {
+        return nameof(C);
+    }
+}";
+            await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(54972, "https://github.com/dotnet/roslyn/issues/54972")]
+        public async Task RangesIsUsed()
+        {
+            var source =
+@"public class C
+{
+    private int [|i|];
+    public string M()
+    {
+        return ""Hello World!""[0..];
+    }
+}";
+            var fixedSource =
+@"public class C
+{
+    public string M()
+    {
+        return ""Hello World!""[0..];
+    }
+}";
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp31,
+                TestCode = source,
+                FixedCode = fixedSource,
+            }.RunAsync();
         }
     }
 }

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -186,7 +186,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                     void AnalyzeOperationNone(OperationAnalysisContext context)
                     {
                         if (context.Operation.Kind == OperationKind.None &&
-                            context.Operation.Parent != null)
+                            context.Operation.Parent != null &&
+                            context.Operation.Parent.Kind != OperationKind.NameOf)
                         {
                             hasUnsupportedOperation = true;
                         }


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/54972 

Fix only for case when nameof expression is used, there were no problems with range operator.