### PR TITLE
Handle more cases in F1 help service

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -248,6 +248,23 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                         return true;
                     }
                 }
+                else if (token.Parent.IsKind(SyntaxKind.NameEquals))
+                {
+                    if (token.Parent.Parent.IsKind(SyntaxKind.AnonymousObjectMemberDeclarator))
+                    {
+                        // PROTOTYPE: Redirect to https://docs.microsoft.com/dotnet/csharp/fundamentals/types/anonymous-types
+                    }
+                    else if (token.Parent.Parent.IsKind(SyntaxKind.UsingDirective))
+                    {
+                        text = Keyword("using");
+                        return true;
+                    }
+                    else if (token.Parent.Parent.IsKind(SyntaxKind.AttributeArgument))
+                    {
+                        // PROTOTYPE: Redirect to https://docs.microsoft.com/dotnet/csharp/programming-guide/concepts/attributes/creating-custom-attributes
+                    }
+                }
+                // PROTOTYPE: EqualsToken in let clause, XmlAttribute.
 
                 // EqualsToken in assignment expression is handled by syntaxFacts.IsOperator call above.
                 // Here we try to handle other contexts of EqualsToken.

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -201,15 +201,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
-            // Workaround IsPredefinedOperator returning true for '<' in generics.
-            if (token is { RawKind: (int)SyntaxKind.LessThanToken, Parent: not BinaryExpressionSyntax })
-            {
-                text = null;
-                return false;
-            }
-
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
-            if (syntaxFacts.IsOperator(token) || syntaxFacts.IsPredefinedOperator(token) || SyntaxFacts.IsAssignmentExpressionOperatorToken(token.Kind()))
+            if (syntaxFacts.IsOperator(token) || SyntaxFacts.IsAssignmentExpressionOperatorToken(token.Kind()))
             {
                 text = Keyword(syntaxFacts.GetText(token.RawKind));
                 return true;
@@ -236,6 +229,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             if (token.IsKind(SyntaxKind.EqualsGreaterThanToken))
             {
                 text = Keyword("=>");
+                return true;
+            }
+
+            if (token.IsKind(SyntaxKind.LessThanToken, SyntaxKind.GreaterThanToken) && token.Parent.IsKind(SyntaxKind.TypeParameterList, SyntaxKind.TypeArgumentList))
+            {
+                text = Keyword("generics");
                 return true;
             }
 

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -237,6 +237,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                         text = Keyword("propertyInitializer");
                         return true;
                     }
+                    else if (token.Parent.Parent.IsKind(SyntaxKind.EnumMemberDeclaration))
+                    {
+                        text = Keyword("enum");
+                        return true;
+                    }
+                    else if (token.Parent.Parent.IsKind(SyntaxKind.VariableDeclarator))
+                    {
+                        text = Keyword("=");
+                        return true;
+                    }
                 }
 
                 // EqualsToken in assignment expression is handled by syntaxFacts.IsOperator call above.

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -292,8 +292,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             {
                 if (token.Parent.IsKind(SyntaxKind.FunctionPointerParameterList))
                 {
-                    // PROTOTYPE: Figure out where to redirect.
-
+                    text = Keyword("functionPointer");
+                    return true;
                 }
             }
 

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -51,14 +51,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 var semanticModel = await document.ReuseExistingSpeculativeModelAsync(span, cancellationToken).ConfigureAwait(false);
 
                 var result = TryGetText(token, semanticModel, document, cancellationToken);
-                if (string.IsNullOrEmpty(result))
+                if (result is null)
                 {
                     var previousToken = token.GetPreviousToken();
                     if (previousToken.Span.IntersectsWith(span))
                         result = TryGetText(previousToken, semanticModel, document, cancellationToken);
                 }
 
-                return result;
+                // This redirects to https://docs.microsoft.com/visualstudio/ide/not-in-toc/default, indicating nothing is found.
+                return result ?? "vs.texteditor";
             }
 
             var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
@@ -86,10 +87,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return text.GetSubText(TextSpan.FromBounds(start, end)).ToString();
             }
 
-            return string.Empty;
+            // This redirects to https://docs.microsoft.com/visualstudio/ide/not-in-toc/default, indicating nothing is found.
+            return "vs.texteditor";
         }
 
