### PR TITLE
Analyze flow in receiver of extension method group in delegate creation

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1515,20 +1515,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             var methodGroup = node.Argument as BoundMethodGroup;
             if (methodGroup != null)
             {
-                if ((object)node.MethodOpt != null && node.MethodOpt.RequiresInstanceReceiver)
+                if (node.MethodOpt?.OriginalDefinition is LocalFunctionSymbol localFunc)
+                {
+                    VisitLocalFunctionUse(localFunc, node.Syntax, isCall: false);
+                }
+                else if (node.MethodOpt is not null && methodGroup.ReceiverOpt is not null)
                 {
                     EnterRegionIfNeeded(methodGroup);
                     VisitRvalue(methodGroup.ReceiverOpt);
                     LeaveRegionIfNeeded(methodGroup);
-                }
-                else if (node.MethodOpt?.OriginalDefinition is LocalFunctionSymbol localFunc)
-                {
-                    VisitLocalFunctionUse(localFunc, node.Syntax, isCall: false);
-                }
-                else
-                {
-                    // TODO2
-                    VisitRvalue(node.Argument);
                 }
             }
             else

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1525,6 +1525,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     VisitLocalFunctionUse(localFunc, node.Syntax, isCall: false);
                 }
+                else
+                {
+                    // TODO2
+                    VisitRvalue(node.Argument);
+                }
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
@@ -9215,6 +9215,76 @@ internal static class NoExtensionMethods
             Assert.Null(GetSymbolNamesJoined(results.UsedLocalFunctions));
         }
 
+
+        [Fact]
+        public void TestDataFlowsOfIdentifierWithDelegateConversionCast()
+        {
+            var analysis = CompileAndAnalyzeDataFlowExpression(@"
+using System;
+
+internal static class NoExtensionMethods
+{
+    internal static Func<T> AsFunc<T>(this T value) where T : class
+    {
+        return (Func<T>)/*<bind>*/ value /*</bind>*/.Return;
+    }
+
+    private static T Return<T>(this T value)
+    {
+        return value;
+    }
+}
+");
+            Assert.True(analysis.Succeeded);
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Equal("value", GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Equal("value", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Equal("value", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Equal("value", GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Equal("value", GetSymbolNamesJoined(analysis.WrittenOutside));
+        }
+
+        [Fact]
+        public void TestDataFlowsOfIdentifierWithDelegateConversionTarget()
+        {
+            var analysis = CompileAndAnalyzeDataFlowExpression(@"
+using System;
+
+internal static class NoExtensionMethods
+{
+    internal static Func<T> AsFunc<T>(this T value) where T : class
+    {
+        Func<T> result =/*<bind>*/ value /*</bind>*/.Return;
+        return result;
+    }
+
+    private static T Return<T>(this T value)
+    {
+        return value;
+    }
+}
+");
+            Assert.True(analysis.Succeeded);
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Equal("value", GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Equal("value", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Equal("value", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Equal("value", GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Equal("result", GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Equal("value, result", GetSymbolNamesJoined(analysis.WrittenOutside));
+        }
+
         [Fact, WorkItem(59738, "https://github.com/dotnet/roslyn/issues/59738")]
         public void DefiniteAssignmentInReceiverOfExtensionMethodInDelegateCreation()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59738

Below is the current behavior of a test that illustrates the problem. The problem occurs when creating a delegate with a method group, using an extension method. In such case, we fail to visit the receiver of the extension method.

Note that local function invocations can have a receiver (implicit `this`) so the local function case was moved to be handled first.

The behavior in the reported issue also results from our not visiting the receiver. The analysis keeps track of when we enter/exit the region marked with `/*<bind>*/` and since we didn't visit the expression, the state of the visitor was stuck on "before" which results in a failed analysis.

```
        [Fact, WorkItem(59738, "https://github.com/dotnet/roslyn/issues/59738")]
        public void DefiniteAssignmentInReceiverOfExtensionMethodInDelegateCreation()
        {
            var comp = CreateCompilation(@"
using System;
bool b = true;
_ = new Func<string>((b ? M(out var i) : i.ToString()).ExtensionMethod);

string M(out int i)
{
    throw null;
}

static class Extension
{
    public static string ExtensionMethod(this string s) => throw null;
}
	");
            comp.VerifyDiagnostics(
                // (3,6): warning CS0219: The variable 'b' is assigned but its value is never used
                // bool b = true;
                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "b").WithArguments("b").WithLocation(3, 6),
                // (4,37): warning CS0168: The variable 'i' is declared but never used
                // _ = new Func<string>((b ? M(out var i) : i.ToString()).ExtensionMethod);
                Diagnostic(ErrorCode.WRN_UnreferencedVar, "i").WithArguments("i").WithLocation(4, 37),
                // (6,8): warning CS8321: The local function 'M' is declared but never used
                // string M(out int i)
                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M").WithArguments("M").WithLocation(6, 8)
                );
        }
```

Co-Authored-By: Bernd Baumanns <baumannsbernd@gmail.com>