### PR TITLE
Remove enableRoslynAnalyzers from codespace default settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,6 @@
     "omnisharp.disableMSBuildDiagnosticWarning": true,
     "omnisharp.enableEditorConfigSupport": true,
     "omnisharp.enableImportCompletion": true,
-    "omnisharp.enableRoslynAnalyzers": true,
     "omnisharp.useModernNet": true,
     "omnisharp.enableAsyncCompletion": true,
     // ms-vscode.powershell settings


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/60165

We don't think this is the right default as users probably don't want this unless they have at least 8 cores.