-        private string TryGetText(SyntaxToken token, SemanticModel semanticModel, Document document, CancellationToken cancellationToken)
+        private string? TryGetText(SyntaxToken token, SemanticModel semanticModel, Document document, CancellationToken cancellationToken)
         {
             if (TryGetTextForSpecialCharacters(token, out var text) ||
                 TryGetTextForContextualKeyword(token, out text) ||
@@ -102,7 +104,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return text;
             }
 
-            return string.Empty;
+            return null;
         }
 
         private static bool TryGetTextForSpecialCharacters(SyntaxToken token, [NotNullWhen(true)] out string? text)

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -350,6 +350,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 case SyntaxKind.StaticKeyword when token.Parent is UsingDirectiveSyntax:
                     text = "using-static_CSharpKeyword";
                     return true;
+                case SyntaxKind.ReturnKeyword when token.Parent.IsKind(SyntaxKind.YieldReturnStatement):
+                case SyntaxKind.BreakKeyword when token.Parent.IsKind(SyntaxKind.YieldBreakStatement):
+                    text = "yield_CSharpKeyword";
+                    return true;
             }
 
             text = null;

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -519,7 +519,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
-        public async Task TestGenericAngle()
+        public async Task TestGenericAngle_LessThanToken_TypeArgument()
         {
             await TestAsync(
 @"class Program
@@ -532,7 +532,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
-        public async Task TestGenericAngle2()
+        public async Task TestGenericAngle_GreaterThanToken_TypeArgument()
         {
             await TestAsync(
 @"class Program
@@ -545,7 +545,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
-        public async Task TestGenericAngle3()
+        public async Task TestGenericAngle_LessThanToken_TypeParameter()
         {
             await TestAsync(
 @"class Program
@@ -558,7 +558,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
-        public async Task TestGenericAngle4()
+        public async Task TestGenericAngle_GreaterThanToken_TypeParameter()
         {
             await TestAsync(
 @"class Program

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1378,5 +1378,15 @@ class C
     object Goo() => null;
 }", "discard");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestNotFound()
+        {
+            await TestAsync(
+@"
+#if ANY[||]THING
+#endif
+", "vs.texteditor");
+        }
     }
 }

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -436,7 +436,7 @@ unsafe class C
 {
     delegate*[||]<int> f;
 }
-", "");
+", "functionPointer_CSharpKeyword");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
@@ -447,7 +447,7 @@ unsafe class C
 {
     delegate*[||]<int> f;
 }
-", "");
+", "functionPointer_CSharpKeyword");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -477,6 +477,17 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestEqualsInEnum()
+        {
+            await TestAsync(
+@"
+enum E
+{
+    A [||]= 1
+}", "enum_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestFromIn()
         {
             await TestAsync(

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -314,19 +314,98 @@ class Program<T> wh[||]ere T : class
 }", "N.C`1.goo``3");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
-        public async Task TestOperator()
+        [Theory, Trait(Traits.Feature, Traits.Features.F1Help)]
+        [InlineData("+")]
+        [InlineData("-")]
+        [InlineData("&")]
+        [InlineData("|")]
+        [InlineData("/")]
+        [InlineData("^")]
+        [InlineData(">")]
+        [InlineData(">=")]
+        [InlineData("!=")]
+        [InlineData("<")]
+        [InlineData("<=")]
+        [InlineData("<<")]
+        [InlineData(">>")]
+        [InlineData("*")]
+        [InlineData("%")]
+        [InlineData("&&")]
+        [InlineData("||")]
+        [InlineData("==")]
+        public async Task TestBinaryOperator(string operatorText)
         {
             await TestAsync(
-@"namespace N
-{
+$@"namespace N
+{{
     class C
-    {
+    {{
         void goo()
-        {
-            var two = 1 [|+|] 1;
+        {{
+            var two = 1 [|{operatorText}|] 1;
+        }}
+    }}", $"{operatorText}_CSharpKeyword");
         }
-    }", "+_CSharpKeyword");
+
+        [Theory, Trait(Traits.Feature, Traits.Features.F1Help)]
+        [InlineData("+=")]
+        [InlineData("-=")]
+        [InlineData("/=")]
+        [InlineData("*=")]
+        [InlineData("%=")]
+        [InlineData("&=")]
+        [InlineData("|=")]
+        [InlineData("^=")]
+        [InlineData("<<=")]
+        [InlineData(">>=")]
+        public async Task TestCompoundOperator(string operatorText)
+        {
+            await TestAsync(
+$@"namespace N
+{{
+    class C
+    {{
+        void goo(int x)
+        {{
+            x [|{operatorText}|] x;
+        }}
+    }}", $"{operatorText}_CSharpKeyword");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.F1Help)]
+        [InlineData("++")]
+        [InlineData("--")]
+        [InlineData("!")]
+        [InlineData("~")]
+        public async Task TestPrefixOperator(string operatorText)
+        {
+            await TestAsync(
+$@"namespace N
+{{
+    class C
+    {{
+        void goo(int x)
+        {{
+            x = [|{operatorText}|]x;
+        }}
+    }}", $"{operatorText}_CSharpKeyword");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.F1Help)]
+        [InlineData("++")]
+        [InlineData("--")]
+        public async Task TestPostfixOperator(string operatorText)
+        {
+            await TestAsync(
+$@"namespace N
+{{
+    class C
+    {{
+        void goo(int x)
+        {{
+            x = x[|{operatorText}|];
+        }}
+    }}", $"{operatorText}_CSharpKeyword");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -413,6 +413,44 @@ $@"namespace N
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestRelationalPattern()
+        {
+            await TestAsync(
+@"namespace N
+{
+    class C
+    {
+        void goo(string x)
+        {
+            if (x is { Length: [||]> 5 }) { }
+        }
+    }
+}", ">_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestGreaterThanInFunctionPointer()
+        {
+            await TestAsync(@"
+unsafe class C
+{
+    delegate*[||]<int> f;
+}
+", "");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestLessThanInFunctionPointer()
+        {
+            await TestAsync(@"
+unsafe class C
+{
+    delegate*[||]<int> f;
+}
+", "");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestEqualsOperatorInParameter()
         {
             await TestAsync(
@@ -498,7 +536,7 @@ using System;
 class MyAttribute : Attribute
 {
 }
-", "");
+", "attributeNamedArgument_CSharpKeyword");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
@@ -522,7 +560,63 @@ class C
         var x = new { X [||]= 0 };
     }
 }
-", "");
+", "anonymousObject_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestEqualsInDocumentationComment()
+        {
+            await TestAsync(
+@"
+class C
+{
+    /// <summary>
+    /// <a b[||]=""c"" />
+    /// </summary>
+    void M()
+    {
+        var x = new { X [||]= 0 };
+    }
+}
+", "see");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestEqualsInLet()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M()
+    {
+        var y =
+            from x1 in x2
+            let x3 [||]= x4
+            select x5;
+    }
+}
+
+", "let_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestLetKeyword()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M()
+    {
+        var y =
+            from x1 in x2
+            [||]let x3 = x4
+            select x5;
+    }
+}
+
+", "let_CSharpKeyword");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -488,6 +488,44 @@ enum E
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestEqualsInAttribute()
+        {
+            await TestAsync(
+@"
+using System;
+
+[AttributeUsage(AttributeTargets.Class, Inherited [|=|] true)]
+class MyAttribute : Attribute
+{
+}
+", "");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestEqualsInUsingAlias()
+        {
+            await TestAsync(
+@"
+using SC [||]= System.Console;
+", "using_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestEqualsInAnonymousObjectMemberDeclarator()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M()
+    {
+        var x = new { X [||]= 0 };
+    }
+}
+", "");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestFromIn()
         {
             await TestAsync(

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -449,7 +449,46 @@ class Program
     {
         generic[||]<int>(0);
     }
-}", "Program.generic``1");
+}", "generics_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestGenericAngle2()
+        {
+            await TestAsync(
+@"class Program
+{
+    static void generic<T>(T t)
+    {
+        generic<int[|>|](0);
+    }
+}", "generics_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestGenericAngle3()
+        {
+            await TestAsync(
+@"class Program
+{
+    static void generic[|<|]T>(T t)
+    {
+        generic<int>(0);
+    }
+}", "generics_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestGenericAngle4()
+        {
+            await TestAsync(
+@"class Program
+{
+    static void generic<T[|>|](T t)
+    {
+        generic<int>(0);
+    }
+}", "generics_CSharpKeyword");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -344,7 +344,8 @@ $@"namespace N
         {{
             var two = 1 [|{operatorText}|] 1;
         }}
-    }}", $"{operatorText}_CSharpKeyword");
+    }}
+}}", $"{operatorText}_CSharpKeyword");
         }
 
         [Theory, Trait(Traits.Feature, Traits.Features.F1Help)]
@@ -369,7 +370,8 @@ $@"namespace N
         {{
             x [|{operatorText}|] x;
         }}
-    }}", $"{operatorText}_CSharpKeyword");
+    }}
+}}", $"{operatorText}_CSharpKeyword");
         }
 
         [Theory, Trait(Traits.Feature, Traits.Features.F1Help)]
@@ -388,7 +390,8 @@ $@"namespace N
         {{
             x = [|{operatorText}|]x;
         }}
-    }}", $"{operatorText}_CSharpKeyword");
+    }}
+}}", $"{operatorText}_CSharpKeyword");
         }
 
         [Theory, Trait(Traits.Feature, Traits.Features.F1Help)]
@@ -405,7 +408,36 @@ $@"namespace N
         {{
             x = x[|{operatorText}|];
         }}
-    }}", $"{operatorText}_CSharpKeyword");
+    }}
+}}", $"{operatorText}_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestEqualsOperatorInParameter()
+        {
+            await TestAsync(
+@"namespace N
+{
+    class C
+    {
+        void goo(int x [|=|] 0)
+        {
+        }
+    }
+}", "optionalParameter_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestEqualsOperatorInPropertyInitializer()
+        {
+            await TestAsync(
+@"namespace N
+{
+    class C
+    {
+        int P { get; } [|=|] 5;
+    }
+}", "propertyInitializer_CSharpKeyword");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -673,6 +673,70 @@ class Program
 }", "System.Int32");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestYieldReturn_OnYield()
+        {
+            await TestAsync(@"
+using System.Collections.Generic;
+
+public class C
+{
+    public IEnumerable<int> M()
+    {
+        [|yield|] return 0;
+    }
+}
+", "yield_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestYieldReturn_OnReturn()
+        {
+            await TestAsync(@"
+using System.Collections.Generic;
+
+public class C
+{
+    public IEnumerable<int> M()
+    {
+        yield [|return|] 0;
+    }
+}
+", "yield_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestYieldBreak_OnYield()
+        {
+            await TestAsync(@"
+using System.Collections.Generic;
+
+public class C
+{
+    public IEnumerable<int> M()
+    {
+        [|yield|] break;
+    }
+}
+", "yield_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestYieldBreak_OnBreak()
+        {
+            await TestAsync(@"
+using System.Collections.Generic;
+
+public class C
+{
+    public IEnumerable<int> M()
+    {
+        yield [|break|] 0;
+    }
+}
+", "yield_CSharpKeyword");
+        }
+
         [WorkItem(862396, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/862396")]
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestNoToken()
@@ -683,7 +747,7 @@ class Program
     static void Main(string[] args)
     {
     }
-}[||]", "");
+}[||]", "vs.texteditor");
         }
 
         [WorkItem(862328, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/862328")]
@@ -821,7 +885,7 @@ class Program
         {
         }
     }
-}", "");
+}", "vs.texteditor");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
             return
                 (SyntaxFacts.IsAnyUnaryExpression(kind) &&
                     (token.Parent is PrefixUnaryExpressionSyntax || token.Parent is PostfixUnaryExpressionSyntax || token.Parent is OperatorDeclarationSyntax)) ||
-                (SyntaxFacts.IsBinaryExpression(kind) && (token.Parent is BinaryExpressionSyntax || token.Parent is OperatorDeclarationSyntax)) ||
+                (SyntaxFacts.IsBinaryExpression(kind) && (token.Parent is BinaryExpressionSyntax or OperatorDeclarationSyntax or RelationalPatternSyntax)) ||
                 (SyntaxFacts.IsAssignmentExpressionOperatorToken(kind) && token.Parent is AssignmentExpressionSyntax);
         }
 


### PR DESCRIPTION
Fixes #60154
Fixes #51878

- Handles different meanings of EqualsToken (part of https://github.com/dotnet/roslyn/issues/48392).

- Handles `yield return` and `yield break` (https://github.com/dotnet/roslyn/issues/23881#issuecomment-353659895)

docs PR: https://github.com/dotnet/docs/pull/28653 https://github.com/dotnet/docs/pull/28660

@davidwengier @CyrusNajmabadi Can you take a look? Thanks!