### PR TITLE
Ensure declaring compilation can be located for source symbols created during compilation for EE evaluation.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.PlaceholderLocal.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.PlaceholderLocal.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public PlaceholderLocal(Symbol containingSymbol, object identifier, TypeWithAnnotations type)
             {
                 Debug.Assert(identifier != null);
+                Debug.Assert(containingSymbol is null || containingSymbol.DeclaringCompilation is not null);
                 _containingSymbol = containingSymbol;
                 _type = type;
                 _identifier = identifier;

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureMethod.cs
@@ -41,6 +41,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     : MakeName(topLevelMethod.Name, topLevelMethodId, closureKind, lambdaId),
                    MakeDeclarationModifiers(closureKind, originalMethod))
         {
+            Debug.Assert(containingType.DeclaringCompilation is not null);
+
             TopLevelMethod = topLevelMethod;
             ClosureKind = closureKind;
             LambdaId = lambdaId;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -47,6 +47,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             base(unboundLambda.Syntax.GetReference())
         {
             Debug.Assert(syntaxReferenceOpt is not null);
+            Debug.Assert(containingSymbol.DeclaringCompilation == compilation);
+
             _binder = binder;
             _containingSymbol = containingSymbol;
             _messageID = unboundLambda.Data.MessageID;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -39,6 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             LocalFunctionStatementSyntax syntax)
             : base(syntax.GetReference())
         {
+            Debug.Assert(containingSymbol.DeclaringCompilation == binder.Compilation);
             _containingSymbol = containingSymbol;
 
             _declarationDiagnostics = new BindingDiagnosticBag();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(identifierToken.Kind() != SyntaxKind.None);
             Debug.Assert(declarationKind != LocalDeclarationKind.None);
             Debug.Assert(scopeBinder != null);
+            Debug.Assert(containingSymbol.DeclaringCompilation == scopeBinder.Compilation);
 
             this._scopeBinder = scopeBinder;
             this._containingSymbol = containingSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -231,6 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert((object)containingType != null);
             Debug.Assert(!locations.IsEmpty);
+            Debug.Assert(containingType.DeclaringCompilation is not null);
 
             _containingType = containingType;
             this.locations = locations;

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
@@ -181,5 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return _map.SubstituteType(_underlyingTypeParameter.GetDeducedBaseType(inProgress)).AsTypeSymbolOnly();
         }
+
+        internal override CSharpCompilation DeclaringCompilation => ContainingSymbol.DeclaringCompilation;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
@@ -187,6 +188,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
+                if (!this.IsDefinition)
+                {
+                    return OriginalDefinition.DeclaringCompilation;
+                }
+
                 switch (this.Kind)
                 {
                     case SymbolKind.ErrorType:
@@ -199,8 +205,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return null;
                 }
 
-                var sourceModuleSymbol = this.ContainingModule as SourceModuleSymbol;
-                return (object)sourceModuleSymbol == null ? null : sourceModuleSymbol.DeclaringCompilation;
+                switch (this.ContainingModule)
+                {
+                    case SourceModuleSymbol sourceModuleSymbol:
+                        return sourceModuleSymbol.DeclaringCompilation;
+
+                    case PEModuleSymbol:
+                        // A special handling for EE.
+                        return ContainingSymbol?.DeclaringCompilation;
+                }
+
+                return null;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -48,6 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!type.IsVoidType());
             Debug.Assert(!kind.IsLongLived() || syntaxOpt != null);
             Debug.Assert(refKind != RefKind.Out);
+            Debug.Assert(containingMethodOpt is null || containingMethodOpt.DeclaringCompilation is not null);
 
             _containingMethodOpt = containingMethodOpt;
             _type = type;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(originalVariable != null);
             Debug.Assert(type.HasType);
             Debug.Assert(containingSymbol != null);
+            Debug.Assert(containingSymbol.DeclaringCompilation is not null);
 
             _originalVariable = originalVariable;
             _type = type;

--- a/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             RoslynDebug.Assert(underlyingLocal is object);
             RoslynDebug.Assert(updatedContainingSymbol is object);
