### PR TITLE
Unify our test artifacts directory to upload more stuff on failure

### DIFF
--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -47,9 +47,9 @@ steps:
     condition: not(succeeded())
 
   - task: PublishBuildArtifacts@1
-    displayName: Publish Screenshots
+    displayName: Publish Screenshots and Test Attachments
     inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin\Microsoft.VisualStudio.LanguageServices.IntegrationTests\${{ parameters.configuration }}\net472\xUnitResults'
+      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin\Microsoft.VisualStudio.LanguageServices.IntegrationTests\${{ parameters.configuration }}\net472\TestResults'
       ArtifactName: '$(System.JobAttempt)-Screenshots ${{ parameters.configuration }} OOP64_${{ parameters.oop64bit }} OOPCoreClr_${{ parameters.oopCoreClr }} LspEditor_${{ parameters.lspEditor }} $(Build.BuildNumber)'
       publishLocation: Container
     continueOnError: true

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 var assemblyDirectory = GetAssemblyDirectory();
                 var testName = CaptureTestNameAttribute.CurrentName ?? "Unknown";
-                var logDir = Path.Combine(assemblyDirectory, "xUnitResults", "Screenshots");
+                var logDir = Path.Combine(assemblyDirectory, "TestResults", "Screenshots");
                 var baseFileName = $"{DateTime.UtcNow:HH.mm.ss}-{testName}-{eventArgs.Exception.GetType().Name}";
 
                 var maxLength = logDir.Length + 1 + baseFileName.Length + ".Watson.log".Length + 1;


### PR DESCRIPTION
dotnet test sticks file attachments for the run into the TestResults directory, but we had a separate directory xUnitResults for where we were putting screenshots. This unifies the directories so we are uploading everything.