### PR TITLE
Implement source generator timing APIs

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3043,8 +3043,7 @@ public static readonly string F = ""a""
             Assert.NotEqual(TimeSpan.Zero, generatorTiming.ElapsedTime);
             Assert.True(timing.ElapsedTime >= generatorTiming.ElapsedTime);
 
-
-            // run a second time. No steps should be performed, so overall time should be less
+            // run a second time. No steps should be performed, so overall time should be less 
             driver = driver.RunGenerators(compilation);
             var timing2 = driver.GetTimingInfo();
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -2907,5 +2907,109 @@ public static readonly string F = ""a""
 
             Assert.Single(result.GeneratedTrees);
         }
+
+        [Fact]
+        public void Timing_Info_Is_Empty_If_Not_Run()
+        {
+            var source = "class C{}";
+
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (context, text) =>
+                {
+                    context.AddSource("generated", "");
+                });
+            }).AsSourceGenerator();
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions, driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
+
+            var timing = driver.GetTimingInfo();
+
+            Assert.Equal(TimeSpan.Zero, timing.ElapsedTime);
+
+            var generatorTiming = Assert.Single(timing.GeneratorTimes);
+            Assert.Equal(generator, generatorTiming.Generator);
+            Assert.Equal(TimeSpan.Zero, generatorTiming.ElapsedTime);
+        }
+
+        [Fact]
+        public void Can_Get_Timing_Info()
+        {
+            var source = "class C{}";
+
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (context, text) =>
+                {
+                    context.AddSource("generated", "");
+                });
+            }).AsSourceGenerator();
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions, driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
+
+            driver = driver.RunGenerators(compilation);
+            var timing = driver.GetTimingInfo();
+
+            Assert.NotEqual(TimeSpan.Zero, timing.ElapsedTime);
+
+            var generatorTiming = Assert.Single(timing.GeneratorTimes);
+            Assert.Equal(generator, generatorTiming.Generator);
+            Assert.NotEqual(TimeSpan.Zero, generatorTiming.ElapsedTime);
+            Assert.True(timing.ElapsedTime >= generatorTiming.ElapsedTime);
+        }
+
+        [Fact]
+        public void Can_Get_Timing_Info_From_Multiple_Generators()
+        {
+            var source = "class C{}";
+
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            var generator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (context, text) =>
+                {
+                    context.AddSource("generated", "");
+                });
+            }).AsSourceGenerator();
+
+            var generator2 = new PipelineCallbackGenerator2(ctx =>
+            {
+                ctx.RegisterSourceOutput(ctx.CompilationProvider, (context, text) =>
+                {
+                    context.AddSource("generated", "");
+                });
+            }).AsSourceGenerator();
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator, generator2 }, parseOptions: parseOptions, driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
+
+            driver = driver.RunGenerators(compilation);
+            var timing = driver.GetTimingInfo();
+
+            Assert.NotEqual(TimeSpan.Zero, timing.ElapsedTime);
+            Assert.Equal(2, timing.GeneratorTimes.Length);
+
+            var timing1 = timing.GeneratorTimes[0];
+            Assert.Equal(generator, timing1.Generator);
+            Assert.NotEqual(TimeSpan.Zero, timing1.ElapsedTime);
+            Assert.True(timing.ElapsedTime >= timing1.ElapsedTime);
+
+            var timing2 = timing.GeneratorTimes[1];
+            Assert.Equal(generator2, timing2.Generator);
+            Assert.NotEqual(TimeSpan.Zero, timing2.ElapsedTime);
+            Assert.True(timing.ElapsedTime >= timing2.ElapsedTime);
+
+            Assert.True(timing.ElapsedTime >= timing1.ElapsedTime + timing2.ElapsedTime);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -2950,6 +2950,7 @@ public static readonly string F = ""a""
                 ctx.RegisterSourceOutput(ctx.CompilationProvider, (context, text) =>
                 {
                     context.AddSource("generated", "");
+                    Thread.Sleep(1);
                 });
             }).AsSourceGenerator();
 
@@ -2980,6 +2981,7 @@ public static readonly string F = ""a""
                 ctx.RegisterSourceOutput(ctx.CompilationProvider, (context, text) =>
                 {
                     context.AddSource("generated", "");
+                    Thread.Sleep(1);
                 });
             }).AsSourceGenerator();
 
@@ -2988,6 +2990,7 @@ public static readonly string F = ""a""
                 ctx.RegisterSourceOutput(ctx.CompilationProvider, (context, text) =>
                 {
                     context.AddSource("generated", "");
+                    Thread.Sleep(1);
                 });
             }).AsSourceGenerator();
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -2077,6 +2077,66 @@ class C
             Assert.Equal("Simulated cancellation from external source", results.Results[0].Exception!.Message);
         }
 
