### PR TITLE
Use frozen partial semantics for syntax classification

### DIFF
--- a/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
@@ -68,6 +68,7 @@ namespace Microsoft.CodeAnalysis.Classification
             // as we do not have to wait on skeletons to be built.
 
             document = document.WithFrozenPartialSemantics(cancellationToken);
+            options = options with { ForceFrozenPartialSemanticsForCrossProcessOperations = true };
 
             var classified = await TryClassifyContainingMemberSpanAsync(
                     context, document, spanToTag.SnapshotSpan, classificationService, typeMap, options, type, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractEditorNavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/AbstractEditorNavigationBarItemService.cs
@@ -25,11 +25,11 @@ namespace Microsoft.CodeAnalysis.Editor.Extensibility.NavigationBar
 
         protected abstract Task<bool> TryNavigateToItemAsync(Document document, WrappedNavigationBarItem item, ITextView textView, ITextVersion textVersion, CancellationToken cancellationToken);
 
-        public async Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(Document document, ITextVersion textVersion, CancellationToken cancellationToken)
+        public async Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(Document document, bool forceFrozenPartialSemanticsForCrossProcessOperations, ITextVersion textVersion, CancellationToken cancellationToken)
         {
             var service = document.GetRequiredLanguageService<CodeAnalysis.NavigationBar.INavigationBarItemService>();
             var workspaceSupportsDocumentChanges = document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocument);
-            var items = await service.GetItemsAsync(document, workspaceSupportsDocumentChanges, cancellationToken).ConfigureAwait(false);
+            var items = await service.GetItemsAsync(document, workspaceSupportsDocumentChanges, forceFrozenPartialSemanticsForCrossProcessOperations, cancellationToken).ConfigureAwait(false);
             return items.SelectAsArray(v => (NavigationBarItem)new WrappedNavigationBarItem(textVersion, v));
         }
 

--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/INavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/INavigationBarItemService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal interface INavigationBarItemService : ILanguageService
     {
-        Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(Document document, ITextVersion textVersion, CancellationToken cancellationToken);
+        Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(Document document, bool forceFrozenPartialSemanticsForCrossProcessOperations, ITextVersion textVersion, CancellationToken cancellationToken);
         bool ShowItemGrayedIfNear(NavigationBarItem item);
 
         /// <summary>

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptNavigationBarItemService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptNavigationBarItemService.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Navigation;
@@ -32,8 +31,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
             _service = service;
         }
 
