### PR TITLE
only include entry points defined in source

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/EntryPointFinder.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/EntryPointFinder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         public static IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol)
         {
             var visitor = new EntryPointFinder();
-            visitor.Visit(symbol);
+            visitor.Visit(symbol.ContainingCompilation.SourceModule.GlobalNamespace);
             return visitor.EntryPoints;
         }
     }

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/EntryPointFinder.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/EntryPointFinder.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         public static IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol)
         {
             var visitor = new EntryPointFinder();
+            // Only search source symbols
             visitor.Visit(symbol.ContainingCompilation.SourceModule.GlobalNamespace);
             return visitor.EntryPoints;
         }

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/EntryPointFinder.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/EntryPointFinder.vb
@@ -25,12 +25,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
         Public Shared Function FindEntryPoints(symbol As INamespaceSymbol, findFormsOnly As Boolean) As IEnumerable(Of INamedTypeSymbol)
             Dim visitor = New EntryPointFinder(findFormsOnly)
-            visitor.Visit(symbol)
+            ' Only search source symbols
+            visitor.Visit(symbol.ContainingCompilation.SourceModule.GlobalNamespace)
             Return visitor.EntryPoints
         End Function
 
         Public Overrides Sub VisitNamedType(symbol As INamedTypeSymbol)
-            ' It's a form if it Inherits System.Windows.Forms.Form. 
+            ' It's a form if it Inherits System.Windows.Forms.Form.
             Dim baseType = symbol.BaseType
             While baseType IsNot Nothing
                 If baseType.ToDisplayString() = "System.Windows.Forms.Form" Then


### PR DESCRIPTION
Fixes #59696

In winforms apps on .NET Core we are given a global namespace that contains symbols defined as metadata. This never happened on .NET Framework. We now filter out all symbols not in metadata so we don't show incorrect entry points.