### PR TITLE
Skip failing test GoToBaseFromMetadataAsSource

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToBase.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToBase.cs
@@ -20,7 +20,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
         {
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/60386")]
         public async Task GoToBaseFromMetadataAsSource()
         {
             await TestServices.SolutionExplorer.AddFileAsync(ProjectName, "C.cs", cancellationToken: HangMitigatingCancellationToken);


### PR DESCRIPTION
Filed tracking issue: https://github.com/dotnet/roslyn/issues/60386
Skipping for now to unblock CI