### PR TITLE
Use synthesized methods for compiler-generated switch exceptions

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1853,7 +1853,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 privateImplClass,
                 returnType,
                 PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName,
-                WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor).GetCciAdapter());
+                factory.WellKnownMethod(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor)).GetCciAdapter());
             return (MethodSymbol)privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName)!.GetInternalSymbol()!;
         }
 
@@ -1878,7 +1878,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 privateImplClass,
                 returnType,
                 PrivateImplementationDetails.SynthesizedThrowInvalidOperationExceptionFunctionName,
-                WellKnownMember.System_InvalidOperationException__ctor).GetCciAdapter());
+                factory.WellKnownMethod(WellKnownMember.System_InvalidOperationException__ctor)).GetCciAdapter());
             return (MethodSymbol)privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowInvalidOperationExceptionFunctionName)!.GetInternalSymbol()!;
         }
 #nullable disable

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1787,7 +1787,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         /// The ThrowIfNull and Throw helpers are modeled off of the helpers on ArgumentNullException.
         /// https://github.com/dotnet/runtime/blob/22663769611ba89cd92d14cfcb76e287f8af2335/src/libraries/System.Private.CoreLib/src/System/ArgumentNullException.cs#L56-L69
         /// </remarks>
-        internal MethodSymbol EnsureThrowIfNullFunctionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag? diagnostics)
+        internal MethodSymbol EnsureThrowIfNullFunctionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag diagnostics)
         {
             var privateImplClass = GetPrivateImplClass(syntaxNode, diagnostics);
             var throwIfNullAdapter = privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowIfNullFunctionName);
@@ -1814,7 +1814,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         /// <summary>
         /// Creates the ThrowSwitchExpressionException helper if needed.
         /// </summary>
-        internal MethodSymbol EnsureThrowSwitchExpressionExceptionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag? diagnostics)
+        internal MethodSymbol EnsureThrowSwitchExpressionExceptionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag diagnostics)
         {
             var privateImplClass = GetPrivateImplClass(syntaxNode, diagnostics);
             var throwSwitchExpressionAdapter = privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionFunctionName);
@@ -1833,9 +1833,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         }
 
         /// <summary>
-        /// Creates the ThrowSwitchExpressionException helper if needed.
+        /// Creates the ThrowSwitchExpressionExceptionParameterless helper if needed.
         /// </summary>
-        internal MethodSymbol EnsureThrowSwitchExpressionExceptionParameterlessExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag? diagnostics)
+        internal MethodSymbol EnsureThrowSwitchExpressionExceptionParameterlessExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag diagnostics)
         {
             var privateImplClass = GetPrivateImplClass(syntaxNode, diagnostics);
             var throwSwitchExpressionAdapter = privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName);
@@ -1860,7 +1860,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         /// <summary>
         /// Creates the ThrowInvalidOperationException helper if needed.
         /// </summary>
-        internal MethodSymbol EnsureThrowInvalidOperationExceptionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag? diagnostics)
+        internal MethodSymbol EnsureThrowInvalidOperationExceptionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag diagnostics)
         {
             var privateImplClass = GetPrivateImplClass(syntaxNode, diagnostics);
             var throwAdapter = privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowInvalidOperationExceptionFunctionName);

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1854,7 +1854,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 returnType,
                 PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName,
                 WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor).GetCciAdapter());
-            return (MethodSymbol)privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionFunctionName)!.GetInternalSymbol()!;
+            return (MethodSymbol)privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName)!.GetInternalSymbol()!;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1810,6 +1810,77 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             Debug.Assert((object?)privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowFunctionName)!.GetInternalSymbol() == internalSymbol.ThrowMethod);
             return internalSymbol;
         }
