### PR TITLE
Revert "Push the two-step navigation system further through roslyn."

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveDocumentNavigationService.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveDocumentNavigationService.cs
@@ -26,8 +26,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             _threadingContext = threadingContext;
         }
 
-        public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
-            => SpecializedTasks.True;
+        public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
+        {
+            return SpecializedTasks.True;
+        }
 
         public Task<bool> CanNavigateToLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
             => SpecializedTasks.False;
@@ -35,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
         public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
             => SpecializedTasks.False;
 
-        public async Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+        public async Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, bool allowInvalidSpan, CancellationToken cancellationToken)
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             if (workspace is not InteractiveWindowWorkspace interactiveWorkspace)
@@ -68,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
                 return null;
             }
 
-            return new NavigableLocation(async (options, cancellationToken) =>
+            return new NavigableLocation(async cancellationToken =>
             {
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
@@ -87,10 +89,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             });
         }
 
-        public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<INavigableLocation>();
+        public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, NavigationOptions options, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
 
-        public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<INavigableLocation>();
+        public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, NavigationOptions options, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
     }
 }

--- a/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindUsages;
-using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
@@ -80,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                         _definitions,
                         cancellationToken).ConfigureAwait(false);
                     if (location != null)
-                        await location.NavigateToAsync(new NavigationOptions(PreferProvisionalTab: true, ActivateTab: true), cancellationToken).ConfigureAwait(false);
+                        await location.NavigateToAsync(cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/EditorFeatures/Core/CommandHandlers/AbstractGoToCommandHandler`2.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/AbstractGoToCommandHandler`2.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -195,7 +194,7 @@ internal abstract class AbstractGoToCommandHandler<TLanguageService, TCommandArg
                     definitions,
                     cancellationToken).ConfigureAwait(false);
                 if (location != null)
