### PR TITLE
Disable IntelliCode RepositoryAttachedModels in CI

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -579,6 +579,9 @@ function Deploy-VsixViaTool() {
   # Disable IntelliCode line completions to avoid interference with argument completion testing
   &$vsRegEdit set "$vsDir" $hive HKCU "ApplicationPrivateSettings\Microsoft\VisualStudio\IntelliCode" wholeLineCompletions string "0*System.Int32*2"
 
+  # Disable IntelliCode RepositoryAttachedModels since it requires authentication which can fail in CI
+  &$vsRegEdit set "$vsDir" $hive HKCU "ApplicationPrivateSettings\Microsoft\VisualStudio\IntelliCode" repositoryAttachedModels string "0*System.Int32*2"
+
   # Disable background download UI to avoid toasts
   &$vsRegEdit set "$vsDir" $hive HKCU "FeatureFlags\Setup\BackgroundDownload" Value dword 0
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -328,6 +328,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 // Disable IntelliCode line completions to avoid interference with argument completion testing
                 Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"ApplicationPrivateSettings\\Microsoft\\VisualStudio\\IntelliCode\" wholeLineCompletions string \"0*System.Int32*2\"")).WaitForExit();
 
+                // Disable IntelliCode RepositoryAttachedModels since it requires authentication which can fail in CI
+                Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"ApplicationPrivateSettings\\Microsoft\\VisualStudio\\IntelliCode\" repositoryAttachedModels string \"0*System.Int32*2\"")).WaitForExit();
+
                 // Disable background download UI to avoid toasts
                 Process.Start(CreateSilentStartInfo(vsRegEditExeFile, $"set \"{installationPath}\" {Settings.Default.VsRootSuffix} HKCU \"FeatureFlags\\Setup\\BackgroundDownload\" Value dword 0")).WaitForExit();
 


### PR DESCRIPTION
This feature requires authentication which can fail in CI, as shown in the following:

![06 14 32-CSharpCodeActions GenerateMethodInClosedFile-EqualException](https://user-images.githubusercontent.com/1408396/157953869-1a31a64a-5a81-42ee-9cb2-19d54b5e880c.png)
