### PR TITLE
Completion textedits cursor

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/Handlers/Completion/CompletionHandler.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/Completion/CompletionHandler.cs
@@ -34,6 +34,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     [Method(LSP.Methods.TextDocumentCompletionName)]
     internal class CompletionHandler : IRequestHandler<LSP.CompletionParams, LSP.CompletionList?>
     {
+        internal const string EditRangeSetting = "editRange";
+
         private readonly IGlobalOptionService _globalOptions;
         private readonly ImmutableHashSet<char> _csharpTriggerCharacters;
         private readonly ImmutableHashSet<char> _vbTriggerCharacters;
@@ -64,6 +66,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
         {
             var document = context.Document;
             Contract.ThrowIfNull(document);
+            Contract.ThrowIfNull(context.Solution);
 
             // C# and VB share the same LSP language server, and thus share the same default trigger characters.
             // We need to ensure the trigger character is valid in the document's language. For example, the '{'
@@ -89,31 +92,27 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             var (list, isIncomplete, resultId) = completionListResult.Value;
 
+            if (list.IsEmpty)
+            {
+                return new LSP.VSInternalCompletionList
+                {
+                    Items = Array.Empty<LSP.CompletionItem>(),
+                    SuggestionMode = list.SuggestionModeItem != null,
+                    IsIncomplete = isIncomplete,
+                };
+            }
+
             var lspVSClientCapability = context.ClientCapabilities.HasVisualStudioLspCapability() == true;
             var snippetsSupported = context.ClientCapabilities.TextDocument?.Completion?.CompletionItem?.SnippetSupport ?? false;
+            var itemDefaultsSupported = context.ClientCapabilities.TextDocument?.Completion?.CompletionListSetting?.ItemDefaults?.Contains(EditRangeSetting) == true;
             var commitCharactersRuleCache = new Dictionary<ImmutableArray<CharacterSetModificationRule>, string[]>(CommitCharacterArrayComparer.Instance);
 
-            // Feature flag to enable the return of TextEdits instead of InsertTexts (will increase payload size).
-            Contract.ThrowIfNull(context.Solution);
-            var returnTextEdits = _globalOptions.GetOption(LspOptions.LspCompletionFeatureFlag);
-
-            TextSpan? defaultSpan = null;
-            LSP.Range? defaultRange = null;
-            if (returnTextEdits)
-            {
-                // We want to compute the document's text just once.
-                documentText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
-                // We use the first item in the completion list as our comparison point for span
-                // and range for optimization when generating the TextEdits later on.
-                var completionChange = await completionService.GetChangeAsync(
-                    document, list.Items.First(), cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                // If possible, we want to compute the item's span and range just once.
-                // Individual items can override this range later.
-                defaultSpan = completionChange.TextChange.Span;
-                defaultRange = ProtocolConversions.TextSpanToRange(defaultSpan.Value, documentText);
-            }
+            // We use the first item in the completion list as our comparison point for span
+            // and range for optimization when generating the TextEdits later on.
+            var completionChange = await completionService.GetChangeAsync(
+                document, list.Items.First(), cancellationToken: cancellationToken).ConfigureAwait(false);
+            var defaultSpan = completionChange.TextChange.Span;
+            var defaultRange = ProtocolConversions.TextSpanToRange(defaultSpan, documentText);
 
             var supportsCompletionListData = context.ClientCapabilities.HasCompletionListDataCapability();
             var completionResolveData = new CompletionResolveData()
@@ -127,8 +126,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 var completionItemResolveData = supportsCompletionListData ? null : completionResolveData;
                 var lspCompletionItem = await CreateLSPCompletionItemAsync(
                     request, document, item, completionItemResolveData, lspVSClientCapability, commitCharactersRuleCache,
-                    completionService, returnTextEdits, snippetsSupported, stringBuilder, documentText,
-                    defaultSpan, defaultRange, cancellationToken).ConfigureAwait(false);
+                    completionService, snippetsSupported, itemDefaultsSupported, stringBuilder, documentText,
+                    defaultSpan, cancellationToken).ConfigureAwait(false);
                 lspCompletionItems.Add(lspCompletionItem);
             }
 
@@ -147,6 +146,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             if (context.ClientCapabilities.HasCompletionListCommitCharactersCapability())
             {
                 PromoteCommonCommitCharactersOntoList(completionList);
+            }
+
+            if (itemDefaultsSupported)
+            {
+                completionList.ItemDefaults = new LSP.CompletionListItemDefaults
+                {
+                    EditRange = defaultRange,
+                };
             }
 
             var optimizedCompletionList = new LSP.OptimizedVSCompletionList(completionList);
@@ -177,12 +184,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 bool supportsVSExtensions,
                 Dictionary<ImmutableArray<CharacterSetModificationRule>, string[]> commitCharacterRulesCache,
                 CompletionService completionService,
-                bool returnTextEdits,
                 bool snippetsSupported,
+                bool itemDefaultsSupported,
                 StringBuilder stringBuilder,
-                SourceText? documentText,
-                TextSpan? defaultSpan,
-                LSP.Range? defaultRange,
+                SourceText documentText,
+                TextSpan defaultSpan,
                 CancellationToken cancellationToken)
             {
                 // Generate display text
@@ -212,17 +218,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         completionItem.InsertTextFormat = LSP.InsertTextFormat.Snippet;
                     }
                 }
