### PR TITLE
Correct change ObjectCreationExpression to ImplictObjectCreationExpression for SmartBreakline

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
             //
             // Step 3. Add semicolon if needed
             // e.g. var c = new Bar() => var c = new Bar();
-            if (selectedNode is ObjectCreationExpressionSyntax objectCreationExpressionNode)
+            if (selectedNode is BaseObjectCreationExpressionSyntax objectCreationExpressionNode)
             {
                 var (newNode, oldNode) = ModifyObjectCreationExpressionNode(objectCreationExpressionNode, addOrRemoveInitializer: false, documentOptions);
                 var newRoot = ReplaceNodeAndFormat(

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
@@ -439,6 +439,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
                 return SyntaxFactory.ImplicitObjectCreationExpression(newKeywordToken.WithoutTrailingTrivia(), newArgumentList, baseObjectCreationExpressionNode.Initializer);
             }
 
+            RoslynDebug.Assert(false, $"New derived type of {nameof(BaseObjectCreationExpressionSyntax)} is added");
             return baseObjectCreationExpressionNode;
         }
 

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
@@ -518,7 +518,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
         /// Add brace for ObjectCreationExpression if it doesn't have initializer
         /// </summary>
         private static bool ShouldAddBraceForObjectCreationExpression(ObjectCreationExpressionSyntax objectCreationExpressionNode)
-            => objectCreationExpressionNode.Initializer == null && !objectCreationExpressionNode.NewKeyword.IsMissing;
+            => objectCreationExpressionNode.Initializer == null;
 
         /// <summary>
         /// Add braces for field and event field if they only have one variable, semicolon is missing and don't have readonly keyword

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -3107,6 +3107,31 @@ public class Bar
 }");
         }
 
+        [WpfFact]
+        public void TestRemoveInitializerForImplicitObjectCreationExpression()
+        {
+            Test(@"
+public class Bar
+{
+    public void Bar2()
+    {
+        Bar b = new();
+        $$
+    }
+}",
+@"
+public class Bar
+{
+    public void Bar2()
+    {
+        Bar b = new()
+        {
+            $$
+        };
+    }
+}");
+        }
+
         protected override string Language => LanguageNames.CSharp;
 
         protected override Action CreateNextHandler(TestWorkspace workspace)

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -3083,6 +3083,30 @@ public class Bar
 }");
         }
 
+        [WpfFact]
+        public void TestObjectCreationExpressionWithMissingType()
+        {
+            Test(@"
+public class Bar
+{
+    public void Bar2()
+    {
+        Bar b = new()
+        {
+            $$
+        };
+    }
+}",
+@"
+public class Bar
+{
+    public void Bar2()
+    {
+        Bar b = new$$
+    }
+}");
+        }
+
         protected override string Language => LanguageNames.CSharp;
 
         protected override Action CreateNextHandler(TestWorkspace workspace)


### PR DESCRIPTION
Fix [AB#1484764](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1484764)
It is caused because
```
Bar b = new
```
`new` is considered as ObjectCreationExpressionSyntax, with the TypeSyntax node missing.
The existing code will only move the trailing trivia of the TypeSyntax after the newly generated argument list, and because the TypeSyntax is missing, it would become
```
Bar b = new
()
{
}
```
The fix is to check if ObjectCreationExpressionSyntax doesn't have a TypeSyntax, then generate a ImplicitObjectCreationExpressionSyntax.
