### PR TITLE
Update NuGet version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -202,7 +202,7 @@
       is expected by the NET SDK used in the Workspace.MSBuild UnitTests. In order to test against the same verion of NuGet
       as our configured SDK, we must set the version to be the same.
      -->
-    <NuGetCommonVersion>6.0.0</NuGetCommonVersion>
+    <NuGetCommonVersion>6.1.0</NuGetCommonVersion>
     <NuGetConfigurationVersion>$(NuGetCommonVersion)</NuGetConfigurationVersion>
     <NuGetFrameworksVersion>$(NuGetCommonVersion)</NuGetFrameworksVersion>
     <NuGetPackagingVersion>$(NuGetCommonVersion)</NuGetPackagingVersion>


### PR DESCRIPTION
MSBuildWorkspace tests that run on .NET Core need to have NuGet dependencies that are version matched to those that ship in the SDK pinned by the global.json. 

Resolves https://github.com/dotnet/roslyn/issues/60218