-                // If the feature flag is on, always return a TextEdit.
-                else if (returnTextEdits)
-                {
-                    var textEdit = await GenerateTextEdit(
-                        document, item, completionService, documentText, defaultSpan, defaultRange, cancellationToken).ConfigureAwait(false);
-                    completionItem.TextEdit = textEdit;
-                }
-                // If the feature flag is off, return an InsertText.
                 else
                 {
-                    completionItem.InsertText = SymbolCompletionItem.TryGetInsertionText(item, out var insertionText) ? insertionText : completeDisplayText;
+                    await AddTextEdit(
+                        document, item, completionItem, completionService, documentText, defaultSpan, itemDefaultsSupported, cancellationToken).ConfigureAwait(false);
                 }
 
                 var commitCharacters = GetCommitCharacters(item, commitCharacterRulesCache, supportsVSExtensions);
@@ -238,32 +237,36 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
                 return completionItem;
 
-                static async Task<LSP.TextEdit> GenerateTextEdit(
+                static async Task AddTextEdit(
                     Document document,
                     CompletionItem item,
+                    LSP.CompletionItem lspItem,
                     CompletionService completionService,
-                    SourceText? documentText,
-                    TextSpan? defaultSpan,
-                    LSP.Range? defaultRange,
+                    SourceText documentText,
+                    TextSpan defaultSpan,
+                    bool itemDefaultsSupported,
                     CancellationToken cancellationToken)
                 {
-                    Contract.ThrowIfNull(documentText);
-                    Contract.ThrowIfNull(defaultSpan);
-                    Contract.ThrowIfNull(defaultRange);
-
                     var completionChange = await completionService.GetChangeAsync(
                         document, item, cancellationToken: cancellationToken).ConfigureAwait(false);
                     var completionChangeSpan = completionChange.TextChange.Span;
+                    var newText = completionChange.TextChange.NewText ?? "";
 
-                    var textEdit = new LSP.TextEdit()
+                    if (itemDefaultsSupported && completionChangeSpan == defaultSpan)
                     {
-                        NewText = completionChange.TextChange.NewText ?? "",
-                        Range = completionChangeSpan == defaultSpan.Value
-                            ? defaultRange
-                            : ProtocolConversions.TextSpanToRange(completionChangeSpan, documentText),
-                    };
-
-                    return textEdit;
+                        // The span is the same as the default, we just need to store the new text as
+                        // the insert text so the client can create the text edit from it and the default range.
+                        lspItem.InsertText = newText;
+                    }
+                    else
+                    {
+                        var textEdit = new LSP.TextEdit()
+                        {
+                            NewText = newText,
+                            Range = ProtocolConversions.TextSpanToRange(completionChangeSpan, documentText),
+                        };
+                        lspItem.TextEdit = textEdit;
+                    }
                 }
             }
 

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/Completion/CompletionHandler.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/Completion/CompletionHandler.cs
@@ -226,10 +226,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     vsItem.VsResolveTextEditOnCommit = true;
                     // Razor C# is currently the only language client that supports LSP.InsertTextFormat.Snippet.
                     // We can enable it for regular C# once LSP is used for local completion.
