### PR TITLE
Remove enableRoslynAnalyzers from settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,6 @@
     "omnisharp.disableMSBuildDiagnosticWarning": true,
     "omnisharp.enableEditorConfigSupport": true,
     "omnisharp.enableImportCompletion": true,
-    "omnisharp.enableRoslynAnalyzers": true,
     "omnisharp.useModernNet": true,
     "omnisharp.enableAsyncCompletion": true,
     // ms-vscode.powershell settings


### PR DESCRIPTION
I found this flag can negatively affect responsiveness of the editor on insufficiently powerful systems. I think it's better to remove this as a workspace setting so that we respect whatever the user setting is, whether it be true or false. @jmarolf @JoeRobich 