+
+        /// <summary>
+        /// Creates the ThrowSwitchExpressionException helper if needed.
+        /// </summary>
+        internal MethodSymbol EnsureThrowSwitchExpressionExceptionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag? diagnostics)
+        {
+            var privateImplClass = GetPrivateImplClass(syntaxNode, diagnostics);
+            var throwSwitchExpressionAdapter = privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionFunctionName);
+            if (throwSwitchExpressionAdapter is not null)
+            {
+                return (MethodSymbol)throwSwitchExpressionAdapter.GetInternalSymbol()!;
+            }
+
+            TypeSymbol returnType = factory.SpecialType(SpecialType.System_Void);
+            TypeSymbol unmatchedValueType = factory.SpecialType(SpecialType.System_Object);
+            var sourceModule = SourceModule;
+
+            // use add-then-get pattern to ensure the symbol exists, and then ensure we use the single "canonical" instance added by whichever thread won the race.
+            privateImplClass.TryAddSynthesizedMethod(new SynthesizedThrowSwitchExpressionExceptionMethod(sourceModule, privateImplClass, returnType, unmatchedValueType).GetCciAdapter());
+            return (MethodSymbol)privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionFunctionName)!.GetInternalSymbol()!;
+        }
+
+        /// <summary>
+        /// Creates the ThrowSwitchExpressionException helper if needed.
+        /// </summary>
+        internal MethodSymbol EnsureThrowSwitchExpressionExceptionParameterlessExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag? diagnostics)
+        {
+            var privateImplClass = GetPrivateImplClass(syntaxNode, diagnostics);
+            var throwSwitchExpressionAdapter = privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName);
+            if (throwSwitchExpressionAdapter is not null)
+            {
+                return (MethodSymbol)throwSwitchExpressionAdapter.GetInternalSymbol()!;
+            }
+
+            TypeSymbol returnType = factory.SpecialType(SpecialType.System_Void);
+            var sourceModule = SourceModule;
+
+            // use add-then-get pattern to ensure the symbol exists, and then ensure we use the single "canonical" instance added by whichever thread won the race.
+            privateImplClass.TryAddSynthesizedMethod(new SynthesizedParameterlessThrowMethod(
+                sourceModule,
+                privateImplClass,
+                returnType,
+                PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName,
+                WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor).GetCciAdapter());
+            return (MethodSymbol)privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionFunctionName)!.GetInternalSymbol()!;
+        }
+
+        /// <summary>
+        /// Creates the ThrowInvalidOperationException helper if needed.
+        /// </summary>
+        internal MethodSymbol EnsureThrowInvalidOperationExceptionExists(SyntaxNode syntaxNode, SyntheticBoundNodeFactory factory, DiagnosticBag? diagnostics)
+        {
+            var privateImplClass = GetPrivateImplClass(syntaxNode, diagnostics);
+            var throwAdapter = privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowInvalidOperationExceptionFunctionName);
+            if (throwAdapter is not null)
+            {
+                return (MethodSymbol)throwAdapter.GetInternalSymbol()!;
+            }
+
+            TypeSymbol returnType = factory.SpecialType(SpecialType.System_Void);
+            var sourceModule = SourceModule;
+
+            // use add-then-get pattern to ensure the symbol exists, and then ensure we use the single "canonical" instance added by whichever thread won the race.
+            privateImplClass.TryAddSynthesizedMethod(new SynthesizedParameterlessThrowMethod(
+                sourceModule,
+                privateImplClass,
+                returnType,
+                PrivateImplementationDetails.SynthesizedThrowInvalidOperationExceptionFunctionName,
+                WellKnownMember.System_InvalidOperationException__ctor).GetCciAdapter());
+            return (MethodSymbol)privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedThrowInvalidOperationExceptionFunctionName)!.GetInternalSymbol()!;
+        }
 #nullable disable
 
         public override IEnumerable<Cci.INamespaceTypeDefinition> GetAdditionalTopLevelTypeDefinitions(EmitContext context)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullChecking.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullChecking.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (throwIfNullMethod is null)
             {
+                Debug.Assert(factory.ModuleBuilderOpt is not null);
                 var module = factory.ModuleBuilderOpt!;
                 var diagnosticSyntax = factory.CurrentFunction.GetNonNullSyntaxNode();
                 var diagnostics = factory.Diagnostics.DiagnosticBag;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchExpression.cs
@@ -155,7 +155,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private static BoundStatement ConstructThrowSwitchExpressionExceptionHelperCall(SyntheticBoundNodeFactory factory, BoundExpression unmatchedValue)
             {
-                var module = factory.ModuleBuilderOpt!;
+                Debug.Assert(factory.ModuleBuilderOpt is not null);
+                var module = factory.ModuleBuilderOpt;
                 var diagnosticSyntax = factory.CurrentFunction.GetNonNullSyntaxNode();
                 var diagnostics = factory.Diagnostics.DiagnosticBag;
                 Debug.Assert(diagnostics is not null);
@@ -169,6 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private static BoundStatement ConstructThrowSwitchExpressionExceptionParameterlessHelperCall(SyntheticBoundNodeFactory factory)
             {
+                Debug.Assert(factory.ModuleBuilderOpt is not null);
                 var module = factory.ModuleBuilderOpt!;
                 var diagnosticSyntax = factory.CurrentFunction.GetNonNullSyntaxNode();
                 var diagnostics = factory.Diagnostics.DiagnosticBag;
@@ -182,6 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private static BoundStatement ConstructThrowInvalidOperationExceptionHelperCall(SyntheticBoundNodeFactory factory)
             {
+                Debug.Assert(factory.ModuleBuilderOpt is not null);
                 var module = factory.ModuleBuilderOpt!;
                 var diagnosticSyntax = factory.CurrentFunction.GetNonNullSyntaxNode();
                 var diagnostics = factory.Diagnostics.DiagnosticBag;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchExpression.cs
@@ -124,14 +124,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (produceDetailedSequencePoints)
                         result.Add(new BoundRestorePreviousSequencePoint(node.Syntax, restorePointForSwitchBody));
                     var objectType = _factory.SpecialType(SpecialType.System_Object);
-                    var thrownExpression =
+                    var throwCall =
                         (implicitConversionExists(savedInputExpression, objectType) &&
-                                _factory.WellKnownMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject, isOptional: true) is MethodSymbol exception1)
-                            ? _factory.New(exception1, _factory.Convert(objectType, savedInputExpression)) :
-                        (_factory.WellKnownMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor, isOptional: true) is MethodSymbol exception0)
-                            ? _factory.New(exception0) :
-                        _factory.New(_factory.WellKnownMethod(WellKnownMember.System_InvalidOperationException__ctor));
-                    result.Add(_factory.Throw(thrownExpression));
+                                _factory.WellKnownMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject, isOptional: true) is MethodSymbol)
+                            ? ConstructThrowSwitchExpressionExceptionHelperCall(_factory, _factory.Convert(objectType, savedInputExpression)) :
+                        (_factory.WellKnownMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor, isOptional: true) is MethodSymbol)
+                            ? ConstructThrowSwitchExpressionExceptionParameterlessHelperCall(_factory) :
+                        ConstructThrowInvalidOperationExceptionHelperCall(_factory);
+
+                    result.Add(throwCall);
                 }
 
                 if (GenerateInstrumentation)
@@ -150,6 +151,46 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Conversion c = _localRewriter._compilation.Conversions.ClassifyConversionFromExpression(expression, type, ref discardedUseSiteInfo);
                     return c.IsImplicit;
                 }
