### PR TITLE
Break out embedded language classification entirely from normal classification

### DIFF
--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeEmbeddedLanguage.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeEmbeddedLanguage.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.DateAndTime.LanguageServices
         public readonly EmbeddedLanguageInfo Info;
 
         // We don't currently expose a classifier for Date/Time literals.  However, one could always be added in the future.
-        public ISyntaxClassifier? Classifier => null;
+        public IEmbeddedLanguageClassifier? Classifier => null;
 
         public DateAndTimeEmbeddedLanguage(EmbeddedLanguageInfo info)
         {

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/JsonEmbeddedLanguage.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/JsonEmbeddedLanguage.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 {
     internal class JsonEmbeddedLanguage : IEmbeddedLanguageFeatures
     {
-        public ISyntaxClassifier Classifier { get; }
+        public IEmbeddedLanguageClassifier? Classifier { get; }
 
         // No document-highlights for embedded json currently.
         public IDocumentHighlightsService? DocumentHighlightsService => null;
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
 
         public JsonEmbeddedLanguage(EmbeddedLanguageInfo info)
         {
-            Classifier = new JsonEmbeddedClassifier(info);
+            Classifier = new JsonEmbeddedLanguageClassifier(info);
         }
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedLanguage.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedLanguage.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
 
         private readonly AbstractEmbeddedLanguageFeaturesProvider _provider;
 
-        public ISyntaxClassifier Classifier { get; }
+        public IEmbeddedLanguageClassifier? Classifier { get; }
         public IDocumentHighlightsService? DocumentHighlightsService { get; }
         public EmbeddedLanguageCompletionProvider CompletionProvider { get; }
 
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
             EmbeddedLanguageInfo info)
         {
             Info = info;
-            Classifier = new RegexSyntaxClassifier(info);
+            Classifier = new RegexEmbeddedLanguageClassifier(info);
 
             _provider = provider;
 

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedLanguage.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexEmbeddedLanguage.cs
@@ -4,13 +4,10 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification.Classifiers;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions;
-using Microsoft.CodeAnalysis.LanguageServices;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.LanguageServices
 {

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/CSharpEmbeddedLanguageClassificationServiceFactory.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/CSharpEmbeddedLanguageClassificationServiceFactory.cs
@@ -6,6 +6,7 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -22,6 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-            => new EmbeddedLanguageClassificationService(languageServices.GetRequiredService<IEmbeddedLanguagesProvider>());
+            => new EmbeddedLanguageClassificationService(languageServices.GetRequiredService<IEmbeddedLanguagesProvider>(), CSharpSyntaxKinds.Instance);
     }
 }

--- a/src/Workspaces/Core/Portable/Classification/ClassifiedSpan.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifiedSpan.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.Classification
         }
 
         public ClassifiedSpan(TextSpan textSpan, string classificationType)
-            : this()
         {
             this.ClassificationType = classificationType;
             this.TextSpan = textSpan;

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -59,6 +59,7 @@ namespace Microsoft.CodeAnalysis.Classification
         {
             var languageServices = workspaceServices.GetLanguageServices(semanticModel.Language);
             var classsificationService = languageServices.GetRequiredService<ISyntaxClassificationService>();
+            var embeddedLanguageService = languageServices.GetRequiredService<IEmbeddedLanguageClassificationService>();
 
             var syntaxClassifiers = classsificationService.GetDefaultSyntaxClassifiers();
 
@@ -73,13 +74,9 @@ namespace Microsoft.CodeAnalysis.Classification
 
             classsificationService.AddSyntacticClassifications(root, textSpan, syntacticClassifications, cancellationToken);
             classsificationService.AddSemanticClassifications(semanticModel, textSpan, getNodeClassifiers, getTokenClassifiers, semanticClassifications, options, cancellationToken);
-
-            var embeddedLanguageService = languageServices.GetService<IEmbeddedLanguageClassificationService>();
-            if (embeddedLanguageService != null)
-            {
-                // intentionally adding to the semanticClassifications array here.
-                embeddedLanguageService.AddEmbeddedLanguageClassifications(semanticModel, textSpan, options, semanticClassifications, cancellationToken);
-            }
+            
+            // intentionally adding to the semanticClassifications array here.
+            embeddedLanguageService.AddEmbeddedLanguageClassifications(semanticModel, textSpan, options, semanticClassifications, cancellationToken);
 
             var allClassifications = new List<ClassifiedSpan>(semanticClassifications.Where(s => s.TextSpan.OverlapsWith(textSpan)));
             var semanticSet = semanticClassifications.Select(s => s.TextSpan).ToSet();

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Classification
 
             classsificationService.AddSyntacticClassifications(root, textSpan, syntacticClassifications, cancellationToken);
             classsificationService.AddSemanticClassifications(semanticModel, textSpan, getNodeClassifiers, getTokenClassifiers, semanticClassifications, options, cancellationToken);
-            
+
             // intentionally adding to the semanticClassifications array here.
             embeddedLanguageService.AddEmbeddedLanguageClassifications(semanticModel, textSpan, options, semanticClassifications, cancellationToken);
 

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/EmbeddedLanguageClassifierContext.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/EmbeddedLanguageClassifierContext.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
+{
+    internal struct EmbeddedLanguageClassifierContext
+    {
+        internal readonly ClassificationOptions Options;
+        private readonly ArrayBuilder<ClassifiedSpan> _result;
+
+        /// <summary>
+        /// The string or character token to classify.
+        /// </summary>
+        public SyntaxToken SyntaxToken { get; }
+
+        /// <summary>
+        /// SemanticModel that <see cref="SyntaxToken"/> is contained in.
+        /// </summary>
+        public SemanticModel SemanticModel { get; }
+
+        public CancellationToken CancellationToken { get; }
+
+        internal EmbeddedLanguageClassifierContext(
+            SemanticModel semanticModel,
+            SyntaxToken syntaxToken,
+            ClassificationOptions options,
+            ArrayBuilder<ClassifiedSpan> result,
+            CancellationToken cancellationToken)
+        {
+            SemanticModel = semanticModel;
+            SyntaxToken = syntaxToken;
+            Options = options;
+            _result = result;
+            CancellationToken = cancellationToken;
+        }
+
+        public void AddClassification(string classificationType, TextSpan span)
+            => _result.Add(new ClassifiedSpan(classificationType, span));
+    }
+}

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/FallbackEmbeddedLanguage.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/FallbackEmbeddedLanguage.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
     /// </summary>
     internal partial class FallbackEmbeddedLanguage : IEmbeddedLanguage
     {
-        public ISyntaxClassifier Classifier { get; }
+        public IEmbeddedLanguageClassifier Classifier { get; }
 
         public FallbackEmbeddedLanguage(EmbeddedLanguageInfo info)
-            => Classifier = new FallbackSyntaxClassifier(info);
+            => Classifier = new FallbackEmbeddedLanguageClassifier(info);
     }
 }

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/IEmbeddedLanguage.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/IEmbeddedLanguage.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Classification.Classifiers;
 
 namespace Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
 {
@@ -17,6 +14,6 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
         /// <summary>
         /// A optional classifier that can produce <see cref="ClassifiedSpan"/>s for an embedded language string.
         /// </summary>
-        ISyntaxClassifier Classifier { get; }
+        IEmbeddedLanguageClassifier? Classifier { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/IEmbeddedLanguageClassifier.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/LanguageServices/IEmbeddedLanguageClassifier.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
+{
+    internal interface IEmbeddedLanguageClassifier
+    {
+        /// <summary>
+        /// This method will be called for all string and character tokens in a file to determine if there are special
+        /// embedded language strings to classify.
+        /// </summary>
+        void RegisterClassifications(EmbeddedLanguageClassifierContext context);
+    }
+}

--- a/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/VisualBasicEmbeddedLanguageClassificationServiceFactory.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/SyntaxClassification/VisualBasicEmbeddedLanguageClassificationServiceFactory.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Classification.Classifiers
 Imports Microsoft.CodeAnalysis.EmbeddedLanguages.LanguageServices
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
     <ExportLanguageServiceFactory(GetType(IEmbeddedLanguageClassificationService), LanguageNames.VisualBasic), [Shared]>
@@ -20,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
         End Sub
 
         Public Function CreateLanguageService(languageServices As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
-            Return New EmbeddedLanguageClassificationService(languageServices.GetRequiredService(Of IEmbeddedLanguagesProvider))
+            Return New EmbeddedLanguageClassificationService(languageServices.GetRequiredService(Of IEmbeddedLanguagesProvider), VisualBasicSyntaxKinds.Instance)
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Continued part of the effort to expose an extension point for 3rd parties to classify strings containing embedded DSLs.

There will be a followup to this to allow embedded language classifiers to be found and used using MEF.