### PR TITLE
Analyze flow in receiver of extension method group in delegate creation

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1513,15 +1513,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             var methodGroup = node.Argument as BoundMethodGroup;
             if (methodGroup != null)
             {
-                if ((object)node.MethodOpt != null && node.MethodOpt.RequiresInstanceReceiver)
+                if (node.MethodOpt?.OriginalDefinition is LocalFunctionSymbol localFunc)
+                {
+                    VisitLocalFunctionUse(localFunc, node.Syntax, isCall: false);
+                }
+                else if (node.MethodOpt is not null && methodGroup.ReceiverOpt is not null)
                 {
                     EnterRegionIfNeeded(methodGroup);
                     VisitRvalue(methodGroup.ReceiverOpt);
                     LeaveRegionIfNeeded(methodGroup);
-                }
-                else if (node.MethodOpt?.OriginalDefinition is LocalFunctionSymbol localFunc)
-                {
-                    VisitLocalFunctionUse(localFunc, node.Syntax, isCall: false);
                 }
             }
             else

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1517,7 +1517,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     VisitLocalFunctionUse(localFunc, node.Syntax, isCall: false);
                 }
-                else if (node.MethodOpt is not null && methodGroup.ReceiverOpt is not null)
+                else if (node.MethodOpt is { } method && methodGroup.ReceiverOpt is { } receiver && !ignoreReceiver(receiver, method))
                 {
                     EnterRegionIfNeeded(methodGroup);
                     VisitRvalue(methodGroup.ReceiverOpt);
@@ -1530,6 +1530,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return null;
+
+            static bool ignoreReceiver(BoundExpression receiver, MethodSymbol method)
+            {
+                // ignore the implicit `this` receiver on a static method
+                return method.IsStatic && receiver is { Kind: BoundKind.ThisReference, WasCompilerGenerated: true };
+            }
         }
 
         public override BoundNode VisitTypeExpression(BoundTypeExpression node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1533,8 +1533,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             static bool ignoreReceiver(BoundExpression receiver, MethodSymbol method)
             {
-                // ignore the implicit `this` receiver on a static method
-                return method.IsStatic && receiver is { Kind: BoundKind.ThisReference, WasCompilerGenerated: true };
+                // static methods that aren't extensions get an implicit `this` receiver that should be ignored
+                return method.IsStatic && !method.IsExtensionMethod;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1520,7 +1520,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (node.MethodOpt is { } method && methodGroup.ReceiverOpt is { } receiver && !ignoreReceiver(receiver, method))
                 {
                     EnterRegionIfNeeded(methodGroup);
-                    VisitRvalue(methodGroup.ReceiverOpt);
+                    VisitRvalue(receiver);
                     LeaveRegionIfNeeded(methodGroup);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/59738 again

This is PR https://github.com/dotnet/roslyn/pull/59874, but with an extra commit to ignore the implicit `this` receiver on a static method. 
Adjusting the initial binding to remove that receiver seems desirable but riskier, so I'm sticking with a local fix. See https://github.com/dotnet/roslyn/pull/56395 for a similar situation.