### PR TITLE
Stabilize ErrorsAfterClosingFile test

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpErrorListCommon.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpErrorListCommon.cs
@@ -133,9 +133,11 @@ class Program2
                 string.Join(Environment.NewLine, actualContents));
         }
 
-        [IdeFact]
-        public virtual async Task ErrorsAfterClosingFile()
+        [IdeTheory(MaxAttempts = 1)]
+        [CombinatorialData]
+        public virtual async Task ErrorsAfterClosingFile([CombinatorialRange(0, 20)] int iteration)
         {
+            _ = iteration;
             await TestServices.Editor.SetTextAsync(@"
 class Program2
 {


### PR DESCRIPTION
This test occasionally fails to save a document prior to sending <kbd>Ctrl</kbd>+<kbd>F4</kbd>, which leads to a Save File dialog that causes a test failure.