### PR TITLE
Expose ForceExpandedCompletionIndexCreation option to O#

### DIFF
--- a/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionOptions.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Completion/OmniSharpCompletionOptions.cs
@@ -7,9 +7,14 @@ using Microsoft.CodeAnalysis.Completion;
 namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Completion
 {
     internal readonly record struct OmniSharpCompletionOptions(
-        bool ShowItemsFromUnimportedNamespaces)
+        bool ShowItemsFromUnimportedNamespaces,
+        bool ForceExpandedCompletionIndexCreation)
     {
         internal CompletionOptions ToCompletionOptions()
-            => CompletionOptions.Default with { ShowItemsFromUnimportedNamespaces = ShowItemsFromUnimportedNamespaces };
+            => CompletionOptions.Default with
+            {
+                ShowItemsFromUnimportedNamespaces = ShowItemsFromUnimportedNamespaces,
+                ForceExpandedCompletionIndexCreation = ForceExpandedCompletionIndexCreation
+            };
     }
 }


### PR DESCRIPTION
This can be used to tweak test behavior to make it deterministic.

Cherry-picked from https://github.com/dotnet/roslyn/pull/59760