### PR TITLE
[LSP] Explicitly define the completion items to resolve

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,7 +29,7 @@
     <VisualStudioEditorNewPackagesVersion>17.0.487</VisualStudioEditorNewPackagesVersion>
     <ILAsmPackageVersion>5.0.0-alpha1.19409.1</ILAsmPackageVersion>
     <ILDAsmPackageVersion>5.0.0-preview.1.20112.8</ILDAsmPackageVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.2.3</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.2.8</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.0.31723.112</MicrosoftVisualStudioShellPackagesVersion>
     <RefOnlyMicrosoftBuildPackagesVersion>16.5.0</RefOnlyMicrosoftBuildPackagesVersion>
     <!-- The version of Roslyn we build Source Generators against that are built in this

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/Completion/CompletionHandler.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/Completion/CompletionHandler.cs
@@ -186,42 +186,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 LSP.Range? defaultRange,
                 CancellationToken cancellationToken)
             {
-                if (supportsVSExtensions)
-                {
-                    var vsCompletionItem = await CreateCompletionItemAsync<LSP.VSInternalCompletionItem>(
-                        request, document, item, completionResolveData, supportsVSExtensions, commitCharacterRulesCache,
-                        completionService, clientName, returnTextEdits, snippetsSupported, stringBuilder,
-                        documentText, defaultSpan, defaultRange, cancellationToken).ConfigureAwait(false);
-                    vsCompletionItem.Icon = new ImageElement(item.Tags.GetFirstGlyph().GetImageId());
-                    return vsCompletionItem;
-                }
-                else
-                {
-                    var roslynCompletionItem = await CreateCompletionItemAsync<LSP.CompletionItem>(
-                        request, document, item, completionResolveData, supportsVSExtensions, commitCharacterRulesCache,
-                        completionService, clientName, returnTextEdits, snippetsSupported, stringBuilder,
-                        documentText, defaultSpan, defaultRange, cancellationToken).ConfigureAwait(false);
-                    return roslynCompletionItem;
-                }
-            }
-
-            static async Task<TCompletionItem> CreateCompletionItemAsync<TCompletionItem>(
-                LSP.CompletionParams request,
-                Document document,
-                CompletionItem item,
-                CompletionResolveData? completionResolveData,
-                bool supportsVSExtensions,
-                Dictionary<ImmutableArray<CharacterSetModificationRule>, string[]> commitCharacterRulesCache,
-                CompletionService completionService,
-                string? clientName,
-                bool returnTextEdits,
-                bool snippetsSupported,
-                StringBuilder stringBuilder,
-                SourceText? documentText,
-                TextSpan? defaultSpan,
-                LSP.Range? defaultRange,
-                CancellationToken cancellationToken) where TCompletionItem : LSP.CompletionItem, new()
-            {
                 // Generate display text
                 stringBuilder.Append(item.DisplayTextPrefix);
                 stringBuilder.Append(item.DisplayText);
@@ -229,20 +193,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 var completeDisplayText = stringBuilder.ToString();
                 stringBuilder.Clear();
 
-                var completionItem = new TCompletionItem
-                {
-                    Label = completeDisplayText,
-                    SortText = item.SortText,
-                    FilterText = item.FilterText,
-                    Kind = GetCompletionKind(item.Tags),
-                    Data = completionResolveData,
-                    Preselect = ShouldItemBePreselected(item),
-                };
+                var completionItem = supportsVSExtensions ? new LSP.VSInternalCompletionItem() : new LSP.CompletionItem();
+                completionItem.Label = completeDisplayText;
+                completionItem.SortText = item.SortText;
+                completionItem.FilterText = item.FilterText;
+                completionItem.Kind = GetCompletionKind(item.Tags);
+                completionItem.Data = completionResolveData;
+                completionItem.Preselect = ShouldItemBePreselected(item);
 
                 // Complex text edits (e.g. override and partial method completions) are always populated in the
                 // resolve handler, so we leave both TextEdit and InsertText unpopulated in these cases.
-                if (item.IsComplexTextEdit)
+                if (item.IsComplexTextEdit && completionItem is LSP.VSInternalCompletionItem vsItem)
                 {
+                    vsItem.VsResolveTextEditOnCommit = true;
                     // Razor C# is currently the only language client that supports LSP.InsertTextFormat.Snippet.
                     // We can enable it for regular C# once LSP is used for local completion.
                     if (snippetsSupported)
@@ -267,6 +230,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 if (commitCharacters != null)
                 {
                     completionItem.CommitCharacters = commitCharacters;
+                }
+
+                if (completionItem is LSP.VSInternalCompletionItem vsCompletionItem)
+                {
+                    vsCompletionItem.Icon = new ImageElement(item.Tags.GetFirstGlyph().GetImageId());
                 }
 
                 return completionItem;

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -556,6 +556,7 @@ class B : A
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             Assert.Null(results.Items.First().TextEdit);
             Assert.Null(results.Items.First().InsertText);
+            Assert.True(((LSP.VSInternalCompletionItem)results.Items.First()).VsResolveTextEditOnCommit);
         }
 
         [Fact]


### PR DESCRIPTION
Response to https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/385546

Instead of relying on the implicit contract of no insert text + text edit (which is not necessarily applicable with item defaults), we specify a property to VS which tells them to resolve on commit.