### PR TITLE
Normalize values for `ROSLYN_TEST_*` in `TestRunner`

### DIFF
--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -170,8 +170,7 @@ namespace RunTests
                 var knownEnvironmentVariables = new[] { "ROSLYN_TEST_IOPERATION", "ROSLYN_TEST_USEDASSEMBLIES" };
                 foreach (var knownEnvironmentVariable in knownEnvironmentVariables)
                 {
-                    if (Environment.GetEnvironmentVariable(knownEnvironmentVariable) is string iop &&
-                        string.Equals(iop, "true", StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(Environment.GetEnvironmentVariable(knownEnvironmentVariable), "true", StringComparison.OrdinalIgnoreCase))
                     {
                         command.AppendLine($"{setEnvironmentVariable} {knownEnvironmentVariable}=true");
                     }

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -170,8 +170,11 @@ namespace RunTests
                 var knownEnvironmentVariables = new[] { "ROSLYN_TEST_IOPERATION", "ROSLYN_TEST_USEDASSEMBLIES" };
                 foreach (var knownEnvironmentVariable in knownEnvironmentVariables)
                 {
-                    if (Environment.GetEnvironmentVariable(knownEnvironmentVariable) is string iop)
-                        command.AppendLine($"{setEnvironmentVariable} {knownEnvironmentVariable}={iop}");
+                    if (Environment.GetEnvironmentVariable(knownEnvironmentVariable) is string iop &&
+                        string.Equals(iop, "true", StringComparison.OrdinalIgnoreCase))
+                    {
+                        command.AppendLine($"{setEnvironmentVariable} {knownEnvironmentVariable}=true");
+                    }
                 }
 
                 command.AppendLine($"dotnet {commandLineArguments}");


### PR DESCRIPTION
Use fixed values for `ROSLYN_TEST_*` variables.