### PR TITLE
Fix parameter scoping on lambdas

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override Binder SignatureBinder => _binder;
 
-        internal override Binder ParameterBinder => new WithLambdaParametersBinder(this, _binder);
+        internal override Binder ParameterBinder => _binder;
 
         internal override OneOrMany<SyntaxList<AttributeListSyntax>> GetAttributeDeclarations()
         {


### PR DESCRIPTION
In working on `nameof(parameter)` feature ([draft PR](https://github.com/dotnet/roslyn/pull/40525)), I found a bug in scoping for lambda parameters. One-line fix.

TODO2 document breaking change

```
class C
{
    void M()
    {
        // error CS1503: Argument 1: cannot convert from 'int' to 'string'
        var _ = void ([My(parameter)] int parameter) => throw null;
    }
    // error CS0103: The name 'parameter' does not exist in the current context
    void M2([My(parameter)] int parameter) => throw null;
}
public class MyAttribute : System.Attribute
{
    public MyAttribute(string name1) { }
}
```