### PR TITLE
Check for prototype comments in separate job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,6 +209,17 @@ jobs:
         publishLocation: Container
       condition: succeeded()
 
+- job: Correctness_TodoCheck
+  pool:
+    name: NetCore1ESPool-Public
+    queue: Build.Ubuntu.1804.Amd64.Open
+  timeoutInMinutes: 10
+  steps:
+    - template: eng/pipelines/checkout-unix-task.yml
+    
+    - script: eng/todo-check.ps1
+      displayName: Validate TODO/PROTOTYPE comments are not present
+
 - job: Correctness_Rebuild
   pool:
     name: NetCore1ESPool-Public

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,7 +217,7 @@ jobs:
   steps:
     - template: eng/pipelines/checkout-unix-task.yml
     
-    - script: eng/todo-check.ps1
+    - pwsh: eng/todo-check.ps1
       displayName: Validate TODO/PROTOTYPE comments are not present
 
 - job: Correctness_Rebuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,12 +211,11 @@ jobs:
 
 - job: Correctness_TodoCheck
   pool:
-    name: NetCore1ESPool-Public
-    queue: Build.Ubuntu.1804.Amd64.Open
+    vmImage: ubuntu-20.04
   timeoutInMinutes: 10
   steps:
     - template: eng/pipelines/checkout-unix-task.yml
-    
+
     - pwsh: eng/todo-check.ps1
       displayName: Validate TODO/PROTOTYPE comments are not present
 

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -42,25 +42,6 @@ try {
     New-ItemProperty -Path $key -Name 'DumpFolder' -PropertyType 'String' -Value $LogDir -Force
   }
 
-  # Verify no PROTOTYPE marker left in main
-  if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
-    Write-Host "Checking no PROTOTYPE markers in source"
-    $prototypes = Get-ChildItem -Path src, eng, scripts -Exclude *.dll,*.exe,*.pdb,*.xlf,test-build-correctness.ps1 -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
-    if ($prototypes) {
-      Write-Host "Found PROTOTYPE markers in source:"
-      Write-Host $prototypes
-      throw "PROTOTYPE markers disallowed in compiler source"
-    }
-  }
-
-  # Verify no TODO2 marker left
-  $prototypes = Get-ChildItem -Path src, eng, scripts -Exclude *.dll,*.exe,*.pdb,*.xlf,test-build-correctness.ps1 -Recurse | Select-String -Pattern 'TODO2' -CaseSensitive -SimpleMatch
-  if ($prototypes) {
-    Write-Host "Found TODO2 markers in source:"
-    Write-Host $prototypes
-    throw "TODO2 markers disallowed in compiler source"
-  }
-
   Write-Host "Building Roslyn"
   Exec-Block { & (Join-Path $PSScriptRoot "build.ps1") -restore -build -bootstrap -bootstrapConfiguration:Debug -ci:$ci -runAnalyzers:$true -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -warnAsError:$true -properties "/p:RoslynEnforceCodeStyle=true"}
 

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -2,6 +2,7 @@
   Checks that TODO and PROTOTYPE comments are not present.
 #>
 
+# Verify no PROTOTYPE marker left in main
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
 if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {

--- a/eng/todo-check.ps1
+++ b/eng/todo-check.ps1
@@ -1,0 +1,24 @@
+<#
+  Checks that TODO and PROTOTYPE comments are not present.
+#>
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -eq "main") {
+  Write-Host "Checking no PROTOTYPE markers in source"
+  $prototypes = Get-ChildItem -Path src, eng, scripts -Exclude *.dll,*.exe,*.pdb,*.xlf,todo-check.ps1 -Recurse | Select-String -Pattern 'PROTOTYPE' -CaseSensitive -SimpleMatch
+  if ($prototypes) {
+    Write-Host "Found PROTOTYPE markers in source:"
+    Write-Host $prototypes
+    throw "PROTOTYPE markers disallowed in compiler source"
+  }
+}
+
+# Verify no TODO2 marker left
+$prototypes = Get-ChildItem -Path src, eng, scripts -Exclude *.dll,*.exe,*.pdb,*.xlf,todo-check.ps1 -Recurse | Select-String -Pattern 'TODO2' -CaseSensitive -SimpleMatch
+if ($prototypes) {
+  Write-Host "Found TODO2 markers in source:"
+  Write-Host $prototypes
+  throw "TODO2 markers disallowed in compiler source"
+}
+  


### PR DESCRIPTION
Testing in #59865 [dev/rigibson/check-prototype..dev/rigibson/check-prototype2](https://github.com/dotnet/roslyn/compare/dev/rigibson/check-prototype..dev/rigibson/check-prototype2)

Example failure of the job: https://dev.azure.com/dnceng/public/_build/results?buildId=1639389&view=logs&j=872d814b-4814-5698-9f4a-d11d341be637&t=b0c549dd-012d-53e4-cee9-a1bc93631260

@jcouv I'd like to run this check as a separate job so that PRs to main can contain the prototype comments but we can still run the rest of the Correctness_Build checks. What do you think?