### PR TITLE
[Infra] Skip flaky integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRenameFileToMatchTypeRefactoring.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRenameFileToMatchTypeRefactoring.cs
@@ -24,7 +24,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/60463"), Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
         public void RenameFileToMatchType_ExistingCode()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -82,7 +82,7 @@ class Program
             await TestServices.EditorVerifier.CodeActionAsync("using System;", cancellationToken: HangMitigatingCancellationToken);
         }
 
-        [IdeFact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/60460"), Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
         public async Task FastDoubleInvoke()
         {
             // We want to invoke the first smart tag and then *immediately* try invoking the next.
@@ -462,7 +462,7 @@ class D
             AssertEx.EqualOrDiff(expectedSecondFile, await TestServices.Editor.GetTextAsync(HangMitigatingCancellationToken));
         }
 
-        [IdeFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/60461"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public async Task ClassificationInPreviewPane()
         {
             await SetUpEditorAsync(@"
@@ -538,7 +538,7 @@ public class P2 { }", HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.TextContainsAsync("using System.IO;", cancellationToken: HangMitigatingCancellationToken);
         }
 
-        [IdeFact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/60461"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public async Task GFUFuzzyMatchAfterRenameTrackingAndAfterGenerateType()
         {
             await SetUpEditorAsync(@"

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpUpdateProjectToAllowUnsafe.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpUpdateProjectToAllowUnsafe.cs
@@ -48,7 +48,7 @@ unsafe class C
             VerifyPropertyOutsideConfiguration(await GetProjectFileElementAsync(project, HangMitigatingCancellationToken), "AllowUnsafeBlocks", "true");
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/60461")]
         public async Task LegacyProject_AllConfigurationsUpdated()
         {
             var project = ProjectName;

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpUpgradeProject.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpUpgradeProject.cs
@@ -47,7 +47,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
             VerifyPropertyOutsideConfiguration(await GetProjectFileElementAsync(project, HangMitigatingCancellationToken), "LangVersion", "latest");
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/60463")]
         public async Task LegacyProject_AllConfigurationsUpdated()
         {
             var project = ProjectName;


### PR DESCRIPTION
We're down to a 22% integration rolling pass rate. We should skip the top affected tests to unblock our merges.

Filed
https://github.com/dotnet/roslyn/issues/60461
https://github.com/dotnet/roslyn/issues/60463
to track the top hitters.