### PR TITLE
Disallow converted string as default argument value

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -101,7 +101,7 @@ https://github.com/dotnet/roslyn/issues/57750
 
 7. <a name="7"></a>Before Visual Studio 17.2, the C# compiler would accept incorrect default argument values involving a reference conversion of a string constant, and would emit `null` as the constant value instead of the default value specified in source. In Visual Studio 17.2, this becomes an error. See [roslyn#59806](https://github.com/dotnet/roslyn/pull/59806).
 
-    For instance, the following results in an error in 17.1:
+    For instance, the following results in an error in 17.2:
     ```csharp
     void M(IEnumerable<char> s = "hello")
     ```

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -98,3 +98,11 @@ https://github.com/dotnet/roslyn/issues/57750
         public S() { Y = 0; } // ok
     }
     ```
+
+7. <a name="7"></a>Before Visual Studio 17.2, the C# compiler would accept incorrect default argument values involving a reference conversion of a string constant, and would emit `null` as the constant value instead of the default value specified in source. In Visual Studio 17.2, this becomes an error. See [roslyn#59806](https://github.com/dotnet/roslyn/pull/59806).
+
+    For instance, the following results in an error in 17.1:
+    ```csharp
+    void M(IEnumerable<char> s = "hello")
+    ```
+

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -624,12 +624,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 hasErrors = true;
             }
             else if (conversion.IsReference &&
-                (parameterType.SpecialType == SpecialType.System_Object || parameterType.Kind == SymbolKind.DynamicType) &&
                 (object)defaultExpression.Type != null &&
                 defaultExpression.Type.SpecialType == SpecialType.System_String ||
                 conversion.IsBoxing)
             {
-                // We don't allow object x = "hello", object x = 123, dynamic x = "hello", etc.
+                // We don't allow object x = "hello", object x = 123, dynamic x = "hello", IEnumerable<char> x = "hello", etc.
                 // error CS1763: '{0}' is of type '{1}'. A default parameter value of a reference type other than string can only be initialized with null
                 diagnostics.Add(ErrorCode.ERR_NotNullRefDefaultParameter, parameterSyntax.Identifier.GetLocation(),
                     parameterSyntax.Identifier.ValueText, parameterType);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -2490,5 +2490,58 @@ class C
                 //     C(object obj = System.DayOfWeek.Monday) // 2
                 Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "obj").WithArguments("obj", "object").WithLocation(8, 14));
         }
+
+        [Fact, WorkItem(59789, "https://github.com/dotnet/roslyn/issues/59789")]
+        public void DefaultValue_NonNullConvertedString()
+        {
+            var source = @"
+using System.Collections.Generic;
+
+class C
+{
+    const IEnumerable<char> y = ""world""; // 1
+    const string y2 = ""world"";
+    const object y3 = ""world""; // 2
+    const dynamic y4 = ""world""; // 3
+
+    void M(IEnumerable<char> x = ""hello"") // 4
+    {
+    }
+
+    void M2(string x = ""hello"")
+    {
+    }
+
+    void M3(object x = ""hello"") // 5
+    {
+    }
+
+    void M4(dynamic x = ""hello"") // 6
+    {
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,33): error CS0134: 'C.y' is of type 'IEnumerable<char>'. A const field of a reference type other than string can only be initialized with null.
+                //     const IEnumerable<char> y = "world"; // 1
+                Diagnostic(ErrorCode.ERR_NotNullConstRefField, @"""world""").WithArguments("C.y", "System.Collections.Generic.IEnumerable<char>").WithLocation(6, 33),
+                // (8,23): error CS0134: 'C.y3' is of type 'object'. A const field of a reference type other than string can only be initialized with null.
+                //     const object y3 = "world"; // 2
+                Diagnostic(ErrorCode.ERR_NotNullConstRefField, @"""world""").WithArguments("C.y3", "object").WithLocation(8, 23),
+                // (9,24): error CS0134: 'C.y4' is of type 'dynamic'. A const field of a reference type other than string can only be initialized with null.
+                //     const dynamic y4 = "world"; // 3
+                Diagnostic(ErrorCode.ERR_NotNullConstRefField, @"""world""").WithArguments("C.y4", "dynamic").WithLocation(9, 24),
+                // (11,30): error CS1763: 'x' is of type 'IEnumerable<char>'. A default parameter value of a reference type other than string can only be initialized with null
+                //     void M(IEnumerable<char> x = "hello") // 4
+                Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "x").WithArguments("x", "System.Collections.Generic.IEnumerable<char>").WithLocation(11, 30),
+                // (19,20): error CS1763: 'x' is of type 'object'. A default parameter value of a reference type other than string can only be initialized with null
+                //     void M3(object x = "hello") // 5
+                Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "x").WithArguments("x", "object").WithLocation(19, 20),
+                // (23,21): error CS1763: 'x' is of type 'dynamic'. A default parameter value of a reference type other than string can only be initialized with null
+                //     void M4(dynamic x = "hello") // 6
+                Diagnostic(ErrorCode.ERR_NotNullRefDefaultParameter, "x").WithArguments("x", "dynamic").WithLocation(23, 21)
+                );
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59789

See relevant section of the [spec](https://github.com/dotnet/roslyn/issues/59789#issuecomment-1054568347).
Note, this is aligning the behavior with that of `const`, which makes sense. In our constant folding logic (`FoldConstantConversion`), only `null` remains a constant when subjected to a reference conversion. So we produce a diagnostic for `const` scenario in `GetAndValidateConstantValue`.