### PR TITLE
Zero fields before running field initializers in struct constructor with default `: this()` initializer

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3517,16 +3517,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, ErrorCode.ERR_RecordStructConstructorCallsDefaultConstructor, initializer.ThisOrBaseKeyword);
             }
 
-            // The `: this()` initializer is ignored when it is a default value type constructor
-            // and we need to include field initializers into the constructor.
-            bool skipInitializer = includesFieldInitializers
-                && isDefaultValueTypeInitializer;
-
             // Using BindStatement to bind block to make sure we are reusing results of partial binding in SemanticModel
             return new BoundConstructorMethodBody(constructor,
                                                   bodyBinder.GetDeclaredLocalsForScope(constructor),
-                                                  skipInitializer ? new BoundNoOpStatement(constructor, NoOpStatementFlavor.Default)
-                                                      : initializer == null ? null : bodyBinder.BindConstructorInitializer(initializer, diagnostics),
+                                                  initializer == null ? null : bodyBinder.BindConstructorInitializer(initializer, diagnostics),
                                                   constructor.Body == null ? null : (BoundBlock)bodyBinder.BindStatement(constructor.Body, diagnostics),
                                                   constructor.ExpressionBody == null ?
                                                       null :

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3402,7 +3402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return requiredValueKind;
         }
 
-        public virtual BoundNode BindMethodBody(CSharpSyntaxNode syntax, BindingDiagnosticBag diagnostics, bool includesFieldInitializers = false)
+        public virtual BoundNode BindMethodBody(CSharpSyntaxNode syntax, BindingDiagnosticBag diagnostics)
         {
             switch (syntax)
             {
@@ -3412,7 +3412,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BaseMethodDeclarationSyntax method:
                     if (method.Kind() == SyntaxKind.ConstructorDeclaration)
                     {
-                        return BindConstructorBody((ConstructorDeclarationSyntax)method, diagnostics, includesFieldInitializers);
+                        return BindConstructorBody((ConstructorDeclarationSyntax)method, diagnostics);
                     }
 
                     return BindMethodBody(method, method.Body, method.ExpressionBody, diagnostics);
@@ -3484,7 +3484,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return constructorInitializer;
         }
 
-        private BoundNode BindConstructorBody(ConstructorDeclarationSyntax constructor, BindingDiagnosticBag diagnostics, bool includesFieldInitializers)
+        private BoundNode BindConstructorBody(ConstructorDeclarationSyntax constructor, BindingDiagnosticBag diagnostics)
         {
             ConstructorInitializerSyntax initializer = constructor.Initializer;
             if (initializer == null && constructor.Body == null && constructor.ExpressionBody == null)

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -2474,7 +2474,7 @@ foundParent:;
                 return null;
             }
 
-            public override BoundNode BindMethodBody(CSharpSyntaxNode node, BindingDiagnosticBag diagnostics, bool includeInitializersInBody)
+            public override BoundNode BindMethodBody(CSharpSyntaxNode node, BindingDiagnosticBag diagnostics)
             {
                 BoundNode boundNode = TryGetBoundNodeFromMap(node);
 
@@ -2483,7 +2483,7 @@ foundParent:;
                     return boundNode;
                 }
 
-                boundNode = base.BindMethodBody(node, diagnostics, includeInitializersInBody);
+                boundNode = base.BindMethodBody(node, diagnostics);
 
                 return boundNode;
             }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1086,7 +1086,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // In order to get correct diagnostics, we need to analyze initializers and the body together.
                             int insertAt = 0;
                             if (originalBodyNested &&
-                                methodSymbol.ContainingType.IsStructType() &&
                                 prependedDefaultValueTypeConstructorInitializer)
                             {
                                 insertAt = 1;

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1054,7 +1054,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         diagsForCurrentMethod,
                         processedInitializers.AfterInitializersState,
                         ReportNullableDiagnostics,
-                        includesFieldInitializers: includeInitializersInBody && !processedInitializers.BoundInitializers.IsEmpty,
                         out importChain,
                         out originalBodyNested,
                         out forSemanticModel);
