### PR TITLE
Ignore documents from projects that do not support EnC when calculating active statements

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -621,6 +621,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         continue;
                     }
 
+                    if (!document.Project.SupportsEditAndContinue())
+                    {
+                        // document is in a project that does not support EnC
+                        continue;
+                    }
+
                     // Multiple documents may have the same path (linked file).
                     // The documents represent the files that #line directives map to.
                     // Documents that have the same path must have different project id.
@@ -643,6 +649,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     var newProject = solution.GetRequiredProject(projectId);
                     var analyzer = newProject.LanguageServices.GetRequiredService<IEditAndContinueAnalyzer>();
+
                     await foreach (var documentId in EditSession.GetChangedDocumentsAsync(oldProject, newProject, cancellationToken).ConfigureAwait(false))
                     {
                         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59826