### PR TITLE
Make navigate-to navigation cancellable.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
@@ -8,14 +8,17 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Drawing;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Navigation;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Language.NavigateTo.Interfaces;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
@@ -23,12 +26,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
     internal sealed class NavigateToItemDisplay : INavigateToItemDisplay3
     {
         private readonly IThreadingContext _threadingContext;
+        private readonly IUIThreadOperationExecutor _threadOperationExecutor;
+        private readonly IAsynchronousOperationListener _asyncListener;
         private readonly INavigateToSearchResult _searchResult;
         private ReadOnlyCollection<DescriptionItem> _descriptionItems;
 
-        public NavigateToItemDisplay(IThreadingContext threadingContext, INavigateToSearchResult searchResult)
+        public NavigateToItemDisplay(
+            IThreadingContext threadingContext,
+            IUIThreadOperationExecutor threadOperationExecutor,
+            IAsynchronousOperationListener asyncListener,
+            INavigateToSearchResult searchResult)
         {
             _threadingContext = threadingContext;
+            _threadOperationExecutor = threadOperationExecutor;
+            _asyncListener = asyncListener;
             _searchResult = searchResult;
         }
 
@@ -40,11 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
         {
             get
             {
-                if (_descriptionItems == null)
-                {
-                    _descriptionItems = CreateDescriptionItems();
-                }
-
+                _descriptionItems ??= CreateDescriptionItems();
                 return _descriptionItems;
             }
         }
@@ -99,11 +106,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
 
         public void NavigateTo()
         {
+            var token = _asyncListener.BeginAsyncOperation(nameof(NavigateTo));
+            NavigateToAsync().ReportNonFatalErrorAsync().CompletesAsyncOperation(token);
+        }
+
+        private async Task NavigateToAsync()
+        {
             var document = _searchResult.NavigableItem.Document;
             if (document == null)
-            {
                 return;
-            }
 
             var workspace = document.Project.Solution.Workspace;
             var navigationService = workspace.Services.GetService<IDocumentNavigationService>();
@@ -114,16 +125,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             //
             // In the case of a stale item, don't require that the span be in bounds of the document
             // as it exists right now.
-            //
-            // TODO: Get the platform to use and pass us an operation context, or create one
-            // ourselves.
-            _threadingContext.JoinableTaskFactory.Run(() => navigationService.TryNavigateToSpanAsync(
+            using var context = _threadOperationExecutor.BeginExecute(
+                EditorFeaturesResources.Navigating_to_definition, EditorFeaturesResources.Navigating_to_definition, allowCancellation: true, showProgress: false);
+            await navigationService.TryNavigateToSpanAsync(
                 workspace,
                 document.Id,
                 _searchResult.NavigableItem.SourceSpan,
                 NavigationOptions.Default,
                 allowInvalidSpan: _searchResult.NavigableItem.IsStale,
-                CancellationToken.None));
+                context.UserCancellationToken).ConfigureAwait(false);
         }
 
         public int GetProvisionalViewingStatus()

--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplayFactory.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplayFactory.cs
@@ -4,23 +4,30 @@
 
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.NavigateTo;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.NavigateTo.Interfaces;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
 {
     internal sealed class NavigateToItemDisplayFactory : INavigateToItemDisplayFactory
     {
         private readonly IThreadingContext _threadingContext;
+        private readonly IUIThreadOperationExecutor _threadOperationExecutor;
+        private readonly IAsynchronousOperationListener _asyncListener;
 
-        public NavigateToItemDisplayFactory(IThreadingContext threadingContext)
+        public NavigateToItemDisplayFactory(
+            IThreadingContext threadingContext,
+            IUIThreadOperationExecutor threadOperationExecutor,
+            IAsynchronousOperationListenerProvider asyncListenerProvider)
         {
             _threadingContext = threadingContext;
+            _threadOperationExecutor = threadOperationExecutor;
+            _asyncListener = asyncListenerProvider.GetListener(FeatureAttribute.NavigateTo);
         }
 
         public INavigateToItemDisplay CreateItemDisplay(NavigateToItem item)
-        {
-            var searchResult = (INavigateToSearchResult)item.Tag;
-            return new NavigateToItemDisplay(_threadingContext, searchResult);
-        }
+            => new NavigateToItemDisplay(
+                _threadingContext, _threadOperationExecutor, _asyncListener, (INavigateToSearchResult)item.Tag);
     }
 }


### PR DESCRIPTION
Previously, we would synchronously block the UI thread while trying to navigate to a nav-to location.  Now, we do it asychronously with a cancellable threaded-wait-dialog.