### PR TITLE
Avoid resizing array builder while get unaliased references

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1207,7 +1207,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var referenceManager = GetBoundReferenceManager();
 
-            for (int i = 0; i < referenceManager.ReferencedAssemblies.Length; i++)
+            int length = referenceManager.ReferencedAssemblies.Length;
+
+            assemblies.EnsureCapacity(assemblies.Count + length);
+
+            for (int i = 0; i < length; i++)
             {
                 if (referenceManager.DeclarationsAccessibleWithoutAlias(i))
                 {


### PR DESCRIPTION
This was being resized constantly after opening Orchard Core, allocating about 2 GB. The fact that is being called this many times appears to be another bug that I'm following up on.

![image](https://user-images.githubusercontent.com/1103906/158724105-dd18e9bb-37de-42cb-8f8b-41e27c7cff7f.png)
