### PR TITLE
Fix handling for source generated documents in LSIF

### DIFF
--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -131,6 +131,8 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
             string? contentBase64Encoded = null;
 
+            var uri = syntaxTree.FilePath;
+
             // TODO: move to checking the enum member mentioned in https://github.com/dotnet/roslyn/issues/49326 when that
             // is implemented. In the mean time, we'll use a heuristic of the path being a relative path as a way to indicate
             // this is a source generated file.
@@ -141,9 +143,13 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 // We always use UTF-8 encoding when writing out file contents, as that's expected by LSIF implementations.
                 // TODO: when we move to .NET Core, is there a way to reduce allocations here?
                 contentBase64Encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(text.ToString()));
+
+                // There is a triple slash here, so the "host" portion of the URI is empty, similar to
+                // how file URIs work.
+                uri = "source-generated:///" + syntaxTree.FilePath.Replace('\\', '/');
             }
 
-            var documentVertex = new Graph.LsifDocument(new Uri(syntaxTree.FilePath, UriKind.RelativeOrAbsolute), GetLanguageKind(semanticModel.Language), contentBase64Encoded, idFactory);
+            var documentVertex = new Graph.LsifDocument(new Uri(uri, UriKind.RelativeOrAbsolute), GetLanguageKind(semanticModel.Language), contentBase64Encoded, idFactory);
 
             lsifJsonWriter.Write(documentVertex);
             lsifJsonWriter.Write(new Event(Event.EventKind.Begin, documentVertex.GetId(), idFactory));

--- a/src/Features/Lsif/Generator/Writing/LsifConverter.cs
+++ b/src/Features/Lsif/Generator/Writing/LsifConverter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
                     break;
 
                 case Uri uri:
-                    writer.WriteValue(uri.AbsoluteUri);
+                    writer.WriteValue(uri.ToString());
                     break;
 
                 default:

--- a/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
+++ b/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                 Dim contents = Encoding.UTF8.GetString(Convert.FromBase64String(contentBase64Encoded))
 
                 Dim compilation = Await workspace.CurrentSolution.Projects.Single().GetCompilationAsync()
-                Dim tree = Assert.Single(compilation.SyntaxTrees, Function(t) t.FilePath = generatedDocumentVertex.Uri.OriginalString)
+                Dim tree = Assert.Single(compilation.SyntaxTrees, Function(t) "source-generated:///" + t.FilePath.Replace("\"c, "/"c) = generatedDocumentVertex.Uri.OriginalString)
 
                 Assert.Equal(tree.GetText().ToString(), contents)
             Next
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 
         <Fact>
         <WorkItem(59692, "https://github.com/dotnet/roslyn/issues/59692")>
-        Public Async Function SourceGeneratedDocumentHasRelativeUrlInJson() As Task
+        Public Async Function SourceGeneratedDocumentHasUriInJson() As Task
             Dim workspace = TestWorkspace.CreateWorkspace(
                     <Workspace>
                         <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj" CommonReferences="true">
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 
             Dim generatedDocument = Assert.Single(Await workspace.CurrentSolution.Projects.Single().GetSourceGeneratedDocumentsAsync())
             Dim outputText = stringWriter.ToString()
-            Assert.Contains($"""uri"":""{generatedDocument.FilePath.Replace("\", "\\")}""", outputText)
+            Assert.Contains($"""uri"":""source-generated:///{generatedDocument.FilePath.Replace("\", "/")}""", outputText)
         End Function
     End Class
 End Namespace

--- a/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
+++ b/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
@@ -2,8 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System.IO
 Imports System.Text
+Imports System.Text.Json.Nodes
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
 
@@ -60,6 +63,24 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 
                 Assert.Equal(tree.GetText().ToString(), contents)
             Next
+        End Function
+
+        <Fact>
+        <WorkItem(59692, "https://github.com/dotnet/roslyn/issues/59692")>
+        Public Async Function SourceGeneratedDocumentHasRelativeUrlInJson() As Task
+            Dim workspace = TestWorkspace.CreateWorkspace(
+                    <Workspace>
+                        <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                            <DocumentFromSourceGenerator></DocumentFromSourceGenerator>
+                        </Project>
+                    </Workspace>)
+
+            Dim stringWriter = New StringWriter
+            Await TestLsifOutput.GenerateForWorkspaceAsync(workspace, New LineModeLsifJsonWriter(stringWriter))
+
+            Dim generatedDocument = Assert.Single(Await workspace.CurrentSolution.Projects.Single().GetSourceGeneratedDocumentsAsync())
+            Dim outputText = stringWriter.ToString()
+            Assert.Contains($"""uri"":""{generatedDocument.FilePath.Replace("\", "\\")}""", outputText)
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
We correctly handled them in the core generation code, but failed as we were actually serializing out JSON.

Fixes https://github.com/dotnet/roslyn/issues/59692