-                    if (snippetsSupported)
-                    {
-                        lspItem.InsertTextFormat = LSP.InsertTextFormat.Snippet;
-                    }
+
+                    // Old contract - no insert text / textedit / and snippet means the client resolved.
+                    // Once we have inserted VsResolveTextEditOnCommit and the client has removed the old code path we can delete.
+                    lspItem.InsertTextFormat = LSP.InsertTextFormat.Snippet;
                 }
                 else
                 {
@@ -248,6 +248,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         // map the additional text edits for all the completion items.
                         // Tracking issue: https://github.com/dotnet/razor-tooling/issues/6242
                         vsCompletionItem.VsResolveTextEditOnCommit = true;
+
+                        // Old contract - no insert text / textedit / and snippet means the client resolved.
+                        // Once we have inserted VsResolveTextEditOnCommit and the client has removed the old code path we can delete.
+                        lspItem.InsertTextFormat = LSP.InsertTextFormat.Snippet;
                     }
                     else
                     {

--- a/src/Features/LanguageServer/Protocol/LspOptions.cs
+++ b/src/Features/LanguageServer/Protocol/LspOptions.cs
@@ -25,10 +25,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             storageLocation: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(MaxCompletionListSize)));
 
         // Flag is defined in VisualStudio\Core\Def\PackageRegistration.pkgdef.
-        public static readonly Option2<bool> LspCompletionFeatureFlag = new(FeatureName, nameof(LspCompletionFeatureFlag), defaultValue: false,
-            new FeatureFlagStorageLocation("Roslyn.LSP.Completion"));
-
-        // Flag is defined in VisualStudio\Core\Def\PackageRegistration.pkgdef.
         public static readonly Option2<bool> LspEditorFeatureFlag = new(FeatureName, nameof(LspEditorFeatureFlag), defaultValue: false,
             new FeatureFlagStorageLocation("Roslyn.LSP.Editor"));
 
@@ -38,7 +34,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
         public ImmutableArray<IOption> Options { get; } = ImmutableArray.Create<IOption>(
             MaxCompletionListSize,
-            LspCompletionFeatureFlag,
             LspEditorFeatureFlag);
 
         [ImportingConstructor]

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -180,13 +180,16 @@ class B : A
             var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
 
             var selectedItem = CodeAnalysis.Completion.CompletionItem.Create(displayText: "M");
-            var textEdit = await CompletionResolveHandler.GenerateTextEditAsync(
-                document, new TestCaretOutOfScopeCompletionService(), selectedItem, snippetsSupported: true, CancellationToken.None).ConfigureAwait(false);
+            var documentText = await document.GetTextAsync(CancellationToken.None).ConfigureAwait(false);
+            var lspItem = new LSP.CompletionItem();
+            await CompletionResolveHandler.AddTextEditAsync(
+                lspItem, document, documentText, new TestCaretOutOfScopeCompletionService(),
+                selectedItem, snippetsSupported: true, TextSpan.FromBounds(77, 77), itemDefaultSpan: null, CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(@"public override void M()
     {
         throw new System.NotImplementedException();
-    }", textEdit.NewText);
+    }", lspItem.TextEdit.NewText);
         }
 
         [Fact]

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -345,6 +345,8 @@ link text";
                 testLspServer, clientCompletionItem).ConfigureAwait(false);
             Assert.Equal("(byte)", results.Label);
             Assert.NotNull(results.Description);
+            Assert.Equal(")", results.TextEdit.NewText);
+            Assert.Equal("((byte)", results.AdditionalTextEdits.Single().NewText);
         }
 
         [Fact]

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -182,9 +182,9 @@ class B : A
             var selectedItem = CodeAnalysis.Completion.CompletionItem.Create(displayText: "M");
             var documentText = await document.GetTextAsync(CancellationToken.None).ConfigureAwait(false);
             var lspItem = new LSP.CompletionItem();
