### PR TITLE
Add an aggregate logger for inheritance margin

### DIFF
--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginLogger.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginLogger.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Internal.Log;
+
+namespace Microsoft.VisualStudio.LanguageServices.InheritanceMargin
+{
+    internal static class InheritanceMarginLogger
+    {
+        // 1 sec per bucket, and if it takes more than 1 min, then this log is considered as time-out in the last bucket.
+        private static readonly HistogramLogAggregator s_histogramLogAggregator = new(1000, 60000);
+
+        private enum ActionInfo
+        {
+            GetInheritanceMarginMember,
+        }
+
+        public static void LogGenerateBackgroundInheritanceInfo(TimeSpan elapsedTime)
+            => s_histogramLogAggregator.IncreaseCount(
+                ActionInfo.GetInheritanceMarginMember, Convert.ToDecimal(elapsedTime.TotalMilliseconds));
+
+        public static void LogInheritanceTargetsMenuOpen()
+            => Logger.Log(FunctionId.InheritanceMargin_TargetsMenuOpen, KeyValueLogMessage.Create(LogType.UserAction));
+
+        public static void LogNavigateToTarget()
+            => Logger.Log(FunctionId.InheritanceMargin_NavigateToTarget, KeyValueLogMessage.Create(LogType.UserAction));
+
+        public static void ReportTelemetry()
+        {
+            Logger.Log(FunctionId.InheritanceMargin_GetInheritanceMemberItems,
+                KeyValueLogMessage.Create(LogType.UserAction,
+                m =>
+                {
+                    var histogramLogAggragator = s_histogramLogAggregator.GetValue(ActionInfo.GetInheritanceMarginMember);
+                    if (histogramLogAggragator != null)
+                    {
+                        m[$"{ActionInfo.GetInheritanceMarginMember}.BucketSize"] = histogramLogAggragator.BucketSize;
+                        m[$"{ActionInfo.GetInheritanceMarginMember}.BucketCount"] = histogramLogAggragator.BucketCount;
+                        m[$"{ActionInfo.GetInheritanceMarginMember}.Bucket"] = histogramLogAggragator.GetBucketsAsString();
+                    }
+                }));
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml.cs
@@ -8,13 +8,11 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.FindUsages;
-using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.LanguageServices.InheritanceMargin;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph
@@ -49,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         {
             if (e.OriginalSource is MenuItem { DataContext: TargetMenuItemViewModel viewModel })
             {
-                Logger.Log(FunctionId.InheritanceMargin_NavigateToTarget, KeyValueLogMessage.Create(LogType.UserAction));
+                InheritanceMarginLogger.LogNavigateToTarget();
 
                 var token = _listener.BeginAsyncOperation(nameof(TargetMenuItem_OnClick));
                 TargetMenuItem_OnClickAsync(viewModel).CompletesAsyncOperation(token);
@@ -79,7 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
 
         private void TargetsSubmenu_OnOpen(object sender, RoutedEventArgs e)
         {
-            Logger.Log(FunctionId.InheritanceMargin_TargetsMenuOpen, KeyValueLogMessage.Create(LogType.UserAction));
+            InheritanceMarginLogger.LogInheritanceTargetsMenuOpen();
         }
     }
 }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginGlyph.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginGlyph.cs
@@ -11,9 +11,9 @@ using System.Windows.Media;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.LanguageServices.InheritanceMargin;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Classification;
@@ -179,7 +179,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                 //                           -> Target4
                 // If the first level of the context menu contains a TargetMenuItemViewModel, it means here it is case 1,
                 // user is viewing the targets menu.
-                Logger.Log(FunctionId.InheritanceMargin_TargetsMenuOpen, KeyValueLogMessage.Create(LogType.UserAction));
+                InheritanceMarginLogger.LogInheritanceTargetsMenuOpen();
             }
         }
 

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -32,6 +32,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Suppression;
 using Microsoft.VisualStudio.LanguageServices.Implementation.SyncNamespaces;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource;
 using Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReferences;
+using Microsoft.VisualStudio.LanguageServices.InheritanceMargin;
 using Microsoft.VisualStudio.LanguageServices.StackTraceExplorer;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -316,6 +317,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             AsyncCompletionLogger.ReportTelemetry();
             CompletionProvidersLogger.ReportTelemetry();
             ChangeSignatureLogger.ReportTelemetry();
+            InheritanceMarginLogger.ReportTelemetry();
         }
 
         private void DisposeVisualStudioServices()


### PR DESCRIPTION
As discussed offline, because 'GetInheritanceItem' is frequently triggered by the view tagger, it generates a lot of telemetry log.
This PR change it to use a HistogramLogger, which reports the time of 'GetInheritanceItem' based on seconds.
If it takes more than 1min to get it, then it is put in the last bucket and we should considered it as time-out