### PR TITLE
Initial work to move indentation services down to codestyle layer (step 1/N)

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/RemoveUnusedParametersAndValues/CSharpRemoveUnusedValuesCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/RemoveUnusedParametersAndValues/CSharpRemoveUnusedValuesCodeFixProvider.cs
@@ -35,8 +35,8 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedParametersAndValues
         }
 
 #if CODE_STYLE
-        protected override ISyntaxFormattingService GetSyntaxFormattingService()
-            => CSharpSyntaxFormattingService.Instance;
+        protected override ISyntaxFormatting GetSyntaxFormatting()
+            => CSharpSyntaxFormatting.Instance;
 #endif
 
         protected override BlockSyntax WrapWithBlockIfNecessary(IEnumerable<StatementSyntax> statements)

--- a/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/CSharpUseConditionalExpressionForAssignmentCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/CSharpUseConditionalExpressionForAssignmentCodeFixProvider.cs
@@ -66,8 +66,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
             => CSharpUseConditionalExpressionHelpers.ConvertToExpression(throwOperation);
 
 #if CODE_STYLE
-        protected override ISyntaxFormattingService GetSyntaxFormattingService()
-            => CSharpSyntaxFormattingService.Instance;
+        protected override ISyntaxFormatting GetSyntaxFormatting()
+            => CSharpSyntaxFormatting.Instance;
 #endif
     }
 }

--- a/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/CSharpUseConditionalExpressionForReturnCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/CSharpUseConditionalExpressionForReturnCodeFixProvider.cs
@@ -52,8 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
             => CSharpUseConditionalExpressionHelpers.ConvertToExpression(throwOperation);
 
 #if CODE_STYLE
-        protected override ISyntaxFormattingService GetSyntaxFormattingService()
-            => CSharpSyntaxFormattingService.Instance;
+        protected override ISyntaxFormatting GetSyntaxFormatting()
+            => CSharpSyntaxFormatting.Instance;
 #endif
     }
 }

--- a/src/Analyzers/Core/CodeFixes/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeQuality;
 
 #if CODE_STYLE
