### PR TITLE
Don't get nullable slot if property sub-pattern has error

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -187,7 +187,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             foreach (BoundPropertySubpattern subpattern in rp.Properties)
                             {
-                                if (subpattern.Member is BoundPropertySubpatternMember { HasErrors: false } member)
+                                if (subpattern.Member is BoundPropertySubpatternMember member
+                                    && member.Symbol.Kind is SymbolKind.Property or SymbolKind.Field)
                                 {
                                     LearnFromAnyNullPatterns(getExtendedPropertySlot(member, inputSlot), member.Type, subpattern.Pattern);
                                 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -187,8 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             foreach (BoundPropertySubpattern subpattern in rp.Properties)
                             {
-                                if (subpattern.Member is BoundPropertySubpatternMember member
-                                    && member.Symbol.Kind is SymbolKind.Property or SymbolKind.Field)
+                                if (subpattern.Member is BoundPropertySubpatternMember member)
                                 {
                                     LearnFromAnyNullPatterns(getExtendedPropertySlot(member, inputSlot), member.Type, subpattern.Pattern);
                                 }
@@ -222,6 +221,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (inputSlot < 0)
                 {
                     return inputSlot;
+                }
+
+                if (member.Symbol.Kind is not (SymbolKind.Property or SymbolKind.Field))
+                {
+                    return -1;
                 }
 
                 return GetOrCreateSlot(member.Symbol, inputSlot);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             foreach (BoundPropertySubpattern subpattern in rp.Properties)
                             {
-                                if (subpattern.Member is BoundPropertySubpatternMember member)
+                                if (subpattern.Member is BoundPropertySubpatternMember { HasErrors: false } member)
                                 {
                                     LearnFromAnyNullPatterns(getExtendedPropertySlot(member, inputSlot), member.Type, subpattern.Pattern);
                                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -2746,5 +2746,76 @@ public class C
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "a").WithLocation(74, 28)
                 );
         }
+
+        [Fact, WorkItem(59804, "https://github.com/dotnet/roslyn/issues/59804")]
+        public void NestedTypeUsedInPropertyPattern()
+        {
+            var source = @"
+public class Class1
+{
+    public class Inner1
+    {
+    }
+}
+
+public class Class2
+{
+    public bool Test()
+    {
+        Class1 test = null;
+        test switch { { Inner1: """" } => """" };
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (11,17): error CS0161: 'Class2.Test()': not all code paths return a value
+                //     public bool Test()
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "Test").WithArguments("Class2.Test()").WithLocation(11, 17),
+                // (14,9): error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
+                //         test switch { { Inner1: "" } => "" };
+                Diagnostic(ErrorCode.ERR_IllegalStatement, @"test switch { { Inner1: """" } => """" }").WithLocation(14, 9),
+                // (14,25): error CS0572: 'Inner1': cannot reference a type through an expression; try 'Class1.Inner1' instead
+                //         test switch { { Inner1: "" } => "" };
+                Diagnostic(ErrorCode.ERR_BadTypeReference, "Inner1").WithArguments("Inner1", "Class1.Inner1").WithLocation(14, 25),
+                // (14,25): error CS0154: The property or indexer 'Inner1' cannot be used in this context because it lacks the get accessor
+                //         test switch { { Inner1: "" } => "" };
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "Inner1").WithArguments("Inner1").WithLocation(14, 25)
+                );
+        }
+
+        [Fact, WorkItem(59804, "https://github.com/dotnet/roslyn/issues/59804")]
+        public void MethodUsedInPropertyPattern()
+        {
+            var source = @"
+public class Class1
+{
+    public void Method()
+    {
+    }
+}
+
+public class Class2
+{
+    public bool Test()
+    {
+        Class1 test = null;
+        test switch { { Method: """" } => """" };
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (11,17): error CS0161: 'Class2.Test()': not all code paths return a value
+                //     public bool Test()
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "Test").WithArguments("Class2.Test()").WithLocation(11, 17),
+                // (14,9): error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
+                //         test switch { { Method: "" } => "" };
+                Diagnostic(ErrorCode.ERR_IllegalStatement, @"test switch { { Method: """" } => """" }").WithLocation(14, 9),
+                // (14,25): error CS0154: The property or indexer 'Method' cannot be used in this context because it lacks the get accessor
+                //         test switch { { Method: "" } => "" };
+                Diagnostic(ErrorCode.ERR_PropertyLacksGet, "Method").WithArguments("Method").WithLocation(14, 25)
+                );
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59804