### PR TITLE
Preserve the lack of trivia at the end of the file

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertNamespaceCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertNamespaceCommandHandlerTests.cs
@@ -70,8 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
 
 class C
 {
-}
-");
+}");
         }
 
         [WpfFact]
@@ -115,8 +114,7 @@ class C
 
 class C
 {
-}
-");
+}");
         }
 
         [WpfFact]
@@ -199,8 +197,7 @@ class C
 
 class C
 {
-}
-");
+}");
         }
 
         [WpfFact]
@@ -305,8 +302,7 @@ namespace N;$$
 
 class C
 {
-}
-");
+}");
         }
 
         [WpfFact]
@@ -334,8 +330,7 @@ using B;
 
 class C
 {
-}
-");
+}");
         }
 
         [WpfFact]
@@ -355,8 +350,7 @@ class C
 
 class C
 {
-}
-");
+}");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.ConvertNamespace;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
@@ -708,6 +709,104 @@ class C { } ",
 namespace $$N;
 
 class C { } ",
+                LanguageVersion = LanguageVersion.CSharp10,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(59728, "https://github.com/dotnet/roslyn/issues/59728")]
+        public async Task TestConvertToFileScopedWithNoNewlineAtEnd()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+[|namespace N|]
+{
+    class C
+    {
+    }
+}",
+                FixedCode = @"
+namespace $$N;
+
+class C
+{
+}",
+                LanguageVersion = LanguageVersion.CSharp10,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(59728, "https://github.com/dotnet/roslyn/issues/59728")]
+        public async Task TestConvertToFileScopedWithNoMembersAndNoNewlineAtEnd()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+[|namespace N|]
+{
+}",
+                FixedCode = @"
+namespace $$N;",
+                LanguageVersion = LanguageVersion.CSharp10,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(59728, "https://github.com/dotnet/roslyn/issues/59728")]
+        public async Task TestConvertToFileScopedPreserveNewlineAtEnd()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+[|namespace N|]
+{
+    class C
+    {
+    }
+}
+",
+                FixedCode = @"
+namespace $$N;
+
+class C
+{
+}
+",
+                LanguageVersion = LanguageVersion.CSharp10,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(59728, "https://github.com/dotnet/roslyn/issues/59728")]
+        public async Task TestConvertToFileScopedWithNoMembersPreserveNewlineAtEnd()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+[|namespace N|]
+{
+}
+",
+                FixedCode = @"
+namespace $$N;
+",
                 LanguageVersion = LanguageVersion.CSharp10,
                 Options =
                 {

--- a/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CSharpNewDocumentFormattingServiceTests.cs
@@ -36,8 +36,7 @@ namespace Goo;
 
 internal class C
 {
-}
-",
+}",
             options: new[]
             {
                 (CSharpCodeStyleOptions.NamespaceDeclarations, new CodeStyleOption2<NamespaceDeclarationPreference>(NamespaceDeclarationPreference.FileScoped, NotificationOption2.Error))
@@ -188,8 +187,7 @@ namespace Goo
 namespace Goo;
 internal class C
 {
-}
-",
+}",
             options: new (OptionKey, object)[]
             {
                 (new OptionKey(CSharpCodeStyleOptions.NamespaceDeclarations), new CodeStyleOption2<NamespaceDeclarationPreference>(NamespaceDeclarationPreference.FileScoped, NotificationOption2.Error)),

--- a/src/Features/CSharp/Portable/ConvertNamespace/ConvertNamespaceTransform.cs
+++ b/src/Features/CSharp/Portable/ConvertNamespace/ConvertNamespaceTransform.cs
@@ -208,6 +208,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
             // Copy leading trivia from the close brace to the end of the file scoped namespace (which means after all of the members)
             fileScopedNamespace = fileScopedNamespace.WithAppendedTrailingTrivia(namespaceDeclaration.CloseBraceToken.LeadingTrivia);
 
+            // If the previous namespace declaration had no trailing trivia and the last member only has a newline, then assume the user
+            // doesn't want that newline any more.
+            if (!namespaceDeclaration.HasTrailingTrivia &&
+                namespaceDeclaration.CloseBraceToken.GetPreviousToken() is var lastMemberToken &&
+                lastMemberToken.TrailingTrivia is [{ RawKind: (int)SyntaxKind.EndOfLineTrivia }])
+            {
+                fileScopedNamespace = fileScopedNamespace.WithoutTrailingTrivia();
+            }
+
             return fileScopedNamespace;
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59728