-            await CompletionResolveHandler.AddTextEditAsync(
-                lspItem, document, documentText, new TestCaretOutOfScopeCompletionService(),
-                selectedItem, snippetsSupported: true, TextSpan.FromBounds(77, 77), itemDefaultSpan: null, CancellationToken.None).ConfigureAwait(false);
+
+            var completionChange = await (new TestCaretOutOfScopeCompletionService()).GetChangeAsync(document, selectedItem).ConfigureAwait(false);
+            CompletionResolveHandler.AddTextEdits(lspItem, completionChange, documentText, TextSpan.FromBounds(77, 77), itemDefaultSpan: null, snippetsSupported: true);
 
             Assert.Equal(@"public override void M()
     {

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -21,6 +21,20 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
 {
     public class CompletionTests : AbstractLanguageServerProtocolTests
     {
+        private static readonly LSP.VSInternalClientCapabilities s_vsCompletionCapabilities = new LSP.VSInternalClientCapabilities
+        {
+            SupportsVisualStudioExtensions = true,
+            TextDocument = new LSP.TextDocumentClientCapabilities
+            {
+                Completion = new LSP.VSInternalCompletionSetting
+                {
+                    CompletionListSetting = new LSP.CompletionListSetting
+                    {
+                        ItemDefaults = new string[] { CompletionHandler.EditRangeSetting }
+                    }
+                }
+            }
+        };
 
         [Fact]
         public async Task TestGetCompletionsAsync_PromotesCommitCharactersToListAsync()
@@ -28,15 +42,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var clientCapabilities = new LSP.VSInternalClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,
-                TextDocument = new LSP.TextDocumentClientCapabilities()
+                TextDocument = new LSP.TextDocumentClientCapabilities
                 {
-                    Completion = new LSP.VSInternalCompletionSetting()
+                    Completion = new LSP.VSInternalCompletionSetting
                     {
-                        CompletionList = new LSP.VSInternalCompletionListSetting()
+                        CompletionListSetting = new LSP.CompletionListSetting
+                        {
+                            ItemDefaults = new string[] { CompletionHandler.EditRangeSetting }
+                        },
+                        CompletionList = new LSP.VSInternalCompletionListSetting
                         {
                             CommitCharacters = true,
                         }
-                    }
+                    },
                 }
             };
             var markup =
@@ -75,15 +93,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             var clientCapabilities = new LSP.VSInternalClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,
-                TextDocument = new LSP.TextDocumentClientCapabilities()
+                TextDocument = new LSP.TextDocumentClientCapabilities
                 {
-                    Completion = new LSP.VSInternalCompletionSetting()
+                    Completion = new LSP.VSInternalCompletionSetting
                     {
-                        CompletionList = new LSP.VSInternalCompletionListSetting()
+                        CompletionListSetting = new LSP.CompletionListSetting
+                        {
+                            ItemDefaults = new string[] { CompletionHandler.EditRangeSetting }
+                        },
+                        CompletionList = new LSP.VSInternalCompletionListSetting
                         {
                             CommitCharacters = true,
                         }
-                    }
+                    },
                 }
             };
             var markup =
@@ -123,7 +145,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
         {|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
@@ -137,6 +159,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());
+            Assert.NotNull(results.ItemDefaults.EditRange);
         }
 
         [Fact]
@@ -150,7 +173,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
         A{|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
@@ -177,7 +200,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
         {|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var solution = testLspServer.TestWorkspace.CurrentSolution;
 
             // Make sure the unimported types option is on by default.
@@ -202,7 +225,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
     {|caret:|}
 }";
 
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
 
             testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(
                 new OptionKey(CompletionOptionsStorage.SnippetsBehavior, LanguageNames.CSharp), SnippetsRule.NeverInclude);
@@ -228,7 +251,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
         A classA = new {|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
@@ -262,7 +285,7 @@ namespace M
         }
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
@@ -286,7 +309,7 @@ class A
         DateTime.Now.ToString(""{|caret:|});
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
@@ -340,7 +363,7 @@ class A
         new Regex(""{|caret:|}"");
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
@@ -350,18 +373,19 @@ class A
             var solution = testLspServer.GetCurrentSolution();
             var document = solution.Projects.First().Documents.First();
 
-            // Set to use prototype completion behavior (i.e. feature flag).
-            var globalOptions = testLspServer.TestWorkspace.GetService<IGlobalOptionService>();
-            globalOptions.SetGlobalOption(new OptionKey(LspOptions.LspCompletionFeatureFlag), true);
-
-            var textEdit = GenerateTextEdit(@"\\A", startLine: 5, startChar: 19, endLine: 5, endChar: 19);
+            var defaultRange = new LSP.Range
+            {
+                Start = new LSP.Position { Line = 5, Character = 19 },
+                End = new LSP.Position { Line = 5, Character = 19 }
+            };
 
             var expected = await CreateCompletionItemAsync(
-                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, textEdit: textEdit,
+                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, insertText: @"\\A",
                 sortText: "0000").ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());