-        protected abstract ISyntaxFormattingService GetSyntaxFormattingService();
+        protected abstract ISyntaxFormatting GetSyntaxFormatting();
 #endif
         /// <summary>
         /// Method to update the identifier token for the local/parameter declaration or reference
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
         protected sealed override async Task FixAllAsync(Document document, ImmutableArray<Diagnostic> diagnostics, SyntaxEditor editor, CancellationToken cancellationToken)
         {
 #if CODE_STYLE
-            var provider = GetSyntaxFormattingService();
+            var provider = GetSyntaxFormatting();
             var options = provider.GetFormattingOptions(document.Project.AnalyzerOptions.GetAnalyzerOptionSet(editor.OriginalRoot.SyntaxTree, cancellationToken));
 #else
             var provider = document.Project.Solution.Workspace.Services;
@@ -832,7 +832,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 
             // Run formatter prior to invoking IMoveDeclarationNearReferenceService.
 #if CODE_STYLE
-            var provider = GetSyntaxFormattingService();
+            var provider = GetSyntaxFormatting();
             rootWithTrackedNodes = FormatterHelper.Format(rootWithTrackedNodes, originalDeclStatementsToMoveOrRemove.Select(s => s.Span), provider, options, rules: null, cancellationToken);
 #else
             var provider = document.Project.Solution.Workspace.Services;

--- a/src/Analyzers/Core/CodeFixes/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UseConditionalExpression/AbstractUseConditionalExpressionCodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
         protected abstract AbstractFormattingRule GetMultiLineFormattingRule();
 
 #if CODE_STYLE
-        protected abstract ISyntaxFormattingService GetSyntaxFormattingService();
+        protected abstract ISyntaxFormatting GetSyntaxFormatting();
 #endif
 
         protected abstract TExpressionSyntax ConvertToExpression(IThrowOperation throwOperation);
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.UseConditionalExpression
             var rules = new List<AbstractFormattingRule> { GetMultiLineFormattingRule() };
 
 #if CODE_STYLE
-            var provider = GetSyntaxFormattingService();
+            var provider = GetSyntaxFormatting();
             var options = provider.GetFormattingOptions(document.Project.AnalyzerOptions.GetAnalyzerOptionSet(root.SyntaxTree, cancellationToken));
 #else
             var provider = document.Project.Solution.Workspace.Services;

--- a/src/Analyzers/VisualBasic/CodeFixes/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedValuesCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedValuesCodeFixProvider.vb
@@ -26,8 +26,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedParametersAndValues
         End Sub
 
 #If CODE_STYLE Then
-        Protected Overrides Function GetSyntaxFormattingService() As ISyntaxFormattingService
-            Return VisualBasicSyntaxFormattingService.Instance
+        Protected Overrides Function GetSyntaxFormatting() As ISyntaxFormatting
+            Return VisualBasicSyntaxFormatting.Instance
         End Function
 #End If
 

--- a/src/Analyzers/VisualBasic/CodeFixes/UseConditionalExpression/VisualBasicUseConditionalExpressionForAssignmentCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/UseConditionalExpression/VisualBasicUseConditionalExpressionForAssignmentCodeFixProvider.vb
@@ -60,8 +60,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
         End Function
 
 #If CODE_STYLE Then
-        Protected Overrides Function GetSyntaxFormattingService() As ISyntaxFormattingService
-            Return VisualBasicSyntaxFormattingService.Instance
+        Protected Overrides Function GetSyntaxFormatting() As ISyntaxFormatting
+            Return VisualBasicSyntaxFormatting.Instance
         End Function
 #End If
     End Class

--- a/src/Analyzers/VisualBasic/CodeFixes/UseConditionalExpression/VisualBasicUseConditionalExpressionForReturnCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/UseConditionalExpression/VisualBasicUseConditionalExpressionForReturnCodeFixProvider.vb
@@ -44,8 +44,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
         End Function
 
 #If CODE_STYLE Then
-        Protected Overrides Function GetSyntaxFormattingService() As ISyntaxFormattingService
-            Return VisualBasicSyntaxFormattingService.Instance
+        Protected Overrides Function GetSyntaxFormatting() As ISyntaxFormatting
+            Return VisualBasicSyntaxFormatting.Instance
         End Function
 #End If
     End Class

--- a/src/CodeStyle/CSharp/Analyzers/CSharpFormattingAnalyzer.cs
+++ b/src/CodeStyle/CSharp/Analyzers/CSharpFormattingAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
@@ -13,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class CSharpFormattingAnalyzer : AbstractFormattingAnalyzer
     {
-        protected override ISyntaxFormattingService SyntaxFormattingService
-            => CSharpSyntaxFormattingService.Instance;
+        protected override ISyntaxFormatting SyntaxFormatting
+            => CSharpSyntaxFormatting.Instance;
     }
 }

--- a/src/CodeStyle/CSharp/CodeFixes/CSharpFormattingCodeFixProvider.cs
+++ b/src/CodeStyle/CSharp/CodeFixes/CSharpFormattingCodeFixProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -13,8 +11,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.CodeStyle
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.FixFormatting)]
-    [Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.FixFormatting), Shared]
     internal class CSharpFormattingCodeFixProvider : AbstractFormattingCodeFixProvider
     {
         [ImportingConstructor]
@@ -23,6 +20,6 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         {
         }
 
-        protected override ISyntaxFormattingService SyntaxFormattingService => CSharpSyntaxFormattingService.Instance;
+        protected override ISyntaxFormatting SyntaxFormatting => CSharpSyntaxFormatting.Instance;
     }
 }

--- a/src/CodeStyle/Core/Analyzers/AbstractFormattingAnalyzer.cs
+++ b/src/CodeStyle/Core/Analyzers/AbstractFormattingAnalyzer.cs
@@ -27,15 +27,15 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         public sealed override DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
 
-        protected abstract ISyntaxFormattingService SyntaxFormattingService { get; }
+        protected abstract ISyntaxFormatting SyntaxFormatting { get; }
 
         protected sealed override void InitializeWorker(AnalysisContext context)
             => context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
 
         private void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
         {
-            var options = SyntaxFormattingService.GetFormattingOptions(context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Tree));
-            FormattingAnalyzerHelper.AnalyzeSyntaxTree(context, SyntaxFormattingService, Descriptor, options);
+            var options = SyntaxFormatting.GetFormattingOptions(context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Tree));
+            FormattingAnalyzerHelper.AnalyzeSyntaxTree(context, SyntaxFormatting, Descriptor, options);
         }
     }
 }

