### PR TITLE
Don't block on clearing the output window on the UI thread when generating a file

### DIFF
--- a/src/Features/Core/Portable/PdbSourceDocument/IPdbSourceDocumentLogger.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/IPdbSourceDocumentLogger.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
     /// </summary>
     internal interface IPdbSourceDocumentLogger
     {
-        Task ClearAsync();
+        void Clear();
         void Log(string message);
     }
 

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -60,13 +60,8 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
             var assemblyName = symbol.ContainingAssembly.Identity.Name;
             var assemblyVersion = symbol.ContainingAssembly.Identity.Version.ToString();
 
-            if (_logger is not null)
-            {
-                // We block to clear the log from the previous operation, so things don't get confusing
-                // if the log messages are delayed
-                await _logger.ClearAsync().ConfigureAwait(false);
-            }
-
+            // Clear the log so messages from the previously generated file don't confuse the user
+            _logger?.Clear();
             _logger?.Log(FeaturesResources.Navigating_to_symbol_0_from_1, symbol, assemblyName);
 
             var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/PdbSourceDocument/PdbSourceDocumentOutputWindowLogger.cs
+++ b/src/VisualStudio/Core/Def/PdbSourceDocument/PdbSourceDocumentOutputWindowLogger.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.PdbSourceDocument
 
         public void Clear()
         {
-            _logItemsQueue.AddWork(null);
+            _logItemsQueue.AddWork<string?>(null);
         }
 
         public void Log(string value)

--- a/src/VisualStudio/Core/Def/PdbSourceDocument/PdbSourceDocumentOutputWindowLogger.cs
+++ b/src/VisualStudio/Core/Def/PdbSourceDocument/PdbSourceDocumentOutputWindowLogger.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.PdbSourceDocument
 
         public void Clear()
         {
-            _logItemsQueue.AddWork<string?>(null);
+            _logItemsQueue.AddWork((string?)null);
         }
 
         public void Log(string value)

--- a/src/VisualStudio/Core/Def/PdbSourceDocument/PdbSourceDocumentOutputWindowLogger.cs
+++ b/src/VisualStudio/Core/Def/PdbSourceDocument/PdbSourceDocumentOutputWindowLogger.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.PdbSourceDocument
         private IVsOutputWindowPane? _outputPane;
 
         private readonly IThreadingContext _threadingContext;
-        private readonly AsyncBatchingWorkQueue<string> _logItemsQueue;
+        private readonly AsyncBatchingWorkQueue<string?> _logItemsQueue;
         private readonly IServiceProvider _serviceProvider;
 
         private readonly CancellationTokenSource _cancellationTokenSource = new();
@@ -41,14 +41,14 @@ namespace Microsoft.VisualStudio.LanguageServices.PdbSourceDocument
 
             var asyncListener = listenerProvider.GetListener(nameof(PdbSourceDocumentOutputWindowLogger));
 
-            _logItemsQueue = new AsyncBatchingWorkQueue<string>(
+            _logItemsQueue = new AsyncBatchingWorkQueue<string?>(
                 DelayTimeSpan.NearImmediate,
                 ProcessLogMessagesAsync,
                 asyncListener,
                 _cancellationTokenSource.Token);
         }
 
-        private async ValueTask ProcessLogMessagesAsync(ImmutableArray<string> messages, CancellationToken cancellationToken)
+        private async ValueTask ProcessLogMessagesAsync(ImmutableArray<string?> messages, CancellationToken cancellationToken)
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
@@ -60,7 +60,11 @@ namespace Microsoft.VisualStudio.LanguageServices.PdbSourceDocument
                     return;
                 }
 
-                if (pane is IVsOutputWindowPaneNoPump noPumpPane)
+                if (message is null)
+                {
+                    pane.Clear();
+                }
+                else if (pane is IVsOutputWindowPaneNoPump noPumpPane)
                 {
                     noPumpPane.OutputStringNoPump(message + Environment.NewLine);
                 }
@@ -71,11 +75,9 @@ namespace Microsoft.VisualStudio.LanguageServices.PdbSourceDocument
             }
         }
 
-        public async Task ClearAsync()
+        public void Clear()
         {
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            GetPane()?.Clear();
+            _logItemsQueue.AddWork(null);
         }
 
         public void Log(string value)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/60115 ?