### PR TITLE
Remove unneeded `isPartial` check

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -85,7 +85,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                  isExtensionMethod: syntax.ParameterList.Parameters.FirstOrDefault() is ParameterSyntax firstParam &&
                                     !firstParam.IsArgList &&
                                     firstParam.Modifiers.Any(SyntaxKind.ThisKeyword),
-                 isPartial: syntax.Modifiers.IndexOf(SyntaxKind.PartialKeyword) >= 0,
                  isReadOnly: false,
                  hasBody: syntax.Body != null || syntax.ExpressionBody != null,
                  isNullableAnalysisEnabled: isNullableAnalysisEnabled,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                  isExtensionMethod: syntax.ParameterList.Parameters.FirstOrDefault() is ParameterSyntax firstParam &&
                                     !firstParam.IsArgList &&
                                     firstParam.Modifiers.Any(SyntaxKind.ThisKeyword),
-                 isPartial: syntax.Modifiers.IndexOf(SyntaxKind.PartialKeyword) < 0,
+                 isPartial: syntax.Modifiers.IndexOf(SyntaxKind.PartialKeyword) >= 0,
                  isReadOnly: false,
                  hasBody: syntax.Body != null || syntax.ExpressionBody != null,
                  isNullableAnalysisEnabled: isNullableAnalysisEnabled,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbolBase.cs
@@ -208,7 +208,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             bool isInterface = this.ContainingType.IsInterface;
             bool isExplicitInterfaceImplementation = methodKind == MethodKind.ExplicitInterfaceImplementation;
-            var defaultAccess = isInterface && isPartial && !isExplicitInterfaceImplementation ? DeclarationModifiers.Public : DeclarationModifiers.Private;
+            var defaultAccess = isInterface && !isPartial && !isExplicitInterfaceImplementation ? DeclarationModifiers.Public : DeclarationModifiers.Private;
+            // | isInterface | isPartial | isExplicitInterfaceImplementation |
+            // |-------------|-----------|-----------------------------------|
+            // |    false    |   false   |              false                |    => private
+            // |    false    |   false   |              true                 |    => private
+            // |    false    |   true    |              false                |    => private
+            // |    false    |   true    |              true                 |    => private
+            // |    true     |   false   |              false                |    => public  => None (see code path below which sets defaultAccess to DeclarationModifiers.None)
+            // |    true     |   false   |              true                 |    => private
+            // |    true     |   true    |              false                |    => private => None (see code path below which sets defaultAccess to DeclarationModifiers.None)
+            // |    true     |   true    |              true                 |    => private
+
 
             // Check that the set of modifiers is allowed
             var allowedModifiers = DeclarationModifiers.Partial | DeclarationModifiers.Unsafe;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbolBase.cs
@@ -34,7 +34,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             MethodKind methodKind,
             bool isIterator,
             bool isExtensionMethod,
-            bool isPartial,
             bool isReadOnly,
             bool hasBody,
             bool isNullableAnalysisEnabled,
@@ -55,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             const bool returnsVoid = false;
 
             DeclarationModifiers declarationModifiers;
-            (declarationModifiers, HasExplicitAccessModifier) = this.MakeModifiers(methodKind, isPartial, isReadOnly, hasBody, location, diagnostics);
+            (declarationModifiers, HasExplicitAccessModifier) = this.MakeModifiers(methodKind, isReadOnly, hasBody, location, diagnostics);
 
             //explicit impls must be marked metadata virtual unless static
             var isMetadataVirtualIgnoringModifiers = methodKind == MethodKind.ExplicitInterfaceImplementation && (declarationModifiers & DeclarationModifiers.Static) == 0;
@@ -204,22 +203,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal bool HasExplicitAccessModifier { get; }
 