+            }
+
+            private static BoundStatement ConstructThrowSwitchExpressionExceptionHelperCall(SyntheticBoundNodeFactory factory, BoundExpression unmatchedValue)
+            {
+                var module = factory.ModuleBuilderOpt!;
+                var diagnosticSyntax = factory.CurrentFunction.GetNonNullSyntaxNode();
+                var diagnostics = factory.Diagnostics.DiagnosticBag;
+                Debug.Assert(diagnostics is not null);
+                var throwSwitchExpressionExceptionMethod = module.EnsureThrowSwitchExpressionExceptionExists(diagnosticSyntax, factory, diagnostics);
+                var call = factory.Call(
+                    receiver: null,
+                    throwSwitchExpressionExceptionMethod,
+                    arg0: unmatchedValue);
+                return factory.HiddenSequencePoint(factory.ExpressionStatement(call));
+            }
+
+            private static BoundStatement ConstructThrowSwitchExpressionExceptionParameterlessHelperCall(SyntheticBoundNodeFactory factory)
+            {
+                var module = factory.ModuleBuilderOpt!;
+                var diagnosticSyntax = factory.CurrentFunction.GetNonNullSyntaxNode();
+                var diagnostics = factory.Diagnostics.DiagnosticBag;
+                Debug.Assert(diagnostics is not null);
+                var throwSwitchExpressionExceptionMethod = module.EnsureThrowSwitchExpressionExceptionParameterlessExists(diagnosticSyntax, factory, diagnostics);
+                var call = factory.Call(
+                    receiver: null,
+                    throwSwitchExpressionExceptionMethod);
+                return factory.HiddenSequencePoint(factory.ExpressionStatement(call));
+            }
+
+            private static BoundStatement ConstructThrowInvalidOperationExceptionHelperCall(SyntheticBoundNodeFactory factory)
+            {
+                var module = factory.ModuleBuilderOpt!;
+                var diagnosticSyntax = factory.CurrentFunction.GetNonNullSyntaxNode();
+                var diagnostics = factory.Diagnostics.DiagnosticBag;
+                Debug.Assert(diagnostics is not null);
+                var throwMethod = module.EnsureThrowInvalidOperationExceptionExists(diagnosticSyntax, factory, diagnostics);
+                var call = factory.Call(
+                    receiver: null,
+                    throwMethod);
+                return factory.HiddenSequencePoint(factory.ExpressionStatement(call));
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterlessThrowMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterlessThrowMethod.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeGen;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// Throws an exception of a given type using a parameterless constructor.
+    /// </summary>
+    internal sealed class SynthesizedParameterlessThrowMethod : SynthesizedGlobalMethodSymbol
+    {
+        private readonly WellKnownMember _exceptionConstructor;
+
+        internal SynthesizedParameterlessThrowMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, TypeSymbol returnType, string synthesizedMethodName, WellKnownMember exceptionConstructor)
+            : base(containingModule, privateImplType, returnType, synthesizedMethodName)
+        {
+            _exceptionConstructor = exceptionConstructor;
+            this.SetParameters(ImmutableArray<ParameterSymbol>.Empty);
+        }
+
+        internal override void GenerateMethodBody(TypeCompilationState compilationState, BindingDiagnosticBag diagnostics)
+        {
+            SyntheticBoundNodeFactory F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
+            F.CurrentFunction = this;
+
+            try
+            {
+                //throw new GivenException();
+
+                var body = F.Block(
+                        ImmutableArray<LocalSymbol>.Empty,
+                        F.Throw(F.New(F.WellKnownMethod(_exceptionConstructor), ImmutableArray<BoundExpression>.Empty)));
+
+                // NOTE: we created this block in its most-lowered form, so analysis is unnecessary
+                F.CloseMethod(body);
+            }
+            catch (SyntheticBoundNodeFactory.MissingPredefinedMember ex)
+            {
+                diagnostics.Add(ex.Diagnostic);
+                F.CloseMethod(F.ThrowNull());
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterlessThrowMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterlessThrowMethod.cs
@@ -30,9 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 //throw new GivenException();
 
-                var body = F.Block(
-                        ImmutableArray<LocalSymbol>.Empty,
-                        F.Throw(F.New(_exceptionConstructor, ImmutableArray<BoundExpression>.Empty)));
+                var body = F.Throw(F.New(_exceptionConstructor, ImmutableArray<BoundExpression>.Empty));
 
                 // NOTE: we created this block in its most-lowered form, so analysis is unnecessary
                 F.CloseMethod(body);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterlessThrowMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterlessThrowMethod.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal sealed class SynthesizedParameterlessThrowMethod : SynthesizedGlobalMethodSymbol
     {
-        private readonly WellKnownMember _exceptionConstructor;
+        private readonly MethodSymbol _exceptionConstructor;
 
-        internal SynthesizedParameterlessThrowMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, TypeSymbol returnType, string synthesizedMethodName, WellKnownMember exceptionConstructor)
+        internal SynthesizedParameterlessThrowMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, TypeSymbol returnType, string synthesizedMethodName, MethodSymbol exceptionConstructor)
             : base(containingModule, privateImplType, returnType, synthesizedMethodName)
         {
             _exceptionConstructor = exceptionConstructor;
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 var body = F.Block(
                         ImmutableArray<LocalSymbol>.Empty,
-                        F.Throw(F.New(F.WellKnownMethod(_exceptionConstructor), ImmutableArray<BoundExpression>.Empty)));
+                        F.Throw(F.New(_exceptionConstructor, ImmutableArray<BoundExpression>.Empty)));
 
                 // NOTE: we created this block in its most-lowered form, so analysis is unnecessary
                 F.CloseMethod(body);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowMethod.cs
@@ -29,9 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 //throw new ArgumentNullException(paramName);
 
-                var body = F.Block(
-                        ImmutableArray<LocalSymbol>.Empty,
-                        F.Throw(F.New(F.WellKnownMethod(WellKnownMember.System_ArgumentNullException__ctorString), ImmutableArray.Create<BoundExpression>(F.Parameter(paramName)))));
+                var body = F.Throw(F.New(F.WellKnownMethod(WellKnownMember.System_ArgumentNullException__ctorString), ImmutableArray.Create<BoundExpression>(F.Parameter(paramName))));
 
                 // NOTE: we created this block in its most-lowered form, so analysis is unnecessary
                 F.CloseMethod(body);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeGen;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -27,8 +28,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 ParameterSymbol unmatchedValue = this.Parameters[0];
 
-                //throw new SwitchExpressionException((object)unmatchedValue);
+                //throw new SwitchExpressionException(unmatchedValue);
 
+                Debug.Assert(unmatchedValue.Type.SpecialType == SpecialType.System_Object);
                 var body = F.Block(
                         ImmutableArray<LocalSymbol>.Empty,
                         F.Throw(F.New(F.WellKnownMethod(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject), ImmutableArray.Create<BoundExpression>(F.Parameter(unmatchedValue)))));

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
@@ -31,9 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 //throw new SwitchExpressionException(unmatchedValue);
 
                 Debug.Assert(unmatchedValue.Type.SpecialType == SpecialType.System_Object);
-                var body = F.Block(
-                        ImmutableArray<LocalSymbol>.Empty,
-                        F.Throw(F.New(F.WellKnownMethod(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject), ImmutableArray.Create<BoundExpression>(F.Parameter(unmatchedValue)))));
+                var body = F.Throw(F.New(F.WellKnownMethod(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject), ImmutableArray.Create<BoundExpression>(F.Parameter(unmatchedValue))));
 
                 // NOTE: we created this block in its most-lowered form, so analysis is unnecessary
                 F.CloseMethod(body);

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.CodeGen;
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
-    /// Throws a <see cref="System.Runtime.CompilerServices.SwitchExpressionException" /> with the given 'unmatchedValue'.
+    /// Throws a 'System.Runtime.CompilerServices.SwitchExpressionException' with the given 'unmatchedValue'.
     /// </summary>
     internal sealed class SynthesizedThrowSwitchExpressionExceptionMethod : SynthesizedGlobalMethodSymbol
     {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedThrowSwitchExpressionExceptionMethod.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeGen;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// Throws a <see cref="System.Runtime.CompilerServices.SwitchExpressionException" /> with the given 'unmatchedValue'.
+    /// </summary>
+    internal sealed class SynthesizedThrowSwitchExpressionExceptionMethod : SynthesizedGlobalMethodSymbol
+    {
+        internal SynthesizedThrowSwitchExpressionExceptionMethod(SourceModuleSymbol containingModule, PrivateImplementationDetails privateImplType, TypeSymbol returnType, TypeSymbol paramType)
+            : base(containingModule, privateImplType, returnType, PrivateImplementationDetails.SynthesizedThrowSwitchExpressionExceptionFunctionName)
+        {
+            this.SetParameters(ImmutableArray.Create(SynthesizedParameterSymbol.Create(this, TypeWithAnnotations.Create(paramType), 0, RefKind.None, "unmatchedValue")));
+        }
+
+        internal override void GenerateMethodBody(TypeCompilationState compilationState, BindingDiagnosticBag diagnostics)
+        {
+            SyntheticBoundNodeFactory F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
+            F.CurrentFunction = this;
+
+            try
+            {
+                ParameterSymbol unmatchedValue = this.Parameters[0];
+
+                //throw new SwitchExpressionException((object)unmatchedValue);
+
+                var body = F.Block(
+                        ImmutableArray<LocalSymbol>.Empty,
+                        F.Throw(F.New(F.WellKnownMethod(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject), ImmutableArray.Create<BoundExpression>(F.Parameter(unmatchedValue)))));
+
+                // NOTE: we created this block in its most-lowered form, so analysis is unnecessary
+                F.CloseMethod(body);
+            }
+            catch (SyntheticBoundNodeFactory.MissingPredefinedMember ex)
+            {
+                diagnostics.Add(ex.Diagnostic);
+                F.CloseMethod(F.ThrowNull());
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -3321,6 +3321,24 @@ static class C {
             compilation.GetEmitDiagnostics().Verify(
                 // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
                 Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1),
+                // (9,5): error CS0518: Predefined type 'System.Byte' is not defined or imported
+                //     public static bool M(int i) => i switch { 1 => true };
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "public static bool M(int i) => i switch { 1 => true };").WithArguments("System.Byte").WithLocation(9, 5),
+                // (9,5): error CS0518: Predefined type 'System.Byte' is not defined or imported
+                //     public static bool M(int i) => i switch { 1 => true };
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "public static bool M(int i) => i switch { 1 => true };").WithArguments("System.Byte").WithLocation(9, 5),
+                // (9,5): error CS0518: Predefined type 'System.Int16' is not defined or imported
+                //     public static bool M(int i) => i switch { 1 => true };
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "public static bool M(int i) => i switch { 1 => true };").WithArguments("System.Int16").WithLocation(9, 5),
+                // (9,5): error CS0518: Predefined type 'System.Int16' is not defined or imported
+                //     public static bool M(int i) => i switch { 1 => true };
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "public static bool M(int i) => i switch { 1 => true };").WithArguments("System.Int16").WithLocation(9, 5),
+                // (9,5): error CS0518: Predefined type 'System.Int64' is not defined or imported
+                //     public static bool M(int i) => i switch { 1 => true };
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "public static bool M(int i) => i switch { 1 => true };").WithArguments("System.Int64").WithLocation(9, 5),
+                // (9,5): error CS0518: Predefined type 'System.Int64' is not defined or imported
+                //     public static bool M(int i) => i switch { 1 => true };
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "public static bool M(int i) => i switch { 1 => true };").WithArguments("System.Int64").WithLocation(9, 5),
                 // (9,36): error CS0656: Missing compiler required member 'System.InvalidOperationException..ctor'
                 //     public static bool M(int i) => i switch { 1 => true };
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "i switch { 1 => true }").WithArguments("System.InvalidOperationException", ".ctor").WithLocation(9, 36),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests4.cs
@@ -2077,7 +2077,74 @@ public class C
                 //             _ = t switch { (3, 4) => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(0, _)").WithLocation(9, 19)
                 );
