### PR TITLE
Ensure generated trees have a full path 

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
@@ -184,6 +184,77 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
         }
 
         [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
+        public void SourceGenerator()
+        {
+            SourceGeneratorImpl();
+        }
+
+        internal override string GetExpectedOutputForSourceGenerator(CommonCompiler cmd, string sourceFile)
+        {
+            var expectedHeader = GetExpectedErrorLogHeader(cmd);
+            var expectedIssues = string.Format(@"
+      ""results"": [
+        {{
+          ""ruleId"": ""CS0116"",
+          ""level"": ""error"",
+          ""message"": ""A namespace cannot directly contain members such as fields, methods or statements"",
+          ""locations"": [
+            {{
+              ""resultFile"": {{
+                ""uri"": ""{0}"",
+                ""region"": {{
+                  ""startLine"": 1,
+                  ""startColumn"": 1,
+                  ""endLine"": 1,
+                  ""endColumn"": 9
+                }}
+              }}
+            }}
+          ]
+        }},
+        {{
+          ""ruleId"": ""CS5001"",
+          ""level"": ""error"",
+          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point""
+        }}
+      ],
+      ""rules"": {{
+        ""CS0116"": {{
+          ""id"": ""CS0116"",
+          ""defaultLevel"": ""error"",
+          ""helpUri"": ""https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0116)"",
+          ""properties"": {{
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry"",
+              ""NotConfigurable""
+            ]
+          }}
+        }},
+        ""CS5001"": {{
+          ""id"": ""CS5001"",
+          ""defaultLevel"": ""error"",
+          ""helpUri"": ""https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS5001)"",
+          ""properties"": {{
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry"",
+              ""NotConfigurable""
+            ]
+          }}
+        }}
+      }}
+    }}
+  ]
+}}", AnalyzerForErrorLogTest.GetUriForPath(sourceFile));
+            return expectedHeader + expectedIssues;
+        }
+
+        [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/30289")]
         public void SimpleCompilerDiagnosticsSuppressed()
         {
             SimpleCompilerDiagnosticsSuppressedImpl();

--- a/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV2ErrorLoggerTests.cs
@@ -349,6 +349,103 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             AnalyzerDiagnosticsSuppressedWithNullJustificationImpl();
         }
 
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void SourceGenerator()
+        {
+            SourceGeneratorImpl();
+        }
+
+        internal override string GetExpectedOutputForSourceGenerator(CommonCompiler cmd, string sourceFile)
+        {
+            var expectedOutput = @"{{
+  ""$schema"": ""http://json.schemastore.org/sarif-2.1.0"",
+  ""version"": ""2.1.0"",
+  ""runs"": [
+    {{
+      ""results"": [
+        {{
+          ""ruleId"": ""CS0116"",
+          ""ruleIndex"": 0,
+          ""level"": ""error"",
+          ""message"": {{
+            ""text"": ""A namespace cannot directly contain members such as fields, methods or statements""
+          }},
+          ""locations"": [
+            {{
+              ""physicalLocation"": {{
+                ""artifactLocation"": {{
+                  ""uri"": ""{5}""
+                }},
+                ""region"": {{
+                  ""startLine"": 1,
+                  ""startColumn"": 1,
+                  ""endLine"": 1,
+                  ""endColumn"": 9
+                }}
+              }}
+            }}
+          ]
+        }},
+        {{
+          ""ruleId"": ""CS5001"",
+          ""ruleIndex"": 1,
+          ""level"": ""error"",
+          ""message"": {{
+            ""text"": ""Program does not contain a static 'Main' method suitable for an entry point""
+          }}
+        }}
+      ],
+      ""tool"": {{
+        ""driver"": {{
+          ""name"": ""{0}"",
+          ""version"": ""{1}"",
+          ""dottedQuadFileVersion"": ""{2}"",
+          ""semanticVersion"": ""{3}"",
+          ""language"": ""{4}"",
+          ""rules"": [
+            {{
+              ""id"": ""CS0116"",
+              ""defaultConfiguration"": {{
+                ""level"": ""error""
+              }},
+              ""helpUri"": ""https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0116)"",
+              ""properties"": {{
+                ""category"": ""Compiler"",
+                ""tags"": [
+                  ""Compiler"",
+                  ""Telemetry"",
+                  ""NotConfigurable""
+                ]
+              }}
+            }},
+            {{
+              ""id"": ""CS5001"",
+              ""defaultConfiguration"": {{
+                ""level"": ""error""
+              }},
+              ""helpUri"": ""https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS5001)"",
+              ""properties"": {{
+                ""category"": ""Compiler"",
+                ""tags"": [
+                  ""Compiler"",
+                  ""Telemetry"",
+                  ""NotConfigurable""
+                ]
+              }}
+            }}
+          ]
+        }}
+      }},
+      ""columnKind"": ""utf16CodeUnits""
+    }}
+  ]
+}}";
+            return FormatOutputText(
+              expectedOutput,
+              cmd,
+              AnalyzerForErrorLogTest.GetUriForPath(sourceFile));
+        }
+
         private string FormatOutputText(
           string s,
           CommonCompiler compiler,

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -1050,21 +1050,22 @@ namespace Microsoft.CodeAnalysis
                             // write out the file if we have an output path
                             if (hasGeneratedOutputPath)
                             {
+                                var path = tree.FilePath;
                                 if (Directory.Exists(Arguments.GeneratedFilesOutputDirectory))
                                 {
-                                    Directory.CreateDirectory(Path.GetDirectoryName(tree.FilePath)!);
+                                    Directory.CreateDirectory(Path.GetDirectoryName(path)!);
                                 }
 
-                                var fileStream = OpenFile(tree.FilePath, diagnostics, FileMode.Create, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
+                                var fileStream = OpenFile(path, diagnostics, FileMode.Create, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
                                 if (fileStream is object)
                                 {
                                     Debug.Assert(tree.Encoding is object);
 
-                                    using var disposer = new NoThrowStreamDisposer(fileStream, tree.FilePath, diagnostics, MessageProvider);
+                                    using var disposer = new NoThrowStreamDisposer(fileStream, path, diagnostics, MessageProvider);
                                     using var writer = new StreamWriter(fileStream, tree.Encoding);
 
                                     sourceText.Write(writer, cancellationToken);
-                                    touchedFilesLogger?.AddWritten(tree.FilePath);
+                                    touchedFilesLogger?.AddWritten(path);
                                 }
                             }
                         }


### PR DESCRIPTION
- Use GeneratedFilesOutputDirectory as the base if provided
- Fallback to OutputDirectory when not
- Add tests and fix full PDB verification

Fixes https://github.com/dotnet/roslyn/issues/51998 
Fixes https://github.com/dotnet/roslyn/issues/51773