-        public async Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(
+        public Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(
             Document document, ITextVersion textVersion, CancellationToken cancellationToken)
+        {
+            return ((INavigationBarItemService)this).GetItemsAsync(document, forceFrozenPartialSemanticsForCrossProcessOperations: false, textVersion, cancellationToken);
+        }
+
+        async Task<ImmutableArray<NavigationBarItem>> INavigationBarItemService.GetItemsAsync(
+            Document document, bool forceFrozenPartialSemanticsForCrossProcessOperations, ITextVersion textVersion, CancellationToken cancellationToken)
         {
             var items = await _service.GetItemsAsync(document, cancellationToken).ConfigureAwait(false);
             return ConvertItems(items, textVersion);

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/Symbols/DocumentSymbolsHandler.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/Symbols/DocumentSymbolsHandler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             Contract.ThrowIfNull(document);
 
             var navBarService = document.Project.LanguageServices.GetRequiredService<INavigationBarItemService>();
-            var navBarItems = await navBarService.GetItemsAsync(document, supportsCodeGeneration: false, cancellationToken).ConfigureAwait(false);
+            var navBarItems = await navBarService.GetItemsAsync(document, supportsCodeGeneration: false, forceFrozenPartialSemanticsForCrossProcessOperations: false, cancellationToken).ConfigureAwait(false);
             if (navBarItems.IsEmpty)
                 return Array.Empty<object>();
 

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -46,6 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
                 // as this is just something that happens during solution load and will pass once that is over.  By using
                 // partial semantics, we can ensure we don't spend an inordinate amount of time computing and using full
                 // compilation data (like skeleton assemblies).
+                var forceFrozenPartialSemanticsForCrossProcessOperations = true;
                 var document = textSnapshot.AsText().GetDocumentWithFrozenPartialSemantics(cancellationToken);
                 if (document == null)
                     return null;
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
 
                 using (Logger.LogBlock(FunctionId.NavigationBar_ComputeModelAsync, cancellationToken))
                 {
-                    var items = await itemService.GetItemsAsync(document, textSnapshot.Version, cancellationToken).ConfigureAwait(false);
+                    var items = await itemService.GetItemsAsync(document, forceFrozenPartialSemanticsForCrossProcessOperations, textSnapshot.Version, cancellationToken).ConfigureAwait(false);
                     return new NavigationBarModel(itemService, items);
                 }
             }

--- a/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 Dim snapshot = (Await document.GetTextAsync()).FindCorrespondingEditorTextSnapshot()
 
                 Dim service = document.GetLanguageService(Of INavigationBarItemService)()
-                Dim actualItems = Await service.GetItemsAsync(document, snapshot.Version, Nothing)
+                Dim actualItems = Await service.GetItemsAsync(document, forceFrozenPartialSemanticsForCrossProcessOperations:=False, snapshot.Version, Nothing)
 
                 AssertEqual(expectedItems, actualItems, document.GetLanguageService(Of ISyntaxFactsService)().IsCaseSensitive)
             End Using
@@ -56,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 Dim snapshot = (Await document.GetTextAsync()).FindCorrespondingEditorTextSnapshot()
 
                 Dim service = document.GetLanguageService(Of INavigationBarItemService)()
-                Dim items = Await service.GetItemsAsync(document, snapshot.Version, Nothing)
+                Dim items = Await service.GetItemsAsync(document, forceFrozenPartialSemanticsForCrossProcessOperations:=False, snapshot.Version, Nothing)
 
                 Dim hostDocument = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
                 Dim model As New NavigationBarModel(service, items)
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
 
                 Dim service = document.GetLanguageService(Of INavigationBarItemService)()
 
-                Dim items = Await service.GetItemsAsync(document, snapshot.Version, Nothing)
+                Dim items = Await service.GetItemsAsync(document, forceFrozenPartialSemanticsForCrossProcessOperations:=False, snapshot.Version, Nothing)
 
                 Dim leftItem = items.Single(Function(i) i.Text = leftItemToSelectText)
                 Dim rightItem = selectRightItem(leftItem.ChildItems)
@@ -117,7 +117,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 Dim snapshot = (Await sourceDocument.GetTextAsync()).FindCorrespondingEditorTextSnapshot()
 
                 Dim service = DirectCast(sourceDocument.GetLanguageService(Of INavigationBarItemService)(), AbstractEditorNavigationBarItemService)
-                Dim items = Await service.GetItemsAsync(sourceDocument, snapshot.Version, Nothing)
+                Dim items = Await service.GetItemsAsync(sourceDocument, forceFrozenPartialSemanticsForCrossProcessOperations:=False, snapshot.Version, Nothing)
 
                 Dim leftItem = items.Single(Function(i) i.Text = leftItemToSelectText)
                 Dim rightItem = leftItem.ChildItems.Single(Function(i) i.Text = rightItemToSelectText)

--- a/src/Features/Core/Portable/NavigationBar/INavigationBarItemService.cs
+++ b/src/Features/Core/Portable/NavigationBar/INavigationBarItemService.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.NavigationBar
 {
     internal interface INavigationBarItemService : ILanguageService
     {
-        Task<ImmutableArray<RoslynNavigationBarItem>> GetItemsAsync(Document document, bool supportsCodeGeneration, CancellationToken cancellationToken);
+        Task<ImmutableArray<RoslynNavigationBarItem>> GetItemsAsync(Document document, bool supportsCodeGeneration, bool forceFrozenPartialSemanticsForCrossProcessOperations, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/NavigationBar/IRemoteNavigationBarItemService.cs
+++ b/src/Features/Core/Portable/NavigationBar/IRemoteNavigationBarItemService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.NavigationBar
     internal interface IRemoteNavigationBarItemService
     {
         ValueTask<ImmutableArray<SerializableNavigationBarItem>> GetItemsAsync(
-            PinnedSolutionInfo solutionInfo, DocumentId documentId, bool supportsCodeGeneration, CancellationToken cancellationToken);
+            PinnedSolutionInfo solutionInfo, DocumentId documentId, bool supportsCodeGeneration, bool forceFrozenPartialSemanticsForCrossProcessOperations, CancellationToken cancellationToken);
     }
 
     [DataContract]

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -39,7 +38,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
             _service = service;
         }
 
-        public async Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(Document document, ITextVersion textVersion, CancellationToken cancellationToken)
+        public Task<ImmutableArray<NavigationBarItem>> GetItemsAsync(Document document, ITextVersion textVersion, CancellationToken cancellationToken)
+        {
+            return ((INavigationBarItemService)this).GetItemsAsync(document, forceFrozenPartialSemanticsForCrossProcessOperations: false, textVersion, cancellationToken);
+        }
+
+        async Task<ImmutableArray<NavigationBarItem>> INavigationBarItemService.GetItemsAsync(
+            Document document, bool forceFrozenPartialSemanticsForCrossProcessOperations, ITextVersion textVersion, CancellationToken cancellationToken)
         {
             var items = await _service.GetItemsAsync(document, cancellationToken).ConfigureAwait(false);
             return items == null

--- a/src/Workspaces/Core/Portable/Classification/ClassificationOptions.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassificationOptions.cs
@@ -10,7 +10,8 @@ namespace Microsoft.CodeAnalysis.Classification
     internal readonly record struct ClassificationOptions(
         [property: DataMember(Order = 0)] bool ClassifyReassignedVariables = false,
         [property: DataMember(Order = 1)] bool ColorizeRegexPatterns = true,
-        [property: DataMember(Order = 2)] bool ColorizeJsonPatterns = true)
+        [property: DataMember(Order = 2)] bool ColorizeJsonPatterns = true,
+        [property: DataMember(Order = 3)] bool ForceFrozenPartialSemanticsForCrossProcessOperations = false)
     {
         public ClassificationOptions()
             : this(ClassifyReassignedVariables: false)

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
@@ -38,7 +38,8 @@ namespace Microsoft.CodeAnalysis.Classification
         {
             try
             {
-                var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var (_, semanticModel) = await document.GetPartialSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                semanticModel ??= await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 AddSemanticClassifications(semanticModel, textSpan, getNodeClassifiers, getTokenClassifiers, result, options, cancellationToken);
             }
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
@@ -38,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Classification
         {
             try
             {
-                var (_, semanticModel) = await document.GetPartialSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                semanticModel ??= await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 AddSemanticClassifications(semanticModel, textSpan, getNodeClassifiers, getTokenClassifiers, result, options, cancellationToken);
             }
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
@@ -36,6 +36,12 @@ namespace Microsoft.CodeAnalysis.Remote
                 var document = solution.GetDocument(documentId) ?? await solution.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfNull(document);
 
+                if (options.ForceFrozenPartialSemanticsForCrossProcessOperations)
+                {
+                    // Frozen partial semantics is not automatically passed to OOP, so enable it explicitly when desired
+                    document = document.WithFrozenPartialSemantics(cancellationToken);
+                }
+
                 using var _ = ArrayBuilder<ClassifiedSpan>.GetInstance(out var temp);
                 await AbstractClassificationService.AddClassificationsInCurrentProcessAsync(
                     document, span, type, options, temp, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
* Update OOP classification to use frozen partial semantics when in-process request uses it
* Update OOP navigation bars to use frozen partial semantics when in-process request uses it

Fixes [AB#1488520](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1488520)