### PR TITLE
[LSP] Don't adjust breakpoints when there are diagnostics in the document

### DIFF
--- a/src/Features/LanguageServer/ProtocolUnitTests/ValidateBreakableRange/ValidateBreakableRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ValidateBreakableRange/ValidateBreakableRangeTests.cs
@@ -23,18 +23,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.ValidateBreakableRange
 {
     void M()
     {
-        {|caret:|}M();
+        {|expected:{|caret:|}M();|}
     }
 }";
             using var testLspServer = await CreateTestLspServerAsync(markup);
 
             var caret = testLspServer.GetLocations("caret").Single();
 
-            var expected = new LSP.Range()
-            {
-                Start = caret.Range.Start,
-                End = new LSP.Position(caret.Range.Start.Line, caret.Range.Start.Character + "M();".Length),
-            };
+            var expected = testLspServer.GetLocations("expected").Single().Range;
 
             var result = await RunAsync(testLspServer, caret);
             AssertJsonEquals(expected, result);
@@ -57,11 +53,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.ValidateBreakableRange
 
             var caret = testLspServer.GetLocations("caret").Single();
 
-            var expected = new LSP.Range()
-            {
-                Start = caret.Range.Start,
-                End = caret.Range.Start,
-            };
+            var expected = caret.Range;
 
             var result = await RunAsync(testLspServer, caret);
             AssertJsonEquals(expected, result);
@@ -87,6 +79,27 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.ValidateBreakableRange
         }
 
         [Fact]
+        public async Task SplitBreakpoint()
+        {
+            var markup =
+@"class A
+{
+    void M()
+    {
+        {|breakpoint:{|expected:int a = 1;|} Console.WriteLine(""hello"");|}
+    }
+}";
+            using var testLspServer = await CreateTestLspServerAsync(markup);
+
+            var breakpoint = testLspServer.GetLocations("breakpoint").Single();
+
+            var expected = testLspServer.GetLocations("expected").Single().Range;
+
+            var result = await RunAsync(testLspServer, breakpoint);
+            AssertJsonEquals(expected, result);
+        }
+
+        [Fact]
         [WorkItem(1501785, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1501785")]
         public async Task InvalidExistingBreakpoint1()
         {
@@ -100,11 +113,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.ValidateBreakableRange
 }";
             using var testLspServer = await CreateTestLspServerAsync(markup);
 
-            var caret = testLspServer.GetLocations("breakpoint").Single();
+            var breakpoint = testLspServer.GetLocations("breakpoint").Single();
 
-            var expected = caret.Range;
+            var expected = breakpoint.Range;
 
-            var result = await RunAsync(testLspServer, caret);
+            var result = await RunAsync(testLspServer, breakpoint);
             AssertJsonEquals(expected, result);
         }
 
@@ -123,11 +136,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.ValidateBreakableRange
 }";
             using var testLspServer = await CreateTestLspServerAsync(markup);
 
-            var caret = testLspServer.GetLocations("breakpoint").Single();
+            var breakpoint = testLspServer.GetLocations("breakpoint").Single();
 
-            var expected = caret.Range;
+            var expected = breakpoint.Range;
 
-            var result = await RunAsync(testLspServer, caret);
+            var result = await RunAsync(testLspServer, breakpoint);
             AssertJsonEquals(expected, result);
         }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/ValidateBreakableRange/ValidateBreakableRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ValidateBreakableRange/ValidateBreakableRangeTests.cs
@@ -86,6 +86,51 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.ValidateBreakableRange
             Assert.Null(result);
         }
 
+        [Fact]
+        [WorkItem(1501785, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1501785")]
+        public async Task InvalidExistingBreakpoint1()
+        {
+            var markup =
+@"class A
+{
+    void M()
+    {
+        {|breakpoint:int a Console.WriteLine(""hello"");|}
+    }
+}";
+            using var testLspServer = await CreateTestLspServerAsync(markup);
+
+            var caret = testLspServer.GetLocations("breakpoint").Single();
+
+            var expected = caret.Range;
+
+            var result = await RunAsync(testLspServer, caret);
+            AssertJsonEquals(expected, result);
+        }
+
+        [Fact]
+        [WorkItem(1501882, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1501882")]
+        public async Task InvalidExistingBreakpoint2()
+        {
+            var markup =
+@"class A
+{
+    void M()
+    {
+        int b=
+     {|breakpoint:int a = 1;|}
+    }
+}";
+            using var testLspServer = await CreateTestLspServerAsync(markup);
+
+            var caret = testLspServer.GetLocations("breakpoint").Single();
+
+            var expected = caret.Range;
+
+            var result = await RunAsync(testLspServer, caret);
+            AssertJsonEquals(expected, result);
+        }
+
         private static async Task<LSP.Range?> RunAsync(TestLspServer testLspServer, LSP.Location caret)
         {
             return await testLspServer.ExecuteRequestAsync<LSP.VSInternalValidateBreakableRangeParams, LSP.Range?>(


### PR DESCRIPTION
Fixes [AB#1501882](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1501882)
Fixes [AB#1501785](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1501785)

This just resurrects some logic that the local scenario does that wasn't done in LSP. I didn't write it, I just translated it a bit.

Original code (and really long comment) is here:
https://github.com/dotnet/roslyn/blob/main/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService%602.VsLanguageDebugInfo.cs#L284-L311