--- a/src/CodeStyle/Core/Analyzers/Formatting/FormatterHelper.cs
+++ b/src/CodeStyle/Core/Analyzers/Formatting/FormatterHelper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         /// <summary>
         /// Gets the formatting rules that would be applied if left unspecified.
         /// </summary>
-        internal static IEnumerable<AbstractFormattingRule> GetDefaultFormattingRules(ISyntaxFormattingService syntaxFormattingService)
+        internal static IEnumerable<AbstractFormattingRule> GetDefaultFormattingRules(ISyntaxFormatting syntaxFormattingService)
             => syntaxFormattingService.GetDefaultFormattingRules();
 
         /// <summary>
@@ -29,10 +29,10 @@ namespace Microsoft.CodeAnalysis.Formatting
         /// <param name="options">An optional set of formatting options. If these options are not supplied the current set of options from the workspace will be used.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         /// <returns>The formatted tree's root node.</returns>
-        public static SyntaxNode Format(SyntaxNode node, ISyntaxFormattingService syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
+        public static SyntaxNode Format(SyntaxNode node, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
             => Format(node, SpecializedCollections.SingletonEnumerable(node.FullSpan), syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
 
-        public static SyntaxNode Format(SyntaxNode node, TextSpan spanToFormat, ISyntaxFormattingService syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
+        public static SyntaxNode Format(SyntaxNode node, TextSpan spanToFormat, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
             => Format(node, SpecializedCollections.SingletonEnumerable(spanToFormat), syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
 
         /// <summary>
@@ -43,16 +43,16 @@ namespace Microsoft.CodeAnalysis.Formatting
         /// <param name="options">An optional set of formatting options. If these options are not supplied the current set of options from the workspace will be used.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         /// <returns>The formatted tree's root node.</returns>
-        public static SyntaxNode Format(SyntaxNode node, SyntaxAnnotation annotation, ISyntaxFormattingService syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+        public static SyntaxNode Format(SyntaxNode node, SyntaxAnnotation annotation, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
             => Format(node, GetAnnotatedSpans(node, annotation), syntaxFormattingService, options, rules, cancellationToken: cancellationToken);
 
-        internal static SyntaxNode Format(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormattingService syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+        internal static SyntaxNode Format(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
             => GetFormattingResult(node, spans, syntaxFormattingService, options, rules, cancellationToken).GetFormattedRoot(cancellationToken);
 
-        internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormattingService syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+        internal static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
             => GetFormattingResult(node, spans, syntaxFormattingService, options, rules, cancellationToken).GetTextChanges(cancellationToken);
 
-        internal static IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormattingService syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
+        internal static IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan> spans, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken)
             => syntaxFormattingService.GetFormattingResult(node, spans, options, rules, cancellationToken);
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         /// <param name="options">An optional set of formatting options. If these options are not supplied the current set of options from the workspace will be used.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
         /// <returns>The changes necessary to format the tree.</returns>
-        public static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, ISyntaxFormattingService syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
+        public static IList<TextChange> GetFormattedTextChanges(SyntaxNode node, ISyntaxFormatting syntaxFormattingService, SyntaxFormattingOptions options, CancellationToken cancellationToken)
             => GetFormattedTextChanges(node, SpecializedCollections.SingletonEnumerable(node.FullSpan), syntaxFormattingService, options, rules: null, cancellationToken: cancellationToken);
     }
 }

--- a/src/CodeStyle/Core/Analyzers/FormattingAnalyzerHelper.cs
+++ b/src/CodeStyle/Core/Analyzers/FormattingAnalyzerHelper.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 
 #if CODE_STYLE
 using Formatter = Microsoft.CodeAnalysis.Formatting.FormatterHelper;
-using FormattingProvider = Microsoft.CodeAnalysis.Formatting.ISyntaxFormattingService;
+using FormattingProvider = Microsoft.CodeAnalysis.Formatting.ISyntaxFormatting;
 #else
 using FormattingProvider = Microsoft.CodeAnalysis.Host.HostWorkspaceServices;
 #endif

--- a/src/CodeStyle/Core/CodeFixes/FormattingCodeFixHelper.cs
+++ b/src/CodeStyle/Core/CodeFixes/FormattingCodeFixHelper.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 
 #if CODE_STYLE
 using Formatter = Microsoft.CodeAnalysis.Formatting.FormatterHelper;
-using FormattingProvider = Microsoft.CodeAnalysis.Formatting.ISyntaxFormattingService;
+using FormattingProvider = Microsoft.CodeAnalysis.Formatting.ISyntaxFormatting;
 #else
 using Microsoft.CodeAnalysis.Options;
 using FormattingProvider = Microsoft.CodeAnalysis.Host.HostWorkspaceServices;

--- a/src/CodeStyle/Core/CodeFixes/FormattingCodeFixProvider.cs
+++ b/src/CodeStyle/Core/CodeFixes/FormattingCodeFixProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         public sealed override ImmutableArray<string> FixableDiagnosticIds
             => ImmutableArray.Create(IDEDiagnosticIds.FormattingDiagnosticId);
 
-        protected abstract ISyntaxFormattingService SyntaxFormattingService { get; }
+        protected abstract ISyntaxFormatting SyntaxFormatting { get; }
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         {
             var options = await GetOptionsAsync(context.Document, cancellationToken).ConfigureAwait(false);
             var tree = await context.Document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            var updatedTree = await FormattingCodeFixHelper.FixOneAsync(tree, SyntaxFormattingService, options, diagnostic, cancellationToken).ConfigureAwait(false);
+            var updatedTree = await FormattingCodeFixHelper.FixOneAsync(tree, this.SyntaxFormatting, options, diagnostic, cancellationToken).ConfigureAwait(false);
             return context.Document.WithText(await updatedTree.GetTextAsync(cancellationToken).ConfigureAwait(false));
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         {
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var analyzerConfigOptions = document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(tree);
-            return SyntaxFormattingService.GetFormattingOptions(analyzerConfigOptions);
+            return this.SyntaxFormatting.GetFormattingOptions(analyzerConfigOptions);
         }
 
         public sealed override FixAllProvider GetFixAllProvider()
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                 var cancellationToken = context.CancellationToken;
                 var options = await GetOptionsAsync(document, cancellationToken).ConfigureAwait(false);
                 var syntaxRoot = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-                var updatedSyntaxRoot = Formatter.Format(syntaxRoot, this.SyntaxFormattingService, options, cancellationToken);
+                var updatedSyntaxRoot = Formatter.Format(syntaxRoot, this.SyntaxFormatting, options, cancellationToken);
                 return document.WithSyntaxRoot(updatedSyntaxRoot);
             });
     }

--- a/src/CodeStyle/VisualBasic/Analyzers/VisualBasicFormattingAnalyzer.vb
+++ b/src/CodeStyle/VisualBasic/Analyzers/VisualBasicFormattingAnalyzer.vb
@@ -11,9 +11,9 @@ Namespace Microsoft.CodeAnalysis.CodeStyle
     Friend Class VisualBasicFormattingAnalyzer
         Inherits AbstractFormattingAnalyzer
 
-        Protected Overrides ReadOnly Property SyntaxFormattingService As ISyntaxFormattingService
+        Protected Overrides ReadOnly Property SyntaxFormatting As ISyntaxFormatting
             Get
-                Return VisualBasicSyntaxFormattingService.Instance
+                Return VisualBasicSyntaxFormatting.Instance
             End Get
         End Property
     End Class

--- a/src/CodeStyle/VisualBasic/CodeFixes/VisualBasicFormattingCodeFixProvider.vb
+++ b/src/CodeStyle/VisualBasic/CodeFixes/VisualBasicFormattingCodeFixProvider.vb
@@ -19,9 +19,9 @@ Namespace Microsoft.CodeAnalysis.CodeStyle
         Public Sub New()
         End Sub
 
-        Protected Overrides ReadOnly Property SyntaxFormattingService As ISyntaxFormattingService
+        Protected Overrides ReadOnly Property SyntaxFormatting As ISyntaxFormatting
             Get
-                Return VisualBasicSyntaxFormattingService.Instance
+                Return VisualBasicSyntaxFormatting.Instance
             End Get
         End Property
     End Class

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
 
             var options = await IndentationOptions.FromDocumentAsync(document, CancellationToken.None);
             var formatter = new CSharpSmartTokenFormatter(options, rules, root);
-            var changes = await formatter.FormatTokenAsync(workspace.Services, token, CancellationToken.None);
+            var changes = await formatter.FormatTokenAsync(token, CancellationToken.None);
 
             ApplyChanges(buffer, changes);
         }

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
@@ -202,7 +202,7 @@ End Class
 
                 Dim formatOptions = Await SyntaxFormattingOptions.FromDocumentAsync(document, CancellationToken.None)
                 Dim smartFormatter = New VisualBasicSmartTokenFormatter(formatOptions, formattingRules, root)
-                Dim changes = Await smartFormatter.FormatTokenAsync(workspace.Services, token, Nothing)
+                Dim changes = Await smartFormatter.FormatTokenAsync(token, Nothing)
 
                 Using edit = buffer.CreateEdit()
                     For Each change In changes

--- a/src/Features/CSharp/Portable/Formatting/CSharpFormattingInteractionService.cs
+++ b/src/Features/CSharp/Portable/Formatting/CSharpFormattingInteractionService.cs
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var formatter = CreateSmartTokenFormatter(options, formattingRules, root);
-            var changes = await formatter.FormatTokenAsync(document.Project.Solution.Workspace.Services, token, cancellationToken).ConfigureAwait(false);
+            var changes = await formatter.FormatTokenAsync(token, cancellationToken).ConfigureAwait(false);
             return changes;
         }
 

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpSmartTokenFormatter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
         }
 
         public async Task<IList<TextChange>> FormatTokenAsync(
-            HostWorkspaceServices services, SyntaxToken token, CancellationToken cancellationToken)
+            SyntaxToken token, CancellationToken cancellationToken)
         {
             Contract.ThrowIfTrue(token.Kind() is SyntaxKind.None or SyntaxKind.EndOfFileToken);
 
@@ -113,7 +113,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
                 }
             }
 
