### PR TITLE
Fix reporting Hot Reload diagnostics for cshtml files

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/CompileTimeSolutionProviderTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/CompileTimeSolutionProviderTests.cs
@@ -25,17 +25,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
     public class CompileTimeSolutionProviderTests
     {
         [Theory]
-        [CombinatorialData]
-        public async Task TryGetCompileTimeDocumentAsync([CombinatorialValues(@"_a_X_razor.cs", @"a_X_razor.g.cs")] string generatedHintName)
+        [InlineData("razor")]
+        [InlineData("cshtml")]
+        public async Task TryGetCompileTimeDocumentAsync(string kind)
         {
             var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features);
             var projectId = ProjectId.CreateNewId();
 
             var projectFilePath = Path.Combine(TempRoot.Root, "a.csproj");
-            var additionalFilePath = Path.Combine(TempRoot.Root, "a", "X.razor");
-            var designTimeFilePath = Path.Combine(TempRoot.Root, "a", "X.razor.g.cs");
+            var additionalFilePath = Path.Combine(TempRoot.Root, "a", $"X.{kind}");
+            var designTimeFilePath = Path.Combine(TempRoot.Root, "a", $"X.{kind}.g.cs");
 
-            var generator = new TestSourceGenerator() { ExecuteImpl = context => context.AddSource(generatedHintName, "") };
+            var generator = new TestSourceGenerator() { ExecuteImpl = context => context.AddSource($"a_X_{kind}.g.cs", "") };
             var sourceGeneratedPathPrefix = Path.Combine(typeof(TestSourceGenerator).Assembly.GetName().Name, typeof(TestSourceGenerator).FullName);
             var analyzerConfigId = DocumentId.CreateNewId(projectId);
             var documentId = DocumentId.CreateNewId(projectId);

--- a/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
+++ b/src/Features/Core/Portable/Workspace/CompileTimeSolutionProvider.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Host
         }
 
         private static bool IsRazorDesignTimeDocument(DocumentState documentState)
-            => documentState.Attributes.DesignTimeOnly && documentState.FilePath?.EndsWith(".razor.g.cs") == true;
+            => documentState.Attributes.DesignTimeOnly && (documentState.FilePath?.EndsWith(".razor.g.cs") == true || documentState.FilePath?.EndsWith(".cshtml.g.cs") == true);
 
         internal static async Task<Document?> TryGetCompileTimeDocumentAsync(
             Document designTimeDocument,
@@ -205,57 +205,37 @@ namespace Microsoft.CodeAnalysis.Host
             var designTimeProjectDirectoryName = PathUtilities.GetDirectoryName(designTimeDocument.Project.FilePath)!;
 
             var generatedDocumentPath = BuildGeneratedDocumentPath(designTimeProjectDirectoryName, designTimeDocument.FilePath!, generatedDocumentPathPrefix);
-            var generatedDocumentPathNet6Preview7 = BuildGeneratedDocumentPathNet6Preview7(designTimeProjectDirectoryName, designTimeDocument.FilePath!, generatedDocumentPathPrefix);
 
             var sourceGeneratedDocuments = await compileTimeSolution.GetRequiredProject(designTimeDocument.Project.Id).GetSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false);
-            return sourceGeneratedDocuments.SingleOrDefault(d => d.FilePath == generatedDocumentPath || d.FilePath == generatedDocumentPathNet6Preview7);
+            return sourceGeneratedDocuments.SingleOrDefault(d => d.FilePath == generatedDocumentPath);
         }
 
         /// <summary>