-                    await location.NavigateToAsync(new NavigationOptions(PreferProvisionalTab: true, ActivateTab: true), cancellationToken).ConfigureAwait(false);
+                    await location.NavigateToAsync(cancellationToken).ConfigureAwait(false);
                 return;
             }
         }

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractEditorNavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractEditorNavigationBarItemService.cs
@@ -50,12 +50,10 @@ namespace Microsoft.CodeAnalysis.Editor.Extensibility.NavigationBar
         protected async Task NavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
         {
             var navigationService = workspace.Services.GetRequiredService<IDocumentNavigationService>();
-            var location = await navigationService.GetLocationForPositionAsync(
-                workspace, documentId, position, virtualSpace, cancellationToken).ConfigureAwait(false);
-
-            if (location != null)
+            if (await navigationService.CanNavigateToPositionAsync(workspace, documentId, position, virtualSpace, cancellationToken).ConfigureAwait(false))
             {
-                await location.NavigateToAsync(NavigationOptions.Default, cancellationToken).ConfigureAwait(false);
+                await navigationService.TryNavigateToPositionAsync(
+                    workspace, documentId, position, virtualSpace, NavigationOptions.Default, cancellationToken).ConfigureAwait(false);
             }
             else
             {

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptFindUsagesContext.cs
@@ -70,10 +70,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             public override Task<bool> CanNavigateToAsync(Workspace workspace, CancellationToken cancellationToken)
                 => _navigator.CanNavigateToAsync(workspace, cancellationToken);
 
-#pragma warning disable CS0672 // Member overrides obsolete member
             public override Task<bool> TryNavigateToAsync(Workspace workspace, NavigationOptions options, CancellationToken cancellationToken)
                 => _navigator.TryNavigateToAsync(workspace, options.PreferProvisionalTab, options.ActivateTab, cancellationToken);
-#pragma warning restore CS0672 // Member overrides obsolete member
         }
 
         internal readonly DefinitionItem UnderlyingObject;
@@ -112,10 +110,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         public Task<bool> CanNavigateToAsync(Workspace workspace, CancellationToken cancellationToken)
             => UnderlyingObject.CanNavigateToAsync(workspace, cancellationToken);
 
-#pragma warning disable CS0612 // Type or member is obsolete
         public Task<bool> TryNavigateToAsync(Workspace workspace, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken)
             => UnderlyingObject.TryNavigateToAsync(workspace, new NavigationOptions(showInPreviewTab, activateTab), cancellationToken);
-#pragma warning restore CS0612 // Type or member is obsolete
     }
 
     internal sealed class VSTypeScriptSourceReferenceItem

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -37,7 +37,8 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             var service = workspace.Services.GetRequiredService<IDocumentNavigationService>();
 
             return service.GetLocationForPositionAsync(
-                workspace, document.Id, position, virtualSpace: 0, cancellationToken);
+                workspace, document.Id, position, virtualSpace: 0,
+                new NavigationOptions(PreferProvisionalTab: true, ActivateTab: true), cancellationToken);
         }
 
         public async Task<INavigableLocation?> FindDefinitionLocationAsync(Document document, int position, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -88,8 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
                 {
                     var location = await asyncService.FindDefinitionLocationAsync(document, caretPosition, cancellationToken).ConfigureAwait(false);
                     var success = location != null &&
-                        await location.NavigateToAsync(
-                            new NavigationOptions(PreferProvisionalTab: true, ActivateTab: true), cancellationToken).ConfigureAwait(false);
+                        await location.NavigateToAsync(cancellationToken).ConfigureAwait(false);
 
                     if (success)
                         return;

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -341,11 +341,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
                         {
                             var editorWorkspace = workspace;
                             var navigationService = editorWorkspace.Services.GetRequiredService<IDocumentNavigationService>();
-                            var location = await navigationService.GetLocationForSpanAsync(
-                                editorWorkspace, documentId, resolvedRenameToken.Span, cancellationToken).ConfigureAwait(false);
-
-                            if (location != null &&
-                                await location.NavigateToAsync(NavigationOptions.Default, cancellationToken).ConfigureAwait(false))
+                            if (await navigationService.TryNavigateToSpanAsync(
+                                    editorWorkspace, documentId, resolvedRenameToken.Span, cancellationToken).ConfigureAwait(false))
                             {
                                 var openDocument = workspace.CurrentSolution.GetRequiredDocument(documentId);
                                 var openRoot = await openDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Helpers.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text.Adornments;
@@ -222,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
                     var location = await GoToDefinitionHelpers.GetDefinitionLocationAsync(
                         symbol, solution, threadingContext, streamingPresenter, cancellationToken).ConfigureAwait(false);
                     if (location != null)
-                        await location.NavigateToAsync(new NavigationOptions(PreferProvisionalTab: true, ActivateTab: true), cancellationToken).ConfigureAwait(false);
+                        await location.NavigateToAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTestsBase.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTestsBase.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
 
                 Dim defLocation = Await goToDefService.FindDefinitionLocationAsync(document, cursorPosition, CancellationToken.None)
                 Dim actualResult = defLocation IsNot Nothing AndAlso
-                    Await defLocation.NavigateToAsync(NavigationOptions.Default, CancellationToken.None)
+                    Await defLocation.NavigateToAsync(CancellationToken.None)
                 Assert.Equal(expectedResult, actualResult)
 
                 Dim expectedLocations As New List(Of FilePathAndSpan)

--- a/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockDocumentNavigationService.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockDocumentNavigationService.vb
@@ -21,6 +21,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
         Public _triedNavigationToSpan As Boolean
 
         Public _documentId As DocumentId
+        Public _options As NavigationOptions
         Public _line As Integer = -1
         Public _offset As Integer = -1
         Public _span As TextSpan = Nothing
@@ -35,31 +36,34 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
             Return If(_canNavigateToPosition, SpecializedTasks.True, SpecializedTasks.False)
         End Function
 
-        Public Function CanNavigateToSpanAsync(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, allowInvalidSpan As Boolean, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDocumentNavigationService.CanNavigateToSpanAsync
+        Public Function CanNavigateToSpanAsync(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDocumentNavigationService.CanNavigateToSpanAsync
             Return If(_canNavigateToSpan, SpecializedTasks.True, SpecializedTasks.False)
         End Function
 
-        Public Function GetLocationForLineAndOffsetAsync(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForLineAndOffsetAsync
+        Public Function GetLocationForLineAndOffsetAsync(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, options As NavigationOptions, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForLineAndOffsetAsync
             _triedNavigationToLineAndOffset = True
             _documentId = documentId
+            _options = options
             _line = lineNumber
             _offset = offset
 
             Return NavigableLocation.TestAccessor.Create(_canNavigateToLineAndOffset)
         End Function
 
-        Public Function GetLocationForPositionAsync(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForPositionAsync
+        Public Function GetLocationForPositionAsync(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, options As NavigationOptions, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForPositionAsync
             _triedNavigationToPosition = True
             _documentId = documentId
+            _options = options
             _position = position
             _positionVirtualSpace = virtualSpace
 
             Return NavigableLocation.TestAccessor.Create(_canNavigateToPosition)
         End Function
 
-        Public Function GetLocationForSpanAsync(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, allowInvalidSpan As Boolean, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForSpanAsync
+        Public Function GetLocationForSpanAsync(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, options As NavigationOptions, allowInvalidSpan As Boolean, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForSpanAsync
             _triedNavigationToSpan = True
             _documentId = documentId
+            _options = options
             _span = textSpan
 
             Return NavigableLocation.TestAccessor.Create(_canNavigateToSpan)

--- a/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockSymbolNavigationService.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockSymbolNavigationService.vb
@@ -16,9 +16,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
         Public _triedSymbolNavigationNotify As Boolean
         Public _wouldNavigateToSymbol As Boolean
 
-        Public Function GetNavigableLocationAsync(symbol As ISymbol, project As Project, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements ISymbolNavigationService.GetNavigableLocationAsync
+        Public Function TryNavigateToSymbolAsync(symbol As ISymbol, project As Project, options As NavigationOptions, cancellationToken As CancellationToken) As Task(Of Boolean) Implements ISymbolNavigationService.TryNavigateToSymbolAsync
             _triedNavigationToSymbol = True
-            Return NavigableLocation.TestAccessor.Create(True)
+            Return SpecializedTasks.True
         End Function
 
         Public Function TrySymbolNavigationNotifyAsync(symbol As ISymbol, project As Project, cancellationToken As CancellationToken) As Task(Of Boolean) Implements ISymbolNavigationService.TrySymbolNavigationNotifyAsync

--- a/src/EditorFeatures/TestUtilities2/Utilities/MockDocumentNavigationServiceProvider.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/MockDocumentNavigationServiceProvider.vb
@@ -7,6 +7,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Navigation
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Roslyn.Utilities
 
@@ -37,6 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             Public ProvidedOffset As Integer
             Public ProvidedPosition As Integer
             Public ProvidedVirtualSpace As Integer
+            Public ProvidedOptions As NavigationOptions
 
             Public CanNavigateToLineAndOffsetReturnValue As Boolean = True
             Public CanNavigateToPositionReturnValue As Boolean = True
@@ -61,32 +63,35 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
                 Return If(CanNavigateToPositionReturnValue, SpecializedTasks.True, SpecializedTasks.False)
             End Function
 
-            Public Function CanNavigateToSpanAsync(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, allowInvalidSpan As Boolean, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDocumentNavigationService.CanNavigateToSpanAsync
+            Public Function CanNavigateToSpanAsync(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, cancellationToken As CancellationToken) As Task(Of Boolean) Implements IDocumentNavigationService.CanNavigateToSpanAsync
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedTextSpan = textSpan
 
                 Return If(CanNavigateToSpanReturnValue, SpecializedTasks.True, SpecializedTasks.False)
             End Function
 
-            Public Function GetLocationForLineAndOffsetAsync(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForLineAndOffsetAsync
+            Public Function GetLocationForLineAndOffsetAsync(workspace As Workspace, documentId As DocumentId, lineNumber As Integer, offset As Integer, options As NavigationOptions, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForLineAndOffsetAsync
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedLineNumber = lineNumber
                 Me.ProvidedOffset = offset
+                Me.ProvidedOptions = options
 
                 Return NavigableLocation.TestAccessor.Create(TryNavigateToLineAndOffsetReturnValue)
             End Function
 
-            Public Function GetLocationForPositionAsync(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForPositionAsync
+            Public Function GetLocationForPositionAsync(workspace As Workspace, documentId As DocumentId, position As Integer, virtualSpace As Integer, options As NavigationOptions, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForPositionAsync
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedPosition = position
                 Me.ProvidedVirtualSpace = virtualSpace
+                Me.ProvidedOptions = options
 
                 Return NavigableLocation.TestAccessor.Create(TryNavigateToPositionReturnValue)
             End Function
 
-            Public Function GetLocationForSpanAsync(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, allowInvalidSpans As Boolean, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForSpanAsync
+            Public Function GetLocationForSpanAsync(workspace As Workspace, documentId As DocumentId, textSpan As TextSpan, options As NavigationOptions, allowInvalidSpans As Boolean, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements IDocumentNavigationService.GetLocationForSpanAsync
                 Me.ProvidedDocumentId = documentId
                 Me.ProvidedTextSpan = textSpan
+                Me.ProvidedOptions = options
 
                 Return NavigableLocation.TestAccessor.Create(TryNavigateToSpanReturnValue)
             End Function

--- a/src/EditorFeatures/TestUtilities2/Utilities/MockSymbolNavigationServiceProvider.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/MockSymbolNavigationServiceProvider.vb
@@ -35,6 +35,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 
             Public TryNavigateToSymbolProvidedSymbol As ISymbol
             Public TryNavigateToSymbolProvidedProject As Project
+            Public TryNavigateToSymbolProvidedOptions As NavigationOptions
 
             Public TrySymbolNavigationNotifyProvidedSymbol As ISymbol
             Public TrySymbolNavigationNotifyProvidedProject As Project
@@ -45,10 +46,11 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             Public NavigationLineNumberReturnValue As Integer
             Public NavigationCharOffsetReturnValue As Integer
 
-            Public Function GetNavigableLocationAsync(symbol As ISymbol, project As Project, cancellationToken As CancellationToken) As Task(Of INavigableLocation) Implements ISymbolNavigationService.GetNavigableLocationAsync
+            Public Function TryNavigateToSymbolAsync(symbol As ISymbol, project As Project, options As NavigationOptions, cancellationToken As CancellationToken) As Task(Of Boolean) Implements ISymbolNavigationService.TryNavigateToSymbolAsync
                 Me.TryNavigateToSymbolProvidedSymbol = symbol
                 Me.TryNavigateToSymbolProvidedProject = project
-                Return NavigableLocation.TestAccessor.Create(True)
+                Me.TryNavigateToSymbolProvidedOptions = options
+                Return SpecializedTasks.True
             End Function
 
             Public Function TrySymbolNavigationNotifyAsync(

--- a/src/Features/Core/Portable/DocumentSpanExtensions.cs
+++ b/src/Features/Core/Portable/DocumentSpanExtensions.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Navigation;
-using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -14,7 +17,7 @@ namespace Microsoft.CodeAnalysis
         public static Task<bool> CanNavigateToAsync(this DocumentSpan documentSpan, CancellationToken cancellationToken)
         {
             var workspace = documentSpan.Document.Project.Solution.Workspace;
-            var service = workspace.Services.GetRequiredService<IDocumentNavigationService>();
+            var service = workspace.Services.GetService<IDocumentNavigationService>();
             return service.CanNavigateToSpanAsync(workspace, documentSpan.Document.Id, documentSpan.SourceSpan, cancellationToken);
         }
 
@@ -22,7 +25,7 @@ namespace Microsoft.CodeAnalysis
         {
             var solution = documentSpan.Document.Project.Solution;
             var workspace = solution.Workspace;
-            var service = workspace.Services.GetRequiredService<IDocumentNavigationService>();
+            var service = workspace.Services.GetService<IDocumentNavigationService>();
             return (workspace, service);
         }
 
@@ -32,19 +35,13 @@ namespace Microsoft.CodeAnalysis
             return service.TryNavigateToSpanAsync(workspace, documentSpan.Document.Id, documentSpan.SourceSpan, options, cancellationToken);
         }
 
-        public static Task<INavigableLocation?> GetNavigableLocationAsync(this DocumentSpan documentSpan, CancellationToken cancellationToken)
-        {
-            var (workspace, service) = GetNavigationParts(documentSpan);
-            return service.GetLocationForSpanAsync(workspace, documentSpan.Document.Id, documentSpan.SourceSpan, allowInvalidSpan: false, cancellationToken);
-        }
-
         public static async Task<bool> IsHiddenAsync(
             this DocumentSpan documentSpan, CancellationToken cancellationToken)
         {
             var document = documentSpan.Document;
             if (document.SupportsSyntaxTree)
             {
-                var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 return tree.IsHiddenPosition(documentSpan.SourceSpan.Start, cancellationToken);
             }
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingStackTraceServiceAccessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/UnitTestingStackTraceServiceAccessor.cs
@@ -41,11 +41,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting
             return result.ParsedFrames.SelectAsArray(p => new UnitTestingParsedFrameWrapper(p));
         }
 
-        public async Task<bool> TryNavigateToAsync(Workspace workspace, UnitTestingDefinitionItemWrapper definitionItem, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken)
-        {
-            var location = await definitionItem.UnderlyingObject.GetNavigableLocationAsync(workspace, cancellationToken).ConfigureAwait(false);
-            return location != null &&
-                await location.NavigateToAsync(new NavigationOptions(showInPreviewTab, activateTab), cancellationToken).ConfigureAwait(false);
-        }
+        public Task<bool> TryNavigateToAsync(Workspace workspace, UnitTestingDefinitionItemWrapper definitionItem, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken)
+            => definitionItem.UnderlyingObject.TryNavigateToAsync(workspace, new NavigationOptions(showInPreviewTab, activateTab), cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DefaultDefinitionItem.cs
@@ -51,10 +51,10 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 return await SourceSpans[0].CanNavigateToAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            public override async Task<INavigableLocation?> GetNavigableLocationAsync(Workspace workspace, CancellationToken cancellationToken)
+            public sealed override async Task<bool> TryNavigateToAsync(Workspace workspace, NavigationOptions options, CancellationToken cancellationToken)
             {
                 if (Properties.ContainsKey(NonNavigable))
-                    return null;
+                    return false;
 
                 if (Properties.TryGetValue(MetadataSymbolKey, out var symbolKey))
                 {
@@ -64,14 +64,14 @@ namespace Microsoft.CodeAnalysis.FindUsages
                         Contract.ThrowIfNull(project);
 
                         var navigationService = workspace.Services.GetRequiredService<ISymbolNavigationService>();
-                        return await navigationService.GetNavigableLocationAsync(
-                            symbol, project, cancellationToken).ConfigureAwait(false);
+                        return await navigationService.TryNavigateToSymbolAsync(
+                            symbol, project, options with { PreferProvisionalTab = true }, cancellationToken).ConfigureAwait(false);
                     }
 
-                    return null;
+                    return false;
                 }
 
-                return await SourceSpans[0].GetNavigableLocationAsync(cancellationToken).ConfigureAwait(false);
+                return await SourceSpans[0].TryNavigateToAsync(options, cancellationToken).ConfigureAwait(false);
             }
 
             public DetachedDefinitionItem Detach()

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
@@ -160,29 +160,23 @@ namespace Microsoft.CodeAnalysis.FindUsages
             }
         }
 
+#pragma warning disable CS0612 // Type or member is obsolete - TypeScript
         [Obsolete]
         public virtual bool CanNavigateTo(Workspace workspace, CancellationToken cancellationToken) => false;
 
         [Obsolete]
         public virtual bool TryNavigateTo(Workspace workspace, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken) => false;
 
-#pragma warning disable CS0612 // Type or member is obsolete - TypeScript
         public virtual Task<bool> CanNavigateToAsync(Workspace workspace, CancellationToken cancellationToken)
             => Task.FromResult(CanNavigateTo(workspace, cancellationToken));
-#pragma warning restore CS0612 // Type or member is obsolete - TypeScript
 
         [Obsolete]
         public virtual Task<bool> TryNavigateToAsync(Workspace workspace, bool showInPreviewTab, bool activateTab, CancellationToken cancellationToken)
             => Task.FromResult(TryNavigateTo(workspace, showInPreviewTab, activateTab, cancellationToken));
 
-        [Obsolete]
         public virtual Task<bool> TryNavigateToAsync(Workspace workspace, NavigationOptions options, CancellationToken cancellationToken)
             => TryNavigateToAsync(workspace, options.PreferProvisionalTab, options.ActivateTab, cancellationToken);
-
-#pragma warning disable CS0612 // Type or member is obsolete - TypeScript
-        public virtual Task<INavigableLocation?> GetNavigableLocationAsync(Workspace workspace, CancellationToken cancellationToken)
-            => Task.FromResult<INavigableLocation?>(new NavigableLocation((options, cancellationToken) => TryNavigateToAsync(workspace, options, cancellationToken)));
-#pragma warning restore CS0612 // Type or member is obsolete - TypeScript
+#pragma warning restore
 
         public static DefinitionItem Create(
             ImmutableArray<string> tags,

--- a/src/Features/Core/Portable/Navigation/DefaultDocumentNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/DefaultDocumentNavigationService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Navigation
 {
     internal sealed class DefaultDocumentNavigationService : IDocumentNavigationService
     {
-        public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+        public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
             => SpecializedTasks.False;
 
         public Task<bool> CanNavigateToLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
@@ -20,13 +20,13 @@ namespace Microsoft.CodeAnalysis.Navigation
         public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
             => SpecializedTasks.False;
 
-        public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+        public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, bool allowInvalidSpan, CancellationToken cancellationToken)
             => SpecializedTasks.Null<INavigableLocation>();
 
-        public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
+        public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, NavigationOptions options, CancellationToken cancellationToken)
             => SpecializedTasks.Null<INavigableLocation>();
 
-        public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+        public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, NavigationOptions options, CancellationToken cancellationToken)
             => SpecializedTasks.Null<INavigableLocation>();
     }
 }

--- a/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/DefaultSymbolNavigationService.cs
@@ -5,6 +5,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -12,13 +13,16 @@ namespace Microsoft.CodeAnalysis.Navigation
 {
     internal sealed class DefaultSymbolNavigationService : ISymbolNavigationService
     {
-        public Task<INavigableLocation?> GetNavigableLocationAsync(ISymbol symbol, Project project, CancellationToken cancellationToken)
-            => SpecializedTasks.Null<INavigableLocation>();
+        public Task<bool> TryNavigateToSymbolAsync(ISymbol symbol, Project project, NavigationOptions options, CancellationToken cancellationToken)
+            => SpecializedTasks.False;
 
         public Task<bool> TrySymbolNavigationNotifyAsync(ISymbol symbol, Project project, CancellationToken cancellationToken)
             => SpecializedTasks.False;
 
-        public Task<(string filePath, LinePosition linePosition)?> GetExternalNavigationSymbolLocationAsync(DefinitionItem definitionItem, CancellationToken cancellationToken)
-            => Task.FromResult<(string filePath, LinePosition linePosition)?>(null);
+        public Task<(string filePath, LinePosition linePosition)?> GetExternalNavigationSymbolLocationAsync(
+            DefinitionItem definitionItem, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<(string filePath, LinePosition linePosition)?>(null);
+        }
     }
 }

--- a/src/Features/Core/Portable/Navigation/IDocumentNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/IDocumentNavigationService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// Determines whether it is possible to navigate to the given position in the specified document.
         /// </summary>
         /// <remarks>Legal to call from any thread.</remarks>
-        Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken);
+        Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken);
 
         /// <summary>
         /// Determines whether it is possible to navigate to the given line/offset in the specified document.
@@ -27,24 +27,24 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// </summary>
         Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
 
-        Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken);
-        Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken);
-        Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken);
+        Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, bool allowInvalidSpan, CancellationToken cancellationToken);
+        Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, NavigationOptions options, CancellationToken cancellationToken);
+        Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, NavigationOptions options, CancellationToken cancellationToken);
     }
 
     internal static class IDocumentNavigationServiceExtensions
     {
-        public static Task<bool> CanNavigateToSpanAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
-            => service.CanNavigateToSpanAsync(workspace, documentId, textSpan, allowInvalidSpan: false, cancellationToken);
-
         public static Task<bool> CanNavigateToPositionAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
             => service.CanNavigateToPositionAsync(workspace, documentId, position, virtualSpace: 0, cancellationToken);
 
-        public static Task<INavigableLocation?> GetLocationForSpanAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
-            => service.GetLocationForSpanAsync(workspace, documentId, textSpan, allowInvalidSpan: false, cancellationToken);
+        public static Task<bool> TryNavigateToSpanAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
+            => service.TryNavigateToSpanAsync(workspace, documentId, textSpan, NavigationOptions.Default, cancellationToken);
 
         public static Task<bool> TryNavigateToSpanAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, CancellationToken cancellationToken)
             => service.TryNavigateToSpanAsync(workspace, documentId, textSpan, options, allowInvalidSpan: false, cancellationToken);
+
+        public static Task<bool> TryNavigateToLineAndOffsetAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
+            => service.TryNavigateToLineAndOffsetAsync(workspace, documentId, lineNumber, offset, NavigationOptions.Default, cancellationToken);
 
         public static Task<bool> TryNavigateToPositionAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int position, CancellationToken cancellationToken)
             => service.TryNavigateToPositionAsync(workspace, documentId, position, virtualSpace: 0, NavigationOptions.Default, cancellationToken);
@@ -55,9 +55,9 @@ namespace Microsoft.CodeAnalysis.Navigation
         public static async Task<bool> TryNavigateToSpanAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, bool allowInvalidSpan, CancellationToken cancellationToken)
         {
             var location = await service.GetLocationForSpanAsync(
-                workspace, documentId, textSpan, allowInvalidSpan, cancellationToken).ConfigureAwait(false);
+                workspace, documentId, textSpan, options, allowInvalidSpan, cancellationToken).ConfigureAwait(false);
             return location != null &&
-                await location.NavigateToAsync(options, cancellationToken).ConfigureAwait(false);
+                await location.NavigateToAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -66,9 +66,9 @@ namespace Microsoft.CodeAnalysis.Navigation
         public static async Task<bool> TryNavigateToLineAndOffsetAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int lineNumber, int offset, NavigationOptions options, CancellationToken cancellationToken)
         {
             var location = await service.GetLocationForLineAndOffsetAsync(
-                workspace, documentId, lineNumber, offset, cancellationToken).ConfigureAwait(false);
+                workspace, documentId, lineNumber, offset, options, cancellationToken).ConfigureAwait(false);
             return location != null &&
-                await location.NavigateToAsync(options, cancellationToken).ConfigureAwait(false);
+                await location.NavigateToAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -77,9 +77,9 @@ namespace Microsoft.CodeAnalysis.Navigation
         public static async Task<bool> TryNavigateToPositionAsync(this IDocumentNavigationService service, Workspace workspace, DocumentId documentId, int position, int virtualSpace, NavigationOptions options, CancellationToken cancellationToken)
         {
             var location = await service.GetLocationForPositionAsync(
-                workspace, documentId, position, virtualSpace, cancellationToken).ConfigureAwait(false);
+                workspace, documentId, position, virtualSpace, options, cancellationToken).ConfigureAwait(false);
             return location != null &&
-                await location.NavigateToAsync(options, cancellationToken).ConfigureAwait(false);
+                await location.NavigateToAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Features/Core/Portable/Navigation/INavigableLocation.cs
+++ b/src/Features/Core/Portable/Navigation/INavigableLocation.cs
@@ -17,18 +17,18 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// allow final clients to call this from a non-UI thread while allowing the navigation to jump to the UI
         /// thread.
         /// </summary>
-        Task<bool> NavigateToAsync(NavigationOptions options, CancellationToken cancellationToken);
+        Task<bool> NavigateToAsync(CancellationToken cancellationToken);
     }
 
     internal class NavigableLocation : INavigableLocation
     {
-        private readonly Func<NavigationOptions, CancellationToken, Task<bool>> _callback;
+        private readonly Func<CancellationToken, Task<bool>> _callback;
 
-        public NavigableLocation(Func<NavigationOptions, CancellationToken, Task<bool>> callback)
+        public NavigableLocation(Func<CancellationToken, Task<bool>> callback)
             => _callback = callback;
 
-        public Task<bool> NavigateToAsync(NavigationOptions options, CancellationToken cancellationToken)
-            => _callback(options, cancellationToken);
+        public Task<bool> NavigateToAsync(CancellationToken cancellationToken)
+            => _callback(cancellationToken);
 
         public static class TestAccessor
         {
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Navigation
 #pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
             {
                 return Task.FromResult<INavigableLocation?>(
-                    new NavigableLocation((_, _) => value ? SpecializedTasks.True : SpecializedTasks.False));
+                    new NavigableLocation(c => value ? SpecializedTasks.True : SpecializedTasks.False));
             }
         }
     }

--- a/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ISymbolNavigationService.cs
@@ -18,8 +18,10 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// <param name="project">A project context with which to generate source for symbol
         /// if it has no source locations</param>
         /// <param name="symbol">The symbol to navigate to</param>
+        /// <param name="options">A set of options. If these options are not supplied the
+        /// current set of options from the project's workspace will be used.</param>
         /// <param name="cancellationToken">The token to check for cancellation</param>
-        Task<INavigableLocation?> GetNavigableLocationAsync(ISymbol symbol, Project project, CancellationToken cancellationToken);
+        Task<bool> TryNavigateToSymbolAsync(ISymbol symbol, Project project, NavigationOptions options, CancellationToken cancellationToken);
 
         /// <returns>True if the navigation was handled, indicating that the caller should not 
         /// perform the navigation.</returns>

--- a/src/VisualStudio/Core/Def/Implementation/CallHierarchy/CallHierarchyProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CallHierarchy/CallHierarchyProvider.cs
@@ -147,10 +147,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
             var options = NavigationOptions.Default with { PreferProvisionalTab = true };
             var symbolNavigationService = workspace.Services.GetService<ISymbolNavigationService>();
 
-            var location = await symbolNavigationService.GetNavigableLocationAsync(
-                resolution.Symbol, project, cancellationToken).ConfigureAwait(false);
-            if (location != null)
-                await location.NavigateToAsync(options, cancellationToken).ConfigureAwait(false);
+            await symbolNavigationService.TryNavigateToSymbolAsync(
+                resolution.Symbol, project, options, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/MetadataDefinitionItemEntry.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/Entries/MetadataDefinitionItemEntry.cs
@@ -45,13 +45,9 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             public bool CanNavigateTo()
                 => true;
 
-            public async Task NavigateToAsync(NavigationOptions options, CancellationToken cancellationToken)
-            {
-                var location = await DefinitionBucket.DefinitionItem.GetNavigableLocationAsync(
-                    Presenter._workspace, cancellationToken).ConfigureAwait(false);
-                if (location != null)
-                    await location.NavigateToAsync(options, cancellationToken).ConfigureAwait(false);
-            }
+            public Task NavigateToAsync(NavigationOptions options, CancellationToken cancellationToken)
+                => DefinitionBucket.DefinitionItem.TryNavigateToAsync(
+                    Presenter._workspace, options, cancellationToken); // Only activate the tab if requested
 
             protected override IList<Inline> CreateLineTextInlines()
                 => DefinitionBucket.DefinitionItem.DisplayParts

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/RoslynDefinitionBucket.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/RoslynDefinitionBucket.cs
@@ -67,13 +67,8 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             public bool CanNavigateTo()
                 => true;
 
-            public async Task NavigateToAsync(NavigationOptions options, CancellationToken cancellationToken)
-            {
-                var location = await DefinitionItem.GetNavigableLocationAsync(
-                    _presenter._workspace, cancellationToken).ConfigureAwait(false);
-                if (location != null)
-                    await location.NavigateToAsync(options, cancellationToken).ConfigureAwait(false);
-            }
+            public Task NavigateToAsync(NavigationOptions options, CancellationToken cancellationToken)
+                => DefinitionItem.TryNavigateToAsync(_presenter._workspace, options, cancellationToken);
 
             public override bool TryGetValue(string key, out object? content)
             {

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
@@ -117,7 +117,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.FindReferences
             public override Task<bool> CanNavigateToAsync(Workspace workspace, CancellationToken cancellationToken)
                 => SpecializedTasks.True;
 
-            [Obsolete]
             public override async Task<bool> TryNavigateToAsync(Workspace workspace, NavigationOptions options, CancellationToken cancellationToken)
             {
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
@@ -77,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                 ImmutableArray.Create<DefinitionItem>(rehydrated),
                 cancellationToken).ConfigureAwait(false);
             if (location != null)
-                await location.NavigateToAsync(new NavigationOptions(PreferProvisionalTab: true, ActivateTab: true), cancellationToken).ConfigureAwait(false);
+                await location.NavigateToAsync(cancellationToken).ConfigureAwait(false);
         }
 
         private void TargetsSubmenu_OnOpen(object sender, RoutedEventArgs e)

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.VsLanguageDebugInfo.cs
@@ -217,7 +217,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                                     var breakpoints = await _breakpointService.ResolveBreakpointsAsync(
                                         solution, pszName, cancellationToken).ConfigureAwait(false);
                                     var debugNames = await breakpoints.SelectAsArrayAsync(
-                                        bp => CreateDebugNameAsync(bp, solution, cancellationToken)).ConfigureAwait(false);
+                                        async bp => await CreateDebugNameAsync(
+                                            bp, solution, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
 
                                     enumName = new VsEnumDebugName(debugNames);
                                 }
@@ -230,7 +231,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 }
             }
 
-            private async ValueTask<IVsDebugName> CreateDebugNameAsync(
+            private async Task<IVsDebugName> CreateDebugNameAsync(
                 BreakpointResolutionResult breakpoint, Solution solution, CancellationToken cancellationToken)
             {
                 var document = breakpoint.Document;

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphNavigatorExtension.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphNavigatorExtension.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.GraphModel;
 using Microsoft.VisualStudio.GraphModel.CodeSchema;
 using Microsoft.VisualStudio.GraphModel.Schemas;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 {
@@ -102,14 +103,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                     var navigationService = editorWorkspace.Services.GetService<IDocumentNavigationService>();
 
                     // TODO: Get the platform to use and pass us an operation context, or create one ourselves.
-                    var location = await navigationService.GetLocationForLineAndOffsetAsync(
+                    await navigationService.TryNavigateToLineAndOffsetAsync(
                         editorWorkspace,
                         document.Id,
                         sourceLocation.StartPosition.Line,
                         sourceLocation.StartPosition.Character,
                         cancellationToken).ConfigureAwait(false);
-                    if (location != null)
-                        await location.NavigateToAsync(NavigationOptions.Default, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioDocumentNavigationService.cs
@@ -58,18 +58,35 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _sourceGeneratedFileManager = sourceGeneratedFileManager;
         }
 
-        public async Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+        public async Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
             // Navigation should not change the context of linked files and Shared Projects.
             documentId = workspace.GetDocumentIdInCurrentContext(documentId);
 
             if (!IsSecondaryBuffer(workspace, documentId))
+            {
                 return true;
+            }
 
             var document = workspace.CurrentSolution.GetRequiredDocument(documentId);
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
-            var vsTextSpan = GetVsTextSpan(text, textSpan, allowInvalidSpan);
+            var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
+            if (boundedTextSpan != textSpan)
+            {
+                try
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+                catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
+                {
+                }
+
+                return false;
+            }
+
+            var vsTextSpan = text.GetVsTextSpanForSpan(textSpan);
+
             return await CanMapFromSecondaryBufferToPrimaryBufferAsync(
                 workspace, documentId, vsTextSpan, cancellationToken).ConfigureAwait(false);
         }
@@ -125,30 +142,43 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 workspace, documentId, vsTextSpan, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<INavigableLocation?> GetLocationForSpanAsync(
-            Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+        public Task<INavigableLocation?> GetLocationForSpanAsync(
+            Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, bool allowInvalidSpan, CancellationToken cancellationToken)
         {
-            if (!await this.CanNavigateToSpanAsync(workspace, documentId, textSpan, allowInvalidSpan, cancellationToken).ConfigureAwait(false))
-                return null;
-
-            return await GetNavigableLocationAsync(workspace,
+            return GetNavigableLocationAsync(workspace,
                 documentId,
                 _ => Task.FromResult(textSpan),
                 text => GetVsTextSpan(text, textSpan, allowInvalidSpan),
-                cancellationToken).ConfigureAwait(false);
+                options,
+                cancellationToken);
+
+            static VsTextSpan GetVsTextSpan(SourceText text, TextSpan textSpan, bool allowInvalidSpan)
+            {
+                var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
+                if (boundedTextSpan != textSpan && !allowInvalidSpan)
+                {
+                    try
+                    {
+                        throw new ArgumentOutOfRangeException();
+                    }
+                    catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
+                    {
+                    }
+                }
+
+                return text.GetVsTextSpanForSpan(boundedTextSpan);
+            }
         }
 
-        public async Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(
-            Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
+        public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(
+            Workspace workspace, DocumentId documentId, int lineNumber, int offset, NavigationOptions options, CancellationToken cancellationToken)
         {
-            if (!await this.CanNavigateToLineAndOffsetAsync(workspace, documentId, lineNumber, offset, cancellationToken).ConfigureAwait(false))
-                return null;
-
-            return await GetNavigableLocationAsync(workspace,
+            return GetNavigableLocationAsync(workspace,
                 documentId,
                 document => GetTextSpanFromLineAndOffsetAsync(document, lineNumber, offset, cancellationToken),
                 text => GetVsTextSpan(text, lineNumber, offset),
-                cancellationToken).ConfigureAwait(false);
+                options,
+                cancellationToken);
 
             static async Task<TextSpan> GetTextSpanFromLineAndOffsetAsync(Document document, int lineNumber, int offset, CancellationToken cancellationToken)
             {
@@ -164,17 +194,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             }
         }
 
-        public async Task<INavigableLocation?> GetLocationForPositionAsync(
-            Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+        public Task<INavigableLocation?> GetLocationForPositionAsync(
+            Workspace workspace, DocumentId documentId, int position, int virtualSpace, NavigationOptions options, CancellationToken cancellationToken)
         {
-            if (!await this.CanNavigateToPositionAsync(workspace, documentId, position, virtualSpace, cancellationToken).ConfigureAwait(false))
-                return null;
-
-            return await GetNavigableLocationAsync(workspace,
+            return GetNavigableLocationAsync(workspace,
                 documentId,
                 document => GetTextSpanFromPositionAsync(document, position, virtualSpace, cancellationToken),
                 text => GetVsTextSpan(text, position, virtualSpace),
-                cancellationToken).ConfigureAwait(false);
+                options,
+                cancellationToken);
 
             static async Task<TextSpan> GetTextSpanFromPositionAsync(Document document, int position, int virtualSpace, CancellationToken cancellationToken)
             {
@@ -210,6 +238,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             DocumentId documentId,
             Func<Document, Task<TextSpan>> getTextSpanForMappingAsync,
             Func<SourceText, VsTextSpan> getVsTextSpan,
+            NavigationOptions options,
             CancellationToken cancellationToken)
         {
             var callback = await GetNavigationCallbackAsync(
@@ -217,7 +246,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             if (callback == null)
                 return null;
 
-            return new NavigableLocation(async (options, cancellationToken) =>
+            return new NavigableLocation(async cancellationToken =>
             {
                 await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
                 using (OpenNewDocumentStateScope(options))
@@ -392,23 +421,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         /// </summary>
         private static int GetPositionWithinDocumentBounds(int position, int documentLength)
             => Math.Min(documentLength, Math.Max(position, 0));
-
-        private static VsTextSpan GetVsTextSpan(SourceText text, TextSpan textSpan, bool allowInvalidSpan)
-        {
-            var boundedTextSpan = GetSpanWithinDocumentBounds(textSpan, text.Length);
-            if (boundedTextSpan != textSpan && !allowInvalidSpan)
-            {
-                try
-                {
-                    throw new ArgumentOutOfRangeException();
-                }
-                catch (ArgumentOutOfRangeException e) when (FatalError.ReportAndCatch(e))
-                {
-                }
-            }
-
-            return text.GetVsTextSpanForSpan(boundedTextSpan);
-        }
 
         /// <summary>
         /// It is unclear why, but we are sometimes asked to navigate to a <see cref="TextSpan"/>

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackFrameViewModel.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackFrameViewModel.cs
@@ -68,25 +68,19 @@ namespace Microsoft.VisualStudio.LanguageServices.StackTraceExplorer
             try
             {
                 var definition = await GetDefinitionAsync(StackFrameSymbolPart.ContainingType, cancellationToken).ConfigureAwait(false);
-                await NavigateToDefinitionAsync(definition, cancellationToken).ConfigureAwait(false);
+                if (definition is null)
+                {
+                    return;
+                }
+
+                var canNavigate = await definition.CanNavigateToAsync(_workspace, cancellationToken).ConfigureAwait(false);
+                if (canNavigate)
+                {
+                    await definition.TryNavigateToAsync(_workspace, new NavigationOptions(PreferProvisionalTab: true, ActivateTab: false), cancellationToken).ConfigureAwait(false);
+                }
             }
             catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex, cancellationToken))
             {
-            }
-        }
-
-        private async Task NavigateToDefinitionAsync(DefinitionItem? definition, CancellationToken cancellationToken)
-        {
-            if (definition is null)
-                return;
-
-            var canNavigate = await definition.CanNavigateToAsync(_workspace, cancellationToken).ConfigureAwait(false);
-            if (canNavigate)
-            {
-                var location = await definition.GetNavigableLocationAsync(
-                    _workspace, cancellationToken).ConfigureAwait(false);
-                if (location != null)
-                    await location.NavigateToAsync(new NavigationOptions(PreferProvisionalTab: true, ActivateTab: false), cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -101,7 +95,16 @@ namespace Microsoft.VisualStudio.LanguageServices.StackTraceExplorer
             try
             {
                 var definition = await GetDefinitionAsync(StackFrameSymbolPart.Method, cancellationToken).ConfigureAwait(false);
-                await NavigateToDefinitionAsync(definition, cancellationToken).ConfigureAwait(false);
+                if (definition is null)
+                {
+                    return;
+                }
+
+                var canNavigate = await definition.CanNavigateToAsync(_workspace, cancellationToken).ConfigureAwait(false);
+                if (canNavigate)
+                {
+                    await definition.TryNavigateToAsync(_workspace, new NavigationOptions(PreferProvisionalTab: true, ActivateTab: false), cancellationToken).ConfigureAwait(false);
+                }
             }
             catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex, cancellationToken))
             {

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -16,7 +16,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Undo;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
@@ -110,7 +109,7 @@ namespace Microsoft.VisualStudio.LanguageServices
                 symbolInfo.Symbol, currentProject.Solution,
                 _threadingContext, _streamingPresenter.Value, cancellationToken).ConfigureAwait(false);
             return location != null &&
-                await location.NavigateToAsync(new NavigationOptions(PreferProvisionalTab: true, ActivateTab: true), cancellationToken).ConfigureAwait(false);
+                await location.NavigateToAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public override bool TryFindAllReferences(ISymbol symbol, Project project, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Test/GoToDefinition/GoToDefinitionApiTests.vb
+++ b/src/VisualStudio/Core/Test/GoToDefinition/GoToDefinitionApiTests.vb
@@ -8,7 +8,6 @@ Imports Microsoft.CodeAnalysis.Editor.GoToDefinition
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
-Imports Microsoft.CodeAnalysis.Navigation
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Utilities
@@ -51,7 +50,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.GoToDefinition
                     thirdPartyNavigationAllowed:=True,
                     cancellationToken:=CancellationToken.None)
                 Dim success = location IsNot Nothing AndAlso
-                    Await location.NavigateToAsync(NavigationOptions.Default, CancellationToken.None)
+                    Await location.NavigateToAsync(CancellationToken.None)
 
                 Assert.Equal(expectSuccess, success)
             End Using

--- a/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
+++ b/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
@@ -37,15 +37,15 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests
 
             public Task<bool> CanNavigateToPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken) => SpecializedTasks.True;
 
-            public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken) => SpecializedTasks.True;
+            public Task<bool> CanNavigateToSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken) => SpecializedTasks.True;
 
-            public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, CancellationToken cancellationToken)
+            public Task<INavigableLocation?> GetLocationForLineAndOffsetAsync(Workspace workspace, DocumentId documentId, int lineNumber, int offset, NavigationOptions options, CancellationToken cancellationToken)
                 => NavigableLocation.TestAccessor.Create(true);
 
-            public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, CancellationToken cancellationToken)
+            public Task<INavigableLocation?> GetLocationForPositionAsync(Workspace workspace, DocumentId documentId, int position, int virtualSpace, NavigationOptions options, CancellationToken cancellationToken)
                 => NavigableLocation.TestAccessor.Create(true);
 
-            public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, bool allowInvalidSpan, CancellationToken cancellationToken)
+            public Task<INavigableLocation?> GetLocationForSpanAsync(Workspace workspace, DocumentId documentId, TextSpan textSpan, NavigationOptions options, bool allowInvalidSpan, CancellationToken cancellationToken)
                 => NavigableLocation.TestAccessor.Create(true);
         }
     }


### PR DESCRIPTION
#59802 is suspected of introducing RPS regressions.

Last known good: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/383846
First known bad: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/383867
Revert validation: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=5837378&view=results

Regressed counters:
- UWP64.BuildAndDebug - RegressedBeyondThreshold / 0400.Close Solution / CLR_AdjustedMethodsJitted_Total_devenv / Regressed: 731.80 Count (6.14%)

Please advise whether the failures are plausibly connected with this PR, and if so, whether we should revert, or take a follow-up PR to fix, or seek an exception. @genlu @CyrusNajmabadi @jasonmalinowski.
