### PR TITLE
Don't add spaces when list pattern is inside parentheses

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -10353,6 +10353,62 @@ class C
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatListPattern_Parentheses()
+        {
+            var code = @"
+class C
+{
+    void M((int[], int[]) a) {
+_ = a is([1,2,>=3],[1,2]);
+}
+}";
+            await AssertFormatAsync(code: code, expected: @"
+class C
+{
+    void M((int[], int[]) a)
+    {
+        _ = a is ([1, 2, >= 3], [1, 2]);
+    }
+}");
+
+            var options = new OptionsCollection(LanguageNames.CSharp)
+            {
+                { SpaceBetweenEmptySquareBrackets, false },
+                { SpaceWithinSquareBrackets, false },
+                { SpaceBeforeComma, false },
+                { SpaceAfterComma, false },
+            };
+
+            await AssertFormatAsync(code: code, changedOptionSet: options, expected: @"
+class C
+{
+    void M((int[], int[]) a)
+    {
+        _ = a is ([1,2,>= 3],[1,2]);
+    }
+}");
+
+            options = new OptionsCollection(LanguageNames.CSharp)
+            {
+                { SpaceBeforeOpenSquareBracket, false }, // ignored
+                { SpaceBetweenEmptySquareBrackets, true },
+                { SpaceWithinSquareBrackets, true },
+                { SpaceBeforeComma, true },
+                { SpaceAfterComma, true },
+            };
+
+            await AssertFormatAsync(code: code, changedOptionSet: options, expected: @"
+class C
+{
+    void M((int[ ], int[ ]) a)
+    {
+        _ = a is ([ 1 , 2 , >= 3 ], [ 1 , 2 ]);
+    }
+}");
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task FormatListPattern_TrailingComma()
         {
             var code = @"

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
@@ -206,11 +206,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return AdjustSpacesOperationZeroOrOne(_options.Spacing.HasFlag(SpacePlacement.AfterCast));
             }
 
+            // List patterns
             if (currentKind == SyntaxKind.OpenBracketToken && currentToken.Parent.IsKind(SyntaxKind.ListPattern))
             {
-                // is [
-                // and [
-                return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+                // For the space after the middle comma in ([1, 2], [1, 2])
+                if (previousKind == SyntaxKind.CommaToken)
+                {
+                    return AdjustSpacesOperationZeroOrOne(_options.Spacing.HasFlag(SpacePlacement.AfterComma));
+                }
+
+                // For "is [", "and [", but not "(["
+                if (previousKind != SyntaxKind.OpenParenToken)
+                {
+                    return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+                }
             }
 
             // For spacing Before Square Braces


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/60160