### PR TITLE
Change Visual Studio Cache version to stop restoring System.Text.Encodings.Web 4.6.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -119,7 +119,7 @@
     <MicrosoftServiceHubFrameworkVersion>3.1.3058</MicrosoftServiceHubFrameworkVersion>
     <MicrosoftSourceLinkToolsVersion>1.1.1-beta-21566-01</MicrosoftSourceLinkToolsVersion>
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
-    <MicrosoftVisualStudioCacheVersion>17.2.41-alpha</MicrosoftVisualStudioCacheVersion>
+    <MicrosoftVisualStudioCacheVersion>17.0.42</MicrosoftVisualStudioCacheVersion>
     <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.8.27812-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.8.27812-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>
     <MicrosoftVisualStudioComponentModelHostVersion>17.2.140-preview-ga1e1777dca</MicrosoftVisualStudioComponentModelHostVersion>


### PR DESCRIPTION
We update VisualStudioCache version to 17.2.41-alpha in main-vs-deps, and it is restoring System.Text.Encodings.Web 4.6.0
Per my understanding,
17.2.41-alpha
![image](https://user-images.githubusercontent.com/24360909/159352983-a3435a2a-b014-491f-838b-322d4f3954f6.png)
It is referencing
![image](https://user-images.githubusercontent.com/24360909/159353265-3b02e149-8a46-418c-a055-7ae82b66f391.png)
And System.Text.Json 4.6.0 is referencing System.Text.Encodings.Web 4.6.0
https://www.nuget.org/packages/System.Text.Json/4.6.0

But for 17.0.42 
![image](https://user-images.githubusercontent.com/24360909/159353088-5adef16a-e62b-424c-89c8-924d5c8f0622.png)
It is directly referencing 4.7.2 so System.Text.Encodings.Web 4.6.0 is not restored.
