### PR TITLE
[LSP] Remove the majority of usages of client name.

### DIFF
--- a/src/EditorFeatures/Core.Cocoa/Lsp/VSMacLspLoggerFactoryWrapper.cs
+++ b/src/EditorFeatures/Core.Cocoa/Lsp/VSMacLspLoggerFactoryWrapper.cs
@@ -29,9 +29,9 @@ internal class VSMacLspLoggerFactoryWrapper : ILspLoggerFactory
         _loggerFactory = loggerFactory;
     }
 
-    public async Task<ILspLogger> CreateLoggerAsync(string serverTypeName, string? clientName, JsonRpc jsonRpc, CancellationToken cancellationToken)
+    public async Task<ILspLogger> CreateLoggerAsync(string serverTypeName, JsonRpc jsonRpc, CancellationToken cancellationToken)
     {
-        var vsMacLogger = await _loggerFactory.CreateLoggerAsync(serverTypeName, clientName, jsonRpc, cancellationToken).ConfigureAwait(false);
+        var vsMacLogger = await _loggerFactory.CreateLoggerAsync(serverTypeName, jsonRpc, cancellationToken).ConfigureAwait(false);
         return new VSMacLspLoggerWrapper(vsMacLogger);
     }
 }

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptInProcLanguageClient.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
             DefaultCapabilitiesProvider defaultCapabilitiesProvider,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
-            : base(requestDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
+            : base(requestDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext)
         {
             _typeScriptCapabilitiesProvider = typeScriptCapabilitiesProvider;
         }

--- a/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
 {
     internal abstract partial class AbstractInProcLanguageClient : ILanguageClient, ILanguageServerFactory, ICapabilitiesProvider
     {
-        private readonly string? _diagnosticsClientName;
         private readonly IThreadingContext _threadingContext;
         private readonly ILspLoggerFactory _lspLoggerFactory;
 
@@ -86,14 +85,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             IAsynchronousOperationListenerProvider listenerProvider,
             LspWorkspaceRegistrationService lspWorkspaceRegistrationService,
             ILspLoggerFactory lspLoggerFactory,
-            IThreadingContext threadingContext,
-            string? diagnosticsClientName)
+            IThreadingContext threadingContext)
         {
             _requestDispatcherFactory = requestDispatcherFactory;
             GlobalOptions = globalOptions;
             _listenerProvider = listenerProvider;
             _lspWorkspaceRegistrationService = lspWorkspaceRegistrationService;
-            _diagnosticsClientName = diagnosticsClientName;
             _lspLoggerFactory = lspLoggerFactory;
             _threadingContext = threadingContext;
         }
@@ -146,7 +143,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
                 serverStream,
                 serverStream,
                 _lspLoggerFactory,
-                _diagnosticsClientName,
                 cancellationToken).ConfigureAwait(false);
 
             return new Connection(clientStream, clientStream);
@@ -180,7 +176,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             Stream inputStream,
             Stream outputStream,
             ILspLoggerFactory lspLoggerFactory,
-            string? clientName,
             CancellationToken cancellationToken)
         {
             var jsonMessageFormatter = new JsonMessageFormatter();
@@ -193,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
 
             var serverTypeName = languageClient.GetType().Name;
 
-            var logger = await lspLoggerFactory.CreateLoggerAsync(serverTypeName, clientName, jsonRpc, cancellationToken).ConfigureAwait(false);
+            var logger = await lspLoggerFactory.CreateLoggerAsync(serverTypeName, jsonRpc, cancellationToken).ConfigureAwait(false);
 
             var server = languageClient.Create(
                 jsonRpc,
@@ -219,7 +214,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
                 _listenerProvider,
                 logger,
                 SupportedLanguages,
-                clientName: _diagnosticsClientName,
                 ServerKind);
         }
 

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             DefaultCapabilitiesProvider defaultCapabilitiesProvider,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
-            : base(csharpVBRequestDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
+            : base(csharpVBRequestDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext)
         {
             _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
         }

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
@@ -86,6 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             public LanguageClientMetadata(string[] contentTypes, string clientName = null)
             {
                 this.ContentTypes = contentTypes;
+                this.ClientName = clientName;
             }
 
             public string ClientName { get; }

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
@@ -86,7 +86,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             public LanguageClientMetadata(string[] contentTypes, string clientName = null)
             {
                 this.ContentTypes = contentTypes;
-                this.ClientName = clientName;
             }
 
             public string ClientName { get; }

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/Completion/CompletionHandler.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/Completion/CompletionHandler.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 var completionItemResolveData = supportsCompletionListData ? null : completionResolveData;
                 var lspCompletionItem = await CreateLSPCompletionItemAsync(
                     request, document, item, completionItemResolveData, lspVSClientCapability, commitCharactersRuleCache,
-                    completionService, context.ClientName, returnTextEdits, snippetsSupported, stringBuilder, documentText,
+                    completionService, returnTextEdits, snippetsSupported, stringBuilder, documentText,
                     defaultSpan, defaultRange, cancellationToken).ConfigureAwait(false);
                 lspCompletionItems.Add(lspCompletionItem);
             }
