### PR TITLE
Update 17.1-vs-deps to 17.1 in PublishData.json

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -200,7 +200,7 @@
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[d17.0]"
     },
-    "release/dev17.1-vs-deps": {
+    "release/dev17.1": {
       "nugetKind": [
         "Shipping",
         "NonShipping"


### PR DESCRIPTION
Now that 17.1-vs-deps has been removed, we should update references to it in PublishData.json