### PR TITLE
Treat `async` as a modifier in some edge cases for C#

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
@@ -348,6 +348,7 @@ class C
         }
 
         [Fact]
+        [WorkItem(60339, "https://github.com/dotnet/roslyn/issues/60339")]
         public void IncompleteAsync()
         {
             UsingTree(@"
@@ -364,10 +365,7 @@ class C
                     N(SyntaxKind.OpenBraceToken);
                     N(SyntaxKind.IncompleteMember);
                     {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
+                        N(SyntaxKind.AsyncKeyword);
                     }
                     M(SyntaxKind.CloseBraceToken);
                 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/60339

Yes, this is a change in compiler layer. But I don't think it is crucial, because it applies for incomplete trees anyway