+            Debug.Assert(updatedContainingSymbol.DeclaringCompilation is not null);
             Debug.Assert(!assertContaining || updatedContainingSymbol.Equals(underlyingLocal.ContainingSymbol, TypeCompareKind.AllNullableIgnoreOptions));
             ContainingSymbol = updatedContainingSymbol;
             TypeWithAnnotations = updatedType;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/EEMethodBinder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/EEMethodBinder.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal EEMethodBinder(EEMethodSymbol method, MethodSymbol containingMethod, Binder next) : base(next, next.Flags | BinderFlags.InEEMethodBinder)
         {
+            Debug.Assert(method.DeclaringCompilation is not null);
+
             // There are a lot of method symbols floating around and we're doing some subtle things with them.
             //   1) method is the EEMethodSymbol that we're going to synthesize and hand to the debugger to evaluate.
             //   2) containingMethod is the method that we are conceptually in, e.g. the method containing the

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -1613,6 +1613,8 @@ REPARSE:
             MethodSymbol candidateSubstitutedSourceMethod,
             bool sourceMethodMustBeInstance)
         {
+            Debug.Assert(candidateSubstitutedSourceMethod.DeclaringCompilation is not null);
+
             var candidateSubstitutedSourceType = candidateSubstitutedSourceMethod.ContainingType;
 
             string? desiredMethodName;
@@ -1646,9 +1648,12 @@ REPARSE:
                 {
                     if (IsViableSourceMethod(candidateMethod, desiredMethodName, desiredTypeParameters, sourceMethodMustBeInstance))
                     {
+                        MethodSymbol sourceMethod = new EECompilationContextMethod(candidateSubstitutedSourceMethod.DeclaringCompilation!, candidateMethod.OriginalDefinition);
+                        sourceMethod = sourceMethod.AsMember(substitutedSourceType);
+
                         return desiredTypeParameters.Length == 0
-                            ? candidateMethod
-                            : candidateMethod.Construct(candidateSubstitutedSourceType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics);
+                            ? sourceMethod
+                            : sourceMethod.Construct(candidateSubstitutedSourceType.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics);
                     }
                 }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EECompilationContextMethod.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EECompilationContextMethod.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
+{
+    /// <summary>
+    /// The purpose of this symbol is to represent the method that we are actually in during evaluation,
+    /// e.g. a lambda method in a display class. That method is actually a method from a PE module and we want
+    /// to use it as a context for binding in order to make sure that the name lookup and other context dependent
+    /// binding operations work properly. However, if we the use a symbol imported from the PE,
+    /// symbols for locals, lambdas and local functions that will be directly or indirectly parented to it
+    /// during binding won't be able to locate their <see cref="Symbol.DeclaringCompilation"/>, which will break
+    /// assumptions made in different parts of the compilation pipeline. 
+    /// Instead we create this symbol that represents exactly the same method, but pretends that 
+    /// it is declared by EE compilation and allows to return that compilation as <see cref="Symbol.DeclaringCompilation"/>
+    /// for all child symbols created during EE compilation process for evaluation.
+    /// </summary>
+    internal sealed class EECompilationContextMethod : WrappedMethodSymbol
+    {
+        private readonly MethodSymbol _underlyingMethod;
+        private readonly CSharpCompilation _compilation;
+
+        private readonly ImmutableArray<TypeParameterSymbol> _typeParameters;
+        private readonly ImmutableArray<ParameterSymbol> _parameters;
+
+        public EECompilationContextMethod(CSharpCompilation compilation, MethodSymbol underlyingMethod)
+        {
+            Debug.Assert(underlyingMethod.IsDefinition);
+
+            _compilation = compilation;
+
+            var typeMap = underlyingMethod.ContainingType.TypeSubstitution ?? TypeMap.Empty;
+            typeMap.WithAlphaRename(underlyingMethod, this, out _typeParameters);
+
+            _underlyingMethod = underlyingMethod.ConstructIfGeneric(TypeArgumentsWithAnnotations);
+            _parameters = SynthesizedParameterSymbol.DeriveParameters(_underlyingMethod, this);
+        }
+
+        public override MethodSymbol UnderlyingMethod => _underlyingMethod;
+
+        public override ImmutableArray<TypeParameterSymbol> TypeParameters
+        {
+            get { return _typeParameters; }
+        }
+
+        public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
+        {
+            get { return GetTypeParametersAsTypeArguments(); }
+        }
+
+        public override ImmutableArray<ParameterSymbol> Parameters
+        {
+            get { return _parameters; }
+        }
+
+        public override TypeWithAnnotations ReturnTypeWithAnnotations => _underlyingMethod.ReturnTypeWithAnnotations;
+
+        public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<MethodSymbol>.Empty;
+
+        public override ImmutableArray<CustomModifier> RefCustomModifiers => _underlyingMethod.RefCustomModifiers;
+
+        public override Symbol? AssociatedSymbol => _underlyingMethod.AssociatedSymbol;
+
+        public override Symbol ContainingSymbol => _underlyingMethod.ContainingSymbol;
+
+        internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
+        {
+            return _underlyingMethod.CalculateLocalSyntaxOffset(localPosition, localTree);
+        }
+
+        internal override UnmanagedCallersOnlyAttributeData? GetUnmanagedCallersOnlyAttributeData(bool forceComplete)
+        {
+            return _underlyingMethod.GetUnmanagedCallersOnlyAttributeData(forceComplete);
+        }
+
+        internal override bool IsNullableAnalysisEnabled()
+        {
+            return _underlyingMethod.IsNullableAnalysisEnabled();
+        }
+
+        internal override CSharpCompilation DeclaringCompilation => _compilation;
+
+        internal override bool TryGetThisParameter(out ParameterSymbol? thisParameter)
+        {
+            ParameterSymbol underlyingThisParameter;
+            if (!_underlyingMethod.TryGetThisParameter(out underlyingThisParameter))
+            {
+                thisParameter = null;
+                return false;
+            }
+
+            thisParameter = (object)underlyingThisParameter != null
+                ? new ThisParameterSymbol(this)
+                : null;
+            return true;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -94,12 +94,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var sourceMethodTypeParameters = sourceMethod.TypeParameters;
             var allSourceTypeParameters = container.SourceTypeParameters.Concat(sourceMethodTypeParameters);
 
+            sourceMethod = new EECompilationContextMethod(DeclaringCompilation, sourceMethod);
+
+            sourceMethodTypeParameters = sourceMethod.TypeParameters;
+            allSourceTypeParameters = allSourceTypeParameters.Concat(sourceMethodTypeParameters);
+
             var getTypeMap = new Func<TypeMap>(() => this.TypeMap);
             _typeParameters = sourceMethodTypeParameters.SelectAsArray(
                 (tp, i, arg) => (TypeParameterSymbol)new EETypeParameterSymbol(this, tp, i, getTypeMap),
                 (object)null);
-            _allTypeParameters = container.TypeParameters.Concat(_typeParameters);
-            this.TypeMap = new TypeMap(allSourceTypeParameters, _allTypeParameters);
+            _allTypeParameters = container.TypeParameters.Concat(_typeParameters).Concat(_typeParameters);
+            this.TypeMap = new TypeMap(allSourceTypeParameters, _allTypeParameters, allowAlpha: true);
 
             EENamedTypeSymbol.VerifyTypeParameters(this, _typeParameters);
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -1021,7 +1021,7 @@ class C
         }
 
         [WorkItem(1160855, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1160855")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/58198")]
+        [Fact]
         public void AwaitDynamic()
         {
             var source = @"

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -2304,7 +2304,7 @@ class C
         /// normally be allowed.
         /// </remarks>
         [WorkItem(1075258, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1075258")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/58198")]
+        [Fact]
         public void Await()
         {
             var source = @"
@@ -2340,7 +2340,7 @@ class C
         /// This would be illegal in any non-debugger context.
         /// </remarks>
         [WorkItem(1075258, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1075258")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/58198")]
+        [Fact]
         public void AwaitInUnsafeContext()
         {
             var source = @"
@@ -6087,7 +6087,7 @@ class C
         /// <summary>
         /// Ignore accessibility in async rewriter.
         /// </summary>
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/58198")]
+        [Fact]
         public void AsyncRewriterIgnoreAccessibility()
         {
             var source =

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
@@ -1446,8 +1446,8 @@ public class C
             var stateMachineType = originalType.GetMembers().OfType<NamedTypeSymbol>().Single(t => GeneratedNameParser.GetKind(t.Name) == GeneratedNameKind.StateMachineType);
             var moveNextMethod = stateMachineType.GetMember<MethodSymbol>("MoveNext");
 
-            var guessedIterator = CompilationContext.GetSubstitutedSourceMethod(moveNextMethod, sourceMethodMustBeInstance: true);
-            Assert.Equal(iteratorMethod, guessedIterator.OriginalDefinition);
+            var guessedIterator = CompilationContext.GetSubstitutedSourceMethod(new EECompilationContextMethod(comp2, moveNextMethod), sourceMethodMustBeInstance: true);
+            Assert.Equal(iteratorMethod, ((EECompilationContextMethod)guessedIterator.OriginalDefinition).UnderlyingMethod.OriginalDefinition);
         }
     }
 }


### PR DESCRIPTION
Fixes #59093.
Related to #58198.