### PR TITLE
SyntaxContext's GlobalStatementContext changes

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/NewKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/NewKeywordRecommenderTests.cs
@@ -699,7 +699,7 @@ $$");
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterFileScopedNamespace()
         {
-            await VerifyKeywordAsync(
+            await VerifyAbsenceAsync(
 @"namespace N;
 $$");
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -21,8 +21,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
         public readonly bool IsPreProcessorKeywordContext;
 
-        public readonly bool IsGlobalStatementContext;
-
         public readonly bool IsNonAttributeExpressionContext;
         public readonly bool IsConstantExpressionContext;
 
@@ -113,9 +111,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             : base(document, semanticModel, position, leftToken, targetToken,
                    isTypeContext, isNamespaceContext, isNamespaceDeclarationNameContext,
                    isPreProcessorDirectiveContext, isPreProcessorExpressionContext,
-                   isRightOfDotOrArrowOrColonColon, isStatementContext, isAnyExpressionContext,
-                   isAttributeNameContext, isEnumTypeMemberAccessContext, isNameOfContext,
-                   isInQuery, isInImportsDirective, IsWithinAsyncMethod(), isPossibleTupleContext,
+                   isRightOfDotOrArrowOrColonColon, isStatementContext, isGlobalStatementContext,
+                   isAnyExpressionContext, isAttributeNameContext, isEnumTypeMemberAccessContext,
+                   isNameOfContext, isInQuery, isInImportsDirective, IsWithinAsyncMethod(), isPossibleTupleContext,
                    isStartPatternContext, isAfterPatternContext, isRightSideOfNumericType, isInArgumentList,
                    cancellationToken)
         {
@@ -123,7 +121,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             this.ContainingTypeOrEnumDeclaration = containingTypeOrEnumDeclaration;
             this.IsInNonUserCode = isInNonUserCode;
             this.IsPreProcessorKeywordContext = isPreProcessorKeywordContext;
-            this.IsGlobalStatementContext = isGlobalStatementContext;
             this.IsNonAttributeExpressionContext = isNonAttributeExpressionContext;
             this.IsConstantExpressionContext = isConstantExpressionContext;
             this.IsLabelContext = isLabelContext;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -222,6 +222,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 if (globalStatement != null && globalStatement.GetLastToken(includeZeroWidth: true) == token)
                     return true;
 
+                // Need this check to check file scoped namespace declarations prior to a catch-all of 
+                // member declarations since otherwise it would return true.
+                if (token.Parent is FileScopedNamespaceDeclarationSyntax namespaceDeclaration && namespaceDeclaration.SemicolonToken == token)
+                    return false;
+
                 var memberDeclaration = token.GetAncestor<MemberDeclarationSyntax>();
                 if (memberDeclaration != null && memberDeclaration.GetLastToken(includeZeroWidth: true) == token &&
                     memberDeclaration.IsParentKind(SyntaxKind.CompilationUnit))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                     return true;
 
                 if (token.Parent is FileScopedNamespaceDeclarationSyntax namespaceDeclaration && namespaceDeclaration.SemicolonToken == token)
-                    return true;
+                    return false;
 
                 var memberDeclaration = token.GetAncestor<MemberDeclarationSyntax>();
                 if (memberDeclaration != null && memberDeclaration.GetLastToken(includeZeroWidth: true) == token &&

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -222,9 +222,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 if (globalStatement != null && globalStatement.GetLastToken(includeZeroWidth: true) == token)
                     return true;
 
-                if (token.Parent is FileScopedNamespaceDeclarationSyntax namespaceDeclaration && namespaceDeclaration.SemicolonToken == token)
-                    return false;
-
                 var memberDeclaration = token.GetAncestor<MemberDeclarationSyntax>();
                 if (memberDeclaration != null && memberDeclaration.GetLastToken(includeZeroWidth: true) == token &&
                     memberDeclaration.IsParentKind(SyntaxKind.CompilationUnit))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ContextQuery/SyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ContextQuery/SyntaxContext.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             bool isPreProcessorExpressionContext,
             bool isRightOfNameSeparator,
             bool isStatementContext,
+            bool isGlobalStatementContext,
             bool isAnyExpressionContext,
             bool isAttributeNameContext,
             bool isEnumTypeMemberAccessContext,
@@ -57,6 +58,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             this.IsPreProcessorExpressionContext = isPreProcessorExpressionContext;
             this.IsRightOfNameSeparator = isRightOfNameSeparator;
             this.IsStatementContext = isStatementContext;
+            this.IsGlobalStatementContext = isGlobalStatementContext;
             this.IsAnyExpressionContext = isAnyExpressionContext;
             this.IsAttributeNameContext = isAttributeNameContext;
             this.IsEnumTypeMemberAccessContext = isEnumTypeMemberAccessContext;
@@ -98,6 +100,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
 
         public bool IsRightOfNameSeparator { get; }
         public bool IsStatementContext { get; }
+        public bool IsGlobalStatementContext { get; }
         public bool IsAnyExpressionContext { get; }
         public bool IsAttributeNameContext { get; }
         public bool IsEnumTypeMemberAccessContext { get; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
@@ -37,8 +37,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
         Public ReadOnly IsSingleLineStatementContext As Boolean
         Public ReadOnly IsMultiLineStatementContext As Boolean
 
-        Public ReadOnly IsGlobalStatementContext As Boolean
-
         Public ReadOnly IsTypeDeclarationKeywordContext As Boolean
         Public ReadOnly IsTypeMemberDeclarationKeywordContext As Boolean
         Public ReadOnly IsInterfaceMemberDeclarationKeywordContext As Boolean
@@ -66,6 +64,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
             isPreProcessorExpressionContext As Boolean,
             isRightOfNameSeparator As Boolean,
             isSingleLineStatementContext As Boolean,
+            isGlobalStatementContext As Boolean,
             isExpressionContext As Boolean,
             isAttributeNameContext As Boolean,
             isEnumTypeMemberAccessContext As Boolean,
@@ -92,6 +91,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 isPreProcessorExpressionContext,
                 isRightOfNameSeparator,
                 isStatementContext:=isSingleLineStatementContext,
+                isGlobalStatementContext:=isGlobalStatementContext,
                 isAnyExpressionContext:=isExpressionContext,
                 isAttributeNameContext:=isAttributeNameContext,
                 isEnumTypeMemberAccessContext:=isEnumTypeMemberAccessContext,
@@ -113,8 +113,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
             Me.IsSingleLineStatementContext = isSingleLineStatementContext
             Me.IsMultiLineStatementContext = syntaxTree.IsMultiLineStatementStartContext(position, targetToken, cancellationToken)
-
-            Me.IsGlobalStatementContext = syntaxTree.IsGlobalStatementContext(position, cancellationToken)
 
             Me.IsTypeDeclarationKeywordContext = syntaxTree.IsTypeDeclarationKeywordContext(position, targetToken, cancellationToken)
             Me.IsTypeMemberDeclarationKeywordContext = syntaxTree.IsTypeMemberDeclarationKeywordContext(position, targetToken, cancellationToken)
@@ -155,6 +153,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 isPreProcessorExpressionContext:=syntaxTree.IsInPreprocessorExpressionContext(position, cancellationToken),
                 isRightOfNameSeparator:=syntaxTree.IsRightOfDot(position, cancellationToken),
                 isSingleLineStatementContext:=syntaxTree.IsSingleLineStatementContext(position, targetToken, cancellationToken),
+                isGlobalStatementContext:=syntaxTree.IsGlobalStatementContext(position, cancellationToken),
                 isExpressionContext:=syntaxTree.IsExpressionContext(position, targetToken, cancellationToken, semanticModel),
                 isAttributeNameContext:=syntaxTree.IsAttributeNameContext(position, targetToken, cancellationToken),
                 isEnumTypeMemberAccessContext:=syntaxTree.IsEnumTypeMemberAccessContext(position, targetToken, semanticModel, cancellationToken),


### PR DESCRIPTION
#59931

1: Returns false instead of true if we recognize we're in a filescoped namespace
2: abstracts out the global statement context concept