+        [Fact]
+        public void Syntax_Provider_Doesnt_Attribute_Incorrect_Timing()
+        {
+
+            var source = @"
+class C 
+{
+    int Property { get; set; }
+
+    void Function()
+    {
+        var x = 5;
+        x += 4;
+    }
+}
+";
+            var parseOptions = TestOptions.Regular.WithLanguageVersion(LanguageVersion.Preview);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+
+            Assert.Single(compilation.SyntaxTrees);
+
+            var sleepTimeInMs = 50;
+            var testGenerator = new PipelineCallbackGenerator(ctx =>
+            {
+                ctx.RegisterSourceOutput(ctx.SyntaxProvider.CreateSyntaxProvider<object>((s, _) => s is AssignmentExpressionSyntax, (c, _) => { Thread.Sleep(sleepTimeInMs); return true; }), (spc, s) => { });
+            }).AsSourceGenerator();
+
+            var testGenerator2 = new PipelineCallbackGenerator2(ctx =>
+            {
+                ctx.RegisterSourceOutput(ctx.SyntaxProvider.CreateSyntaxProvider<object>((s, _) => s is AssignmentExpressionSyntax, (c, _) => { Thread.Sleep(sleepTimeInMs); return true; }), (spc, s) => { });
+                ctx.RegisterSourceOutput(ctx.SyntaxProvider.CreateSyntaxProvider<object>((s, _) => s is AssignmentExpressionSyntax, (c, _) => { Thread.Sleep(sleepTimeInMs); return true; }), (spc, s) => { });
+            }).AsSourceGenerator();
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator, testGenerator2 }, parseOptions: parseOptions);
+            driver = driver.RunGenerators(compilation);
+
+            var timing = driver.GetTimingInfo();
+
+            Assert.NotEqual(TimeSpan.Zero, timing.ElapsedTime);
+            Assert.Equal(2, timing.GeneratorTimes.Length);
+
+            // check generator one took at least 'sleepTimeInMs'
+            var timing1 = timing.GeneratorTimes[0];
+            Assert.Equal(testGenerator, timing1.Generator);
+            Assert.NotEqual(TimeSpan.Zero, timing1.ElapsedTime);
+            Assert.True(timing.ElapsedTime >= timing1.ElapsedTime);
+            Assert.True(timing1.ElapsedTime.TotalMilliseconds >= sleepTimeInMs);
+
+            // check generator one took at least 'sleepTimeInMs' * 2
+            var timing2 = timing.GeneratorTimes[1];
+            Assert.Equal(testGenerator2, timing2.Generator);
+            Assert.NotEqual(TimeSpan.Zero, timing2.ElapsedTime);
+            Assert.True(timing.ElapsedTime >= timing2.ElapsedTime);
+            Assert.True(timing2.ElapsedTime.TotalMilliseconds >= sleepTimeInMs * 2);
+
+            // now check that generator two took longer than generator one (and one didn't get attributed the time)
+            Assert.True(timing2.ElapsedTime > timing1.ElapsedTime);
+        }
+
         private class TestReceiverBase<T>
         {
             private readonly Action<T>? _callback;

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/SyntaxAwareGeneratorTests.cs
@@ -2080,7 +2080,6 @@ class C
         [Fact]
         public void Syntax_Provider_Doesnt_Attribute_Incorrect_Timing()
         {
-
             var source = @"
 class C 
 {
@@ -2093,8 +2092,7 @@ class C
     }
 }
 ";
-            var parseOptions = TestOptions.Regular.WithLanguageVersion(LanguageVersion.Preview);
-            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDll);
             compilation.VerifyDiagnostics();
 
             Assert.Single(compilation.SyntaxTrees);
@@ -2111,7 +2109,7 @@ class C
                 ctx.RegisterSourceOutput(ctx.SyntaxProvider.CreateSyntaxProvider<object>((s, _) => s is AssignmentExpressionSyntax, (c, _) => { Thread.Sleep(sleepTimeInMs); return true; }), (spc, s) => { });
             }).AsSourceGenerator();
 
-            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator, testGenerator2 }, parseOptions: parseOptions);
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { testGenerator, testGenerator2 });
             driver = driver.RunGenerators(compilation);
 
             var timing = driver.GetTimingInfo();
@@ -2126,7 +2124,7 @@ class C
             Assert.True(timing.ElapsedTime >= timing1.ElapsedTime);
             Assert.True(timing1.ElapsedTime.TotalMilliseconds >= sleepTimeInMs);
 