@@ -1714,7 +1713,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // NOTE: can return null if the method has no body.
         internal static BoundBlock BindMethodBody(MethodSymbol method, TypeCompilationState compilationState, BindingDiagnosticBag diagnostics)
         {
-            return BindMethodBody(method, compilationState, diagnostics, nullableInitialState: null, reportNullableDiagnostics: true, includesFieldInitializers: false, out _, out _, out _);
+            return BindMethodBody(method, compilationState, diagnostics, nullableInitialState: null, reportNullableDiagnostics: true, out _, out _, out _);
         }
 
         // NOTE: can return null if the method has no body.
@@ -1724,7 +1723,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics,
             NullableWalker.VariableState nullableInitialState,
             bool reportNullableDiagnostics,
-            bool includesFieldInitializers,
             out ImportChain importChain,
             out bool originalBodyNested,
             out MethodBodySemanticModel.InitialState forSemanticModel)
@@ -1764,7 +1762,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (bodyBinder != null)
                 {
                     importChain = bodyBinder.ImportChain;
-                    BoundNode methodBody = bodyBinder.BindMethodBody(syntaxNode, diagnostics, includesFieldInitializers);
+                    BoundNode methodBody = bodyBinder.BindMethodBody(syntaxNode, diagnostics);
                     BoundNode methodBodyForSemanticModel = methodBody;
                     NullableWalker.SnapshotManager snapshotManager = null;
                     ImmutableDictionary<Symbol, Symbol> remappedSymbols = null;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -4,7 +4,9 @@
 
 #nullable disable
 
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -1041,6 +1043,28 @@ class Program
   IL_0009:  stfld      ""int R.x""
   IL_000e:  ret
 }");
+
+            var comp = (CSharpCompilation)verifier.Compilation;
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var syntax = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().First();
+            var operation = model.GetOperation(syntax);
+            var actualText = OperationTreeVerifier.GetOperationTree(comp, operation);
+            OperationTreeVerifier.Verify(
+@"    IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null) (Syntax: 'public S(in ... }')
+  Initializer:
+    IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: ': this()')
+      Expression:
+        IInvocationOperation ( S..ctor()) (OperationKind.Invocation, Type: System.Void) (Syntax: ': this()')
+          Instance Receiver:
+            IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: S, IsImplicit) (Syntax: ': this()')
+          Arguments(0)
+  BlockBody:
+    IBlockOperation (0 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+  ExpressionBody:
+    null
+",
+                actualText);
         }
 
         [WorkItem(58790, "https://github.com/dotnet/roslyn/issues/58790")]
@@ -1114,6 +1138,28 @@ class Program
   IL_0010:  stfld      ""int R.y""
   IL_0015:  ret
 }");
+
+            var comp = (CSharpCompilation)verifier.Compilation;
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var syntax = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().First();
+            var operation = model.GetOperation(syntax);
+            var actualText = OperationTreeVerifier.GetOperationTree(comp, operation);
+            OperationTreeVerifier.Verify(
+@"IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null) (Syntax: 'public S(in ... }')
+  Initializer:
+    IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: ': this()')
+      Expression:
+        IInvocationOperation ( S..ctor()) (OperationKind.Invocation, Type: System.Void) (Syntax: ': this()')
+          Instance Receiver:
+            IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: S, IsImplicit) (Syntax: ': this()')
+          Arguments(0)
+  BlockBody:
+    IBlockOperation (0 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+  ExpressionBody:
+    null
+",
+                actualText);
         }
 
         [WorkItem(58790, "https://github.com/dotnet/roslyn/issues/58790")]
@@ -1189,6 +1235,37 @@ class Program
   IL_0010:  stfld      ""int R.y""
   IL_0015:  ret
 }");