-            CompileAndVerify(compilation, expectedOutput: "InvalidOperationException");
+            CompileAndVerify(compilation, expectedOutput: "InvalidOperationException").VerifyIL("C.Main", @"
+{
+  // Code size       83 (0x53)
+  .maxstack  3
+  .locals init (System.ValueTuple<int, int> V_0, //t
+                int V_1,
+                int V_2,
+                System.Exception V_3) //ex
+  IL_0000:  nop
+  IL_0001:  ldloca.s   V_0
+  IL_0003:  ldc.i4.1
+  IL_0004:  ldc.i4.2
+  IL_0005:  call       ""System.ValueTuple<int, int>..ctor(int, int)""
+  .try
+  {
+    IL_000a:  nop
+    IL_000b:  ldc.i4.1
+    IL_000c:  brtrue.s   IL_000f
+    IL_000e:  nop
+    IL_000f:  ldloc.0
+    IL_0010:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+    IL_0015:  stloc.1
+    IL_0016:  ldloc.1
+    IL_0017:  ldc.i4.3
+    IL_0018:  bne.un.s   IL_002b
+    IL_001a:  ldloc.0
+    IL_001b:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+    IL_0020:  stloc.2
+    IL_0021:  ldloc.2
+    IL_0022:  ldc.i4.4
+    IL_0023:  beq.s      IL_0027
+    IL_0025:  br.s       IL_002b
+    IL_0027:  ldc.i4.1
+    IL_0028:  pop
+    IL_0029:  br.s       IL_0035
+    IL_002b:  ldc.i4.1
+    IL_002c:  brtrue.s   IL_002f
+    IL_002e:  nop
+    IL_002f:  call       ""ThrowInvalidOperationException""
+    IL_0034:  nop
+    IL_0035:  ldc.i4.1
+    IL_0036:  brtrue.s   IL_0039
+    IL_0038:  nop
+    IL_0039:  nop
+    IL_003a:  leave.s    IL_0052
+  }
+  catch System.Exception
+  {
+    IL_003c:  stloc.3
+    IL_003d:  nop
+    IL_003e:  ldloc.3
+    IL_003f:  callvirt   ""System.Type System.Exception.GetType()""
+    IL_0044:  callvirt   ""string System.Reflection.MemberInfo.Name.get""
+    IL_0049:  call       ""void System.Console.WriteLine(string)""
+    IL_004e:  nop
+    IL_004f:  nop
+    IL_0050:  leave.s    IL_0052
+  }
+  IL_0052:  ret
+}
+").VerifyIL("ThrowInvalidOperationException", @"
+{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""System.InvalidOperationException..ctor()""
+  IL_0005:  throw
+}
+");
         }
 
         [Fact]
@@ -2120,7 +2187,91 @@ namespace System.Runtime.CompilerServices
                 //             _ = t switch { (3, 4) => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(0, _)").WithLocation(9, 19)
                 );
