### PR TITLE
Do not recommend `async` if such modifier is already present

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/AsyncKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/AsyncKeywordRecommenderTests.cs
@@ -41,6 +41,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestMethodDeclarationAsyncAfterCursor()
+        {
+            await VerifyKeywordAsync(@"class C
+{
+    public $$ async void goo() { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestInsideInterface()
         {
             await VerifyKeywordAsync(@"interface C
@@ -219,7 +228,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotIfAlreadyAsync2()
+        public async Task TestNotIfAlreadyAsyncInLambda()
         {
             await VerifyAbsenceAsync(@"
 class Program
@@ -228,6 +237,30 @@ class Program
     {
         var z = async $$ () => 2;
     }
+}");
+        }
+
+        [WorkItem(60340, "https://github.com/dotnet/roslyn/issues/60340")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotIfAlreadyAsyncBeforeOtherMember()
+        {
+            await VerifyAbsenceAsync(@"
+class Program
+{
+    async $$    
+
+    public void M() {}
+}");
+        }
+
+        [WorkItem(60340, "https://github.com/dotnet/roslyn/issues/60340")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotIfAlreadyAsyncAsLastMember()
+        {
+            await VerifyAbsenceAsync(@"
+class Program
+{
+    async $$
 }");
         }
 

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsyncKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsyncKeywordRecommender.cs
@@ -27,7 +27,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
-            if (context.TargetToken.IsKindOrHasMatchingText(SyntaxKind.PartialKeyword))
+            if (context.TargetToken.IsKindOrHasMatchingText(SyntaxKind.PartialKeyword) ||
+                context.PrecedingModifiers.Contains(SyntaxKind.AsyncKeyword))
             {
                 return false;
             }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/60340

Note: while `async async` can be valid in some cases, the second `async` is never a keyword, so `AsyncKeywordRecommender` should exclude it in such cases anyway