### PR TITLE
Update Roslyn.Diagnostics.Analyzers to 3.3.4-beta1.22160.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versions used by several individual references below -->
-    <RoslynDiagnosticsNugetPackageVersion>3.3.3-beta1.21105.3</RoslynDiagnosticsNugetPackageVersion>
+    <RoslynDiagnosticsNugetPackageVersion>3.3.4-beta1.22160.2</RoslynDiagnosticsNugetPackageVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-rc1.21366.2</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.22122.4</MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.127-beta</MicrosoftVisualStudioExtensibilityTestingVersion>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/TemporaryArray`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Collections/TemporaryArray`1.cs
@@ -286,6 +286,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
         private static void ThrowIndexOutOfRangeException()
             => throw new IndexOutOfRangeException();
 
+        [NonCopyable]
         public struct Enumerator
         {
             private readonly TemporaryArray<T> _array;


### PR DESCRIPTION
Now we have this refactoring:

![image](https://user-images.githubusercontent.com/1408396/157951487-8b13c535-2a31-4e5b-85cb-e12bb071da13.png)

Also works for existing tests that use `[CombinatorialData]` for other reasons:

![image](https://user-images.githubusercontent.com/1408396/157952363-477f465d-a0d5-4427-8a8b-2b72f493c9ff.png)