+
+            var comp = (CSharpCompilation)verifier.Compilation;
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var syntax = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().First();
+            var operation = model.GetOperation(syntax);
+            var actualText = OperationTreeVerifier.GetOperationTree(comp, operation);
+            OperationTreeVerifier.Verify(
+@"IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null) (Syntax: 'public S(in ... }')
+  Initializer:
+    IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: ': this()')
+      Expression:
+        IInvocationOperation ( S..ctor()) (OperationKind.Invocation, Type: System.Void) (Syntax: ': this()')
+          Instance Receiver:
+            IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: S, IsImplicit) (Syntax: ': this()')
+          Arguments(0)
+  BlockBody:
+    IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+      IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'this.y = y;')
+        Expression:
+          ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: 'this.y = y')
+            Left:
+              IFieldReferenceOperation: System.Int32 S.y (OperationKind.FieldReference, Type: System.Int32) (Syntax: 'this.y')
+                Instance Receiver:
+                  IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: S) (Syntax: 'this')
+            Right:
+              IParameterReferenceOperation: y (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'y')
+  ExpressionBody:
+    null
+",
+                actualText);
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -493,12 +493,14 @@ new S2().Value: 1
             verifier.VerifyMissing("S0..ctor()");
             verifier.VerifyIL("S0..ctor(object)",
 @"{
-  // Code size       12 (0xc)
+  // Code size       19 (0x13)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  call       ""int Program.One()""
-  IL_0006:  stfld      ""int S0.Value""
-  IL_000b:  ret
+  IL_0001:  initobj    ""S0""
+  IL_0007:  ldarg.0
+  IL_0008:  call       ""int Program.One()""
+  IL_000d:  stfld      ""int S0.Value""
+  IL_0012:  ret
 }");
             verifier.VerifyIL("S1..ctor()",
 @"{
@@ -596,15 +598,17 @@ new S2().Value: 2
             verifier.VerifyMissing("S0..ctor()");
             verifier.VerifyIL("S0..ctor(object)",
 @"{
-  // Code size       23 (0x17)
+  // Code size       30 (0x1e)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  call       ""int Program.One()""
-  IL_0006:  stfld      ""int S0.Value""
-  IL_000b:  ldarg.0
-  IL_000c:  call       ""int Program.Two()""
-  IL_0011:  stfld      ""int S0.Value""
-  IL_0016:  ret
+  IL_0001:  initobj    ""S0""
+  IL_0007:  ldarg.0
+  IL_0008:  call       ""int Program.One()""
+  IL_000d:  stfld      ""int S0.Value""
+  IL_0012:  ldarg.0
+  IL_0013:  call       ""int Program.Two()""
+  IL_0018:  stfld      ""int S0.Value""
+  IL_001d:  ret
 }");
             verifier.VerifyIL("S1..ctor()",
 @"{
@@ -713,15 +717,17 @@ new S2().Value: 2
             verifier.VerifyMissing("S0..ctor()");
             verifier.VerifyIL("S0..ctor(object)",
 @"{
-  // Code size       19 (0x13)
+  // Code size       26 (0x1a)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.0
-  IL_0002:  stfld      ""int S0.Value""
+  IL_0001:  initobj    ""S0""
   IL_0007:  ldarg.0
-  IL_0008:  call       ""int Program.Two()""
-  IL_000d:  stfld      ""int S0.Value""
-  IL_0012:  ret
+  IL_0008:  ldc.i4.0
+  IL_0009:  stfld      ""int S0.Value""
+  IL_000e:  ldarg.0
+  IL_000f:  call       ""int Program.Two()""
+  IL_0014:  stfld      ""int S0.Value""
+  IL_0019:  ret
 }");
             verifier.VerifyIL("S1..ctor()",
 @"{
@@ -833,6 +839,585 @@ new S1((object)1).Value: 2
   IL_0001:  initobj    ""S1""
   IL_0007:  ret
 }");
+        }
+
+        private static CSharpParseOptions GetParseOptions(LanguageVersion? languageVersion)
+        {
+            return languageVersion is null ?
+                null :
+                TestOptions.Regular.WithLanguageVersion(languageVersion.Value);
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_01(LanguageVersion? languageVersion)
+        {
+            var source =
+@"using System;
+struct S
+{
+    int x;
+    int y;
+    public S(int y) : this()
+    {
+    }
+    public override string ToString() => (x, y).ToString();
+}
+record struct R
+{
+    int x;
+    int y;
+    public R(int y) : this()
+    {
+    }
+    public override string ToString() => (x, y).ToString();
+}
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new S(2));
+        Console.WriteLine(new S());
+        Console.WriteLine(new R(2));
+        Console.WriteLine(new R());
+    }
+}";
+
+            var verifier = CompileAndVerify(source, parseOptions: GetParseOptions(languageVersion), expectedOutput:
+@"(0, 0)
+(0, 0)
+(0, 0)
+(0, 0)
+");
+            verifier.VerifyIL("S..ctor(int)",
+@"{
+  // Code size        8 (0x8)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""S""
+  IL_0007:  ret
+}");
+            verifier.VerifyIL("R..ctor(int)",
+@"{
+  // Code size        8 (0x8)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""R""
+  IL_0007:  ret
+}");
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_02(LanguageVersion? languageVersion)
+        {
+            var source =
+@"using System;
+struct S
+{
+    int x;
+    int y;
+    public S(int y) : this()
+    {
+        this.y = y;
+    }
+    public override string ToString() => (x, y).ToString();
+}
+record struct R
+{
+    int x;
+    int y;
+    public R(int y) : this()
+    {
+        this.y = y;
+    }
+    public override string ToString() => (x, y).ToString();
+}
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new S(2));
+        Console.WriteLine(new S());
+        Console.WriteLine(new R(2));
+        Console.WriteLine(new R());
+    }
+}";
+
+            var verifier = CompileAndVerify(source, parseOptions: GetParseOptions(languageVersion), expectedOutput:
+@"(0, 2)
+(0, 0)
+(0, 2)
+(0, 0)
+");
+            verifier.VerifyIL("S..ctor(int)",
+@"{
+  // Code size       15 (0xf)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""S""
+  IL_0007:  ldarg.0
+  IL_0008:  ldarg.1
+  IL_0009:  stfld      ""int S.y""
+  IL_000e:  ret
+}");
+            verifier.VerifyIL("R..ctor(int)",
+@"{
+  // Code size       15 (0xf)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""R""
+  IL_0007:  ldarg.0
+  IL_0008:  ldarg.1
+  IL_0009:  stfld      ""int R.y""
+  IL_000e:  ret
+}");
+        }
+
+        [WorkItem(58790, "https://github.com/dotnet/roslyn/issues/58790")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_03(LanguageVersion? languageVersion)
+        {
+            var source =
+@"using System;
+struct S
+{
+    int x = 1;
+    int y;
+    public S(int y) : this()
+    {
+    }
+    public override string ToString() => (x, y).ToString();
+}
+record struct R
+{
+    int x = 1;
+    int y;
+    public R(int y) : this()
+    {
+    }
+    public override string ToString() => (x, y).ToString();
+}
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new S(2));
+        Console.WriteLine(new S());
+        Console.WriteLine(new R(2));
+        Console.WriteLine(new R());
+    }
+}";
+
+            var verifier = CompileAndVerify(source, parseOptions: GetParseOptions(languageVersion), expectedOutput:
+@"(1, 0)
+(0, 0)
+(1, 0)
+(0, 0)
+");
+            verifier.VerifyIL("S..ctor(int)",
+@"{
+  // Code size       15 (0xf)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""S""
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.1
+  IL_0009:  stfld      ""int S.x""
+  IL_000e:  ret
+}");
+            verifier.VerifyIL("R..ctor(int)",
+@"{
+  // Code size       15 (0xf)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""R""
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.1
+  IL_0009:  stfld      ""int R.x""
+  IL_000e:  ret
+}");
+        }
+
+        [WorkItem(58790, "https://github.com/dotnet/roslyn/issues/58790")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_04(LanguageVersion? languageVersion)
+        {
+            var source =
+@"using System;
+struct S
+{
+    int x = 1;
+    int y = 2;
+    public S(int y) : this()
+    {
+    }
+    public override string ToString() => (x, y).ToString();
+}
+record struct R
+{
+    int x = 1;
+    int y = 2;
+    public R(int y) : this()
+    {
+    }
+    public override string ToString() => (x, y).ToString();
+}
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new S(2));
+        Console.WriteLine(new S());
+        Console.WriteLine(new R(2));
+        Console.WriteLine(new R());
+    }
+}";
+
+            var verifier = CompileAndVerify(source, parseOptions: GetParseOptions(languageVersion), expectedOutput:
+@"(1, 2)
+(0, 0)
+(1, 2)
+(0, 0)
+");
+            verifier.VerifyIL("S..ctor(int)",
+@"{
+  // Code size       22 (0x16)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""S""
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.1
+  IL_0009:  stfld      ""int S.x""
+  IL_000e:  ldarg.0
+  IL_000f:  ldc.i4.2
+  IL_0010:  stfld      ""int S.y""
+  IL_0015:  ret
+}");
+            verifier.VerifyIL("R..ctor(int)",
+@"{
+  // Code size       22 (0x16)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""R""
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.1
+  IL_0009:  stfld      ""int R.x""
+  IL_000e:  ldarg.0
+  IL_000f:  ldc.i4.2
+  IL_0010:  stfld      ""int R.y""
+  IL_0015:  ret
+}");
+        }
+
+        [WorkItem(58790, "https://github.com/dotnet/roslyn/issues/58790")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_05(LanguageVersion? languageVersion)
+        {
+            var source =
+@"using System;
+struct S
+{
+    int x = 1;
+    int y;
+    public S(int y) : this()
+    {
+        this.y = y;
+    }
+    public override string ToString() => (x, y).ToString();
+}
+record struct R
+{
+    int x = 1;
+    int y;
+    public R(int y) : this()
+    {
+        this.y = y;
+    }
+    public override string ToString() => (x, y).ToString();
+}
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new S(2));
+        Console.WriteLine(new S());
+        Console.WriteLine(new R(2));
+        Console.WriteLine(new R());
+    }
+}";
+
+            var verifier = CompileAndVerify(source, parseOptions: GetParseOptions(languageVersion), expectedOutput:
+@"(1, 2)
+(0, 0)
+(1, 2)
+(0, 0)
+");
+            verifier.VerifyIL("S..ctor(int)",
+@"{
+  // Code size       22 (0x16)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""S""
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.1
+  IL_0009:  stfld      ""int S.x""
+  IL_000e:  ldarg.0
+  IL_000f:  ldarg.1
+  IL_0010:  stfld      ""int S.y""
+  IL_0015:  ret
+}");
+            verifier.VerifyIL("R..ctor(int)",
+@"{
+  // Code size       22 (0x16)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  initobj    ""R""
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.1
+  IL_0009:  stfld      ""int R.x""
+  IL_000e:  ldarg.0
+  IL_000f:  ldarg.1
+  IL_0010:  stfld      ""int R.y""
+  IL_0015:  ret
+}");
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_06(LanguageVersion? languageVersion)
+        {
+            var source =
+@"#pragma warning disable 169
+#pragma warning disable 414
+struct S1
+{
+    int x;
+    int y;
+    public S1(int y) : this()
+    {
+    }
+    public S1() { }
+}
+struct S2
+{
+    int x;
+    int y;
+    public S2(int y) : this()
+    {
+        this.y = y;
+    }
+    public S2() { }
+}
+struct S3
+{
+    int x;
+    int y;
+    public S3(int y) : this()
+    {
+    }
+    public S3()
+    {
+        this.y = -3;
+    }
+}";
+
+            var comp = CreateCompilation(source, parseOptions: GetParseOptions(languageVersion));
+            comp.VerifyDiagnostics(
+                // (10,12): error CS0171: Field 'S1.y' must be fully assigned before control is returned to the caller
+                //     public S1() { }
+                Diagnostic(ErrorCode.ERR_UnassignedThis, "S1").WithArguments("S1.y").WithLocation(10, 12),
+                // (10,12): error CS0171: Field 'S1.x' must be fully assigned before control is returned to the caller
+                //     public S1() { }
+                Diagnostic(ErrorCode.ERR_UnassignedThis, "S1").WithArguments("S1.x").WithLocation(10, 12),
+                // (20,12): error CS0171: Field 'S2.y' must be fully assigned before control is returned to the caller
+                //     public S2() { }
+                Diagnostic(ErrorCode.ERR_UnassignedThis, "S2").WithArguments("S2.y").WithLocation(20, 12),
+                // (20,12): error CS0171: Field 'S2.x' must be fully assigned before control is returned to the caller
+                //     public S2() { }
+                Diagnostic(ErrorCode.ERR_UnassignedThis, "S2").WithArguments("S2.x").WithLocation(20, 12),
+                // (29,12): error CS0171: Field 'S3.x' must be fully assigned before control is returned to the caller
+                //     public S3()
+                Diagnostic(ErrorCode.ERR_UnassignedThis, "S3").WithArguments("S3.x").WithLocation(29, 12));
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_07(LanguageVersion? languageVersion)
+        {
+            var source =
+@"#pragma warning disable 169
+#pragma warning disable 414
+struct S1
+{
+    int x = 1;
+    int y;
+    public S1(int y) : this()
+    {
+    }
+    public S1() { }
+}
+struct S2
+{
+    int x = 2;
+    int y;
+    public S2(int y) : this()
+    {
+        this.y = y;
+    }
+    public S2() { }
+}
+struct S3
+{
+    int x = 3;
+    int y;
+    public S3(int y) : this()
+    {
+    }
+    public S3()
+    {
+        this.y = -3;
+    }
+}";
+
+            var comp = CreateCompilation(source, parseOptions: GetParseOptions(languageVersion));
+            comp.VerifyDiagnostics(
+                // (10,12): error CS0171: Field 'S1.y' must be fully assigned before control is returned to the caller
+                //     public S1() { }
+                Diagnostic(ErrorCode.ERR_UnassignedThis, "S1").WithArguments("S1.y").WithLocation(10, 12),
+                // (20,12): error CS0171: Field 'S2.y' must be fully assigned before control is returned to the caller
+                //     public S2() { }
+                Diagnostic(ErrorCode.ERR_UnassignedThis, "S2").WithArguments("S2.y").WithLocation(20, 12));
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_08(LanguageVersion? languageVersion)
+        {
+            var source =
+@"struct S1
+{
+    int x1 = y1 + 1;
+    int y1;
+    public S1(int y)
+    {
+        this.y1 = y;
+    }
+}
+record struct R1
+{
+    int x1 = y1 + 1;
+    int y1;
+    public R1(int y)
+    {
+        this.y1 = y;
+    }
+}";
+
+            var comp = CreateCompilation(source, parseOptions: GetParseOptions(languageVersion));
+            comp.VerifyDiagnostics(
+                // (3,14): error CS0236: A field initializer cannot reference the non-static field, method, or property 'S1.y1'
+                //     int x1 = y1 + 1;
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "y1").WithArguments("S1.y1").WithLocation(3, 14),
+                // (3,14): error CS0170: Use of possibly unassigned field 'y1'
+                //     int x1 = y1 + 1;
+                Diagnostic(ErrorCode.ERR_UseDefViolationField, "y1").WithArguments("y1").WithLocation(3, 14),
+                // (12,14): error CS0236: A field initializer cannot reference the non-static field, method, or property 'R1.y1'
+                //     int x1 = y1 + 1;
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "y1").WithArguments("R1.y1").WithLocation(12, 14),
+                // (12,14): error CS0170: Use of possibly unassigned field 'y1'
+                //     int x1 = y1 + 1;
+                Diagnostic(ErrorCode.ERR_UseDefViolationField, "y1").WithArguments("y1").WithLocation(12, 14));
+        }
+
+        [WorkItem(58790, "https://github.com/dotnet/roslyn/issues/58790")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_09(LanguageVersion? languageVersion)
+        {
+            var source =
+@"struct S2
+{
+    int x2 = y2 + 1;
+    int y2;
+    public S2(int y) : this()
+    {
+        this.y2 = y;
+    }
+}
+record struct R2
+{
+    int x2 = y2 + 1;
+    int y2;
+    public R2(int y) : this()
+    {
+        this.y2 = y;
+    }
+}";
+
+            var comp = CreateCompilation(source, parseOptions: GetParseOptions(languageVersion));
+            comp.VerifyDiagnostics(
+                // (3,14): error CS0236: A field initializer cannot reference the non-static field, method, or property 'S2.y2'
+                //     int x2 = y2 + 1;
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "y2").WithArguments("S2.y2").WithLocation(3, 14),
+                // (12,14): error CS0236: A field initializer cannot reference the non-static field, method, or property 'R2.y2'
+                //     int x2 = y2 + 1;
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "y2").WithArguments("R2.y2").WithLocation(12, 14));
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_10(LanguageVersion? languageVersion)
+        {
+            var source =
+@"struct S3
+{
+    int x3 = y3 + 1;
+    int y3;
+    public S3(int y)
+    {
+        this = default;
+        this.y3 = y;
+    }
+}
+record struct R3
+{
+    int x3 = y3 + 1;
+    int y3;
+    public R3(int y)
+    {
+        this = default;
+        this.y3 = y;
+    }
+}";
+
+            var comp = CreateCompilation(source, parseOptions: GetParseOptions(languageVersion));
+            comp.VerifyDiagnostics(
+                // (3,14): error CS0236: A field initializer cannot reference the non-static field, method, or property 'S3.y3'
+                //     int x3 = y3 + 1;
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "y3").WithArguments("S3.y3").WithLocation(3, 14),
+                // (3,14): error CS0170: Use of possibly unassigned field 'y3'
+                //     int x3 = y3 + 1;
+                Diagnostic(ErrorCode.ERR_UseDefViolationField, "y3").WithArguments("y3").WithLocation(3, 14),
+                // (13,14): error CS0236: A field initializer cannot reference the non-static field, method, or property 'R3.y3'
+                //     int x3 = y3 + 1;
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "y3").WithArguments("R3.y3").WithLocation(13, 14),
+                // (13,14): error CS0170: Use of possibly unassigned field 'y3'
+                //     int x3 = y3 + 1;
+                Diagnostic(ErrorCode.ERR_UseDefViolationField, "y3").WithArguments("y3").WithLocation(13, 14));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -1549,6 +1549,64 @@ class Program
 }");
         }
 
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_13(LanguageVersion? languageVersion)
+        {
+            var source =
+@"#pragma warning disable 169
+struct S
+{
+    int x1;
+    int y1;
+    public S() : this() { }
+}
+record struct R
+{
+    int x2;
+    int y2;
+    public R() : this() { }
+}";
+            var comp = CreateCompilation(source, parseOptions: GetParseOptions(languageVersion));
+            comp.VerifyDiagnostics(
+                // (6,18): error CS0516: Constructor 'S.S()' cannot call itself
+                //     public S() : this() { }
+                Diagnostic(ErrorCode.ERR_RecursiveConstructorCall, "this").WithArguments("S.S()").WithLocation(6, 18),
+                // (12,18): error CS0516: Constructor 'R.R()' cannot call itself
+                //     public R() : this() { }
+                Diagnostic(ErrorCode.ERR_RecursiveConstructorCall, "this").WithArguments("R.R()").WithLocation(12, 18));
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(null)]
+        public void DefaultThisInitializer_14(LanguageVersion? languageVersion)
+        {
+            var source =
+@"#pragma warning disable 169
+struct S
+{
+    int x1;
+    int y1 = 1;
+    public S() : this() { }
+}
+record struct R
+{
+    int x2;
+    int y2 = 2;
+    public R() : this() { }
+}";
+            var comp = CreateCompilation(source, parseOptions: GetParseOptions(languageVersion));
+            comp.VerifyDiagnostics(
+                // (6,18): error CS0516: Constructor 'S.S()' cannot call itself
+                //     public S() : this() { }
+                Diagnostic(ErrorCode.ERR_RecursiveConstructorCall, "this").WithArguments("S.S()").WithLocation(6, 18),
+                // (12,18): error CS0516: Constructor 'R.R()' cannot call itself
+                //     public R() : this() { }
+                Diagnostic(ErrorCode.ERR_RecursiveConstructorCall, "this").WithArguments("R.R()").WithLocation(12, 18));
+        }
+
         [Fact]
         public void FieldInitializers_None()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -1051,7 +1051,7 @@ class Program
             var operation = model.GetOperation(syntax);
             var actualText = OperationTreeVerifier.GetOperationTree(comp, operation);
             OperationTreeVerifier.Verify(
-@"    IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null) (Syntax: 'public S(in ... }')
+@"IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null) (Syntax: 'public S(in ... }')
   Initializer:
     IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: ': this()')
       Expression:


### PR DESCRIPTION
From the corresponding [proposal change](https://github.com/dotnet/csharplang/pull/5961): 

> **When the constructor initializer `this()` represents the default parameterless struct constructor, all value type fields are set to their default value and all reference type fields are set to `null` _before_ the sequence of assignments specified by the _variable_initializers_ are executed.**

Fixes #58790