-            return Formatter.GetFormattedTextChanges(_root, new[] { TextSpan.FromBounds(adjustedStartPosition, adjustedEndPosition) }, services, _options.FormattingOptions, smartTokenformattingRules, cancellationToken);
+            var formatter = CSharpSyntaxFormatting.Instance;
+            var result = formatter.GetFormattingResult(
+                _root, new[] { TextSpan.FromBounds(adjustedStartPosition, adjustedEndPosition) }, _options.FormattingOptions, smartTokenformattingRules, cancellationToken);
+            return result.GetTextChanges(cancellationToken);
         }
 
         private class NoLineChangeFormattingRule : AbstractFormattingRule

--- a/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.Indenter.cs
+++ b/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.Indenter.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Indentation
                     var sourceText = Tree.GetText(CancellationToken);
 
                     var formatter = _service.CreateSmartTokenFormatter(this);
-                    var changes = formatter.FormatTokenAsync(Document.Project.Solution.Workspace.Services, token, CancellationToken)
+                    var changes = formatter.FormatTokenAsync(token, CancellationToken)
                                            .WaitAndGetResult_CanCallOnBackground(CancellationToken);
 
                     var updatedSourceText = sourceText.WithChanges(changes);

--- a/src/Workspaces/Core/Portable/Indentation/ISmartTokenFormatter.cs
+++ b/src/Workspaces/Core/Portable/Indentation/ISmartTokenFormatter.cs
@@ -5,13 +5,12 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Indentation
 {
     internal interface ISmartTokenFormatter
     {
-        Task<IList<TextChange>> FormatTokenAsync(HostWorkspaceServices services, SyntaxToken token, CancellationToken cancellationToken);
+        Task<IList<TextChange>> FormatTokenAsync(SyntaxToken token, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormattingService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormattingService.cs
@@ -19,37 +19,24 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
-#if !CODE_STYLE
-    [ExportLanguageService(typeof(ISyntaxFormattingService), LanguageNames.CSharp), Shared]
-#endif
-    internal class CSharpSyntaxFormattingService : AbstractSyntaxFormattingService
+    internal class CSharpSyntaxFormatting : AbstractSyntaxFormatting
     {
-        private readonly ImmutableList<AbstractFormattingRule> _rules;
+        public static readonly CSharpSyntaxFormatting Instance = new();
 
-#if CODE_STYLE
-        public static readonly CSharpSyntaxFormattingService Instance = new();
-
-#else
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-#endif
-        public CSharpSyntaxFormattingService()
-        {
-            _rules = ImmutableList.Create<AbstractFormattingRule>(
-                new WrappingFormattingRule(),
-                new SpacingFormattingRule(),
-                new NewLineUserSettingFormattingRule(),
-                new IndentUserSettingsFormattingRule(),
-                new ElasticTriviaFormattingRule(),
-                new EndOfFileTokenFormattingRule(),
-                new StructuredTriviaFormattingRule(),
-                new IndentBlockFormattingRule(),
-                new SuppressFormattingRule(),
-                new AnchorIndentationFormattingRule(),
-                new QueryExpressionFormattingRule(),
-                new TokenBasedFormattingRule(),
-                DefaultOperationProvider.Instance);
-        }
+        private readonly ImmutableList<AbstractFormattingRule> _rules = ImmutableList.Create<AbstractFormattingRule>(
+            new WrappingFormattingRule(),
+            new SpacingFormattingRule(),
+            new NewLineUserSettingFormattingRule(),
+            new IndentUserSettingsFormattingRule(),
+            new ElasticTriviaFormattingRule(),
+            new EndOfFileTokenFormattingRule(),
+            new StructuredTriviaFormattingRule(),
+            new IndentBlockFormattingRule(),
+            new SuppressFormattingRule(),
+            new AnchorIndentationFormattingRule(),
+            new QueryExpressionFormattingRule(),
+            new TokenBasedFormattingRule(),
+            DefaultOperationProvider.Instance);
 
         public override IEnumerable<AbstractFormattingRule> GetDefaultFormattingRules()
             => _rules;
@@ -63,4 +50,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         protected override AbstractFormattingResult Format(SyntaxNode node, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule> formattingRules, SyntaxToken startToken, SyntaxToken endToken, CancellationToken cancellationToken)
             => new CSharpFormatEngine(node, options, formattingRules, startToken, endToken).Format(cancellationToken);
     }
+
+#if !CODE_STYLE
+    [ExportLanguageService(typeof(ISyntaxFormattingService), LanguageNames.CSharp), Shared]
+    internal class CSharpSyntaxFormattingService : CSharpSyntaxFormatting, ISyntaxFormattingService
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpSyntaxFormattingService()
+        {
+        }
+    }
+#endif
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/AbstractSyntaxFormattingService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/AbstractSyntaxFormattingService.cs
@@ -16,11 +16,11 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
-    internal abstract class AbstractSyntaxFormattingService : ISyntaxFormattingService
+    internal abstract class AbstractSyntaxFormatting : ISyntaxFormatting
     {
         private static readonly Func<TextSpan, bool> s_notEmpty = s => !s.IsEmpty;
 
-        protected AbstractSyntaxFormattingService()
+        protected AbstractSyntaxFormatting()
         {
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/ISyntaxFormattingService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/ISyntaxFormattingService.cs
@@ -17,15 +17,18 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Formatting
 {
-    internal interface ISyntaxFormattingService
-#if !CODE_STYLE
-        : ILanguageService
-#endif
+    internal interface ISyntaxFormatting
     {
         SyntaxFormattingOptions GetFormattingOptions(AnalyzerConfigOptions options);
         IEnumerable<AbstractFormattingRule> GetDefaultFormattingRules();
         IFormattingResult GetFormattingResult(SyntaxNode node, IEnumerable<TextSpan>? spans, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule>? rules, CancellationToken cancellationToken);
     }
+
+#if !CODE_STYLE
+    internal interface ISyntaxFormattingService : ISyntaxFormatting, ILanguageService
+    {
+    }
+#endif
 
     internal abstract class SyntaxFormattingOptions
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.cs
@@ -39,8 +39,8 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
         }
 
 #if CODE_STYLE
-        private static ISyntaxFormattingService GetSyntaxFormattingService()
-            => CSharpSyntaxFormattingService.Instance;
+        private static ISyntaxFormatting GetSyntaxFormatting()
+            => CSharpSyntaxFormatting.Instance;
 #endif
 
         protected override IUnnecessaryImportsProvider UnnecessaryImportsProvider
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
 
                 cancellationToken.ThrowIfCancellationRequested();
 #if CODE_STYLE
-                var provider = GetSyntaxFormattingService();
+                var provider = GetSyntaxFormatting();
                 var options = provider.GetFormattingOptions(document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(oldRoot.SyntaxTree));
 #else
                 var provider = document.Project.Solution.Workspace.Services;

--- a/src/Workspaces/VisualBasic/Portable/Formatting/VisualBasicSyntaxFormattingService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/VisualBasicSyntaxFormattingService.vb
@@ -16,35 +16,19 @@ Imports Microsoft.CodeAnalysis.Host.Mef
 #End If
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
-#If Not CODE_STYLE Then
-    <ExportLanguageService(GetType(ISyntaxFormattingService), LanguageNames.VisualBasic), [Shared]>
-    Friend Class VisualBasicSyntaxFormattingService
-#Else
-    Friend Class VisualBasicSyntaxFormattingService
-#End If
-        Inherits AbstractSyntaxFormattingService
 
-        Private ReadOnly _rules As ImmutableList(Of AbstractFormattingRule)
+    Friend Class VisualBasicSyntaxFormatting
+        Inherits AbstractSyntaxFormatting
 
-#If CODE_STYLE Then
-        Public Shared ReadOnly Instance As New VisualBasicSyntaxFormattingService
-#End If
+        Public Shared ReadOnly Instance As New VisualBasicSyntaxFormatting
 
-#If Not CODE_STYLE Then
-        <ImportingConstructor>
-        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
-        Public Sub New()
-#Else
-        Public Sub New()
-#End If
-            _rules = ImmutableList.Create(Of AbstractFormattingRule)(
-                New StructuredTriviaFormattingRule(),
-                New ElasticTriviaFormattingRule(),
-                New AdjustSpaceFormattingRule(),
-                New AlignTokensFormattingRule(),
-                New NodeBasedFormattingRule(),
-                DefaultOperationProvider.Instance)
-        End Sub
+        Private ReadOnly _rules As ImmutableList(Of AbstractFormattingRule) = ImmutableList.Create(Of AbstractFormattingRule)(
+            New StructuredTriviaFormattingRule(),
+            New ElasticTriviaFormattingRule(),
+            New AdjustSpaceFormattingRule(),
+            New AlignTokensFormattingRule(),
+            New NodeBasedFormattingRule(),
+            DefaultOperationProvider.Instance)
 
         Public Overrides Function GetDefaultFormattingRules() As IEnumerable(Of AbstractFormattingRule)
             Return _rules
@@ -62,4 +46,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Return New VisualBasicFormatEngine(root, options, formattingRules, startToken, endToken).Format(cancellationToken)
         End Function
     End Class
+
+#If Not CODE_STYLE Then
+    <ExportLanguageService(GetType(ISyntaxFormattingService), LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicSyntaxFormattingService
+        Inherits VisualBasicSyntaxFormatting
+        Implements ISyntaxFormattingService
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+    End Class
+#End If
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicSmartTokenFormatter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicSmartTokenFormatter.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.CodeAnalysis.VisualBasic.Formatting
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
     Friend Class VisualBasicSmartTokenFormatter
@@ -32,14 +33,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
             Me._root = root
         End Sub
 
-        Public Function FormatTokenAsync(services As HostWorkspaceServices, token As SyntaxToken, cancellationToken As CancellationToken) As Tasks.Task(Of IList(Of TextChange)) Implements ISmartTokenFormatter.FormatTokenAsync
+        Public Function FormatTokenAsync(token As SyntaxToken, cancellationToken As CancellationToken) As Tasks.Task(Of IList(Of TextChange)) Implements ISmartTokenFormatter.FormatTokenAsync
             Contract.ThrowIfTrue(token.Kind = SyntaxKind.None OrElse token.Kind = SyntaxKind.EndOfFileToken)
 
             ' get previous token
             Dim previousToken = token.GetPreviousToken()
 
             Dim spans = SpecializedCollections.SingletonEnumerable(TextSpan.FromBounds(previousToken.SpanStart, token.Span.End))
-            Return Task.FromResult(Formatter.GetFormattedTextChanges(_root, spans, services, _options, _formattingRules, cancellationToken))
+            Dim formatter = VisualBasicSyntaxFormatting.Instance
+            Dim result = formatter.GetFormattingResult(_root, spans, _options, _formattingRules, cancellationToken)
+            Return Task.FromResult(result.GetTextChanges(cancellationToken))
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
This step decouples one of our formatting helpers from teh workspace (specifically workspaceservices).
It also changes a shared type to follow the pattern of a MEF-free impl, with a MEF wrapper that then exports it at the workspace layer.

I'm doing these PRs in multiple parts to make things simpler to review.  Every time i try to tackle the general problem, it explodes into a ton of changes.

The reason for this change overall is that we have fixers taht need to know indentation information.  For example, the 'convert to file-scoped-namespace (and reverse)' fixes have to know indentation information so it can make the right fixes.  Not having indentation info be available at thsi level means that the fixes are constrained to the VS host.  