### PR TITLE
Avoid checking HasValue in nullable comparison for non-default constants

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -2288,7 +2288,7 @@ public class Test
             compilation.VerifyIL("NullableTest.EqualEqual",
 @"
 {
-  // Code size      112 (0x70)
+  // Code size      104 (0x68)
   .maxstack  2
   .locals init (decimal? V_0)
   IL_0000:  ldc.i4.0
@@ -2302,27 +2302,24 @@ public class Test
   IL_001c:  ldloca.s   V_0
   IL_001e:  call       ""decimal decimal?.GetValueOrDefault()""
   IL_0023:  call       ""bool decimal.op_Equality(decimal, decimal)""
-  IL_0028:  ldloca.s   V_0
-  IL_002a:  call       ""bool decimal?.HasValue.get""
-  IL_002f:  and
-  IL_0030:  box        ""bool""
-  IL_0035:  ldc.i4.0
-  IL_0036:  box        ""bool""
-  IL_003b:  call       ""void Test.Eval(object, object)""
-  IL_0040:  ldsfld     ""decimal decimal.Zero""
-  IL_0045:  ldsfld     ""decimal? NullableTest.NULL""
-  IL_004a:  stloc.0
-  IL_004b:  ldloca.s   V_0
-  IL_004d:  call       ""decimal decimal?.GetValueOrDefault()""
-  IL_0052:  call       ""bool decimal.op_Equality(decimal, decimal)""
-  IL_0057:  ldloca.s   V_0
-  IL_0059:  call       ""bool decimal?.HasValue.get""
-  IL_005e:  and
-  IL_005f:  box        ""bool""
-  IL_0064:  ldc.i4.0
-  IL_0065:  box        ""bool""
-  IL_006a:  call       ""void Test.Eval(object, object)""
-  IL_006f:  ret
+  IL_0028:  box        ""bool""
+  IL_002d:  ldc.i4.0
+  IL_002e:  box        ""bool""
+  IL_0033:  call       ""void Test.Eval(object, object)""
+  IL_0038:  ldsfld     ""decimal decimal.Zero""
+  IL_003d:  ldsfld     ""decimal? NullableTest.NULL""
+  IL_0042:  stloc.0
+  IL_0043:  ldloca.s   V_0
+  IL_0045:  call       ""decimal decimal?.GetValueOrDefault()""
+  IL_004a:  call       ""bool decimal.op_Equality(decimal, decimal)""
+  IL_004f:  ldloca.s   V_0
+  IL_0051:  call       ""bool decimal?.HasValue.get""
+  IL_0056:  and
+  IL_0057:  box        ""bool""
+  IL_005c:  ldc.i4.0
+  IL_005d:  box        ""bool""
+  IL_0062:  call       ""void Test.Eval(object, object)""
+  IL_0067:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -534,7 +534,7 @@ class C
             comp.VerifyDiagnostics();
 
             comp.VerifyIL("C.M", @"{
-  // Code size       63 (0x3f)
+  // Code size       45 (0x2d)
   .maxstack  2
   .locals init (System.ValueTuple<int?, bool?> V_0,
                 int? V_1,
@@ -551,26 +551,19 @@ class C
   IL_000b:  ldloca.s   V_1
   IL_000d:  call       ""int int?.GetValueOrDefault()""
   IL_0012:  ldloc.2
-  IL_0013:  ceq
-  IL_0015:  ldloca.s   V_1
-  IL_0017:  call       ""bool int?.HasValue.get""
-  IL_001c:  and
-  IL_001d:  brfalse.s  IL_003d
-  IL_001f:  ldloc.0
-  IL_0020:  ldfld      ""bool? System.ValueTuple<int?, bool?>.Item2""
-  IL_0025:  stloc.3
-  IL_0026:  ldc.i4.1
-  IL_0027:  stloc.s    V_4
-  IL_0029:  ldloca.s   V_3
-  IL_002b:  call       ""bool bool?.GetValueOrDefault()""
-  IL_0030:  ldloc.s    V_4
-  IL_0032:  ceq
-  IL_0034:  ldloca.s   V_3
-  IL_0036:  call       ""bool bool?.HasValue.get""
-  IL_003b:  and
-  IL_003c:  ret
-  IL_003d:  ldc.i4.0
-  IL_003e:  ret
+  IL_0013:  bne.un.s   IL_002b
+  IL_0015:  ldloc.0
+  IL_0016:  ldfld      ""bool? System.ValueTuple<int?, bool?>.Item2""
+  IL_001b:  stloc.3
+  IL_001c:  ldc.i4.1
+  IL_001d:  stloc.s    V_4
+  IL_001f:  ldloca.s   V_3
+  IL_0021:  call       ""bool bool?.GetValueOrDefault()""
+  IL_0026:  ldloc.s    V_4
+  IL_0028:  ceq
+  IL_002a:  ret
+  IL_002b:  ldc.i4.0
+  IL_002c:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -4266,7 +4266,7 @@ public class C
 ");
             compVerifier.VerifyIL("C.M2(int?)", @"
 {
-  // Code size       23 (0x17)
+  // Code size       15 (0xf)
   .maxstack  2
   .locals init (int? V_0,
                 int V_1)
@@ -4278,10 +4278,7 @@ public class C
   IL_0006:  call       ""int int?.GetValueOrDefault()""
   IL_000b:  ldloc.1
   IL_000c:  ceq
-  IL_000e:  ldloca.s   V_0
-  IL_0010:  call       ""bool int?.HasValue.get""
-  IL_0015:  and
-  IL_0016:  ret
+  IL_000e:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenOptimizedNullableOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenOptimizedNullableOperators.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
+{
+    public class CodeGenOptimizedNullableOperators : CSharpTestBase
+    {
+        [Fact]
+        public void TestComparisonNullableWithNonDefaultConstantValue()
+        {
+            var code = @"
+public class C
+{
+    public bool M(int? x)
+    {
+        return x == 42;
+    }
+}
+";
+            CompileAndVerify(code).VerifyDiagnostics().VerifyIL("C.M", @"
+{
+  // Code size       16 (0x10)
+  .maxstack  2
+  .locals init (int? V_0,
+                int V_1)
+  IL_0000:  ldarg.1
+  IL_0001:  stloc.0
+  IL_0002:  ldc.i4.s   42
+  IL_0004:  stloc.1
+  IL_0005:  ldloca.s   V_0
+  IL_0007:  call       ""int int?.GetValueOrDefault()""
+  IL_000c:  ldloc.1
+  IL_000d:  ceq
+  IL_000f:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestComparisonNullableWithDefaultConstantValue()
+        {
+            var code = @"
+public class C
+{
+    public bool M(int? x)
+    {
+        return x == 0;
+    }
+}
+";
+            CompileAndVerify(code).VerifyDiagnostics().VerifyIL("C.M", @"
+{
+  // Code size       23 (0x17)
+  .maxstack  2
+  .locals init (int? V_0,
+                int V_1)
+  IL_0000:  ldarg.1
+  IL_0001:  stloc.0
+  IL_0002:  ldc.i4.0
+  IL_0003:  stloc.1
+  IL_0004:  ldloca.s   V_0
+  IL_0006:  call       ""int int?.GetValueOrDefault()""
+  IL_000b:  ldloc.1
+  IL_000c:  ceq
+  IL_000e:  ldloca.s   V_0
+  IL_0010:  call       ""bool int?.HasValue.get""
+  IL_0015:  and
+  IL_0016:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestComparisonNullableWithNull()
+        {
+            var code = @"
+public class C
+{
+    public bool M(int? x)
+    {
+        return x == null;
+    }
+}
+";
+            CompileAndVerify(code).VerifyDiagnostics().VerifyIL("C.M", @"
+{
+  // Code size       11 (0xb)
+  .maxstack  2
+  IL_0000:  ldarga.s   V_1
+  IL_0002:  call       ""bool int?.HasValue.get""
+  IL_0007:  ldc.i4.0
+  IL_0008:  ceq
+  IL_000a:  ret
+}
+");
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenOptimizedNullableOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenOptimizedNullableOperators.cs
@@ -98,5 +98,46 @@ public class C
 }
 ");
         }
+
+        [Fact]
+        public void TestComparisonTupleContainingNullable()
+        {
+            var code = @"
+public class C
+{
+    public bool M((int?, int) x)
+    {
+        return x == (40, 41);
+    }
+}
+";
+            CompileAndVerify(code).VerifyDiagnostics().VerifyIL("C.M", @"
+{
+  // Code size       35 (0x23)
+  .maxstack  2
+  .locals init (System.ValueTuple<int?, int> V_0,
+                int? V_1,
+                int V_2)
+  IL_0000:  ldarg.1
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldfld      ""int? System.ValueTuple<int?, int>.Item1""
+  IL_0008:  stloc.1
+  IL_0009:  ldc.i4.s   40
+  IL_000b:  stloc.2
+  IL_000c:  ldloca.s   V_1
+  IL_000e:  call       ""int int?.GetValueOrDefault()""
+  IL_0013:  ldloc.2
+  IL_0014:  bne.un.s   IL_0021
+  IL_0016:  ldloc.0
+  IL_0017:  ldfld      ""int System.ValueTuple<int?, int>.Item2""
+  IL_001c:  ldc.i4.s   41
+  IL_001e:  ceq
+  IL_0020:  ret
+  IL_0021:  ldc.i4.0
+  IL_0022:  ret
+}
+");
+        }
     }
 }


### PR DESCRIPTION
Fixes #52629

@RikkiGibson for review

- User defined operators were not considered. (I can try to move the new logic into `TrivialLiftedComparisonOperatorOptimizations` so it's shared between user-defined operators and built-in operators)