### PR TITLE
Fix support for OOP reporting diagnostics in source generated files

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -215,7 +215,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         // TODO: filter in OOP https://github.com/dotnet/roslyn/issues/47859
         private static ImmutableDictionary<DocumentId, ImmutableArray<DiagnosticData>> Hydrate(ImmutableArray<(DocumentId documentId, ImmutableArray<DiagnosticData> diagnostics)> diagnosticByDocument, Project project)
             => diagnosticByDocument
-                .Where(entry => project.GetTextDocument(entry.documentId)?.SupportsDiagnostics() == true)
+                .Where(
+                    entry =>
+                    {
+                        // Source generated documents (for which GetTextDocument returns null) support diagnostics. Only
+                        // filter out diagnostics where the document is non-null and SupportDiagnostics() is false.
+                        return project.GetTextDocument(entry.documentId)?.SupportsDiagnostics() != false;
+                    })
                 .ToImmutableDictionary(entry => entry.documentId, entry => entry.diagnostics);
     }
 }


### PR DESCRIPTION
This change makes the following two filters use the same logic:

https://github.com/dotnet/roslyn/blob/be1e3b799c9d16cbe5377e91c3e0471d9e79bcb9/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs#L215-L219

https://github.com/dotnet/roslyn/blob/be1e3b799c9d16cbe5377e91c3e0471d9e79bcb9/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs#L473-L478