### PR TITLE
Revert "Notify docs team for new breaking change documentation"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,6 @@
 docs/compilers @dotnet/roslyn-compiler
 docs/ide @dotnet/roslyn-ide
 
-# Notify docs team for new breaking change documentation
-docs/compilers/CSharp @dotnet/docs
-docs/compilers/Visual\ Basic @dotnet/docs
-
 eng/ @dotnet/roslyn-infrastructure
 scripts/ @dotnet/roslyn-infrastructure
 


### PR DESCRIPTION
Reverts dotnet/roslyn#59844

FYI @Youssef1313 @cston @BillWagner @RikkiGibson. We'll have to rely on manual notification for now. Let's see how that goes.