### PR TITLE
Fix binder chain for nameof scopes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.WithQueryLambdaParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.WithQueryLambdaParametersBinder.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+            internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
             {
                 if (options.CanConsiderMembers())
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Return the nearest enclosing node being bound as a nameof(...) argument, if any, or null if none.
         protected virtual SyntaxNode? EnclosingNameofArgument => null;
 
-        protected virtual bool IsInsideNameofOperator => NextRequired.IsInsideNameofOperator;
+        protected virtual bool IsInsideNameof => NextRequired.IsInsideNameof;
 
         /// <summary>
         /// Get the next binder in which to look up a name, if not found by this binder.

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Return the nearest enclosing node being bound as a nameof(...) argument, if any, or null if none.
         protected virtual SyntaxNode? EnclosingNameofArgument => null;
 
-        private bool IsInsideNameof => this.EnclosingNameofArgument != null;
+        protected virtual bool IsInsideNameofOperator => NextRequired.IsInsideNameofOperator;
 
         /// <summary>
         /// Get the next binder in which to look up a name, if not found by this binder.

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.BinderFactoryVisitor.cs
@@ -679,8 +679,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // and position is more likely to be in the body, so lets check for "inBody" first.
                 if (parent.OpenBraceToken != default &&
                     parent.CloseBraceToken != default &&
-                    (LookupPosition.IsBetweenTokens(_position, parent.OpenBraceToken, parent.CloseBraceToken) ||
-                     LookupPosition.IsInAttributeSpecification(_position, parent.AttributeLists)))
+                    LookupPosition.IsBetweenTokens(_position, parent.OpenBraceToken, parent.CloseBraceToken))
+                {
+                    extraInfo = NodeUsage.NamedTypeBodyOrTypeParameters;
+                }
+                else if (LookupPosition.IsInAttributeSpecification(_position, parent.AttributeLists))
                 {
                     extraInfo = NodeUsage.NamedTypeBodyOrTypeParameters;
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -539,7 +539,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void VerifyUnchecked(ExpressionSyntax node, BindingDiagnosticBag diagnostics, BoundExpression expr)
         {
-            if (!expr.HasAnyErrors && !IsInsideNameof)
+            if (!expr.HasAnyErrors && !IsInsideNameofOperator)
             {
                 TypeSymbol exprType = expr.Type;
                 if ((object)exprType != null && exprType.IsUnsafe())
@@ -1479,7 +1479,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 options |= LookupOptions.MustBeInvocableIfMember;
             }
 
-            if (!IsInMethodBody && !IsInsideNameof)
+            if (!IsInMethodBody && !IsInsideNameofOperator)
             {
                 Debug.Assert((options & LookupOptions.NamespacesOrTypesOnly) == 0);
                 options |= LookupOptions.MustNotBeMethodTypeParameter;
@@ -1719,7 +1719,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(!symbol.ContainingSymbol.Equals(containingMethod));
 
                     // Captured in a lambda.
-                    return (containingMethod.MethodKind == MethodKind.AnonymousFunction || containingMethod.MethodKind == MethodKind.LocalFunction) && !IsInsideNameof; // false in EE evaluation method
+                    return (containingMethod.MethodKind == MethodKind.AnonymousFunction || containingMethod.MethodKind == MethodKind.LocalFunction) && !IsInsideNameofOperator; // false in EE evaluation method
                 }
             }
             return false;
@@ -1837,7 +1837,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
 
-                        var constantValueOpt = localSymbol.IsConst && !IsInsideNameof && !type.IsErrorType()
+                        var constantValueOpt = localSymbol.IsConst && !IsInsideNameofOperator && !type.IsErrorType()
                             ? localSymbol.GetConstantValue(node, this.LocalInProgress, diagnostics) : null;
                         return new BoundLocal(node, localSymbol, BoundLocalDeclarationKind.None, constantValueOpt: constantValueOpt, isNullableUnknown: isNullableUnknown, type: type, hasErrors: isError);
                     }
@@ -7007,7 +7007,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasError = this.CheckInstanceOrStatic(node, receiver, fieldSymbol, ref resultKind, diagnostics);
             }
 