-        /// Prior to .net6 preview 7, the source generated path was built using a relative path with a preceding \
-        /// and without only .cs as part of the extension.
+        /// Note that in .NET 6 Preview 7 the source generator changed to passing in the relative doc path without a leading \ to GetIdentifierFromPath
+        /// which caused the source generated file name to no longer be prefixed by an _.  Additionally, the file extension was changed to .g.cs
         /// </summary>
         private static string BuildGeneratedDocumentPath(string designTimeProjectDirectoryName, string designTimeDocumentFilePath, string? generatedDocumentPathPrefix)
         {
-            var relativeDocumentPath = GetRelativeDocumentPathWithPrecedingSlash(designTimeProjectDirectoryName, designTimeDocumentFilePath);
-            var generatedDocumentPath = GetGeneratedDocumentPathWithoutExtension(relativeDocumentPath, generatedDocumentPathPrefix) + ".cs";
-            return generatedDocumentPath;
-        }
-
-        /// <summary>
-        /// In .net6 p7 the source generator changed to passing in the relative doc path without a leading \ to GetIdentifierFromPath
-        /// which caused the source generated file name to no longer be prefixed by an _.  Additionally, the file extension was changed to .g.cs
-        /// </summary>
-        private static string BuildGeneratedDocumentPathNet6Preview7(string designTimeProjectDirectoryName, string designTimeDocumentFilePath, string? generatedDocumentPathPrefix)
-        {
             var relativeDocumentPath = GetRelativeDocumentPath(designTimeProjectDirectoryName, designTimeDocumentFilePath);
-            var generatedDocumentPath = GetGeneratedDocumentPathWithoutExtension(relativeDocumentPath, generatedDocumentPathPrefix) + ".g.cs";
-            return generatedDocumentPath;
+            return GetGeneratedDocumentPathWithoutExtension(relativeDocumentPath, generatedDocumentPathPrefix) + ".g.cs";
         }
 
         private static string GetRelativeDocumentPath(string projectDirectory, string designTimeDocumentFilePath)
             => PathUtilities.GetRelativePath(projectDirectory, designTimeDocumentFilePath)[..^".g.cs".Length];
-
-        private static string GetRelativeDocumentPathWithPrecedingSlash(string projectDirectory, string designTimeDocumentFilePath)
-            => Path.Combine("\\", GetRelativeDocumentPath(projectDirectory, designTimeDocumentFilePath));
 
         private static string GetGeneratedDocumentPathWithoutExtension(string relativeDocumentPath, string? generatedDocumentPathPrefix)
             => Path.Combine(generatedDocumentPathPrefix ?? s_razorSourceGeneratorFileNamePrefix, GetIdentifierFromPath(relativeDocumentPath));
 
         private static bool HasMatchingFilePath(string designTimeDocumentFilePath, string designTimeProjectDirectory, string compileTimeFilePath)
         {
-            // Check for matching file names created from a relative path with and without a preceding slash as both
-            // are valid depening on the which sdk.  See BuildGeneratedDocumentPathNet6Preview7.
             var relativeDocumentPath = GetRelativeDocumentPath(designTimeProjectDirectory, designTimeDocumentFilePath);
-            var relativeDocumentPathWithSlash = GetRelativeDocumentPathWithPrecedingSlash(designTimeProjectDirectory, designTimeDocumentFilePath);
 
             var compileTimeFileName = PathUtilities.GetFileName(compileTimeFilePath, includeExtension: false);
 
-            // Sdks including and after .net6 preview7 have compile time file names ending with ".g.cs".
-            if (compileTimeFileName.EndsWith(".g"))
+            if (compileTimeFileName.EndsWith(".g", StringComparison.Ordinal))
                 compileTimeFileName = compileTimeFileName[..^".g".Length];
 
-            return compileTimeFileName == GetIdentifierFromPath(relativeDocumentPath) || compileTimeFileName == GetIdentifierFromPath(relativeDocumentPathWithSlash);
+            return compileTimeFileName == GetIdentifierFromPath(relativeDocumentPath);
         }
 
         internal static async Task<ImmutableArray<DocumentId>> GetDesignTimeDocumentsAsync(


### PR DESCRIPTION
The issue is with mapping between compile-time and design-time-only files. The mapping only handled razor files, not cshtml files.

In addition when an error is reported in `#line hidden` region of the source-generated file it was not mapped to the design-time-only file.

Also removes mapping logic that handled older format of compiler-generated file names (prior .NET 6 Preview 7).

Partially fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1462272