@@ -177,7 +177,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 bool supportsVSExtensions,
                 Dictionary<ImmutableArray<CharacterSetModificationRule>, string[]> commitCharacterRulesCache,
                 CompletionService completionService,
-                string? clientName,
                 bool returnTextEdits,
                 bool snippetsSupported,
                 StringBuilder stringBuilder,
@@ -190,7 +189,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 {
                     var vsCompletionItem = await CreateCompletionItemAsync<LSP.VSInternalCompletionItem>(
                         request, document, item, completionResolveData, supportsVSExtensions, commitCharacterRulesCache,
-                        completionService, clientName, returnTextEdits, snippetsSupported, stringBuilder,
+                        completionService, returnTextEdits, snippetsSupported, stringBuilder,
                         documentText, defaultSpan, defaultRange, cancellationToken).ConfigureAwait(false);
                     vsCompletionItem.Icon = new ImageElement(item.Tags.GetFirstGlyph().GetImageId());
                     return vsCompletionItem;
@@ -199,7 +198,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 {
                     var roslynCompletionItem = await CreateCompletionItemAsync<LSP.CompletionItem>(
                         request, document, item, completionResolveData, supportsVSExtensions, commitCharacterRulesCache,
-                        completionService, clientName, returnTextEdits, snippetsSupported, stringBuilder,
+                        completionService, returnTextEdits, snippetsSupported, stringBuilder,
                         documentText, defaultSpan, defaultRange, cancellationToken).ConfigureAwait(false);
                     return roslynCompletionItem;
                 }
@@ -213,7 +212,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 bool supportsVSExtensions,
                 Dictionary<ImmutableArray<CharacterSetModificationRule>, string[]> commitCharacterRulesCache,
                 CompletionService completionService,
-                string? clientName,
                 bool returnTextEdits,
                 bool snippetsSupported,
                 StringBuilder stringBuilder,

--- a/src/EditorFeatures/Core/LanguageServer/LiveShareInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/LiveShareInProcLanguageClient.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             DefaultCapabilitiesProvider defaultCapabilitiesProvider,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
-            : base(csharpVBRequestDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
+            : base(csharpVBRequestDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext)
         {
             _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
         }

--- a/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             DefaultCapabilitiesProvider defaultCapabilitiesProvider,
             IThreadingContext threadingContext,
             ILspLoggerFactory lspLoggerFactory)
-            : base(csharpVBRequestDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, ClientName)
+            : base(csharpVBRequestDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext)
         {
             _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
         }

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -288,8 +288,8 @@ namespace Roslyn.Test.Utilities
         protected Task<TestLspServer> CreateTestLspServerAsync(string markup, LSP.ClientCapabilities? clientCapabilities = null)
             => CreateTestLspServerAsync(new string[] { markup }, Array.Empty<string>(), LanguageNames.CSharp, clientCapabilities);
 
-        protected Task<TestLspServer> CreateVisualBasicTestLspServerAsync(string markup, LSP.ClientCapabilities? clientCapabilities = null)
-            => CreateTestLspServerAsync(new string[] { markup }, Array.Empty<string>(), LanguageNames.VisualBasic, clientCapabilities);
+        private protected Task<TestLspServer> CreateVisualBasicTestLspServerAsync(string markup, LSP.ClientCapabilities? clientCapabilities = null, WellKnownLspServerKinds serverKind = WellKnownLspServerKinds.AlwaysActiveVSLspServer)
+            => CreateTestLspServerAsync(new string[] { markup }, Array.Empty<string>(), LanguageNames.VisualBasic, clientCapabilities, serverKind);
 
         protected Task<TestLspServer> CreateMultiProjectLspServerAsync(string xmlMarkup, LSP.ClientCapabilities? clientCapabilities = null)
             => CreateTestLspServerAsync(TestWorkspace.Create(xmlMarkup, composition: Composition), clientCapabilities, WellKnownLspServerKinds.AlwaysActiveVSLspServer);
@@ -579,7 +579,6 @@ namespace Roslyn.Test.Utilities
                     listenerProvider,
                     NoOpLspLogger.Instance,
                     ProtocolConstants.RoslynLspLanguages,
-                    clientName: null,
                     serverKind);
 
                 jsonRpc.StartListening();

--- a/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
@@ -51,7 +51,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 _listenerProvider,
                 logger,
                 ProtocolConstants.RoslynLspLanguages,