-        private (DeclarationModifiers mods, bool hasExplicitAccessMod) MakeModifiers(MethodKind methodKind, bool isPartial, bool isReadOnly, bool hasBody, Location location, BindingDiagnosticBag diagnostics)
+        private (DeclarationModifiers mods, bool hasExplicitAccessMod) MakeModifiers(MethodKind methodKind, bool isReadOnly, bool hasBody, Location location, BindingDiagnosticBag diagnostics)
         {
             bool isInterface = this.ContainingType.IsInterface;
             bool isExplicitInterfaceImplementation = methodKind == MethodKind.ExplicitInterfaceImplementation;
-            var defaultAccess = isInterface && !isPartial && !isExplicitInterfaceImplementation ? DeclarationModifiers.Public : DeclarationModifiers.Private;
-            // | isInterface | isPartial | isExplicitInterfaceImplementation |
-            // |-------------|-----------|-----------------------------------|
-            // |    false    |   false   |              false                |    => private
-            // |    false    |   false   |              true                 |    => private
-            // |    false    |   true    |              false                |    => private
-            // |    false    |   true    |              true                 |    => private
-            // |    true     |   false   |              false                |    => public  => None (see code path below which sets defaultAccess to DeclarationModifiers.None)
-            // |    true     |   false   |              true                 |    => private
-            // |    true     |   true    |              false                |    => private => None (see code path below which sets defaultAccess to DeclarationModifiers.None)
-            // |    true     |   true    |              true                 |    => private
 
+            // This is needed to make sure we can detect 'public' modifier specified explicitly and
+            // check it against language version below.
+            var defaultAccess = isInterface && !isExplicitInterfaceImplementation ? DeclarationModifiers.None : DeclarationModifiers.Private;
 
             // Check that the set of modifiers is allowed
             var allowedModifiers = DeclarationModifiers.Partial | DeclarationModifiers.Unsafe;
@@ -240,10 +231,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    // This is needed to make sure we can detect 'public' modifier specified explicitly and
-                    // check it against language version below.
-                    defaultAccess = DeclarationModifiers.None;
-
                     defaultInterfaceImplementationModifiers |= DeclarationModifiers.Sealed |
                                                                DeclarationModifiers.Abstract |
                                                                DeclarationModifiers.Static |

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordOrdinaryMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/Records/SynthesizedRecordOrdinaryMethod.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected SynthesizedRecordOrdinaryMethod(SourceMemberContainerTypeSymbol containingType, string name, bool isReadOnly, bool hasBody, int memberOffset, BindingDiagnosticBag diagnostics)
             : base(containingType, name, containingType.Locations[0], (CSharpSyntaxNode)containingType.SyntaxReferences[0].GetSyntax(), MethodKind.Ordinary,
-                   isIterator: false, isExtensionMethod: false, isPartial: false, isReadOnly: isReadOnly, hasBody: hasBody, isNullableAnalysisEnabled: false, diagnostics)
+                   isIterator: false, isExtensionMethod: false, isReadOnly: isReadOnly, hasBody: hasBody, isNullableAnalysisEnabled: false, diagnostics)
         {
             _memberOffset = memberOffset;
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -33165,6 +33165,29 @@ class Test1 : I1, I2
         }
 
         [Fact]
+        public void PartialMethodAccessibility()
+        {
+            var source1 =
+@"
+public partial interface I
+{
+    partial void M();
+    partial void M() { }
+}
+";
+
+            var comp = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetCoreApp);
+            Assert.True(comp.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+            comp.VerifyDiagnostics();
+
+            var @interface = comp.SourceModule.GlobalNamespace.GetTypeMember("I");
+            var method = @interface.GetMembers().OfType<MethodSymbol>().Single();
+            Assert.Equal(Accessibility.Private, method.DeclaredAccessibility);
+        }
+
+        [Fact]
         [WorkItem(32540, "https://github.com/dotnet/roslyn/issues/32540")]
         public void PropertyImplementationInDerived_01()
         {


### PR DESCRIPTION
Fixes #55825

Commit by commit review will demonstrate why the check is unneeded.

### Commit 1:

- Corrects the value of `isPartial`. For background see #45424, specifically:
    - In #45424, see `SourceOrdinaryMethodSymbol.cs` which had:

        ```csharp
        var defaultAccess = isInterface && modifiers.IndexOf(SyntaxKind.PartialKeyword) < 0 && !isExplicitInterfaceImplementation ? DeclarationModifiers.Public : DeclarationModifiers.Private;
        ```

    - This code was moved to `SourceOrdinaryMethodSymbolBase.cs` as:

        ```csharp
        var defaultAccess = isInterface && isPartial && !isExplicitInterfaceImplementation ? DeclarationModifiers.Public : DeclarationModifiers.Private;
        ```

    - Ooops? The original check was `!isPartial` and the new one is `isPartial`?
    - Nope, `isPartial` passed to `SourceOrdinarySymbolBase` from `SourceOrdinaryMethodSymbol.cs` through base constructor is `isPartial: syntax.Modifiers.IndexOf(SyntaxKind.PartialKeyword) < 0`
    - **NOTE:** The value fixed in commit 1 isn't too important as it will be removed in the second commit. I just wanted to restore the original intent, nothing more.
    - The important part in this commit is following all the possible combinations of `isInterface`, `isPartial`, and `isExplicitInterfaceImplementation` to simplify the code.

### Commit 2:

Look at the truth table I added in commit 1 for all possible combinations, then figure out `isPartial` is unnecessary, and `DeclarationModifiers.Public` is unused.
