### PR TITLE
Avoid Large Object Heap allocations in GetPrioritizedPendingDocuments

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         }
 
                         // Any other high priority documents
-                        foreach (var documentId in _higherPriorityDocumentsNotProcessed.Keys)
+                        foreach (var (documentId, _) in _higherPriorityDocumentsNotProcessed)
                         {
                             yield return documentId;
                         }


### PR DESCRIPTION
Fixes [AB#1493580](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1493580)