-            if (!hasError && fieldSymbol.IsFixedSizeBuffer && !IsInsideNameof)
+            if (!hasError && fieldSymbol.IsFixedSizeBuffer && !IsInsideNameofOperator)
             {
                 // SPEC: In a member access of the form E.I, if E is of a struct type and a member lookup of I in
                 // that struct type identifies a fixed size member, then E.I is evaluated and classified as follows:
@@ -7052,7 +7052,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ConstantValue constantValueOpt = null;
 
-            if (fieldSymbol.IsConst && !IsInsideNameof)
+            if (fieldSymbol.IsConst && !IsInsideNameofOperator)
             {
                 constantValueOpt = fieldSymbol.GetConstantValue(this.ConstantFieldsInProgress, this.IsEarlyAttributeBinder);
                 if (constantValueOpt == ConstantValue.Unset)
@@ -7268,7 +7268,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                if (instanceReceiver == false && !IsInsideNameof)
+                if (instanceReceiver == false && !IsInsideNameofOperator)
                 {
                     Error(diagnostics, ErrorCode.ERR_ObjectRequired, node, symbol);
                     resultKind = LookupResultKind.StaticInstanceMismatch;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -539,7 +539,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void VerifyUnchecked(ExpressionSyntax node, BindingDiagnosticBag diagnostics, BoundExpression expr)
         {
-            if (!expr.HasAnyErrors && !IsInsideNameofOperator)
+            if (!expr.HasAnyErrors && !IsInsideNameof)
             {
                 TypeSymbol exprType = expr.Type;
                 if ((object)exprType != null && exprType.IsUnsafe())
@@ -1479,7 +1479,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 options |= LookupOptions.MustBeInvocableIfMember;
             }
 
-            if (!IsInMethodBody && !IsInsideNameofOperator)
+            if (!IsInMethodBody && !IsInsideNameof)
             {
                 Debug.Assert((options & LookupOptions.NamespacesOrTypesOnly) == 0);
                 options |= LookupOptions.MustNotBeMethodTypeParameter;
@@ -1719,7 +1719,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(!symbol.ContainingSymbol.Equals(containingMethod));
 
                     // Captured in a lambda.
-                    return (containingMethod.MethodKind == MethodKind.AnonymousFunction || containingMethod.MethodKind == MethodKind.LocalFunction) && !IsInsideNameofOperator; // false in EE evaluation method
+                    return (containingMethod.MethodKind == MethodKind.AnonymousFunction || containingMethod.MethodKind == MethodKind.LocalFunction) && !IsInsideNameof; // false in EE evaluation method
                 }
             }
             return false;
@@ -1837,7 +1837,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
 
-                        var constantValueOpt = localSymbol.IsConst && !IsInsideNameofOperator && !type.IsErrorType()
+                        var constantValueOpt = localSymbol.IsConst && !IsInsideNameof && !type.IsErrorType()
                             ? localSymbol.GetConstantValue(node, this.LocalInProgress, diagnostics) : null;
                         return new BoundLocal(node, localSymbol, BoundLocalDeclarationKind.None, constantValueOpt: constantValueOpt, isNullableUnknown: isNullableUnknown, type: type, hasErrors: isError);
                     }
@@ -7007,7 +7007,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasError = this.CheckInstanceOrStatic(node, receiver, fieldSymbol, ref resultKind, diagnostics);
             }
 
-            if (!hasError && fieldSymbol.IsFixedSizeBuffer && !IsInsideNameofOperator)
+            if (!hasError && fieldSymbol.IsFixedSizeBuffer && !IsInsideNameof)
             {
                 // SPEC: In a member access of the form E.I, if E is of a struct type and a member lookup of I in
                 // that struct type identifies a fixed size member, then E.I is evaluated and classified as follows:
@@ -7052,7 +7052,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ConstantValue constantValueOpt = null;
 
-            if (fieldSymbol.IsConst && !IsInsideNameofOperator)
+            if (fieldSymbol.IsConst && !IsInsideNameof)
             {
                 constantValueOpt = fieldSymbol.GetConstantValue(this.ConstantFieldsInProgress, this.IsEarlyAttributeBinder);
                 if (constantValueOpt == ConstantValue.Unset)
@@ -7268,7 +7268,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                if (instanceReceiver == false && !IsInsideNameofOperator)
+                if (instanceReceiver == false && !IsInsideNameof)
                 {
                     Error(diagnostics, ErrorCode.ERR_ObjectRequired, node, symbol);
                     resultKind = LookupResultKind.StaticInstanceMismatch;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1862,7 +1862,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.MayBeNameofOperator())
             {
                 var binder = this.GetBinder(node);
-                if (binder.IsInsideNameofOperator)
+                if (binder.IsInsideNameof)
                 {
                     result = binder.BindNameofOperatorInternal(node, diagnostics);
                     return true;
@@ -1980,7 +1980,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Helper method that checks whether there is an invocable 'nameof' in enclosing scope.
+        /// Helper method that checks whether there is an invocable 'nameof' in scope.
         /// </summary>
         internal bool InvocableNameofInScope()
         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1859,31 +1859,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool TryBindNameofOperator(InvocationExpressionSyntax node, BindingDiagnosticBag diagnostics, out BoundExpression result)
         {
+            if (node.MayBeNameofOperator())
+            {
+                var binder = this.GetBinder(node);
+                if (binder.IsInsideNameofOperator)
+                {
+                    result = binder.BindNameofOperatorInternal(node, diagnostics);
+                    return true;
+                }
+            }
+
             result = null;
-            if (node.Expression.Kind() != SyntaxKind.IdentifierName ||
-                ((IdentifierNameSyntax)node.Expression).Identifier.ContextualKind() != SyntaxKind.NameOfKeyword ||
-                node.ArgumentList.Arguments.Count != 1)
-            {
-                return false;
-            }
-
-            ArgumentSyntax argument = node.ArgumentList.Arguments[0];
-            if (argument.NameColon != null || argument.RefOrOutKeyword != default(SyntaxToken) || InvocableNameofInScope())
-            {
-                return false;
-            }
-
-            result = BindNameofOperatorInternal(node, diagnostics);
-            return true;
+            return false;
         }
 
         private BoundExpression BindNameofOperatorInternal(InvocationExpressionSyntax node, BindingDiagnosticBag diagnostics)
         {
             CheckFeatureAvailability(node, MessageID.IDS_FeatureNameof, diagnostics);
             var argument = node.ArgumentList.Arguments[0].Expression;
-            // We relax the instance-vs-static requirement for top-level member access expressions by creating a NameofBinder binder.
-            var nameofBinder = new NameofBinder(argument, this);
-            var boundArgument = nameofBinder.BindExpression(argument, diagnostics);
+            var boundArgument = BindExpression(argument, diagnostics);
 
             bool syntaxIsOk = CheckSyntaxForNameofArgument(argument, out string name, boundArgument.HasAnyErrors ? BindingDiagnosticBag.Discarded : diagnostics);
             if (!boundArgument.HasAnyErrors && syntaxIsOk && boundArgument.Kind == BoundKind.MethodGroup)
@@ -1896,7 +1890,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    nameofBinder.EnsureNameofExpressionSymbols(methodGroup, diagnostics);
+                    EnsureNameofExpressionSymbols(methodGroup, diagnostics);
                 }
             }
 
@@ -1986,9 +1980,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Helper method that checks whether there is an invocable 'nameof' in scope.
+        /// Helper method that checks whether there is an invocable 'nameof' in enclosing scope.
         /// </summary>
-        private bool InvocableNameofInScope()
+        internal bool InvocableNameofInScope()
         {
             var lookupResult = LookupResult.GetInstance();
             const LookupOptions options = LookupOptions.AllMethodsOnArityZero | LookupOptions.MustBeInvocableIfMember;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1764,7 +1764,7 @@ symIsHidden:;
             }
         }
 
-        protected virtual void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo info, LookupOptions options, Binder originalBinder)
+        internal virtual void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo info, LookupOptions options, Binder originalBinder)
         {
             // overridden in other binders
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -932,7 +932,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case UsingDirectiveSyntax parent when parent.Name == node: // using nint; using A = nuint;
                     return null;
                 case ArgumentSyntax parent when // nameof(nint)
-                    (IsInsideNameofOperator &&
+                    (IsInsideNameof &&
                         parent.Parent?.Parent is InvocationExpressionSyntax invocation &&
                         (invocation.Expression as IdentifierNameSyntax)?.Identifier.ContextualKind() == SyntaxKind.NameOfKeyword):
                     // Don't bind nameof(nint) or nameof(nuint) so that ERR_NameNotInContext is reported.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -932,7 +932,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case UsingDirectiveSyntax parent when parent.Name == node: // using nint; using A = nuint;
                     return null;
                 case ArgumentSyntax parent when // nameof(nint)
-                    (IsInsideNameof &&
+                    (IsInsideNameofOperator &&
                         parent.Parent?.Parent is InvocationExpressionSyntax invocation &&
                         (invocation.Expression as IdentifierNameSyntax)?.Identifier.ContextualKind() == SyntaxKind.NameOfKeyword):
                     // Don't bind nameof(nint) or nameof(nuint) so that ERR_NameNotInContext is reported.

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override uint LocalScopeDepth => Binder.ExternalScope;
 
         protected override bool InExecutableBinder => false;
+        protected override bool IsInsideNameofOperator => false;
 
         internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, ConsList<TypeSymbol> basesBeingResolved)
         {

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override uint LocalScopeDepth => Binder.ExternalScope;
 
         protected override bool InExecutableBinder => false;
-        protected override bool IsInsideNameofOperator => false;
+        protected override bool IsInsideNameof => false;
 
         internal override bool IsAccessibleHelper(Symbol symbol, TypeSymbol accessThroughType, out bool failedThroughTypeCheck, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, ConsList<TypeSymbol> basesBeingResolved)
         {

--- a/src/Compilers/CSharp/Portable/Binder/ContextualAttributeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ContextualAttributeBinder.cs
@@ -4,6 +4,8 @@
 
 #nullable disable
 
+using System.Diagnostics;
+
 namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
@@ -11,6 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// might have a CallerMemberName parameter, we need to keep track of which method/property/event
     /// the attribute is on/in (e.g. on a parameter) so that we can use the name of that member as the 
     /// CallerMemberName argument.
+    /// This binder is also needed when a <see cref="NameofBinder"/> introduces type parameters to a scope within an attribute.
     /// </summary>
     internal sealed class ContextualAttributeBinder : Binder
     {
@@ -22,6 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public ContextualAttributeBinder(Binder enclosing, Symbol symbol)
             : base(enclosing, enclosing.Flags | BinderFlags.InContextualAttributeBinder)
         {
+            Debug.Assert(symbol is not null);
             _attributeTarget = symbol;
             _attributedMember = GetAttributedMember(symbol);
         }

--- a/src/Compilers/CSharp/Portable/Binder/HostObjectModeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/HostObjectModeBinder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             var hostObjectType = GetHostObjectType();
             if (hostObjectType.Kind != SymbolKind.ErrorType)

--- a/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             this.AddMemberLookupSymbolsInfo(result, _container, options, originalBinder);
         }

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             if (options.CanConsiderMembers())
             {

--- a/src/Compilers/CSharp/Portable/Binder/InSubmissionClassBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InSubmissionClassBinder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.LookupMembersInSubmissions(result, (NamedTypeSymbol)Container, _declarationSyntax, _inUsings, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteInfo);
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             this.AddMemberLookupSymbolsInfoInSubmissions(result, (NamedTypeSymbol)Container, _inUsings, options, originalBinder);
         }

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -445,7 +445,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             Debug.Assert(options.AreValid());
 

--- a/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
@@ -2,19 +2,52 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
+    /// <summary>
+    /// If a proper method named "nameof" exists in the outer scopes, this binder does nothing.
+    /// Otherwise, it relaxes the instance-vs-static requirement for top-level member access expressions
+    /// and when inside an attribute on a method it adds type parameters from the target of that attribute.
+    /// To do so, it works together with <see cref="ContextualAttributeBinder"/>.
+    /// 
+    /// For other attributes (on types, type parameters or paramaeters) we use a WithTypeParameterBinder directly
+    /// in the binder chain and some filtering (<see cref="LookupOptions.MustNotBeMethodTypeParameter"/>) to keep
+    /// pre-existing behavior.
+    /// </summary>
     internal sealed class NameofBinder : Binder
     {
         private readonly SyntaxNode _nameofArgument;
+        private readonly WithTypeParametersBinder? _nextWhenNameofOperatorInAttribute;
 
-        public NameofBinder(SyntaxNode nameofArgument, Binder next) : base(next)
+        internal NameofBinder(SyntaxNode nameofArgument, Binder nextWhenNameofInvocation, WithTypeParametersBinder? nextWhenNameofOperatorInAttribute)
+            : base(nextWhenNameofInvocation)
         {
             _nameofArgument = nameofArgument;
+            _nextWhenNameofOperatorInAttribute = nextWhenNameofOperatorInAttribute;
         }
 
-        protected override SyntaxNode EnclosingNameofArgument => _nameofArgument;
+        // TODO2 pass in syntax to compare against _nameofArgument
+        protected override bool IsInsideNameofOperator => !NextRequired.InvocableNameofInScope();
+
+        protected override SyntaxNode? EnclosingNameofArgument => !IsInsideNameofOperator ? null : _nameofArgument;
+
+        internal override void LookupSymbolsInSingleBinder(LookupResult result, string name, int arity, ConsList<TypeSymbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        {
+            if (IsInsideNameofOperator && _nextWhenNameofOperatorInAttribute is not null)
+            {
+                _nextWhenNameofOperatorInAttribute.LookupSymbolsInSingleBinder(result, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteInfo);
+            }
+        }
+
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo info, LookupOptions options, Binder originalBinder)
+        {
+            if (IsInsideNameofOperator && _nextWhenNameofOperatorInAttribute is not null)
+            {
+                _nextWhenNameofOperatorInAttribute.AddLookupSymbolsInfoInSingleBinder(info, options, originalBinder);
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
@@ -30,13 +30,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // TODO2 pass in syntax to compare against _nameofArgument
-        protected override bool IsInsideNameofOperator => !NextRequired.InvocableNameofInScope();
+        protected override bool IsInsideNameof => !NextRequired.InvocableNameofInScope();
 
-        protected override SyntaxNode? EnclosingNameofArgument => !IsInsideNameofOperator ? null : _nameofArgument;
+        protected override SyntaxNode? EnclosingNameofArgument => !IsInsideNameof ? null : _nameofArgument;
 
         internal override void LookupSymbolsInSingleBinder(LookupResult result, string name, int arity, ConsList<TypeSymbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
         {
-            if (IsInsideNameofOperator && _nextWhenNameofOperatorInAttribute is not null)
+            if (IsInsideNameof && _nextWhenNameofOperatorInAttribute is not null)
             {
                 _nextWhenNameofOperatorInAttribute.LookupSymbolsInSingleBinder(result, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteInfo);
             }
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo info, LookupOptions options, Binder originalBinder)
         {
-            if (IsInsideNameofOperator && _nextWhenNameofOperatorInAttribute is not null)
+            if (IsInsideNameof && _nextWhenNameofOperatorInAttribute is not null)
             {
                 _nextWhenNameofOperatorInAttribute.AddLookupSymbolsInfoInSingleBinder(info, options, originalBinder);
             }

--- a/src/Compilers/CSharp/Portable/Binder/WithClassTypeParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithClassTypeParametersBinder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             if (CanConsiderTypeParameters(options))
             {

--- a/src/Compilers/CSharp/Portable/Binder/WithCrefTypeParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithCrefTypeParametersBinder.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             if (CanConsiderTypeParameters(options))
             {

--- a/src/Compilers/CSharp/Portable/Binder/WithExternAliasesBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithExternAliasesBinder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ref useSiteInfo);
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             // If we are looking only for labels we do not need to search through the imports.
             if ((options & LookupOptions.LabelsOnly) == 0)

--- a/src/Compilers/CSharp/Portable/Binder/WithExternAndUsingAliasesBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithExternAndUsingAliasesBinder.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ref useSiteInfo);
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             // If we are looking only for labels we do not need to search through the imports.
             if ((options & LookupOptions.LabelsOnly) == 0)

--- a/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             if (options.CanConsiderMembers())
             {

--- a/src/Compilers/CSharp/Portable/Binder/WithMethodTypeParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithMethodTypeParametersBinder.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             if (CanConsiderTypeParameters(options))
             {

--- a/src/Compilers/CSharp/Portable/Binder/WithParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithParametersBinder.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _parameters = parameters;
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             if (options.CanConsiderLocals())
             {

--- a/src/Compilers/CSharp/Portable/Binder/WithUsingNamespacesAndTypesBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithUsingNamespacesAndTypesBinder.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
-        protected override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
+        internal override void AddLookupSymbolsInfoInSingleBinder(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
             // If we are looking only for labels we do not need to search through the imports.
             if ((options & LookupOptions.LabelsOnly) == 0)

--- a/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxTreeSemanticModel? parentSemanticModelOpt = null,
             ImmutableDictionary<Symbol, Symbol>? parentRemappedSymbolsOpt = null,
             int speculatedPosition = 0)
-            : base(syntax, attributeType, new ExecutableCodeBinder(syntax, rootBinder.ContainingMember(), rootBinder), containingSemanticModelOpt, parentSemanticModelOpt, snapshotManagerOpt: null, parentRemappedSymbolsOpt: parentRemappedSymbolsOpt, speculatedPosition)
+            : base(syntax, attributeType, rootBinder, containingSemanticModelOpt, parentSemanticModelOpt, snapshotManagerOpt: null, parentRemappedSymbolsOpt: parentRemappedSymbolsOpt, speculatedPosition)
         {
             Debug.Assert(syntax != null);
             _aliasOpt = aliasOpt;
@@ -35,8 +35,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Creates an AttributeSemanticModel that allows asking semantic questions about an attribute node.
         /// </summary>
-        public static AttributeSemanticModel Create(SyntaxTreeSemanticModel containingSemanticModel, AttributeSyntax syntax, NamedTypeSymbol attributeType, AliasSymbol aliasOpt, Binder rootBinder, ImmutableDictionary<Symbol, Symbol> parentRemappedSymbolsOpt)
+        public static AttributeSemanticModel Create(SyntaxTreeSemanticModel containingSemanticModel, AttributeSyntax syntax, NamedTypeSymbol attributeType, AliasSymbol aliasOpt, Symbol attributeTarget, Binder rootBinder, ImmutableDictionary<Symbol, Symbol> parentRemappedSymbolsOpt)
         {
+            rootBinder = attributeTarget is null ? rootBinder : new ContextualAttributeBinder(rootBinder, attributeTarget);
+            rootBinder = new ExecutableCodeBinder(syntax, rootBinder.ContainingMember(), rootBinder);
             return new AttributeSemanticModel(syntax, attributeType, aliasOpt, rootBinder, containingSemanticModel, parentRemappedSymbolsOpt: parentRemappedSymbolsOpt);
         }
 
@@ -48,7 +50,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(parentSemanticModel != null);
             Debug.Assert(rootBinder != null);
             Debug.Assert(rootBinder.IsSemanticModelBinder);
-
+            // TODO2 need to make a ContextualAttributeBinder for speculation?
+            rootBinder = new ExecutableCodeBinder(syntax, rootBinder.ContainingMember(), rootBinder);
             return new AttributeSemanticModel(syntax, attributeType, aliasOpt, rootBinder, parentSemanticModelOpt: parentSemanticModel, parentRemappedSymbolsOpt: parentRemappedSymbolsOpt, speculatedPosition: position);
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -816,7 +816,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal ParameterSymbol GetLambdaOrLocalFunctionParameterSymbol(
             ParameterSyntax parameter,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             Debug.Assert(parameter != null);
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -336,6 +336,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     binder = rootBinder.GetBinder(current);
                 }
+                else if ((current is InvocationExpressionSyntax invocation) && invocation.MayBeNameofOperator())
+                {
+                    binder = rootBinder.GetBinder(current);
+                }
                 else
                 {
                     // If this ever breaks, make sure that all callers of
@@ -696,7 +700,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return GetRemappedSymbol<LocalSymbol>(local);
         }
 
-        private LocalFunctionSymbol GetDeclaredLocalFunction(LocalFunctionStatementSyntax declarationSyntax)
+        internal LocalFunctionSymbol GetDeclaredLocalFunction(LocalFunctionStatementSyntax declarationSyntax)
         {
             var originalSymbol = GetDeclaredLocalFunction(this.GetEnclosingBinder(GetAdjustedNodePosition(declarationSyntax)), declarationSyntax.Identifier);
             return GetRemappedSymbol(originalSymbol);
@@ -810,9 +814,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ImmutableArray.Create<ISymbol>();
         }
 
-        private ParameterSymbol GetLambdaOrLocalFunctionParameterSymbol(
+        internal ParameterSymbol GetLambdaOrLocalFunctionParameterSymbol(
             ParameterSyntax parameter,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             Debug.Assert(parameter != null);
 
@@ -1167,48 +1171,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return _guardedIOperationNodeMap.TryGetValue(node, out var operation) ? operation : null;
             }
         }
-#nullable disable
 
-        private CSharpSyntaxNode GetBindingRootOrInitializer(CSharpSyntaxNode node)
-        {
-            CSharpSyntaxNode bindingRoot = GetBindingRoot(node);
-
-            // if binding root is parameter, make it equal value
-            // we need to do this since node map doesn't contain bound node for parameter
-            if (bindingRoot is ParameterSyntax parameter && parameter.Default?.FullSpan.Contains(node.Span) == true)
-            {
-                return parameter.Default;
-            }
-
-            // if binding root is field variable declarator, make it initializer
-            // we need to do this since node map doesn't contain bound node for field/event variable declarator
-            if (bindingRoot is VariableDeclaratorSyntax variableDeclarator && variableDeclarator.Initializer?.FullSpan.Contains(node.Span) == true)
-            {
-                if (variableDeclarator.Parent?.Parent.IsKind(SyntaxKind.FieldDeclaration) == true ||
-                    variableDeclarator.Parent?.Parent.IsKind(SyntaxKind.EventFieldDeclaration) == true)
-                {
-                    return variableDeclarator.Initializer;
-                }
-            }
-
-            // if binding root is enum member declaration, make it equal value
-            // we need to do this since node map doesn't contain bound node for enum member decl
-            if (bindingRoot is EnumMemberDeclarationSyntax enumMember && enumMember.EqualsValue?.FullSpan.Contains(node.Span) == true)
-            {
-                return enumMember.EqualsValue;
-            }
-
-            // if binding root is property member declaration, make it equal value
-            // we need to do this since node map doesn't contain bound node for property initializer
-            if (bindingRoot is PropertyDeclarationSyntax propertyMember && propertyMember.Initializer?.FullSpan.Contains(node.Span) == true)
-            {
-                return propertyMember.Initializer;
-            }
-
-            return bindingRoot;
-        }
-
-#nullable enable
         private IOperation GetRootOperation()
         {
             BoundNode highestBoundNode = GetBoundRoot();

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -2034,7 +2034,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private ParameterSymbol GetMethodParameterSymbol(
             ParameterSyntax parameter,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             Debug.Assert(parameter != null);
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -49,6 +49,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal static bool MayBeNameofOperator(this InvocationExpressionSyntax node)
+        {
+            if (node.Expression.Kind() == SyntaxKind.IdentifierName &&
+                ((IdentifierNameSyntax)node.Expression).Identifier.ContextualKind() == SyntaxKind.NameOfKeyword &&
+                node.ArgumentList.Arguments.Count == 1)
+            {
+                ArgumentSyntax argument = node.ArgumentList.Arguments[0];
+                if (argument.NameColon == null && argument.RefOrOutKeyword == default)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// This method is used to keep the code that generates binders in sync
         /// with the code that searches for binders.  We don't want the searcher
@@ -88,8 +104,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
 
                 default:
-                    return syntax is StatementSyntax || IsValidScopeDesignator(syntax as ExpressionSyntax);
-
+                    return syntax is StatementSyntax 
+                        || IsValidScopeDesignator(syntax as ExpressionSyntax) 
+                        || (kind == SyntaxKind.InvocationExpression && ((InvocationExpressionSyntax)syntax).MayBeNameofOperator());
             }
         }
 


### PR DESCRIPTION
Fixes  https://github.com/dotnet/roslyn/issues/60110

Overview:
- `LocalBinderFactory.VisitInvocationExpression` adds a `NameofBinder` for some invocation expressions (that pass syntactic check `MayBeNameofOperator`). 
  `NameofBinder` is a no-op when it detects a proper "nameof" method in its enclosing scope.
  When the `NameofBinder` is chained on a `ContextualAttributeBinder`, it pulls in additional identifiers in scope from type parameters on attribute target (given by `ContextualAttributeBinder`). Since type parameters are in scope (albeit filtered out) in most locations we need them to be (attributes on types, type parameter, parameters), we just need to add them in attributes on methods.
- `Binder.TryBindNameofOperator` gets a binder from binder factories, so that the above scopes kick in.
- `SyntaxTreeSemanticModel.CreateModelForAttribute` adds a `ContextualAttribute` binder (with proper attribute target) in the `RootBinder` for the `AttributeSemanticModel` it creates.
- `MemberSemanticModel.GetEnclosingBinderInternalWithinRoot` adds a `NameofBinder` on some invocation expressions.
- Changes to `BinderFactoryVisitor.VisitTypeDeclarationCore` and `SyntaxTreeSemanticModel.GetDeclarationName` relate to records.

Rules:
- Type parameters from a type declaration are still visible inside attributes on the type. This is consistent with that type's members being visible in those attributes.
- Type parameters from methods are only visible directly for parameter types and type constraints (ie. not in parameter default values and not in attributes on the method, its type parameters, or its parameters), but they are visible inside `nameof` operator in attributes on method, type parameters and parameters.