### PR TITLE
update dependency deployment

### DIFF
--- a/src/Tools/BuildActionTelemetryTable/BuildActionTelemetryTable.csproj
+++ b/src/Tools/BuildActionTelemetryTable/BuildActionTelemetryTable.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +16,16 @@
     <ProjectReference Include="..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
     <ProjectReference Include="..\..\Workspaces\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Workspaces.csproj" />
     <ProjectReference Include="..\..\Workspaces\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj" />
+  </ItemGroup>
+  
+  <!-- These are dependencies that are never deployed but that we need to reflect over the Microsoft.CodeAnalysis.EditorFeatures assemblies -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="$(MicrosoftVisualStudioLanguageServerClientVersion)" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.GraphModel" Version="$(MicrosoftVisualStudioGraphModelVersion)" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="$(MicrosoftVisualStudioImagingVersion)" NoWarn="NU1701" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/BuildActionTelemetryTable/Program.cs
+++ b/src/Tools/BuildActionTelemetryTable/Program.cs
@@ -209,7 +209,7 @@ namespace BuildActionTelemetryTable
             { "Microsoft.CodeAnalysis.ConvertForToForEach.AbstractConvertForToForEachCodeRefactoringProvider`6+MyCodeAction", "Convert For To ForEach" },
             { "Microsoft.CodeAnalysis.ConvertForEachToFor.AbstractConvertForEachToForCodeRefactoringProvider`2+ForEachToForCodeAction", "Convert ForEach To For" },
             { "Microsoft.CodeAnalysis.ConvertCast.AbstractConvertCastCodeRefactoringProvider`3+MyCodeAction", "Convert Cast" },
-            { "Microsoft.CodeAnalysis.ConvertAutoPropertyToFullProperty.AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider`2+ConvertAutoPropertyToFullPropertyCodeAction", "Convert AutoProperty To Full Property" },
+            { "Microsoft.CodeAnalysis.ConvertAutoPropertyToFullProperty.AbstractConvertAutoPropertyToFullPropertyCodeRefactoringProvider`3+ConvertAutoPropertyToFullPropertyCodeAction", "Convert AutoProperty To Full Property" },
             { "Microsoft.CodeAnalysis.ConflictMarkerResolution.AbstractResolveConflictMarkerCodeFixProvider+MyCodeAction", "Resolve Conflict Marker" },
             { "Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass.AbstractConvertAnonymousTypeToClassCodeRefactoringProvider`6+MyCodeAction", "Convert Anonymous Type To Class" },
             { "Microsoft.CodeAnalysis.AddMissingImports.AbstractAddMissingImportsRefactoringProvider+AddMissingImportsCodeAction", "Add Missing Imports (Paste)" },
@@ -282,6 +282,11 @@ namespace BuildActionTelemetryTable
             { "Microsoft.CodeAnalysis.VisualBasic.SimplifyObjectCreation.VisualBasicSimplifyObjectCreationCodeFixProvider+MyCodeAction", "Simplify Object Creation" },
             { "Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking.RenameTrackingTaggerProvider+RenameTrackingCodeAction", "Rename Tracking" },
             { "Microsoft.CodeAnalysis.CSharp.CodeFixes.AddInheritdoc.AddInheritdocCodeFixProvider+MyCodeAction", "Add Inheritdoc" },
+            { "Microsoft.CodeAnalysis.CSharp.CodeFixes.TransposeRecordKeyword.CSharpTransposeRecordKeywordCodeFixProvider+MyCodeAction", "Fix record declaration" },
+            { "Microsoft.CodeAnalysis.CSharp.ConvertToRawString.ConvertRegularStringToRawStringCodeRefactoringProvider+MyCodeAction", "Convert to raw string" },
+            { "Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryLambdaExpression.CSharpRemoveUnnecessaryLambdaExpressionCodeFixProvider+MyCodeAction", "Remove Unnecessary Lambda Expression" },
+            { "Microsoft.CodeAnalysis.CSharp.UseParameterNullChecking.CSharpUseParameterNullCheckingCodeFixProvider+MyCodeAction", "Use Parameter Null Checking" },
+            { "Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageServices.AbstractJsonDetectionCodeFixProvider+MyCodeAction", "Enable all JSON editor features" },
         }.ToImmutableDictionary();
 
         public static void Main(string[] args)


### PR DESCRIPTION
There are several dependencies that are set to `PrivateAssets="all"` in `Microsoft.CodeAnalysis.EditorFeatures` here:

https://github.com/dotnet/roslyn/blob/f6900176d7d351057077805330281947611d1b4a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj#L36-L46

We need to deploy these so we can properly reflect over `Microsoft.CodeAnalysis.EditorFeatures` and discover the set of codefixes and refactorings we ship and compute the telemetry hashes for them. 