### PR TITLE
Inline Hints: More logic around handling named arguments

### DIFF
--- a/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
@@ -1176,5 +1176,49 @@ public class C
 
             Await VerifyParamHints(input, output)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineHints)>
+        <WorkItem(48910, "https://github.com/dotnet/roslyn/issues/59317")>
+        Public Async Function TestMultipleNamedArgumentsWithIncorrectArgumentCount() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+public class C
+{
+    static void F(int a, bool b, string c)
+    {
+    }
+
+    public static void Main()
+    {
+        F({|a:|}1, 2, b: true, c: "str");
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+           <Workspace>
+               <Project Language="C#" CommonReferences="true">
+                   <Document>
+public class C
+{
+    static void F(int a, bool b, string c)
+    {
+    }
+
+    public static void Main()
+    {
+        F(a: 1, 2, b: true, c: "str");
+    }
+}
+                    </Document>
+               </Project>
+           </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
@@ -1132,5 +1132,49 @@ class Program
 
             Await VerifyParamHints(input, output)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineHints)>
+        <WorkItem(48910, "https://github.com/dotnet/roslyn/issues/59317")>
+        Public Async Function TestNamedArgumentsWithIncorrectArgumentCount() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+public class C
+{
+    static void F(int a, bool b, string c)
+    {
+    }
+
+    public static void Main()
+    {
+        F({|a:|}1, {|b:|}2, true, c: "str");
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+           <Workspace>
+               <Project Language="C#" CommonReferences="true">
+                   <Document>
+public class C
+{
+    static void F(int a, bool b, string c)
+    {
+    }
+
+    public static void Main()
+    {
+        F(a: 1, b: 2, true, c: "str");
+    }
+}
+                    </Document>
+               </Project>
+           </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
@@ -1220,5 +1220,49 @@ public class C
 
             Await VerifyParamHints(input, output)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineHints)>
+        <WorkItem(48910, "https://github.com/dotnet/roslyn/issues/59317")>
+        Public Async Function TestMultipleNamedArgumentsWithIncorrectArgumentCountReordered() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+public class C
+{
+    static void F(int a, bool b, string c)
+    {
+    }
+
+    public static void Main()
+    {
+        F({|a:|}1, 2, c: "str", b: true);
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+           <Workspace>
+               <Project Language="C#" CommonReferences="true">
+                   <Document>
+public class C
+{
+    static void F(int a, bool b, string c)
+    {
+    }
+
+    public static void Main()
+    {
+        F(a: 1, 2, c: "str", b: true);
+    }
+}
+                    </Document>
+               </Project>
+           </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
@@ -922,5 +922,43 @@ End Class
 
             Await VerifyParamHints(input, output)
         End Function
+
+        <WorkItem(47597, "https://github.com/dotnet/roslyn/issues/59317")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineHints)>
+        Public Async Function TestMultipleNamedArgumentsWithIncorrectArgumentCount() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub F(a As Integer, b As Boolean, c As String)
+    End Sub
+
+    Sub Main(args As String())
+        F({|a:|}1, 2, b:=True, c:="str")
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub F(a As Integer, b As Boolean, c As String)
+    End Sub
+
+    Sub Main(args As String())
+        F(a:=1, 2, b:=True, c:="str")
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
@@ -884,5 +884,43 @@ end class
 
             Await VerifyParamHints(input, output)
         End Function
+
+        <WorkItem(47597, "https://github.com/dotnet/roslyn/issues/59317")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineHints)>
+        Public Async Function TestNamedArgumentsWithIncorrectArgumentCount() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub F(a As Integer, b As Boolean, c As String)
+    End Sub
+
+    Sub Main(args As String())
+        F({|a:|}1, {|b:|}2, True, c:="str")
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub F(a As Integer, b As Boolean, c As String)
+    End Sub
+
+    Sub Main(args As String())
+        F(a:=1, b:=2, True, c:="str")
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
@@ -960,5 +960,43 @@ End Class
 
             Await VerifyParamHints(input, output)
         End Function
+
+        <WorkItem(47597, "https://github.com/dotnet/roslyn/issues/59317")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.InlineHints)>
+        Public Async Function TestMultipleNamedArgumentsWithIncorrectArgumentCountReordered() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub F(a As Integer, b As Boolean, c As String)
+    End Sub
+
+    Sub Main(args As String())
+        F({|a:|}1, 2, c:="str", b:=True)
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub F(a As Integer, b As Boolean, c As String)
+    End Sub
+
+    Sub Main(args As String())
+        F(a:=1, 2, c:="str", b:=True)
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
@@ -82,11 +82,13 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineHints
 
                 var parameter = argument.DetermineParameter(semanticModel, cancellationToken: cancellationToken);
 
-                if (!parametersOfNamedArguments.Contains(parameter))
+                if (parametersOfNamedArguments.Contains(parameter))
                 {
-                    var identifierArgument = GetIdentifierNameFromArgument(argument, syntaxFacts);
-                    buffer.Add((argument.Span.Start, identifierArgument, parameter, GetKind(argument.Expression)));
+                    continue;
                 }
+
+                var identifierArgument = GetIdentifierNameFromArgument(argument, syntaxFacts);
+                buffer.Add((argument.Span.Start, identifierArgument, parameter, GetKind(argument.Expression)));
             }
         }
 

--- a/src/Features/VisualBasic/Portable/InlineHints/VisualBasicInlineParameterNameHintsService.vb
+++ b/src/Features/VisualBasic/Portable/InlineHints/VisualBasicInlineParameterNameHintsService.vb
@@ -70,6 +70,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InlineHints
             Using ArrayBuilder(Of IParameterSymbol).GetInstance(builder)
                 For Each arg In argumentList.Arguments
                     Dim argument = TryCast(arg, SimpleArgumentSyntax)
+                    If argument Is Nothing Then
+                        Continue For
+                    End If
+
                     If argument.IsNamed OrElse argument.NameColonEquals IsNot Nothing Then
                         Dim parameter = argument.DetermineParameter(semanticModel, allowParamArray:=False, cancellationToken)
                         If String.IsNullOrEmpty(parameter?.Name) Then
@@ -79,9 +83,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.InlineHints
                         builder.Add(parameter)
                     End If
                 Next
-            End Using
 
-            Return builder.ToImmutable()
+                Return builder.ToImmutable()
+            End Using
         End Function
 
         Private Function GetKind(arg As ExpressionSyntax) As HintKind


### PR DESCRIPTION
Fixes: #59317

1) Iterate through the arguments first
2) Create a listing of ParameterSymbols that map back to named arguments
3) Go through the arguments again
4) Get the parameter symbol the argument maps back to
5) If it is a parameter symbol contained in the list, don't add a hint for it