-            // check generator one took at least 'sleepTimeInMs' * 2
+            // check generator two took at least 'sleepTimeInMs' * 2
             var timing2 = timing.GeneratorTimes[1];
             Assert.Equal(testGenerator2, timing2.Generator);
             Assert.NotEqual(TimeSpan.Zero, timing2.ElapsedTime);

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -14,6 +14,15 @@ Microsoft.CodeAnalysis.ImportedXmlNamespace
 Microsoft.CodeAnalysis.ImportedXmlNamespace.DeclaringSyntaxReference.get -> Microsoft.CodeAnalysis.SyntaxReference?
 Microsoft.CodeAnalysis.ImportedXmlNamespace.ImportedXmlNamespace() -> void
 Microsoft.CodeAnalysis.ImportedXmlNamespace.XmlNamespace.get -> string!
+Microsoft.CodeAnalysis.GeneratorDriver.GetTimingInfo() -> Microsoft.CodeAnalysis.GeneratorDriverTimingInfo
+Microsoft.CodeAnalysis.GeneratorDriverTimingInfo
+Microsoft.CodeAnalysis.GeneratorDriverTimingInfo.ElapsedTime.get -> System.TimeSpan
+Microsoft.CodeAnalysis.GeneratorDriverTimingInfo.GeneratorDriverTimingInfo() -> void
+Microsoft.CodeAnalysis.GeneratorDriverTimingInfo.GeneratorTimes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.GeneratorTimingInfo>
+Microsoft.CodeAnalysis.GeneratorTimingInfo
+Microsoft.CodeAnalysis.GeneratorTimingInfo.ElapsedTime.get -> System.TimeSpan
+Microsoft.CodeAnalysis.GeneratorTimingInfo.Generator.get -> Microsoft.CodeAnalysis.ISourceGenerator!
+Microsoft.CodeAnalysis.GeneratorTimingInfo.GeneratorTimingInfo() -> void
 Microsoft.CodeAnalysis.IOperation.ChildOperations.get -> Microsoft.CodeAnalysis.IOperation.OperationList
 Microsoft.CodeAnalysis.IOperation.OperationList
 Microsoft.CodeAnalysis.IOperation.OperationList.Any() -> bool

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis
                     continue;
                 }
 
-                using var generatorTimer = CodeAnalysisEventSource.Log.CreateSingleGeneratorRunTimer(state.Generators[i]);
+                using var generatorTimer = CodeAnalysisEventSource.Log.CreateSingleGeneratorRunTimer(state.Generators[i], (t) => t.Add(syntaxStoreBuilder.GetRuntimeAdjustment(stateBuilder[i].InputNodes)));
                 try
                 {
                     // We do not support incremental step tracking for v1 generators, as the pipeline is implicitly defined.

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -158,6 +158,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        public GeneratorDriverTimingInfo GetTimingInfo()
+        {
+            var generatorTimings = _state.Generators.ZipAsArray(_state.GeneratorStates, (generator, generatorState) => new GeneratorTimingInfo(generator, generatorState.ElapsedTime));
+            return new GeneratorDriverTimingInfo(_state.RunTime, generatorTimings);
+        }
+
         internal GeneratorDriverState RunGeneratorsCore(Compilation compilation, DiagnosticBag? diagnosticsBag, CancellationToken cancellationToken = default)
         {
             // with no generators, there is no work to do

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorTimerExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorTimerExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return new RunTimer();
+                return new RunTimer(adjustRunTime: null);
             }
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorTimerExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorTimerExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                return new RunTimer(adjustRunTime: null);
+                return new RunTimer();
             }
         }
 
@@ -50,10 +50,16 @@ namespace Microsoft.CodeAnalysis
 
             public TimeSpan Elapsed => _adjustRunTime is not null ? _adjustRunTime(_timer.Elapsed) : _timer.Elapsed;
 
-            public RunTimer(Func<TimeSpan, TimeSpan>? adjustRunTime = null)
+            public RunTimer()
             {
                 _timer = SharedStopwatch.StartNew();
                 _callback = null;
+                _adjustRunTime = null;
+            }
+
+            public RunTimer(Func<TimeSpan, TimeSpan>? adjustRunTime)
+                : this()
+            {
                 _adjustRunTime = adjustRunTime;
             }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorTimerExtensions.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorTimerExtensions.cs
