### PR TITLE
KeyOriginatorFile is input to csc task

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -30,7 +30,7 @@
                   @(Compile);
                   @(_CoreCompileResourceInputs);
                   $(ApplicationIcon);
-                  $(AssemblyOriginatorKeyFile);
+                  $(KeyOriginatorFile);
                   @(ReferencePathWithRefAssemblies);
                   @(CompiledLicenseFile);
                   @(LinkResource);

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -8,7 +8,7 @@
                   @(Compile);
                   @(_CoreCompileResourceInputs);
                   $(ApplicationIcon);
-                  $(AssemblyOriginatorKeyFile);
+                  $(KeyOriginatorFile);
                   @(ReferencePathWithRefAssemblies);
                   @(CompiledLicenseFile);
                   @(LinkResource);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59992

I'm not most familiar with target files, but the way we had it did seem wrong, as we use `KeyFile="$(KeyOriginatorFile)"` in the `<Csc>` task a few lines below.
@jaredpar @agocke @chsienki @RikkiGibson for review.