### PR TITLE
Add basic benchmark for returning text edits in LSP completion

### DIFF
--- a/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -58,6 +58,7 @@
     <InternalsVisibleTo Include="Roslyn.VisualStudio.Next.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator" />
     <InternalsVisibleTo Include="IdeCoreBenchmarks" />
+    <InternalsVisibleTo Include="IdeBenchmarks" />
     <InternalsVisibleTo Include="AnalyzerRunner" />
     <InternalsVisibleTo Include="Microsoft.CSharp.VSCode.Extension" Key="$(VisualStudioKey)" />
   </ItemGroup>

--- a/src/Features/LanguageServer/ProtocolUnitTests/Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests.csproj
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests.csproj
@@ -14,6 +14,11 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup Label="Package References">
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetDiagnosticsWindowsVersion)" />
+  </ItemGroup>
+
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
     <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
@@ -42,5 +47,8 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="IdeBenchmarks" />
   </ItemGroup>
 </Project>

--- a/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
+++ b/src/Tools/IdeBenchmarks/IdeBenchmarks.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\Compilers\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
     <ProjectReference Include="..\..\EditorFeatures\Core.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj" />
     <ProjectReference Include="..\..\EditorFeatures\TestUtilities\Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities.csproj" />
+    <ProjectReference Include="..\..\Features\LanguageServer\ProtocolUnitTests\Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests.csproj" />
     <ProjectReference Include="..\..\Features\LanguageServer\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
     <ProjectReference Include="..\..\Interactive\Host\Microsoft.CodeAnalysis.InteractiveHost.csproj" />
     <ProjectReference Include="..\..\Scripting\Core\Microsoft.CodeAnalysis.Scripting.csproj" />

--- a/src/Tools/IdeBenchmarks/Lsp/LspCompletionBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/Lsp/LspCompletionBenchmarks.cs
@@ -1,0 +1,142 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Storage;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Xunit;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace IdeBenchmarks.Lsp
+{
+    [MemoryDiagnoser]
+    public class LspCompletionBenchmarks : AbstractLanguageServerProtocolTests
+    {
+        private readonly UseExportProviderAttribute _useExportProviderAttribute = new UseExportProviderAttribute();
+
+        TestLspServer _testServer;
+        IGlobalOptionService _globalOptionService;
+        LSP.CompletionParams _completionParams;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+        }
+
+        [IterationSetup]
+        public void IterationSetup() => LoadSolutionAsync().Wait();
+
+        private async Task LoadSolutionAsync()
+        {
+            _useExportProviderAttribute.Before(null);
+
+            var markup =
+@"using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Buffers.Text;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Configuration;
+using System.Data;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Dynamic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Media;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+class A
+{
+    void M()
+    {
+        T{|caret:|}
+    }
+}";
+            var testServer = await CreateTestLspServerAsync(markup).ConfigureAwait(false);
+            _testServer = testServer;
+
+            _completionParams = CreateCompletionParams(
+                _testServer.GetLocations("caret").Single(),
+                invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
+                triggerCharacter: "T",
+                triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+            _globalOptionService = testServer.TestWorkspace.GetService<IGlobalOptionService>();
+        }
+
+        [Benchmark]
+        public void GetCompletionsWithTextEdits()
+        {
+            _globalOptionService.SetGlobalOption(new OptionKey(LspOptions.LspCompletionFeatureFlag), true);
+
+            var results = CompletionTests.RunGetCompletionsAsync(_testServer, _completionParams).Result;
+            Assert.Equal(1000, results.Items.Length);
+            Assert.True(results.IsIncomplete);
+            Assert.All(results.Items, (item) => AssertTextEditOrComplexItem(item));
+        }
+
+        [Benchmark]
+        public void GetCompletionsWithoutTextEdits()
+        {
+            _globalOptionService.SetGlobalOption(new OptionKey(LspOptions.LspCompletionFeatureFlag), false);
+
+            var results = CompletionTests.RunGetCompletionsAsync(_testServer, _completionParams).Result;
+            Assert.Equal(1000, results.Items.Length);
+            Assert.True(results.IsIncomplete);
+            Assert.All(results.Items, (item) => Assert.Null(item.TextEdit));
+        }
+
+        private void AssertTextEditOrComplexItem(LSP.CompletionItem item)
+        {
+            if (item.TextEdit == null)
+            {
+                Assert.Null(item.InsertText);
+            }
+            else
+            {
+                Assert.NotNull(item.TextEdit);
+            }
+        }
+
+        [IterationCleanup]
+        public void Cleanup()
+        {
+            _testServer?.Dispose();
+            _useExportProviderAttribute.After(null);
+        }
+    }
+}


### PR DESCRIPTION
In preparation for the fix for https://github.com/dotnet/roslyn/issues/59773 to allow us to specify item defaults, added a benchmark to compare the current performance of the textedits feature flag.

These will need to be updated once the new client packages are ready and we can respond to them, but this just shows the current difference.
|                         Method |      Mean |    Error |   StdDev |    Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------- |----------:|---------:|---------:|----------:|------:|------:|------:|----------:|
|    GetCompletionsWithTextEdits | 129.53 ms | 2.599 ms | 7.456 ms | 125.79 ms |     - |     - |     - |     16 MB |
| GetCompletionsWithoutTextEdits |  83.23 ms | 1.624 ms | 2.277 ms |  82.63 ms |     - |     - |     - |      9 MB |