### PR TITLE
Inline Diagnostics Multi-Line Errors

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManager.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
 
         protected SnapshotPoint? GetMappedPoint(SnapshotSpan snapshotSpan, IMappingTagSpan<T> mappingTagSpan)
         {
-            var point = mappingTagSpan.Span.Start.GetPoint(snapshotSpan.Snapshot, PositionAffinity.Predecessor);
+            var point = mappingTagSpan.Span.End.GetPoint(snapshotSpan.Snapshot, PositionAffinity.Predecessor);
             if (point == null)
             {
                 return null;

--- a/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
@@ -117,47 +117,6 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
         }
 
         /// <summary>
-        /// Get the spans located on each line so that it can only display the first one that appears on the line
-        /// </summary>
-        private void AddSpansOnEachLine(NormalizedSnapshotSpanCollection changedSpanCollection,
-            Dictionary<int, IMappingTagSpan<InlineDiagnosticsTag>> map)
-        {
-            var viewLines = TextView.TextViewLines;
-
-            foreach (var changedSpan in changedSpanCollection)
-            {
-                if (!viewLines.IntersectsBufferSpan(changedSpan))
-                {
-                    continue;
-                }
-
-                var tagSpans = TagAggregator.GetTags(changedSpan);
-                foreach (var tagMappingSpan in tagSpans)
-                {
-                    if (!ShouldDrawTag(changedSpan, tagMappingSpan, out var mappedPoint))
-                    {
-                        continue;
-                    }
-
-                    // mappedPoint is known to not be null here because it is checked in the ShouldDrawTag method call.
-                    var lineNum = mappedPoint.GetContainingLine().LineNumber;
-
-                    // If the line does not have an associated tagMappingSpan and changedSpan, then add the first one.
-                    if (!map.TryGetValue(lineNum, out var value))
-                    {
-                        map.Add(lineNum, tagMappingSpan);
-                    }
-                    else if (value.Tag.ErrorType is not PredefinedErrorTypeNames.SyntaxError && tagMappingSpan.Tag.ErrorType is PredefinedErrorTypeNames.SyntaxError)
-                    {
-                        // Draw the first instance of an error, if what is stored in the map at a specific line is
-                        // not an error, then replace it. Otherwise, just get the first warning on the line.
-                        map[lineNum] = tagMappingSpan;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
         /// Iterates through the mapping of line number to span and draws the diagnostic in the appropriate position on the screen,
         /// as well as adding the tag to the adornment layer.
         /// </summary>
@@ -236,6 +195,47 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
                     tag: tag,
                     adornment: visualElement,
                     removedCallback: delegate { graphicsResult.Dispose(); });
+            }
+        }
+
+        /// <summary>
+        /// Get the spans located on each line so that it can only display the first one that appears on the line
+        /// </summary>
+        private void AddSpansOnEachLine(NormalizedSnapshotSpanCollection changedSpanCollection,
+            Dictionary<int, IMappingTagSpan<InlineDiagnosticsTag>> map)
+        {
+            var viewLines = TextView.TextViewLines;
+
+            foreach (var changedSpan in changedSpanCollection)
+            {
+                if (!viewLines.IntersectsBufferSpan(changedSpan))
+                {
+                    continue;
+                }
+
+                var tagSpans = TagAggregator.GetTags(changedSpan);
+                foreach (var tagMappingSpan in tagSpans)
+                {
+                    if (!ShouldDrawTag(changedSpan, tagMappingSpan, out var mappedPoint))
+                    {
+                        continue;
+                    }
+
+                    // mappedPoint is known to not be null here because it is checked in the ShouldDrawTag method call.
+                    var lineNum = mappedPoint.GetContainingLine().LineNumber;
+
+                    // If the line does not have an associated tagMappingSpan and changedSpan, then add the first one.
+                    if (!map.TryGetValue(lineNum, out var value))
+                    {
+                        map.Add(lineNum, tagMappingSpan);
+                    }
+                    else if (value.Tag.ErrorType is not PredefinedErrorTypeNames.SyntaxError && tagMappingSpan.Tag.ErrorType is PredefinedErrorTypeNames.SyntaxError)
+                    {
+                        // Draw the first instance of an error, if what is stored in the map at a specific line is
+                        // not an error, then replace it. Otherwise, just get the first warning on the line.
+                        map[lineNum] = tagMappingSpan;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes: [AB#1486913](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1486913)

I made an earlier PR (#58398) to look at the ending span location to draw the tag in the correct location. I did not also edit what creates the mapping of line number to tag to use the span end, which is why we were seeing multiple tags on the same line.