### PR TITLE
Allow VS Mac to access a few options and a helper method

### DIFF
--- a/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/AnalyzerHelper.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/AnalyzerHelper.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.VSMac;
+
+internal static class AnalyzerHelper
+{
+    public static DiagnosticData CreateAnalyzerLoadFailureDiagnostic(AnalyzerLoadFailureEventArgs e, string fullPath, ProjectId? projectId, string? language)
+        => DocumentAnalysisExecutor.CreateAnalyzerLoadFailureDiagnostic(e, fullPath, projectId, language);
+}
+

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/CompletionOptionsAccessor.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/CompletionOptionsAccessor.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.VSMac;
+
+internal static class CompletionOptionsAccessor
+{
+    public static PerLanguageOption2<bool?> ShowItemsFromUnimportedNamespaces
+        => CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces;
+
+    public static PerLanguageOption2<bool> TriggerOnTypingLetters
+        => CompletionOptionsStorage.TriggerOnTypingLetters;
+
+    public static PerLanguageOption2<bool?> TriggerOnDeletion
+        => CompletionOptionsStorage.TriggerOnDeletion;
+}
+

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/SolutionCrawlerOptionsAccessor.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/SolutionCrawlerOptionsAccessor.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.SolutionCrawler;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.VSMac;
+
+internal static class SolutionCrawlerOptionsAccessor
+{
+    public static bool LowMemoryForcedMinimalBackgroundAnalysis
+    {
+        get => SolutionCrawlerOptionsStorage.LowMemoryForcedMinimalBackgroundAnalysis;
+        set => SolutionCrawlerOptionsStorage.LowMemoryForcedMinimalBackgroundAnalysis = value;
+    }
+
+    public static PerLanguageOption2<BackgroundAnalysisScope> BackgroundAnalysisScopeOption
+        => SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption;
+
+    public static BackgroundAnalysisScope GetBackgroundAnalysisScope(IGlobalOptionService globalOptions, string language)
+        => SolutionCrawlerOptionsStorage.GetBackgroundAnalysisScope(globalOptions, language);
+}

--- a/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -37,7 +37,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.Test.Utilities2" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.EditorFeatures2.UnitTests" />
-    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Razor"/>
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests" />
@@ -62,6 +62,7 @@
     <InternalsVisibleTo Include="IdeBenchmarks" />
     <InternalsVisibleTo Include="AnalyzerRunner" />
     <InternalsVisibleTo Include="Microsoft.CSharp.VSCode.Extension" Key="$(VisualStudioKey)" />
+    <RestrictedInternalsVisibleTo Include="MonoDevelop.Ide" Key="$(MonoDevelopKey)" Partner="VSMac" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With the move of some things from Features to LanguageServer.Protocol, VS Macs broad IVT stopped working for some things, so I was totally going to just add it to the LanguageServer.Protocol project, but @dibarbet put up https://github.com/dotnet/roslyn/pull/60330 so doing that would have brought (well deserved) shame on my family.

This should unblock https://github.com/xamarin/vsmac/pull/6172