-            CompileAndVerify(compilation, expectedOutput: "SwitchExpressionException()");
+            CompileAndVerify(compilation, expectedOutput: "SwitchExpressionException()").VerifyIL("C.Main", @"
+{
+  // Code size      123 (0x7b)
+  .maxstack  3
+  .locals init (System.ValueTuple<int, int> V_0, //t
+                int V_1,
+                int V_2,
+                System.Runtime.CompilerServices.SwitchExpressionException V_3, //ex
+                System.Exception V_4) //ex
+  IL_0000:  nop
+  IL_0001:  ldloca.s   V_0
+  IL_0003:  ldc.i4.1
+  IL_0004:  ldc.i4.2
+  IL_0005:  call       ""System.ValueTuple<int, int>..ctor(int, int)""
+  .try
+  {
+    IL_000a:  nop
+    IL_000b:  ldc.i4.1
+    IL_000c:  brtrue.s   IL_000f
+    IL_000e:  nop
+    IL_000f:  ldloc.0
+    IL_0010:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+    IL_0015:  stloc.1
+    IL_0016:  ldloc.1
+    IL_0017:  ldc.i4.3
+    IL_0018:  bne.un.s   IL_002b
+    IL_001a:  ldloc.0
+    IL_001b:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+    IL_0020:  stloc.2
+    IL_0021:  ldloc.2
+    IL_0022:  ldc.i4.4
+    IL_0023:  beq.s      IL_0027
+    IL_0025:  br.s       IL_002b
+    IL_0027:  ldc.i4.1
+    IL_0028:  pop
+    IL_0029:  br.s       IL_0035
+    IL_002b:  ldc.i4.1
+    IL_002c:  brtrue.s   IL_002f
+    IL_002e:  nop
+    IL_002f:  call       ""ThrowSwitchExpressionExceptionParameterless""
+    IL_0034:  nop
+    IL_0035:  ldc.i4.1
+    IL_0036:  brtrue.s   IL_0039
+    IL_0038:  nop
+    IL_0039:  nop
+    IL_003a:  leave.s    IL_007a
+  }
+  catch System.Runtime.CompilerServices.SwitchExpressionException
+  {
+    IL_003c:  stloc.3
+    IL_003d:  nop
+    IL_003e:  ldstr      ""{0}({1})""
+    IL_0043:  ldloc.3
+    IL_0044:  callvirt   ""System.Type System.Exception.GetType()""
+    IL_0049:  callvirt   ""string System.Reflection.MemberInfo.Name.get""
+    IL_004e:  ldloc.3
+    IL_004f:  callvirt   ""object System.Runtime.CompilerServices.SwitchExpressionException.UnmatchedValue.get""
+    IL_0054:  call       ""string string.Format(string, object, object)""
+    IL_0059:  call       ""void System.Console.WriteLine(string)""
+    IL_005e:  nop
+    IL_005f:  nop
+    IL_0060:  leave.s    IL_007a
+  }
+  catch System.Exception
+  {
+    IL_0062:  stloc.s    V_4
+    IL_0064:  nop
+    IL_0065:  ldloc.s    V_4
+    IL_0067:  callvirt   ""System.Type System.Exception.GetType()""
+    IL_006c:  callvirt   ""string System.Reflection.MemberInfo.Name.get""
+    IL_0071:  call       ""void System.Console.WriteLine(string)""
+    IL_0076:  nop
+    IL_0077:  nop
+    IL_0078:  leave.s    IL_007a
+  }
+  IL_007a:  ret
+}
+").VerifyIL("ThrowSwitchExpressionExceptionParameterless", @"
+{
+  // Code size        6 (0x6)
+  .maxstack  1
+  IL_0000:  newobj     ""System.Runtime.CompilerServices.SwitchExpressionException..ctor()""
+  IL_0005:  throw
+}
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests4.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests4.cs
@@ -2072,6 +2072,16 @@ public class C
 }
 ";
             var compilation = CreatePatternCompilation(source);
+
+            var ctorObject = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject);
+            Assert.Null(ctorObject);
+
+            var ctor = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor);
+            Assert.Null(ctor);
+
+            var invalidOperationExceptionCtor = compilation.GetWellKnownTypeMember(WellKnownMember.System_InvalidOperationException__ctor);
+            Assert.NotNull(invalidOperationExceptionCtor);
+
             compilation.VerifyDiagnostics(
                 // (9,19): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(0, _)' is not covered.
                 //             _ = t switch { (3, 4) => 1 };
@@ -2085,66 +2095,85 @@ public class C
                 int V_1,
                 int V_2,
                 System.Exception V_3) //ex
+  // sequence point: {
   IL_0000:  nop
+  // sequence point: var t = (1, 2);
   IL_0001:  ldloca.s   V_0
   IL_0003:  ldc.i4.1
   IL_0004:  ldc.i4.2
   IL_0005:  call       ""System.ValueTuple<int, int>..ctor(int, int)""
   .try
   {
+    // sequence point: {
     IL_000a:  nop
+    // sequence point: _ = t switch { (3, 4) => 1 };
     IL_000b:  ldc.i4.1
     IL_000c:  brtrue.s   IL_000f
+    // sequence point: switch { (3, 4) => 1 }
     IL_000e:  nop
+    // sequence point: <hidden>
     IL_000f:  ldloc.0
     IL_0010:  ldfld      ""int System.ValueTuple<int, int>.Item1""
     IL_0015:  stloc.1
+    // sequence point: <hidden>
     IL_0016:  ldloc.1
     IL_0017:  ldc.i4.3
     IL_0018:  bne.un.s   IL_002b
     IL_001a:  ldloc.0
     IL_001b:  ldfld      ""int System.ValueTuple<int, int>.Item2""
     IL_0020:  stloc.2
+    // sequence point: <hidden>
     IL_0021:  ldloc.2
     IL_0022:  ldc.i4.4
     IL_0023:  beq.s      IL_0027
     IL_0025:  br.s       IL_002b
+    // sequence point: 1
     IL_0027:  ldc.i4.1
     IL_0028:  pop
     IL_0029:  br.s       IL_0035
     IL_002b:  ldc.i4.1
     IL_002c:  brtrue.s   IL_002f
+    // sequence point: switch { (3, 4) => 1 }
     IL_002e:  nop
+    // sequence point: <hidden>
     IL_002f:  call       ""ThrowInvalidOperationException""
     IL_0034:  nop
+    // sequence point: <hidden>
     IL_0035:  ldc.i4.1
     IL_0036:  brtrue.s   IL_0039
+    // sequence point: _ = t switch { (3, 4) => 1 };
     IL_0038:  nop
+    // sequence point: }
     IL_0039:  nop
     IL_003a:  leave.s    IL_0052
   }
   catch System.Exception
   {
+    // sequence point: catch (Exception ex)
     IL_003c:  stloc.3
+    // sequence point: {
     IL_003d:  nop
+    // sequence point: Console.WriteLine(ex.GetType().Name);
     IL_003e:  ldloc.3
     IL_003f:  callvirt   ""System.Type System.Exception.GetType()""
     IL_0044:  callvirt   ""string System.Reflection.MemberInfo.Name.get""
     IL_0049:  call       ""void System.Console.WriteLine(string)""
     IL_004e:  nop
+    // sequence point: }
     IL_004f:  nop
     IL_0050:  leave.s    IL_0052
   }
+  // sequence point: }
   IL_0052:  ret
 }
-").VerifyIL("ThrowInvalidOperationException", @"
+", sequencePoints: "C.Main", source: source).VerifyIL("ThrowInvalidOperationException", @"
 {
   // Code size        6 (0x6)
   .maxstack  1
   IL_0000:  newobj     ""System.InvalidOperationException..ctor()""
   IL_0005:  throw
 }
-");
+", sequencePoints: "<PrivateImplementationDetails>.ThrowInvalidOperationException", source: source);
         }
 
         [Fact]
@@ -2182,7 +2211,19 @@ namespace System.Runtime.CompilerServices
 }
 ";
             var compilation = CreatePatternCompilation(source);
+
+            var ctorObject = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject);
+            Assert.Null(ctorObject);
+
+            var ctor = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor);
+            Assert.NotNull(ctor);
+
             compilation.VerifyDiagnostics(
+                // (9,19): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(0, _)' is not covered.
+                //             _ = t switch { (3, 4) => 1 };
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(0, _)").WithLocation(9, 19)
+                );
+            compilation.VerifyEmitDiagnostics(
                 // (9,19): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(0, _)' is not covered.
                 //             _ = t switch { (3, 4) => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(0, _)").WithLocation(9, 19)
@@ -2196,48 +2237,65 @@ namespace System.Runtime.CompilerServices
                 int V_2,
                 System.Runtime.CompilerServices.SwitchExpressionException V_3, //ex
                 System.Exception V_4) //ex
