### PR TITLE
VSMac external access for types required to startup the roslyn LSP server

### DIFF
--- a/src/EditorFeatures/Core.Cocoa/Lsp/VSMacLspLoggerFactoryWrapper.cs
+++ b/src/EditorFeatures/Core.Cocoa/Lsp/VSMacLspLoggerFactoryWrapper.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.VSMac.API;
+using StreamJsonRpc;
+
+namespace Microsoft.CodeAnalysis.EditorFeatures.Cocoa.Lsp;
+
+/// <summary>
+/// Wraps the external access <see cref="IVSMacLspLoggerFactory"/> and exports it
+/// as an <see cref="ILspLoggerFactory"/> for inclusion in the vsmac composition.
+/// </summary>
+[Export(typeof(ILspLoggerFactory)), Shared]
+internal class VSMacLspLoggerFactoryWrapper : ILspLoggerFactory
+{
+    private readonly IVSMacLspLoggerFactory _loggerFactory;
+
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public VSMacLspLoggerFactoryWrapper(IVSMacLspLoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory;
+    }
+
+    public async Task<ILspLogger> CreateLoggerAsync(string serverTypeName, string? clientName, JsonRpc jsonRpc, CancellationToken cancellationToken)
+    {
+        var vsMacLogger = await _loggerFactory.CreateLoggerAsync(serverTypeName, clientName, jsonRpc, cancellationToken).ConfigureAwait(false);
+        return new VSMacLspLoggerWrapper(vsMacLogger);
+    }
+}
+
+internal class VSMacLspLoggerWrapper : ILspLogger
+{
+    private readonly IVSMacLspLogger _logger;
+
+    public VSMacLspLoggerWrapper(IVSMacLspLogger logger)
+    {
+        _logger = logger;
+    }
+
+    public void TraceError(string message) => _logger.TraceError(message);
+
+    public void TraceException(Exception exception) => _logger.TraceException(exception);
+
+    public void TraceInformation(string message) => _logger.TraceInformation(message);
+
+    public void TraceStart(string message) => _logger.TraceStart(message);
+
+    public void TraceStop(string message) => _logger.TraceStop(message);
+
+    public void TraceWarning(string message) => _logger.TraceWarning(message);
+}

--- a/src/EditorFeatures/Core.Cocoa/Lsp/VSMacWorkspaceRegistrationService.cs
+++ b/src/EditorFeatures/Core.Cocoa/Lsp/VSMacWorkspaceRegistrationService.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+
+namespace Microsoft.CodeAnalysis.EditorFeatures.Cocoa.Lsp;
+
+/// <summary>
+/// Implementation of the workspace registration service exported to be included in the VSMac composition.
+/// </summary>
+[Export(typeof(LspWorkspaceRegistrationService)), Shared]
+internal class VSMacWorkspaceRegistrationService : LspWorkspaceRegistrationService
+{
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public VSMacWorkspaceRegistrationService()
+    {
+    }
+
+    /// <summary>
+    /// VSMac uses <see cref="WorkspaceKind.Host"/> for their MonoDevelopWorkspace.
+    /// </summary>
+    public override string GetHostWorkspaceKind() => WorkspaceKind.Host;
+}

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/API/VSMacLspLoggerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/API/VSMacLspLoggerFactory.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using StreamJsonRpc;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.VSMac.API;
+
+internal interface IVSMacLspLoggerFactory
+{
+    Task<IVSMacLspLogger> CreateLoggerAsync(string serverTypeName, string? clientName, JsonRpc jsonRpc, CancellationToken cancellationToken);
+}
+
+internal interface IVSMacLspLogger
+{
+    void TraceInformation(string message);
+    void TraceWarning(string message);
+    void TraceError(string message);
+    void TraceException(Exception exception);
+    void TraceStart(string message);
+    void TraceStop(string message);
+}

--- a/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -37,7 +37,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities2" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures2.UnitTests" />
-    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Razor"/>
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests" />
@@ -62,6 +62,7 @@
     <InternalsVisibleTo Include="IdeBenchmarks" />
     <InternalsVisibleTo Include="AnalyzerRunner" />
     <InternalsVisibleTo Include="Microsoft.CSharp.VSCode.Extension" Key="$(VisualStudioKey)" />
+    <RestrictedInternalsVisibleTo Include="MonoDevelop.Ide" Key="$(MonoDevelopKey)" Partner="VSMac" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Implements two types that are a required part of the mef composition in order to start any of the roslyn LSP servers
1. LspWorkspaceRegistrationService -> We implement this in the .Cocoa dll as we know the host workspace kind for VSMac.
2. ILspLoggerFactory + ILspLogger -> Implement as external access to allow vsmac to provide their own logger implementation.