-                clientName: null,
                 WellKnownLspServerKinds.CSharpVisualBasicLspServer);
         }
     }

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -33,9 +33,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             => ProtocolConversions.TryGetUriFromFilePath(document.FilePath, context);
 
         public static ImmutableArray<Document> GetDocuments(this Solution solution, Uri documentUri)
-            => GetDocuments(solution, documentUri, logger: null);
-
-        public static ImmutableArray<Document> GetDocuments(this Solution solution, Uri documentUri, ILspLogger? logger)
         {
             var documentIds = GetDocumentIds(solution, documentUri);
 
@@ -61,7 +58,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
         public static Document? GetDocument(this Solution solution, TextDocumentIdentifier documentIdentifier)
         {
-            var documents = solution.GetDocuments(documentIdentifier.Uri, logger: null);
+            var documents = solution.GetDocuments(documentIdentifier.Uri);
             if (documents.Length == 0)
             {
                 return null;

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -33,18 +33,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             => ProtocolConversions.TryGetUriFromFilePath(document.FilePath, context);
 
         public static ImmutableArray<Document> GetDocuments(this Solution solution, Uri documentUri)
-            => GetDocuments(solution, documentUri, clientName: null, logger: null);
+            => GetDocuments(solution, documentUri, logger: null);
 
-        public static ImmutableArray<Document> GetDocuments(this Solution solution, Uri documentUri, string? clientName)
-            => GetDocuments(solution, documentUri, clientName, logger: null);
-
-        public static ImmutableArray<Document> GetDocuments(this Solution solution, Uri documentUri, string? clientName, ILspLogger? logger)
+        public static ImmutableArray<Document> GetDocuments(this Solution solution, Uri documentUri, ILspLogger? logger)
         {
             var documentIds = GetDocumentIds(solution, documentUri);
 
             var documents = documentIds.SelectAsArray(id => solution.GetRequiredDocument(id));
 
-            return FilterDocumentsByClientName(documents, clientName, logger);
+            return documents;
         }
 
         public static ImmutableArray<DocumentId> GetDocumentIds(this Solution solution, Uri documentUri)
@@ -62,40 +59,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return documentIds;
         }
 
-        private static ImmutableArray<Document> FilterDocumentsByClientName(ImmutableArray<Document> documents, string? clientName, ILspLogger? logger)
-        {
-            // If we don't have a client name, then we're done filtering
-            if (clientName == null)
-            {
-                return documents;
-            }
-
-            // We have a client name, so we need to filter to only documents that match that name
-            return documents.WhereAsArray(document =>
-            {
-                var documentPropertiesService = document.Services.GetService<DocumentPropertiesService>();
-
-                // When a client name is specified, only return documents that have a matching client name.
-                // Allows the razor lsp server to return results only for razor documents.
-                // This workaround should be removed when https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1106064/
-                // is fixed (so that the razor language server is only asked about razor buffers).
-                var documentClientName = documentPropertiesService?.DiagnosticsLspClientName;
-                var clientNameMatch = Equals(documentClientName, clientName);
-                if (!clientNameMatch && logger is not null)
-                {
-                    logger.TraceInformation($"Found matching document but it's client name '{documentClientName}' is not a match.");
-                }
-
-                return clientNameMatch;
-            });
-        }
-
         public static Document? GetDocument(this Solution solution, TextDocumentIdentifier documentIdentifier)
-            => solution.GetDocument(documentIdentifier, clientName: null);
-
-        public static Document? GetDocument(this Solution solution, TextDocumentIdentifier documentIdentifier, string? clientName)
         {
-            var documents = solution.GetDocuments(documentIdentifier.Uri, clientName, logger: null);
+            var documents = solution.GetDocuments(documentIdentifier.Uri, logger: null);
             if (documents.Length == 0)
             {
                 return null;
@@ -192,14 +158,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
         public static ClassifiedTextElement GetClassifiedText(this DefinitionItem definition)
             => new ClassifiedTextElement(definition.DisplayParts.Select(part => new ClassifiedTextRun(part.Tag.ToClassificationTypeName(), part.Text)));
-
-        public static bool IsRazorDocument(this Document document)
-        {
-            // Only razor docs have an ISpanMappingService, so we can use the presence of that to determine if this doc
-            // belongs to them.
-            var spanMapper = document.Services.GetService<ISpanMappingService>();
-            return spanMapper != null;
-        }
 
         private static bool TryGetVSCompletionListSetting(ClientCapabilities clientCapabilities, [NotNullWhen(returnValue: true)] out VSInternalCompletionListSetting? completionListSetting)
         {

--- a/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/API/VSMacLspLoggerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/ExternalAccess/VSMac/API/VSMacLspLoggerFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.ExternalAccess.VSMac.API;
 
 internal interface IVSMacLspLoggerFactory
 {
-    Task<IVSMacLspLogger> CreateLoggerAsync(string serverTypeName, string? clientName, JsonRpc jsonRpc, CancellationToken cancellationToken);
+    Task<IVSMacLspLogger> CreateLoggerAsync(string serverTypeName, JsonRpc jsonRpc, CancellationToken cancellationToken);
 }
 
 internal interface IVSMacLspLogger

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         protected const int WorkspaceDiagnosticIdentifier = 1;
         protected const int DocumentDiagnosticIdentifier = 2;
 
-        private readonly WellKnownLspServerKinds _serverKind;
         private readonly EditAndContinueDiagnosticUpdateSource _editAndContinueDiagnosticUpdateSource;
 
         protected readonly IDiagnosticService DiagnosticService;
@@ -63,11 +62,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         public bool RequiresLSPSolution => true;
 
         protected AbstractPullDiagnosticHandler(
-            WellKnownLspServerKinds serverKind,
             IDiagnosticService diagnosticService,
             EditAndContinueDiagnosticUpdateSource editAndContinueDiagnosticUpdateSource)
         {
-            _serverKind = serverKind;
             DiagnosticService = diagnosticService;
             _editAndContinueDiagnosticUpdateSource = editAndContinueDiagnosticUpdateSource;
             _versionedCache = new(this.GetType().Name);
@@ -135,11 +132,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             {
                 context.TraceInformation($"Processing: {document.FilePath}");
 
-                if (!IncludeDocument(document, context.ClientName))
-                {
-                    context.TraceInformation($"Ignoring document '{document.FilePath}' because of razor/client-name mismatch");
-                    continue;
-                }
+                // not be asked for workspace docs in razor.
+                // not send razor docs in workspace docs for c#
 
                 var encVersion = _editAndContinueDiagnosticUpdateSource.Version;
 
@@ -173,17 +167,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             return CreateReturn(progress);
         }
 
-        private static bool IncludeDocument(Document document, string? clientName)
-        {
-            // Documents either belong to Razor or not.  We can determine this by checking if the doc has a span-mapping
-            // service or not.  If we're not in razor, we do not include razor docs.  If we are in razor, we only
-            // include razor docs.
-            var isRazorDoc = document.IsRazorDocument();
-            var wantsRazorDoc = clientName != null;
-
-            return wantsRazorDoc == isRazorDoc;
-        }
-
         private static Dictionary<Document, PreviousPullResult> GetDocumentToPreviousDiagnosticParams(
             RequestContext context, ImmutableArray<PreviousPullResult> previousResults)
         {
@@ -210,7 +193,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             ClientCapabilities clientCapabilities,
             CancellationToken cancellationToken)
         {
-            var diagnosticModeOption = _serverKind switch
+            var diagnosticModeOption = context.ServerKind switch
             {
                 WellKnownLspServerKinds.LiveShareLspServer => s_liveShareDiagnosticMode,
                 WellKnownLspServerKinds.RazorLspServer => s_razorDiagnosticMode,

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
@@ -21,11 +21,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         private readonly IDiagnosticAnalyzerService _analyzerService;
 
         public DocumentPullDiagnosticHandler(
-            WellKnownLspServerKinds serverKind,
             IDiagnosticService diagnosticService,
             IDiagnosticAnalyzerService analyzerService,
             EditAndContinueDiagnosticUpdateSource editAndContinueDiagnosticUpdateSource)
-            : base(serverKind, diagnosticService, editAndContinueDiagnosticUpdateSource)
+            : base(diagnosticService, editAndContinueDiagnosticUpdateSource)
         {
             _analyzerService = analyzerService;
         }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalDocumentPullDiagnosticHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalDocumentPullDiagnosticHandlerProvider.cs
@@ -32,6 +32,6 @@ internal class ExperimentalDocumentPullDiagnosticHandlerProvider : IRequestHandl
 
     public ImmutableArray<IRequestHandler> CreateRequestHandlers(WellKnownLspServerKinds serverKind)
     {
-        return ImmutableArray.Create<IRequestHandler>(new ExperimentalDocumentPullDiagnosticsHandler(serverKind, _diagnosticService, _analyzerService, _editAndContinueDiagnosticUpdateSource));
+        return ImmutableArray.Create<IRequestHandler>(new ExperimentalDocumentPullDiagnosticsHandler(_diagnosticService, _analyzerService, _editAndContinueDiagnosticUpdateSource));
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalDocumentPullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalDocumentPullDiagnosticsHandler.cs
@@ -28,11 +28,10 @@ internal class ExperimentalDocumentPullDiagnosticsHandler : AbstractPullDiagnost
     private readonly IDiagnosticAnalyzerService _analyzerService;
 
     public ExperimentalDocumentPullDiagnosticsHandler(
-        WellKnownLspServerKinds serverKind,
         IDiagnosticService diagnosticService,
         IDiagnosticAnalyzerService analyzerService,
         EditAndContinueDiagnosticUpdateSource editAndContinueDiagnosticUpdateSource)
-        : base(serverKind, diagnosticService, editAndContinueDiagnosticUpdateSource)
+        : base(diagnosticService, editAndContinueDiagnosticUpdateSource)
     {
         _analyzerService = analyzerService;
     }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalWorkspacePullDiagnosticHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalWorkspacePullDiagnosticHandlerProvider.cs
@@ -32,6 +32,6 @@ internal class ExperimentalWorkspacePullDiagnosticHandlerProvider : IRequestHand
 
     public ImmutableArray<IRequestHandler> CreateRequestHandlers(WellKnownLspServerKinds serverKind)
     {
-        return ImmutableArray.Create<IRequestHandler>(new ExperimentalWorkspacePullDiagnosticsHandler(serverKind, _diagnosticService, _analyzerService, _editAndContinueDiagnosticUpdateSource));
+        return ImmutableArray.Create<IRequestHandler>(new ExperimentalWorkspacePullDiagnosticsHandler(_diagnosticService, _analyzerService, _editAndContinueDiagnosticUpdateSource));
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalWorkspacePullDiagnosticsHandler.cs
@@ -23,11 +23,10 @@ internal class ExperimentalWorkspacePullDiagnosticsHandler : AbstractPullDiagnos
     private readonly IDiagnosticAnalyzerService _analyzerService;
 
     public ExperimentalWorkspacePullDiagnosticsHandler(
-        WellKnownLspServerKinds serverKind,
         IDiagnosticService diagnosticService,
         IDiagnosticAnalyzerService analyzerService,
         EditAndContinueDiagnosticUpdateSource editAndContinueDiagnosticUpdateSource)
-        : base(serverKind, diagnosticService, editAndContinueDiagnosticUpdateSource)
+        : base(diagnosticService, editAndContinueDiagnosticUpdateSource)
     {
         _analyzerService = analyzerService;
     }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/PullDiagnosticHandlerProvider.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/PullDiagnosticHandlerProvider.cs
@@ -34,8 +34,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         public ImmutableArray<IRequestHandler> CreateRequestHandlers(WellKnownLspServerKinds serverKind)
         {
             return ImmutableArray.Create<IRequestHandler>(
-                new DocumentPullDiagnosticHandler(serverKind, _diagnosticService, _analyzerService, _editAndContinueDiagnosticUpdateSource),
-                new WorkspacePullDiagnosticHandler(serverKind, _diagnosticService, _editAndContinueDiagnosticUpdateSource));
+                new DocumentPullDiagnosticHandler(_diagnosticService, _analyzerService, _editAndContinueDiagnosticUpdateSource),
+                new WorkspacePullDiagnosticHandler(_diagnosticService, _editAndContinueDiagnosticUpdateSource));
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // Only support this for razor as LSP doesn't support overtype yet.
             // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1165179/
             // Once LSP supports overtype we can move all of brace completion to LSP.
-            if (request.Character == "\n" && context.ClientName == document.Services.GetService<DocumentPropertiesService>()?.DiagnosticsLspClientName)
+            if (request.Character == "\n" && context.ServerKind == WellKnownLspServerKinds.RazorLspServer)
             {
                 var indentationOptions = IndentationOptions.From(documentOptions, document.Project.Solution.Workspace.Services, document.Project.Language);
 

--- a/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             Contract.ThrowIfNull(context.Solution);
 
             // We specifically don't use context.Document here because we want multiple
-            var documents = context.Solution.GetDocuments(request.TextDocument.Uri, context.ClientName);
+            var documents = context.Solution.GetDocuments(request.TextDocument.Uri);
 
             if (!documents.Any())
             {

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.QueueItem.cs
@@ -28,9 +28,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             /// <inheritdoc cref="IRequestHandler.MutatesSolutionState" />
             bool MutatesSolutionState { get; }
 
-            /// <inheritdoc cref="RequestContext.ClientName" />
-            string? ClientName { get; }
-
             string MethodName { get; }
 
             /// <summary>
@@ -67,8 +64,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             public bool MutatesSolutionState { get; }
 
-            public string? ClientName { get; }
-
             public string MethodName { get; }
 
             public TextDocumentIdentifier? TextDocument { get; }
@@ -83,7 +78,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 bool mutatesSolutionState,
                 bool requiresLSPSolution,
                 ClientCapabilities clientCapabilities,
-                string? clientName,
                 string methodName,
                 TextDocumentIdentifier? textDocument,
                 TRequestType request,
@@ -107,7 +101,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 MutatesSolutionState = mutatesSolutionState;
                 RequiresLSPSolution = requiresLSPSolution;
                 ClientCapabilities = clientCapabilities;
-                ClientName = clientName;
                 MethodName = methodName;
                 TextDocument = textDocument;
             }
@@ -116,7 +109,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 bool mutatesSolutionState,
                 bool requiresLSPSolution,
                 ClientCapabilities clientCapabilities,
-                string? clientName,
                 string methodName,
                 TextDocumentIdentifier? textDocument,
                 TRequestType request,
@@ -130,7 +122,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     mutatesSolutionState,
                     requiresLSPSolution,
                     clientCapabilities,
-                    clientName,
                     methodName,
                     textDocument,
                     request,

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// </para>
     /// <para>
     /// Regardless of whether a request is mutating or not, or blocking or not, is an implementation detail of this class
-    /// and any consumers observing the results of the task returned from <see cref="ExecuteAsync{TRequestType, TResponseType}(bool, bool, IRequestHandler{TRequestType, TResponseType}, TRequestType, ClientCapabilities, string?, string, CancellationToken)"/>
+    /// and any consumers observing the results of the task returned from <see cref="ExecuteAsync{TRequestType, TResponseType}(bool, bool, IRequestHandler{TRequestType, TResponseType}, TRequestType, ClientCapabilities, string, CancellationToken)"/>
     /// will see the results of the handling of the request, whenever it occurred.
     /// </para>
     /// <para>
@@ -142,7 +142,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         /// <param name="handler">The handler that will handle the request.</param>
         /// <param name="request">The request to handle.</param>
         /// <param name="clientCapabilities">The client capabilities.</param>
-        /// <param name="clientName">The client name.</param>
         /// <param name="methodName">The name of the LSP method.</param>
         /// <param name="requestCancellationToken">A cancellation token that will cancel the handing of this request.
         /// The request could also be cancelled by the queue shutting down.</param>
@@ -153,7 +152,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             IRequestHandler<TRequestType, TResponseType> handler,
             TRequestType request,
             ClientCapabilities clientCapabilities,
-            string? clientName,
             string methodName,
             CancellationToken requestCancellationToken)
             where TRequestType : class
@@ -171,7 +169,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 mutatesSolutionState,
                 requiresLSPSolution,
                 clientCapabilities,
-                clientName,
                 methodName,
                 textDocument,
                 request,
@@ -275,7 +272,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             return RequestContext.Create(
                 queueItem.RequiresLSPSolution,
                 queueItem.TextDocument,
-                queueItem.ClientName,
+                _serverKind,
                 _logger,
                 queueItem.ClientCapabilities,
                 _lspWorkspaceManager,

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;

--- a/src/Features/LanguageServer/Protocol/ILspLoggerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/ILspLoggerFactory.cs
@@ -10,6 +10,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 {
     internal interface ILspLoggerFactory
     {
-        Task<ILspLogger> CreateLoggerAsync(string serverTypeName, string? clientName, JsonRpc jsonRpc, CancellationToken cancellationToken);
+        Task<ILspLogger> CreateLoggerAsync(string serverTypeName, JsonRpc jsonRpc, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
+++ b/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
@@ -28,7 +28,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         private readonly RequestExecutionQueue _queue;
         private readonly IAsynchronousOperationListener _listener;
         private readonly ILspLogger _logger;
-        private readonly string? _clientName;
 
         // Set on first LSP initialize request.
         private ClientCapabilities? _clientCapabilities;
@@ -49,7 +48,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             IAsynchronousOperationListenerProvider listenerProvider,
             ILspLogger logger,
             ImmutableArray<string> supportedLanguages,
-            string? clientName,
             WellKnownLspServerKinds serverKind)
         {
             _requestDispatcher = requestDispatcherFactory.CreateRequestDispatcher(serverKind);
@@ -62,7 +60,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             _jsonRpc.Disconnected += JsonRpc_Disconnected;
 
             _listener = listenerProvider.GetListener(FeatureAttribute.LanguageServer);
-            _clientName = clientName;
 
             _queue = new RequestExecutionQueue(
                 logger,
@@ -115,7 +112,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                     _method,
                     requestType,
                     _target._clientCapabilities,
-                    _target._clientName,
                     _target._queue,
                     cancellationToken).ConfigureAwait(false);
                 return result;
@@ -224,7 +220,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 requestMethod,
                 request,
                 _clientCapabilities,
-                _clientName,
                 _queue,
                 cancellationToken).ConfigureAwait(false);
             return result;

--- a/src/Features/LanguageServer/Protocol/RequestDispatcher.cs
+++ b/src/Features/LanguageServer/Protocol/RequestDispatcher.cs
@@ -91,7 +91,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             string methodName,
             TRequestType request,
             LSP.ClientCapabilities clientCapabilities,
-            string? clientName,
             RequestExecutionQueue queue,
             CancellationToken cancellationToken) where TRequestType : class
         {
@@ -106,7 +105,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             var strongHandler = (IRequestHandler<TRequestType, TResponseType>?)handler;
             Contract.ThrowIfNull(strongHandler, string.Format("Request handler not found for method {0}", methodName));
 
-            var result = await ExecuteRequestAsync(queue, mutatesSolutionState, requiresLspSolution, strongHandler, request, clientCapabilities, clientName, methodName, cancellationToken).ConfigureAwait(false);
+            var result = await ExecuteRequestAsync(queue, mutatesSolutionState, requiresLspSolution, strongHandler, request, clientCapabilities, methodName, cancellationToken).ConfigureAwait(false);
             return result;
         }
 
@@ -117,11 +116,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             IRequestHandler<TRequestType, TResponseType> handler,
             TRequestType request,
             LSP.ClientCapabilities clientCapabilities,
-            string? clientName,
             string methodName,
             CancellationToken cancellationToken) where TRequestType : class
         {
-            return queue.ExecuteAsync(mutatesSolutionState, requiresLSPSolution, handler, request, clientCapabilities, clientName, methodName, cancellationToken);
+            return queue.ExecuteAsync(mutatesSolutionState, requiresLSPSolution, handler, request, clientCapabilities, methodName, cancellationToken);
         }
 
         public ImmutableArray<RequestHandlerMetadata> GetRegisteredMethods()

--- a/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.LinkedDocuments.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.LinkedDocuments.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.DocumentChanges
 
         private static Solution GetLSPSolution(TestLspServer testLspServer, Uri uri)
         {
-            var lspDocument = testLspServer.GetManager().GetLspDocument(new TextDocumentIdentifier { Uri = uri }, null);
+            var lspDocument = testLspServer.GetManager().GetLspDocument(new TextDocumentIdentifier { Uri = uri });
             Contract.ThrowIfNull(lspDocument);
             return lspDocument.Project.Solution;
         }

--- a/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/OnAutoInsert/OnAutoInsertTests.cs
@@ -268,7 +268,7 @@ End Class";
         $0
     }
 }";
-            await VerifyMarkupAndExpected("\n", markup, expected);
+            await VerifyMarkupAndExpected("\n", markup, expected, serverKind: WellKnownLspServerKinds.RazorLspServer);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
@@ -290,7 +290,7 @@ End Class";
 		$0
 	}
 }";
-            await VerifyMarkupAndExpected("\n", markup, expected, insertSpaces: false, tabSize: 4);
+            await VerifyMarkupAndExpected("\n", markup, expected, insertSpaces: false, tabSize: 4, serverKind: WellKnownLspServerKinds.RazorLspServer);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
@@ -316,7 +316,7 @@ End Class";
         }
     }
 }";
-            await VerifyMarkupAndExpected("\n", markup, expected);
+            await VerifyMarkupAndExpected("\n", markup, expected, serverKind: WellKnownLspServerKinds.RazorLspServer);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.AutomaticCompletion)]
@@ -373,16 +373,23 @@ End Class";
             await VerifyNoResult("\n", markup);
         }
 
-        private async Task VerifyMarkupAndExpected(string characterTyped, string markup, string expected, bool insertSpaces = true, int tabSize = 4, string languageName = LanguageNames.CSharp)
+        private async Task VerifyMarkupAndExpected(
+            string characterTyped,
+            string markup,
+            string expected,
+            bool insertSpaces = true,
+            int tabSize = 4,
+            string languageName = LanguageNames.CSharp,
+            WellKnownLspServerKinds serverKind = WellKnownLspServerKinds.AlwaysActiveVSLspServer)
         {
             Task<TestLspServer> testLspServerTask;
             if (languageName == LanguageNames.CSharp)
             {
-                testLspServerTask = CreateTestLspServerAsync(markup);
+                testLspServerTask = CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions, serverKind);
             }
             else if (languageName == LanguageNames.VisualBasic)
             {
-                testLspServerTask = CreateVisualBasicTestLspServerAsync(markup);
+                testLspServerTask = CreateVisualBasicTestLspServerAsync(markup, CapabilitiesWithVSExtensions, serverKind);
             }
             else
             {

--- a/src/Features/LanguageServer/ProtocolUnitTests/VSTypeScriptHandlerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/VSTypeScriptHandlerTests.cs
@@ -103,7 +103,6 @@ public class VSTypeScriptHandlerTests : AbstractLanguageServerProtocolTests
             listenerProvider,
             NoOpLspLogger.Instance,
             ImmutableArray.Create(InternalLanguageNames.TypeScript),
-            clientName: null,
             WellKnownLspServerKinds.RoslynTypeScriptLspServer);
 
         jsonRpc.StartListening();

--- a/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
@@ -523,7 +523,7 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
 
     private static Document? GetLspDocument(Uri uri, TestLspServer testLspServer)
     {
-        return testLspServer.GetManager().GetLspDocument(CreateTextDocumentIdentifier(uri), clientName: null);
+        return testLspServer.GetManager().GetLspDocument(CreateTextDocumentIdentifier(uri));
     }
 
     private static Solution? GetLspHostSolution(TestLspServer testLspServer)

--- a/src/VisualStudio/Core/Def/LanguageClient/VisualStudioLogHubLoggerFactory.cs
+++ b/src/VisualStudio/Core/Def/LanguageClient/VisualStudioLogHubLoggerFactory.cs
@@ -42,9 +42,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
             _threadingContext = threadingContext;
         }
 