@@ -27,18 +27,18 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static RunTimer CreateSingleGeneratorRunTimer(this CodeAnalysisEventSource eventSource, ISourceGenerator generator)
+        public static RunTimer CreateSingleGeneratorRunTimer(this CodeAnalysisEventSource eventSource, ISourceGenerator generator, Func<TimeSpan, TimeSpan> adjustRunTime)
         {
             if (eventSource.IsEnabled(EventLevel.Informational, Keywords.Performance))
             {
                 var id = Guid.NewGuid().ToString();
                 var type = generator.GetGeneratorType();
                 eventSource.StartSingleGeneratorRunTime(type.FullName!, type.Assembly.Location, id);
-                return new RunTimer(t => eventSource.StopSingleGeneratorRunTime(type.FullName!, type.Assembly.Location, t.Ticks, id));
+                return new RunTimer(t => eventSource.StopSingleGeneratorRunTime(type.FullName!, type.Assembly.Location, t.Ticks, id), adjustRunTime);
             }
             else
             {
-                return new RunTimer();
+                return new RunTimer(adjustRunTime);
             }
         }
 
@@ -46,17 +46,19 @@ namespace Microsoft.CodeAnalysis
         {
             private readonly SharedStopwatch _timer;
             private readonly Action<TimeSpan>? _callback;
+            private readonly Func<TimeSpan, TimeSpan>? _adjustRunTime;
 
-            public TimeSpan Elapsed => _timer.Elapsed;
+            public TimeSpan Elapsed => _adjustRunTime is not null ? _adjustRunTime(_timer.Elapsed) : _timer.Elapsed;
 
-            public RunTimer()
+            public RunTimer(Func<TimeSpan, TimeSpan>? adjustRunTime = null)
             {
                 _timer = SharedStopwatch.StartNew();
                 _callback = null;
+                _adjustRunTime = adjustRunTime;
             }
 
-            public RunTimer(Action<TimeSpan> callback)
-                : this()
+            public RunTimer(Action<TimeSpan> callback, Func<TimeSpan, TimeSpan>? adjustRunTime = null)
+                : this(adjustRunTime)
             {
                 _callback = callback;
             }
@@ -65,8 +67,7 @@ namespace Microsoft.CodeAnalysis
             {
                 if (_callback is not null)
                 {
-                    var elapsed = _timer.Elapsed;
-                    _callback(elapsed);
+                    _callback(Elapsed);
                 }
             }
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/RunResults.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/RunResults.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis
     }
 
     /// <summary>
-    /// Contains timing information a full generation pass.
+    /// Contains timing information for a full generation pass.
     /// </summary>
     public readonly struct GeneratorDriverTimingInfo
     {
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// The Generator that was running during the recorded time.
+        /// The <see cref="ISourceGenerator"/> that was running during the recorded time.
         /// </summary>
         public ISourceGenerator Generator { get; }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/RunResults.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/RunResults.cs
@@ -164,4 +164,51 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public string HintName { get; }
     }
+
+    /// <summary>
+    /// Contains timing information a full generation pass.
+    /// </summary>
+    public readonly struct GeneratorDriverTimingInfo
+    {
+        internal GeneratorDriverTimingInfo(TimeSpan elapsedTime, ImmutableArray<GeneratorTimingInfo> generatorTimes)
+        {
+            ElapsedTime = elapsedTime;
+            GeneratorTimes = generatorTimes;
+        }
+
+        /// <summary>
+        /// The wall clock time that the entire generation pass took.
+        /// </summary>
+        /// <remarks>
+        /// This can be more than the sum of times in <see cref="GeneratorTimes"/> as it includes other costs such as setup.
+        /// </remarks>
+        public TimeSpan ElapsedTime { get; }
+
+        /// <summary>
+        /// Individual timings per generator.
+        /// </summary>
+        public ImmutableArray<GeneratorTimingInfo> GeneratorTimes { get; }
+    }
+
+    /// <summary>
+    /// Contains timing information for a single generator.
+    /// </summary>
+    public readonly struct GeneratorTimingInfo
+    {
+        internal GeneratorTimingInfo(ISourceGenerator generator, TimeSpan elapsedTime)
+        {
+            Generator = generator;
+            ElapsedTime = elapsedTime;
+        }
+
+        /// <summary>
+        /// The Generator that was running during the recorded time.
+        /// </summary>
+        public ISourceGenerator Generator { get; }
+
+        /// <summary>
+        /// The wall clock time the generator spent running.
+        /// </summary>
+        public TimeSpan ElapsedTime { get; }
+    }
 }


### PR DESCRIPTION
Implements timing APIs as approved here: https://github.com/dotnet/roslyn/issues/59398

Also fixes a long standing problem where syntax time was misattributed to whichever generator first updated its syntax nodes. This was less of a problem when it was only ETW events, but now we're exposing it via API it needs to be correct.

Closes #59398