+  // sequence point: {
   IL_0000:  nop
+  // sequence point: var t = (1, 2);
   IL_0001:  ldloca.s   V_0
   IL_0003:  ldc.i4.1
   IL_0004:  ldc.i4.2
   IL_0005:  call       ""System.ValueTuple<int, int>..ctor(int, int)""
   .try
   {
+    // sequence point: {
     IL_000a:  nop
+    // sequence point: _ = t switch { (3, 4) => 1 };
     IL_000b:  ldc.i4.1
     IL_000c:  brtrue.s   IL_000f
+    // sequence point: switch { (3, 4) => 1 }
     IL_000e:  nop
+    // sequence point: <hidden>
     IL_000f:  ldloc.0
     IL_0010:  ldfld      ""int System.ValueTuple<int, int>.Item1""
     IL_0015:  stloc.1
+    // sequence point: <hidden>
     IL_0016:  ldloc.1
     IL_0017:  ldc.i4.3
     IL_0018:  bne.un.s   IL_002b
     IL_001a:  ldloc.0
     IL_001b:  ldfld      ""int System.ValueTuple<int, int>.Item2""
     IL_0020:  stloc.2
+    // sequence point: <hidden>
     IL_0021:  ldloc.2
     IL_0022:  ldc.i4.4
     IL_0023:  beq.s      IL_0027
     IL_0025:  br.s       IL_002b
+    // sequence point: 1
     IL_0027:  ldc.i4.1
     IL_0028:  pop
     IL_0029:  br.s       IL_0035
     IL_002b:  ldc.i4.1
     IL_002c:  brtrue.s   IL_002f
+    // sequence point: switch { (3, 4) => 1 }
     IL_002e:  nop
+    // sequence point: <hidden>
     IL_002f:  call       ""ThrowSwitchExpressionExceptionParameterless""
     IL_0034:  nop
+    // sequence point: <hidden>
     IL_0035:  ldc.i4.1
     IL_0036:  brtrue.s   IL_0039
+    // sequence point: _ = t switch { (3, 4) => 1 };
     IL_0038:  nop
+    // sequence point: }
     IL_0039:  nop
     IL_003a:  leave.s    IL_007a
   }
   catch System.Runtime.CompilerServices.SwitchExpressionException
   {
+    // sequence point: catch (SwitchExpressionException ex)
     IL_003c:  stloc.3
+    // sequence point: {
     IL_003d:  nop
+    // sequence point: Console.WriteLine($""{ex.GetType().Name}({ex.UnmatchedValue})"");
     IL_003e:  ldstr      ""{0}({1})""
     IL_0043:  ldloc.3
     IL_0044:  callvirt   ""System.Type System.Exception.GetType()""
@@ -2247,31 +2305,37 @@ namespace System.Runtime.CompilerServices
     IL_0054:  call       ""string string.Format(string, object, object)""
     IL_0059:  call       ""void System.Console.WriteLine(string)""
     IL_005e:  nop
+    // sequence point: }
     IL_005f:  nop
     IL_0060:  leave.s    IL_007a
   }
   catch System.Exception
   {
+    // sequence point: catch (Exception ex)
     IL_0062:  stloc.s    V_4
+    // sequence point: {
     IL_0064:  nop
+    // sequence point: Console.WriteLine(ex.GetType().Name);
     IL_0065:  ldloc.s    V_4
     IL_0067:  callvirt   ""System.Type System.Exception.GetType()""
     IL_006c:  callvirt   ""string System.Reflection.MemberInfo.Name.get""
     IL_0071:  call       ""void System.Console.WriteLine(string)""
     IL_0076:  nop
+    // sequence point: }
     IL_0077:  nop
     IL_0078:  leave.s    IL_007a
   }
+  // sequence point: }
   IL_007a:  ret
 }
-").VerifyIL("ThrowSwitchExpressionExceptionParameterless", @"
+", sequencePoints: "C.Main", source: source).VerifyIL("ThrowSwitchExpressionExceptionParameterless", @"
 {
   // Code size        6 (0x6)
   .maxstack  1
   IL_0000:  newobj     ""System.Runtime.CompilerServices.SwitchExpressionException..ctor()""
   IL_0005:  throw
 }
-");
+", sequencePoints: "<PrivateImplementationDetails>.ThrowSwitchExpressionExceptionParameterless", source: source);
         }
 
         [Fact]
@@ -2351,12 +2415,122 @@ namespace System.Runtime.CompilerServices
 }
 ";
             var compilation = CreatePatternCompilation(source);
+            var ctorObject = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject);
+            Assert.NotNull(ctorObject);
+
             compilation.VerifyDiagnostics(
                 // (8,24): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(0, _)' is not covered.
                 //             _ = (1, 2) switch { (3, 4) => 1 };
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(0, _)").WithLocation(8, 24)
                 );
