### PR TITLE
Keep track of when a file code model is created.

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
@@ -37,6 +38,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             bool isSourceGeneratorOutput,
             ITextManagerAdapter textManagerAdapter)
         {
+            // Keep track that code model was accessed.  We want to get a sense of how widespread usage of it still is.
+            Logger.Log(FunctionId.CodeModel_FileCodeModel_Create);
             return new FileCodeModel(state, parent, documentId, isSourceGeneratorOutput, textManagerAdapter).GetComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>();
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -539,5 +539,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         NavigateToExternalSources = 531,
 
         StackTraceToolWindow_ShowOnActivated = 540,
+
+        CodeModel_FileCodeModel_Create = 550,
     }
 }


### PR DESCRIPTION
Note: we already collect information for CodeFunction.GetXml.