### PR TITLE
Remove .git-blame-ignore-revs to avoid inaccurate blame on github

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,0 @@
-# dotnet-format -w Roslyn.sln on June 18, 2021
-abce41d282ac631be5217140f1bd46d0e250ad02
-fbdb56063e761643707f6bc1e1ba469f6fb9a31a
-57278e7dcbf7bffb310e8b14105f657f0fdbab78


### PR DESCRIPTION
As promised, I avoided sending this PR until the first time it was clear without looking that the blame view was inaccurate and unable to be corrected by a per-user setting.

![image](https://user-images.githubusercontent.com/1408396/159804656-9fa7c489-b2c4-4958-a68d-476302ba05f3.png)