+            Assert.Equal(defaultRange, results.ItemDefaults.EditRange);
         }
 
         [Fact]
@@ -377,7 +401,7 @@ class A
         new Regex(@""\{|caret:|}"");
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
@@ -387,18 +411,19 @@ class A
             var solution = testLspServer.GetCurrentSolution();
             var document = solution.Projects.First().Documents.First();
 
-            // Set to use prototype completion behavior (i.e. feature flag).
-            var globalOptions = testLspServer.TestWorkspace.GetService<IGlobalOptionService>();
-            globalOptions.SetGlobalOption(new OptionKey(LspOptions.LspCompletionFeatureFlag), true);
-
-            var textEdit = GenerateTextEdit(@"\A", startLine: 5, startChar: 20, endLine: 5, endChar: 21);
+            var defaultRange = new LSP.Range
+            {
+                Start = new LSP.Position { Line = 5, Character = 20 },
+                End = new LSP.Position { Line = 5, Character = 21 }
+            };
 
             var expected = await CreateCompletionItemAsync(
-                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, textEdit: textEdit,
+                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document,
                 sortText: "0000").ConfigureAwait(false);
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());
+            Assert.Equal(defaultRange, results.ItemDefaults.EditRange);
         }
 
         [Fact]
@@ -414,7 +439,7 @@ class A
         Regex r = new(""\\{|caret:|}"");
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
@@ -424,11 +449,60 @@ class A
             var solution = testLspServer.GetCurrentSolution();
             var document = solution.Projects.First().Documents.First();
 
-            // Set to use prototype completion behavior (i.e. feature flag).
-            var globalOptions = testLspServer.TestWorkspace.GetService<IGlobalOptionService>();
-            globalOptions.SetGlobalOption(new OptionKey(LspOptions.LspCompletionFeatureFlag), true);
+            var defaultRange = new LSP.Range
+            {
+                Start = new LSP.Position { Line = 5, Character = 23 },
+                End = new LSP.Position { Line = 5, Character = 25 }
+            };
 