-            CompileAndVerify(compilation, expectedOutput: "SwitchExpressionException((1, 2))");
+            compilation.VerifyEmitDiagnostics(
+                // (8,24): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(0, _)' is not covered.
+                //             _ = (1, 2) switch { (3, 4) => 1 };
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(0, _)").WithLocation(8, 24)
+                );
+            CompileAndVerify(compilation, expectedOutput: "SwitchExpressionException((1, 2))").VerifyIL("C.Main", @"
+{
+  // Code size      114 (0x72)
+  .maxstack  3
+  .locals init (int V_0,
+                int V_1,
+                System.Runtime.CompilerServices.SwitchExpressionException V_2, //ex
+                System.Exception V_3) //ex
+  // sequence point: {
+  IL_0000:  nop
+  .try
+  {
+    // sequence point: {
+    IL_0001:  nop
+    // sequence point: _ = (1, 2) switch { (3, 4) => 1 };
+    IL_0002:  ldc.i4.1
+    IL_0003:  stloc.0
+    IL_0004:  ldc.i4.2
+    IL_0005:  stloc.1
+    IL_0006:  ldc.i4.1
+    IL_0007:  brtrue.s   IL_000a
+    // sequence point: switch { (3, 4) => 1 }
+    IL_0009:  nop
+    // sequence point: <hidden>
+    IL_000a:  ldloc.0
+    IL_000b:  ldc.i4.3
+    IL_000c:  bne.un.s   IL_0018
+    IL_000e:  ldloc.1
+    IL_000f:  ldc.i4.4
+    IL_0010:  beq.s      IL_0014
+    IL_0012:  br.s       IL_0018
+    // sequence point: 1
+    IL_0014:  ldc.i4.1
+    IL_0015:  pop
+    IL_0016:  br.s       IL_002e
+    IL_0018:  ldc.i4.1
+    IL_0019:  brtrue.s   IL_001c
+    // sequence point: switch { (3, 4) => 1 }
+    IL_001b:  nop
+    // sequence point: <hidden>
+    IL_001c:  ldloc.0
+    IL_001d:  ldloc.1
+    IL_001e:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
+    IL_0023:  box        ""System.ValueTuple<int, int>""
+    IL_0028:  call       ""ThrowSwitchExpressionException""
+    IL_002d:  nop
+    // sequence point: <hidden>
+    IL_002e:  ldc.i4.1
+    IL_002f:  brtrue.s   IL_0032
+    // sequence point: _ = (1, 2) switch { (3, 4) => 1 };
+    IL_0031:  nop
+    // sequence point: }
+    IL_0032:  nop
+    IL_0033:  leave.s    IL_0071
+  }
+  catch System.Runtime.CompilerServices.SwitchExpressionException
+  {
+    // sequence point: catch (SwitchExpressionException ex)
+    IL_0035:  stloc.2
+    // sequence point: {
+    IL_0036:  nop
+    // sequence point: Console.WriteLine($""{ex.GetType().Name}({ex.UnmatchedValue})"");
+    IL_0037:  ldstr      ""{0}({1})""
+    IL_003c:  ldloc.2
+    IL_003d:  callvirt   ""System.Type System.Exception.GetType()""
+    IL_0042:  callvirt   ""string System.Reflection.MemberInfo.Name.get""
+    IL_0047:  ldloc.2
+    IL_0048:  callvirt   ""object System.Runtime.CompilerServices.SwitchExpressionException.UnmatchedValue.get""
+    IL_004d:  call       ""string string.Format(string, object, object)""
+    IL_0052:  call       ""void System.Console.WriteLine(string)""
+    IL_0057:  nop
+    // sequence point: }
+    IL_0058:  nop
+    IL_0059:  leave.s    IL_0071
+  }
+  catch System.Exception
+  {
+    // sequence point: catch (Exception ex)
+    IL_005b:  stloc.3
+    // sequence point: {
+    IL_005c:  nop
+    // sequence point: Console.WriteLine(ex.GetType().Name);
+    IL_005d:  ldloc.3
+    IL_005e:  callvirt   ""System.Type System.Exception.GetType()""
+    IL_0063:  callvirt   ""string System.Reflection.MemberInfo.Name.get""
+    IL_0068:  call       ""void System.Console.WriteLine(string)""
+    IL_006d:  nop
+    // sequence point: }
+    IL_006e:  nop
+    IL_006f:  leave.s    IL_0071
+  }
+  // sequence point: }
+  IL_0071:  ret
+}
+", sequencePoints: "C.Main", source: source).VerifyIL("ThrowSwitchExpressionException", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  newobj     ""System.Runtime.CompilerServices.SwitchExpressionException..ctor(object)""
+  IL_0006:  throw
+}
+", sequencePoints: "<PrivateImplementationDetails>.ThrowSwitchExpressionException", source: source);
         }
 
         [Fact]
@@ -2404,6 +2578,54 @@ namespace System.Runtime.CompilerServices
                 Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(0, _)").WithLocation(9, 19)
                 );
             CompileAndVerify(compilation, expectedOutput: "SwitchExpressionException()");
+        }
+
+        [Fact]
+        public void UnmatchedInput_08()
+        {
+            var source =
+@"using System;
+public class C
+{
+    static void Main()
+    {
+        var t = (1, 2);
+        try
+        {
+            _ = t switch { (3, 4) => 1 };
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.GetType().Name);
+        }
+    }
+}
+";
+            var compilation = CreatePatternCompilation(source);
+            compilation.MakeTypeMissing(WellKnownType.System_InvalidOperationException);
+
+            var ctorObject = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject);
+            Assert.Null(ctorObject);
+
+            var ctor = compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor);
+            Assert.Null(ctor);
+
+            var invalidOperationExceptionCtor = compilation.GetWellKnownTypeMember(WellKnownMember.System_InvalidOperationException__ctor);
+            Assert.Null(invalidOperationExceptionCtor);
+
+            compilation.VerifyDiagnostics(
+                // (9,19): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(0, _)' is not covered.
+                //             _ = t switch { (3, 4) => 1 };
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(0, _)").WithLocation(9, 19)
+                );
+            compilation.VerifyEmitDiagnostics(
+                // (9,17): error CS0656: Missing compiler required member 'System.InvalidOperationException..ctor'
+                //             _ = t switch { (3, 4) => 1 };
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "t switch { (3, 4) => 1 }").WithArguments("System.InvalidOperationException", ".ctor").WithLocation(9, 17),
+                // (9,19): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(0, _)' is not covered.
+                //             _ = t switch { (3, 4) => 1 };
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(0, _)").WithLocation(9, 19)
+            );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -3495,7 +3495,7 @@ namespace System.Runtime.CompilerServices
 ";
             CompileAndVerify(text, expectedOutput: "12345678💥").VerifyIL("C.Main", @"
 {
-  // Code size      174 (0xae)
+  // Code size      173 (0xad)
   .maxstack  8
   .locals init (int V_0,
                 System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>> V_1)
@@ -3555,23 +3555,22 @@ namespace System.Runtime.CompilerServices
     IL_0086:  bne.un.s   IL_008c
     IL_0088:  ldc.i4.1
     IL_0089:  stloc.0
-    IL_008a:  br.s       IL_0098
+    IL_008a:  br.s       IL_0097
     IL_008c:  ldloc.1
     IL_008d:  box        ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int>>""
-    IL_0092:  newobj     ""System.Runtime.CompilerServices.SwitchExpressionException..ctor(object)""
-    IL_0097:  throw
-    IL_0098:  ldloc.0
-    IL_0099:  call       ""void System.Console.WriteLine(int)""
-    IL_009e:  leave.s    IL_00ad
+    IL_0092:  call       ""ThrowSwitchExpressionException""
+    IL_0097:  ldloc.0
+    IL_0098:  call       ""void System.Console.WriteLine(int)""
+    IL_009d:  leave.s    IL_00ac
   }
   catch System.Runtime.CompilerServices.SwitchExpressionException
   {
-    IL_00a0:  pop
-    IL_00a1:  ldstr      ""💥""
-    IL_00a6:  call       ""void System.Console.Write(string)""
-    IL_00ab:  leave.s    IL_00ad
+    IL_009f:  pop
+    IL_00a0:  ldstr      ""💥""
+    IL_00a5:  call       ""void System.Console.Write(string)""
+    IL_00aa:  leave.s    IL_00ac
   }
-  IL_00ad:  ret
+  IL_00ac:  ret
 }
 ");
         }