-        public async Task<ILspLogger> CreateLoggerAsync(string serverTypeName, string? clientName, JsonRpc jsonRpc, CancellationToken cancellationToken)
+        public async Task<ILspLogger> CreateLoggerAsync(string serverTypeName, JsonRpc jsonRpc, CancellationToken cancellationToken)
         {
-            var logName = $"Roslyn.{serverTypeName}.{clientName ?? "Default"}.{Interlocked.Increment(ref s_logHubSessionId)}";
+            var logName = $"Roslyn.{serverTypeName}.{Interlocked.Increment(ref s_logHubSessionId)}";
             var logId = new LogId(logName, new ServiceMoniker(typeof(LanguageServerTarget).FullName));
 
             var serviceContainer = await _asyncServiceProvider.GetServiceAsync<SVsBrokeredServiceContainer, IBrokeredServiceContainer>(_threadingContext.JoinableTaskFactory).ConfigureAwait(false);

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClient.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             LspWorkspaceRegistrationService lspWorkspaceRegistrationService,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
-            : base(xamlDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
+            : base(xamlDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext)
         {
         }
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClientDisableUX.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageClient/XamlInProcLanguageClientDisableUX.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             LspWorkspaceRegistrationService lspWorkspaceRegistrationService,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
-            : base(xamlDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext, diagnosticsClientName: null)
+            : base(xamlDispatcherFactory, globalOptions, listenerProvider, lspWorkspaceRegistrationService, lspLoggerFactory, threadingContext)
         {
         }
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Implementation.LanguageSe
                 {
                     if (previousResult.TextDocument != null)
                     {
-                        var document = context.Solution.GetDocument(previousResult.TextDocument, context.ClientName);
+                        var document = context.Solution.GetDocument(previousResult.TextDocument);
                         if (document == null)
                         {
                             // We can no longer get this document, return null for both diagnostics and resultId

--- a/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlRequestDispatcherFactory.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/LanguageServer/XamlRequestDispatcherFactory.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
             }
 
             protected override async Task<TResponseType?> ExecuteRequestAsync<TRequestType, TResponseType>(
-                RequestExecutionQueue queue, bool mutatesSolutionState, bool requiresLSPSolution, IRequestHandler<TRequestType, TResponseType> handler, TRequestType request, ClientCapabilities clientCapabilities, string? clientName, string methodName, CancellationToken cancellationToken)
+                RequestExecutionQueue queue, bool mutatesSolutionState, bool requiresLSPSolution, IRequestHandler<TRequestType, TResponseType> handler, TRequestType request, ClientCapabilities clientCapabilities, string methodName, CancellationToken cancellationToken)
                 where TRequestType : class
                 where TResponseType : default
             {
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.LanguageServer
                 {
                     try
                     {
-                        return await base.ExecuteRequestAsync(queue, mutatesSolutionState, requiresLSPSolution, handler, request, clientCapabilities, clientName, methodName, cancellationToken).ConfigureAwait(false);
+                        return await base.ExecuteRequestAsync(queue, mutatesSolutionState, requiresLSPSolution, handler, request, clientCapabilities, methodName, cancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception e) when (e is not OperationCanceledException)
                     {


### PR DESCRIPTION
There was previously [a bug](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1106064/) where both the liveshare c# server and razor c# server were asked for results in a liveshare session.  It has since been resolved so I no longer see the need to carry around the majority of the client name complexity that we had.

Instead of filtering documents by client name, we just respond with what we have that matches the URI.  It is up to the client to appropriately delegate to the correct server.

This at least reduces the complexity in my brain when I try and reason about how we map URIs -> documents.

The usages of client name that still remain are essentially only for diagnostic purposes.  We use it to
a) prevent razor file diagnostics from going to the error list (razor always asks us for them)
b) always calculate razor file diagnostics regardless of if the file is 'open' or not (when asked by razor)
c) prevent razor file diagnostics from being returned in LSP workspace pull diagnostics from the C# server (again, razor will directly ask us for diagnostics if and when they need them).

Can't merge until https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1505437 is fixed so I can verify liveshare