### PR TITLE
Account for possible cache invalidation on a different thread in assert.

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1169,7 +1169,9 @@ namespace Microsoft.CodeAnalysis
             {
                 val = CommonGetTypeByMetadataName(fullyQualifiedMetadataName);
                 var result = _getTypeCache.TryAdd(fullyQualifiedMetadataName, val);
-                Debug.Assert(result || (_getTypeCache.TryGetValue(fullyQualifiedMetadataName, out var addedType) && ReferenceEquals(addedType, val)));
+                Debug.Assert(result
+                 || !_getTypeCache.TryGetValue(fullyQualifiedMetadataName, out var addedType) // Could fail if the type was already evicted from the cache
+                 || ReferenceEquals(addedType, val));
             }
             return val;
         }
@@ -1196,8 +1198,8 @@ namespace Microsoft.CodeAnalysis
                 val = getTypesByMetadataNameImpl();
                 var result = _getTypesCache.TryAdd(fullyQualifiedMetadataName, val);
                 Debug.Assert(result
-                    || (_getTypesCache.TryGetValue(fullyQualifiedMetadataName, out var addedArray)
-                        && Enumerable.SequenceEqual(addedArray, val, ReferenceEqualityComparer.Instance)));
+                    || !_getTypesCache.TryGetValue(fullyQualifiedMetadataName, out var addedArray) // Could fail if the type was already evicted from the cache
+                    || Enumerable.SequenceEqual(addedArray, val, ReferenceEqualityComparer.Instance));
             }
 
             return val;


### PR DESCRIPTION
Attempt at fixing https://github.com/dotnet/roslyn/issues/59395. Reviewing the codepath I don't see any other obvious points that could cause the assert to fail, so if it continues to reproduce after this change we can look at further logging to determine the root cause.