@@ -3619,7 +3618,7 @@ namespace System.Runtime.CompilerServices
 ";
             CompileAndVerify(text, expectedOutput: "123456789💥").VerifyIL("C.Main", @"
 {
-  // Code size      195 (0xc3)
+  // Code size      194 (0xc2)
   .maxstack  9
   .locals init (int V_0,
                 System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>> V_1)
@@ -3686,23 +3685,22 @@ namespace System.Runtime.CompilerServices
     IL_009b:  bne.un.s   IL_00a1
     IL_009d:  ldc.i4.1
     IL_009e:  stloc.0
-    IL_009f:  br.s       IL_00ad
+    IL_009f:  br.s       IL_00ac
     IL_00a1:  ldloc.1
     IL_00a2:  box        ""System.ValueTuple<int, int, int, int, int, int, int, System.ValueTuple<int, int>>""
-    IL_00a7:  newobj     ""System.Runtime.CompilerServices.SwitchExpressionException..ctor(object)""
-    IL_00ac:  throw
-    IL_00ad:  ldloc.0
-    IL_00ae:  call       ""void System.Console.WriteLine(int)""
-    IL_00b3:  leave.s    IL_00c2
+    IL_00a7:  call       ""ThrowSwitchExpressionException""
+    IL_00ac:  ldloc.0
+    IL_00ad:  call       ""void System.Console.WriteLine(int)""
+    IL_00b2:  leave.s    IL_00c1
   }
   catch System.Runtime.CompilerServices.SwitchExpressionException
   {
-    IL_00b5:  pop
-    IL_00b6:  ldstr      ""💥""
-    IL_00bb:  call       ""void System.Console.Write(string)""
-    IL_00c0:  leave.s    IL_00c2
+    IL_00b4:  pop
+    IL_00b5:  ldstr      ""💥""
+    IL_00ba:  call       ""void System.Console.Write(string)""
+    IL_00bf:  leave.s    IL_00c1
   }
-  IL_00c2:  ret
+  IL_00c1:  ret
 }
 ");
         }

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -31,6 +31,10 @@ namespace Microsoft.CodeAnalysis.CodeGen
         internal const string SynthesizedThrowIfNullFunctionName = "ThrowIfNull";
         internal const string SynthesizedThrowFunctionName = "Throw";
 
+        internal const string SynthesizedThrowSwitchExpressionExceptionFunctionName = "ThrowSwitchExpressionException";
+        internal const string SynthesizedThrowSwitchExpressionExceptionParameterlessFunctionName = "ThrowSwitchExpressionExceptionParameterless";
+        internal const string SynthesizedThrowInvalidOperationExceptionFunctionName = "ThrowInvalidOperationException";
+
         private readonly CommonPEModuleBuilder _moduleBuilder;       //the module builder
         private readonly Cci.ITypeReference _systemObject;           //base type
         private readonly Cci.ITypeReference _systemValueType;        //base for nested structs

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -103,7 +103,6 @@ namespace Microsoft.CodeAnalysis.Emit
         /// </summary>
         internal abstract string ModuleName { get; }
 
-        internal abstract Cci.INamedTypeReference GetSpecialType(SpecialType specialType, SyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
         internal abstract Cci.IAssemblyReference Translate(IAssemblySymbolInternal symbol, DiagnosticBag diagnostics);
         internal abstract Cci.ITypeReference Translate(ITypeSymbolInternal symbol, SyntaxNode syntaxOpt, DiagnosticBag diagnostics);
         internal abstract Cci.IMethodReference Translate(IMethodSymbolInternal symbol, DiagnosticBag diagnostics, bool needDeclaration);
@@ -596,6 +595,8 @@ namespace Microsoft.CodeAnalysis.Emit
         internal override IAssemblySymbolInternal CommonCorLibrary => CorLibrary;
         internal abstract TAssemblySymbol CorLibrary { get; }
 
+        internal abstract Cci.INamedTypeReference GetSpecialType(SpecialType specialType, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
+
         internal sealed override Cci.ITypeReference EncTranslateType(ITypeSymbolInternal type, DiagnosticBag diagnostics)
         {
             return EncTranslateLocalVariableType((TTypeSymbol)type, diagnostics);
@@ -1026,8 +1027,12 @@ namespace Microsoft.CodeAnalysis.Emit
                         this,
                         this.SourceModule.Name,
                         Compilation.GetSubmissionSlotIndex(),
-                        syntaxNodeOpt,
-                        diagnostics,
+                        this.GetSpecialType(SpecialType.System_Object, syntaxNodeOpt, diagnostics),
+                        this.GetSpecialType(SpecialType.System_ValueType, syntaxNodeOpt, diagnostics),
+                        this.GetSpecialType(SpecialType.System_Byte, syntaxNodeOpt, diagnostics),
+                        this.GetSpecialType(SpecialType.System_Int16, syntaxNodeOpt, diagnostics),
+                        this.GetSpecialType(SpecialType.System_Int32, syntaxNodeOpt, diagnostics),
+                        this.GetSpecialType(SpecialType.System_Int64, syntaxNodeOpt, diagnostics),
                         SynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
 
                 if (Interlocked.CompareExchange(ref _privateImplementationDetails, result, null) != null)

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -103,6 +103,7 @@ namespace Microsoft.CodeAnalysis.Emit
         /// </summary>
         internal abstract string ModuleName { get; }
 
+        internal abstract Cci.INamedTypeReference GetSpecialType(SpecialType specialType, SyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
         internal abstract Cci.IAssemblyReference Translate(IAssemblySymbolInternal symbol, DiagnosticBag diagnostics);
         internal abstract Cci.ITypeReference Translate(ITypeSymbolInternal symbol, SyntaxNode syntaxOpt, DiagnosticBag diagnostics);
         internal abstract Cci.IMethodReference Translate(IMethodSymbolInternal symbol, DiagnosticBag diagnostics, bool needDeclaration);
@@ -595,8 +596,6 @@ namespace Microsoft.CodeAnalysis.Emit
         internal override IAssemblySymbolInternal CommonCorLibrary => CorLibrary;
         internal abstract TAssemblySymbol CorLibrary { get; }
 
-        internal abstract Cci.INamedTypeReference GetSpecialType(SpecialType specialType, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
-
         internal sealed override Cci.ITypeReference EncTranslateType(ITypeSymbolInternal type, DiagnosticBag diagnostics)
         {
             return EncTranslateLocalVariableType((TTypeSymbol)type, diagnostics);
@@ -1027,12 +1026,8 @@ namespace Microsoft.CodeAnalysis.Emit
                         this,
                         this.SourceModule.Name,
                         Compilation.GetSubmissionSlotIndex(),
-                        this.GetSpecialType(SpecialType.System_Object, syntaxNodeOpt, diagnostics),
-                        this.GetSpecialType(SpecialType.System_ValueType, syntaxNodeOpt, diagnostics),
-                        this.GetSpecialType(SpecialType.System_Byte, syntaxNodeOpt, diagnostics),
-                        this.GetSpecialType(SpecialType.System_Int16, syntaxNodeOpt, diagnostics),
-                        this.GetSpecialType(SpecialType.System_Int32, syntaxNodeOpt, diagnostics),
-                        this.GetSpecialType(SpecialType.System_Int64, syntaxNodeOpt, diagnostics),
+                        syntaxNodeOpt,
+                        diagnostics,
                         SynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor));
 
                 if (Interlocked.CompareExchange(ref _privateImplementationDetails, result, null) != null)


### PR DESCRIPTION
Fixes #59601

@RikkiGibson Tagging you since you self-assigned the issue.