### PR TITLE
Support property initializer statement completion

### DIFF
--- a/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
@@ -248,7 +248,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
 
         private static bool CanHaveSemicolon(SyntaxNode currentNode)
         {
-            if (currentNode.IsKind(SyntaxKind.FieldDeclaration, SyntaxKind.DelegateDeclaration, SyntaxKind.ArrowExpressionClause, SyntaxKind.PropertyDeclaration))
+            if (currentNode.IsKind(SyntaxKind.FieldDeclaration, SyntaxKind.DelegateDeclaration, SyntaxKind.ArrowExpressionClause))
+            {
+                return true;
+            }
+
+            if (currentNode.IsKind(SyntaxKind.EqualsValueClause) && currentNode.IsParentKind(SyntaxKind.PropertyDeclaration))
             {
                 return true;
             }
@@ -340,7 +345,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
                 case SyntaxKind.ArrowExpressionClause:
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.RecordDeclaration:
-                case SyntaxKind.PropertyDeclaration:
+                case SyntaxKind.EqualsValueClause:
                 case SyntaxKind.RecordStructDeclaration:
                     // These statement types end in a semicolon. 
                     // if the original caret was inside any delimiters, `caret` will be after the outermost delimiter

--- a/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
 
         private static bool CanHaveSemicolon(SyntaxNode currentNode)
         {
-            if (currentNode.IsKind(SyntaxKind.FieldDeclaration, SyntaxKind.DelegateDeclaration, SyntaxKind.ArrowExpressionClause))
+            if (currentNode.IsKind(SyntaxKind.FieldDeclaration, SyntaxKind.DelegateDeclaration, SyntaxKind.ArrowExpressionClause, SyntaxKind.PropertyDeclaration))
             {
                 return true;
             }
@@ -340,6 +340,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
                 case SyntaxKind.ArrowExpressionClause:
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.RecordDeclaration:
+                case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.RecordStructDeclaration:
                     // These statement types end in a semicolon. 
                     // if the original caret was inside any delimiters, `caret` will be after the outermost delimiter

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -1994,6 +1994,24 @@ public class SaleItem
             VerifyNoSpecialSemicolonHandling(code);
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CompleteStatement)]
+        public void PropertyAccessors8()
+        {
+            var code = @"
+public class C
+{
+   public static C MyProp { get; } = new C($$)
+}";
+
+            var expected = @"
+public class C
+{
+   public static C MyProp { get; } = new C();$$
+}";
+
+            VerifyTypingSemicolon(code, expected);
+        }
+
         #endregion
 
         #region ParenthesizeExpression

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -1995,7 +1995,7 @@ public class SaleItem
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CompleteStatement)]
-        public void PropertyAccessors8()
+        public void PropertyInitializer1()
         {
             var code = @"
 public class C
@@ -2010,6 +2010,25 @@ public class C
 }";
 
             VerifyTypingSemicolon(code, expected);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CompleteStatement)]
+        public void PropertyAttribute1()
+        {
+            var code = @"
+public class C
+{
+    public int P
+    {
+        [My(typeof(C$$))]
+        get
+        {
+            return 0;
+        }
+    }
+}";
+
+            VerifyNoSpecialSemicolonHandling(code);
         }
 
         #endregion


### PR DESCRIPTION
Fixes: #56533

Unsure if this is the correct level to be adding this fix.
Based on other statements not completing till above the `EqualsValue` node I assumed this would also be the case for property initializers.

I might be missing something obvious here.

Checked some edge cases for this such as:
// Staying inside brackets in this case.
```cs
public class C
{
	public static C Prop { $$ }
}
```





