### PR TITLE
Add back OmniSharpInlineHints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,3 +40,5 @@ src/Compilers/**/PublicAPI.Unshipped.txt @dotnet/roslyn-api-owners
 src/Workspaces/**/PublicAPI.Unshipped.txt @dotnet/roslyn-api-owners
 src/Features/**/PublicAPI.Unshipped.txt @dotnet/roslyn-api-owners
 src/EditorFeatures/**/PublicAPI.Unshipped.txt @dotnet/roslyn-api-owners
+
+src/Tools/ExternalAccess/OmniSharp*/ @333fred @joerobich

--- a/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
@@ -17,24 +17,24 @@ internal readonly record struct OmniSharpInlineHintsOptions(
                SymbolDescriptionOptions.Default);
 }
 internal readonly record struct OmniSharpInlineParameterHintsOptions(
-    bool EnabledForParameters = false,
-    bool ForLiteralParameters = true,
-    bool ForIndexerParameters = true,
-    bool ForObjectCreationParameters = true,
-    bool ForOtherParameters = false,
-    bool SuppressForParametersThatDifferOnlyBySuffix = true,
-    bool SuppressForParametersThatMatchMethodIntent = true,
-    bool SuppressForParametersThatMatchArgumentName = true)
+    bool EnabledForParameters,
+    bool ForLiteralParameters,
+    bool ForIndexerParameters,
+    bool ForObjectCreationParameters,
+    bool ForOtherParameters,
+    bool SuppressForParametersThatDifferOnlyBySuffix,
+    bool SuppressForParametersThatMatchMethodIntent,
+    bool SuppressForParametersThatMatchArgumentName)
 {
     internal InlineParameterHintsOptions ToInlineParameterHintsOptions()
         => new(EnabledForParameters, ForLiteralParameters, ForIndexerParameters, ForObjectCreationParameters, ForOtherParameters, SuppressForParametersThatDifferOnlyBySuffix, SuppressForParametersThatMatchMethodIntent, SuppressForParametersThatMatchArgumentName);
 }
 
 internal readonly record struct OmniSharpInlineTypeHintsOptions(
-    bool EnabledForTypes = false,
-    bool ForImplicitVariableTypes = true,
-    bool ForLambdaParameterTypes = true,
-    bool ForImplicitObjectCreation = true)
+    bool EnabledForTypes,
+    bool ForImplicitVariableTypes,
+    bool ForLambdaParameterTypes,
+    bool ForImplicitObjectCreation)
 {
     internal InlineTypeHintsOptions ToInlineTypeHintsOptions()
         => new(EnabledForTypes, ForImplicitVariableTypes, ForLambdaParameterTypes, ForImplicitObjectCreation);

--- a/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.InlineHints;
+using Microsoft.CodeAnalysis.LanguageServices;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.InlineHints;
+
+internal readonly record struct OmniSharpInlineHintsOptions(
+    OmniSharpInlineParameterHintsOptions ParameterOptions,
+    OmniSharpInlineTypeHintsOptions TypeOptions)
+{
+    internal InlineHintsOptions ToInlineHintsOptions()
+        => new(ParameterOptions.ToInlineParameterHintsOptions(),
+               TypeOptions.ToInlineTypeHintsOptions(),
+               SymbolDescriptionOptions.Default);
+}
+
+
+internal readonly record struct OmniSharpInlineParameterHintsOptions(
+    bool EnabledForParameters = false,
+    bool ForLiteralParameters = true,
+    bool ForIndexerParameters = true,
+    bool ForObjectCreationParameters = true,
+    bool ForOtherParameters = false,
+    bool SuppressForParametersThatDifferOnlyBySuffix = true,
+    bool SuppressForParametersThatMatchMethodIntent = true,
+    bool SuppressForParametersThatMatchArgumentName = true)
+{
+    internal InlineParameterHintsOptions ToInlineParameterHintsOptions()
+        => new(EnabledForParameters, ForLiteralParameters, ForIndexerParameters, ForObjectCreationParameters, ForOtherParameters, SuppressForParametersThatDifferOnlyBySuffix, SuppressForParametersThatMatchMethodIntent, SuppressForParametersThatMatchArgumentName);
+}
+
+internal readonly record struct OmniSharpInlineTypeHintsOptions(
+    bool EnabledForTypes = false,
+    bool ForImplicitVariableTypes = true,
+    bool ForLambdaParameterTypes = true,
+    bool ForImplicitObjectCreation = true)
+{
+    internal InlineTypeHintsOptions ToInlineTypeHintsOptions()
+        => new(EnabledForTypes, ForImplicitVariableTypes, ForLambdaParameterTypes, ForImplicitObjectCreation);
+}

--- a/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
@@ -16,8 +16,6 @@ internal readonly record struct OmniSharpInlineHintsOptions(
                TypeOptions.ToInlineTypeHintsOptions(),
                SymbolDescriptionOptions.Default);
 }
-
-
 internal readonly record struct OmniSharpInlineParameterHintsOptions(
     bool EnabledForParameters = false,
     bool ForLiteralParameters = true,

--- a/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsService.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.InlineHints;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.InlineHints;
+
+internal static class OmniSharpInlineHintsService
+{
+    public static async Task<ImmutableArray<OmniSharpInlineHint>> GetInlineHintsAsync(Document document, TextSpan textSpan, OmniSharpInlineHintsOptions options, CancellationToken cancellationToken)
+    {
+        var service = document.GetRequiredLanguageService<IInlineHintsService>();
+        var roslynOptions = options.ToInlineHintsOptions();
+
+        var hints = await service.GetInlineHintsAsync(document, textSpan, roslynOptions, cancellationToken).ConfigureAwait(false);
+        return hints.SelectAsArray(static h => new OmniSharpInlineHint(
+            h.Span,
+            h.DisplayParts,
+            (document, cancellationToken) => h.GetDescriptionAsync(document, cancellationToken)));
+    }
+}
+
+internal readonly struct OmniSharpInlineHint
+{
+    private readonly Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>> _getDescriptionAsync;
+
+    public OmniSharpInlineHint(
+        TextSpan span,
+        ImmutableArray<TaggedText> displayParts,
+        Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>> getDescriptionAsync)
+    {
+        Span = span;
+        DisplayParts = displayParts;
+        _getDescriptionAsync = getDescriptionAsync;
+    }
+
+    public readonly TextSpan Span { get; }
+    public readonly ImmutableArray<TaggedText> DisplayParts { get; }
+
+    public Task<ImmutableArray<TaggedText>> GetDescrptionAsync(Document document, CancellationToken cancellationToken)
+        => _getDescriptionAsync.Invoke(document, cancellationToken);
+}


### PR DESCRIPTION
This was removed in https://github.com/dotnet/roslyn/pull/59567, just before the vscode API went stable and O# could finally take advantage of it. This adds the EA back.

I also added Joey and I to the codeowners file so we can be aware of any future changes