### PR TITLE
Remove outdated comment

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -5311,8 +5311,6 @@ using System;
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task TopLevelStatement()
         {
-            // Note: we should simplify 'global' as well
-            // https://github.com/dotnet/roslyn/issues/44420
             var code = @"
 int val = 0;
 int [||]val2 = val + 1;
@@ -5334,8 +5332,6 @@ System.Console.WriteLine((int)(val + 1));
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task TopLevelStatement_InScope()
         {
-            // Note: we should simplify 'global' as well
-            // https://github.com/dotnet/roslyn/issues/44420
             await TestAsync(@"
 {
     int val = 0;


### PR DESCRIPTION
`global::` was removed in https://github.com/dotnet/roslyn/commit/18263f7eb1af94d6f2f9e773e665ee1339fa9d41 but the comment was forgotten to be deleted.

Closes #44420