### PR TITLE
Inline Diagnostics: Call dispose and removed event handler that was unnnecessary

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
@@ -179,6 +179,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
                 // Only place the diagnostics if the diagnostic would not intersect with the editor window
                 if (lineView.Right >= TextView.ViewportWidth - visualElement.DesiredSize.Width)
                 {
+                    graphicsResult.Dispose();
                     continue;
                 }
 

--- a/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsTag.cs
@@ -122,7 +122,6 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
             ImageThemingUtilities.SetImageBackgroundColor(border, editorBackground);
 
             border.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
-            view.ViewportWidthChanged += ViewportWidthChangedHandler;
             view.LayoutChanged += View_LayoutChanged;
 
             return new GraphicsResult(border, dispose:
@@ -133,21 +132,8 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
                         hyperlink.RequestNavigate -= HandleRequestNavigate;
                     }
 
-                    view.ViewportWidthChanged -= ViewportWidthChangedHandler;
                     view.LayoutChanged -= View_LayoutChanged;
                 });
-
-            // The tag listens to the width changing to allow the diagnostic UI to move with
-            // the window as it gets moved.
-            // The InlineDiagnosticsAdornmentManager listens to the viewport width
-            // changing to deal with diagnostics intersecting with the text in the editor.
-            void ViewportWidthChangedHandler(object s, EventArgs e)
-            {
-                if (Location is InlineDiagnosticsLocations.PlacedAtEndOfEditor)
-                {
-                    Canvas.SetLeft(border, view.ViewportRight - border.DesiredSize.Width);
-                }
-            }
 
             void View_LayoutChanged(object sender, TextViewLayoutChangedEventArgs e)
             {


### PR DESCRIPTION
Fixes: [AB#1491682](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1491682) 

I was creating GraphicsResults for InlineDiagnostics and not disposing of all of them. In a specific case I was not adding to the adornment layer if it obstructed with the edge of the text view window, but I should have been disposing of them.

I was also subscribing to a ViewPortWidthChanged event for each tag, but it was unnecessary since I was subscribing to the same event in the ```InlineDiagnosticsAdornmentManager``` that removed all inline diagnostic adornments and redrew them.