### PR TITLE
Remove unnecessary conditional logic from FlowAnalysisPass

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (method.ReturnsVoid || method.IsIterator || method.IsAsyncEffectivelyReturningTask(compilation))
             {
                 // we don't analyze synthesized void methods.
-                if ((method.IsImplicitlyDeclared && !method.IsScriptInitializer && !(method.ContainingType.IsStructType() && method.IsParameterlessConstructor() && !method.IsDefaultValueTypeConstructor())) ||
+                if ((method.IsImplicitlyDeclared && !method.IsScriptInitializer) ||
                     Analyze(compilation, method, block, diagnostics))
                 {
                     block = AppendImplicitReturn(block, method, originalBodyNested);


### PR DESCRIPTION
This logic was added to ensure that *synthesized, non-default struct constructors* were flow analyzed to report definite assignment errors. Such constructors no longer exist due to dotnet/csharplang#5552. Therefore there's no longer a need to check for them.

@cston for review.