-            var textEdit = GenerateTextEdit(@"\\A", startLine: 5, startChar: 23, endLine: 5, endChar: 25);
+            var expected = await CreateCompletionItemAsync(
+                label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, insertText: @"\\A",
+                sortText: "0000").ConfigureAwait(false);
+
+            var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
+            AssertJsonEquals(expected, results.Items.First());
+            Assert.Equal(defaultRange, results.ItemDefaults.EditRange);
+        }
+
+        [Fact]
+        [WorkItem(50964, "https://github.com/dotnet/roslyn/issues/50964")]
+        public async Task TestGetRegexCompletionsWithoutItemDefaultSupportAsync()
+        {
+            var clientCapabilities = new LSP.VSInternalClientCapabilities
+            {
+                SupportsVisualStudioExtensions = true,
+                TextDocument = new LSP.TextDocumentClientCapabilities
+                {
+                    Completion = new LSP.VSInternalCompletionSetting
+                    {
+                        CompletionListSetting = new LSP.CompletionListSetting
+                        {
+                            ItemDefaults = null,
+                        },
+                    },
+                }
+            };
+
+            var markup =
+@"using System.Text.RegularExpressions;
+class A
+{
+    void M()
+    {
+        new Regex(""{|caret:|}"");
+    }
+}";
+            using var testLspServer = await CreateTestLspServerAsync(markup, clientCapabilities);
+            var completionParams = CreateCompletionParams(
+                testLspServer.GetLocations("caret").Single(),
+                invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
+                triggerCharacter: "\0",
+                triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+            var solution = testLspServer.GetCurrentSolution();
+            var document = solution.Projects.First().Documents.First();
+
+            var textEdit = GenerateTextEdit(@"\\A", startLine: 5, startChar: 19, endLine: 5, endChar: 19);
 
             var expected = await CreateCompletionItemAsync(
                 label: @"\A", kind: LSP.CompletionItemKind.Text, tags: new string[] { "Text" }, request: completionParams, document: document, textEdit: textEdit,
@@ -436,6 +510,7 @@ class A
 
             var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
             AssertJsonEquals(expected, results.Items.First());
+            Assert.Null(results.ItemDefaults);
         }
 
         [Fact]
@@ -450,7 +525,7 @@ class A
         {|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var cache = GetCompletionListCache(testLspServer);
             Assert.NotNull(cache);
 
@@ -513,7 +588,7 @@ class A
         {|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Deletion,
@@ -544,7 +619,7 @@ class B : A
 {
     override {|caret:|}
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
@@ -572,7 +647,7 @@ partial class C
 {
     partial {|caret:|}
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
@@ -677,7 +752,7 @@ class A
         T{|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Typing,
@@ -729,7 +804,7 @@ class A
         W someW = new {|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var caretLocation = testLspServer.GetLocations("caret").Single();
 
             var completionParams = CreateCompletionParams(
@@ -782,7 +857,7 @@ class A
         T{|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var caretLocation = testLspServer.GetLocations("caret").Single();
             await testLspServer.OpenDocumentAsync(caretLocation.Uri);
 
@@ -848,7 +923,7 @@ class A
         T{|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var caretLocation = testLspServer.GetLocations("caret").Single();
             await testLspServer.OpenDocumentAsync(caretLocation.Uri);
 
@@ -914,7 +989,7 @@ class A
         T{|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var caretLocation = testLspServer.GetLocations("caret").Single();
             await testLspServer.OpenDocumentAsync(caretLocation.Uri);
 
@@ -1009,7 +1084,7 @@ class A
         Console.W{|secondCaret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var firstCaret = testLspServer.GetLocations("firstCaret").Single();
             await testLspServer.OpenDocumentAsync(firstCaret.Uri);
 
@@ -1073,7 +1148,7 @@ class A
         Ta{|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var caretLocation = testLspServer.GetLocations("caret").Single();
 
             var completionParams = CreateCompletionParams(
@@ -1132,7 +1207,7 @@ class A
         {|secondCaret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var firstCaretLocation = testLspServer.GetLocations("firstCaret").Single();
             await testLspServer.OpenDocumentAsync(firstCaretLocation.Uri);
 
@@ -1204,7 +1279,7 @@ class A
         {|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var completionParams = CreateCompletionParams(
                 testLspServer.GetLocations("caret").Single(),
                 invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
@@ -1258,7 +1333,7 @@ class A
         T{|caret:|}
     }
 }";
-            using var testLspServer = await CreateTestLspServerAsync(markup, CapabilitiesWithVSExtensions);
+            using var testLspServer = await CreateTestLspServerAsync(markup, s_vsCompletionCapabilities);
             var caretLocation = testLspServer.GetLocations("caret").Single();
             await testLspServer.OpenDocumentAsync(caretLocation.Uri);
 

--- a/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
+++ b/src/VisualStudio/Core/Def/PackageRegistration.pkgdef
@@ -19,12 +19,6 @@
 "Title"="C#/VB LSP editor (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
 
-[$RootKey$\FeatureFlags\Roslyn\LSP\Completion]
-"Description"="Enables the LSP-powered C#/VB completion experience to operate with prototype behavior. Note this currently will not affect local C#/VB scenarios except for C# in Razor."
-"Value"=dword:00000000
-"Title"="C#/VB LSP completion experience"
-"PreviewPaneChannels"="IntPreview,int.main"
-
 [$RootKey$\FeatureFlags\Roslyn\LSP\SemanticTokens]
 "Description"="Enables the LSP-powered C#/VB semantic tokens experience in the local editor."
 "Value"=dword:00000000


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/60466

Only 81243d897e166e287d99c017771c4ffd37df4366 needs to be reviewed.

TODO
1.  Razor breaks because it does not like when we specify additional text edits up front e.g. for cast completion
```
var a = 10;
a.
```
where a completion is offered to cast a to a byte and turn it into `((byte)a)`
2.  Razor currently Debug asserts in `FormattingContentValidationPass` when we give it `InsertTextFormat.PlainText` edits from the resolve handler in await completion, e.g. https://github.com/dotnet/razor-tooling/issues/6127
In that scenario we split up the edit into an additional edit to change the method to `async` and then another one to just insert `await`, so no snippet formatting is needed.

cc @NTaylorMullen @davidwengier in case they have easy fixes, otherwise I will investigate tomorrow :)