### PR TITLE
Suppress formatting with stackalloc array creations

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -2258,6 +2258,37 @@ using System.B;
             AssertFormatWithView(expected, code);
         }
 
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatStackAllocArrayCreation()
+        {
+            var code = @"class Program
+{
+    static void Main(string[] args)
+    {
+        $$Span<int> span = stackalloc int[4]
+        {
+            1, 2, 3, 4,
+        };
+    }
+}
+";
+
+            var expected = @"class Program
+{
+    static void Main(string[] args)
+    {
+        $$Span<int> span = stackalloc int[4]
+        {
+            1, 2, 3, 4,
+        };
+    }
+}
+";
+
+            AssertFormatWithView(expected, code);
+        }
+
         [Fact, WorkItem(49492, "https://github.com/dotnet/roslyn/issues/49492")]
         public void PreserveAnnotationsOnMultiLineTrivia()
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/FormattingHelpers.cs
@@ -431,6 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 var parent = initializer.Parent;
                 if (parent is ArrayCreationExpressionSyntax ||
+                    parent is StackAllocArrayCreationExpressionSyntax ||
                     parent is ImplicitArrayCreationExpressionSyntax ||
                     parent is EqualsValueClauseSyntax ||
                     parent.IsKind(SyntaxKind.SimpleAssignmentExpression))
@@ -449,6 +450,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 var parent = anonymousObjectInitializer.Parent;
                 if (parent is ArrayCreationExpressionSyntax ||
+                    parent is StackAllocArrayCreationExpressionSyntax ||
                     parent is ImplicitArrayCreationExpressionSyntax ||
                     parent is EqualsValueClauseSyntax ||
                     parent is BaseObjectCreationExpressionSyntax ||


### PR DESCRIPTION
Related
#58157
#59430

----

**Steps to Reproduce**:

```cs
Span<int> span = stackalloc int[4]
{
    1, 2, 3, 4,
};

Span<int> array = new int[4]
{
    1, 2, 3, 4,
};
```

**Expected Behavior**:

There is no IDE0055.

**Actual Behavior**:

IDE0055 (formatting fixes in general) forces this to:

```cs
Span<int> span = stackalloc int[4]
{
    1,
    2,
    3,
    4,
};

Span<int> array = new int[4]
{
    1, 2, 3, 4,
};
```