### PR TITLE
[EE] Implement IDkmClrFullNameProvider2 in Roslyn's ResultProvider Formatter.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -240,7 +240,7 @@
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicroBuildPluginsSwixBuildVersion>1.1.33</MicroBuildPluginsSwixBuildVersion>
     <MicrosoftVSSDKBuildToolsVersion>17.0.1056-Dev17PIAs-g9dffd635</MicrosoftVSSDKBuildToolsVersion>
-    <MicrosoftVSSDKVSDConfigToolVersion>16.0.2032702</MicrosoftVSSDKVSDConfigToolVersion>
+    <MicrosoftVSSDKVSDConfigToolVersion>17.0.1051901-preview</MicrosoftVSSDKVSDConfigToolVersion>
     <VsWebsiteInteropVersion>8.0.50727</VsWebsiteInteropVersion>
     <vswhereVersion>2.4.1</vswhereVersion>
     <XamarinMacVersion>1.0.0</XamarinMacVersion>

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameParser.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameParser.cs
@@ -170,5 +170,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             propertyName = null;
             return false;
         }
+
+        internal static string GetOriginalLocalVariableName(string name)
+        {
+            if (!TryParseGeneratedName(name, out _, out var openBracketOffset, out var closeBracketOffset))
+            {
+                return name;
+            }
+
+            var result = name.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
+            return result;
+        }
+
+        internal static string GetOriginalFieldName(string name)
+        {
+            if (!TryParseGeneratedName(name, out _, out var openBracketOffset, out var closeBracketOffset))
+            {
+                return name;
+            }
+
+            var result = name.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
+            return result;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameParser.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameParser.cs
@@ -170,27 +170,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             propertyName = null;
             return false;
         }
-
-        internal static string GetOriginalLocalVariableName(string name)
-        {
-            if (!TryParseGeneratedName(name, out _, out var openBracketOffset, out var closeBracketOffset))
-            {
-                return name;
-            }
-
-            var result = name.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
-            return result;
-        }
-
-        internal static string GetOriginalFieldName(string name)
-        {
-            if (!TryParseGeneratedName(name, out _, out var openBracketOffset, out var closeBracketOffset))
-            {
-                return name;
-            }
-
-            var result = name.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
-            return result;
-        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.ObjectModel;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Type = Microsoft.VisualStudio.Debugger.Metadata.Type;
@@ -46,6 +47,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             expression = RemoveFormatSpecifiers(expression, out formatSpecifiers);
             return RemoveLeadingAndTrailingContent(expression, 0, expression.Length, IsWhitespace, ch => ch == ';' || IsWhitespace(ch));
         }
+
+        internal override string GetOriginalLocalVariableName(string name) => GeneratedNameParser.GetOriginalLocalVariableName(name);
+        internal override string GetOriginalFieldName(string name) => GeneratedNameParser.GetOriginalFieldName(name);
 
         private static string RemoveComments(string expression)
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -48,8 +48,27 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return RemoveLeadingAndTrailingContent(expression, 0, expression.Length, IsWhitespace, ch => ch == ';' || IsWhitespace(ch));
         }
 
-        internal override string GetOriginalLocalVariableName(string name) => GeneratedNameParser.GetOriginalLocalVariableName(name);
-        internal override string GetOriginalFieldName(string name) => GeneratedNameParser.GetOriginalFieldName(name);
+        internal override string GetOriginalLocalVariableName(string name)
+        {
+            if (!GeneratedNameParser.TryParseGeneratedName(name, out _, out var openBracketOffset, out var closeBracketOffset))
+            {
+                return name;
+            }
+
+            var result = name.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
+            return result;
+        }
+
+        internal override string GetOriginalFieldName(string name)
+        {
+            if (!GeneratedNameParser.TryParseGeneratedName(name, out _, out var openBracketOffset, out var closeBracketOffset))
+            {
+                return name;
+            }
+
+            var result = name.Substring(openBracketOffset + 1, closeBracketOffset - openBracketOffset - 1);
+            return result;
+        }
 
         private static string RemoveComments(string expression)
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.projitems
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.projitems
@@ -16,10 +16,18 @@
     <Compile Include="$(MSBuildThisFileDirectory)CSharpFormatter.Values.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CSharpFormatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CSharpResultProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNameConstants.cs">
+      <Link>Compiler\Symbols\Synthesized\GeneratedNameConstants.cs</Link>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNameKind.cs">
+      <Link>Compiler\Symbols\Synthesized\GeneratedNameKind.cs</Link>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNameParser.cs">
+      <Link>Compiler\Symbols\Synthesized\GeneratedNameParser.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
-    <VsdConfigXmlFiles Include="$(MSBuildThisFileDirectory)CSharpResultProvider.vsdconfigxml">
-      <SubType>Designer</SubType>
-    </VsdConfigXmlFiles>
+    <VsdConfigXmlFiles Include="$(MSBuildThisFileDirectory)CSharpResultProvider.vsdconfigxml" />
+    <None Include="$(MSBuildThisFileDirectory)CSharpResultProvider.vsdconfigxml" />
   </ItemGroup>
 </Project>

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.vsdconfigxml
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpResultProvider.vsdconfigxml
@@ -27,6 +27,7 @@
           <Interface Name="IDkmClrFormatter"/>
           <Interface Name="IDkmClrFormatter2"/>
           <Interface Name="IDkmClrFullNameProvider"/>
+          <Interface Name="IDkmClrFullNameProvider2"/>
         </InterfaceGroup>
       </Implements>
     </Class>

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
@@ -909,5 +909,78 @@ namespace @namespace
             Verify(GetChildren(children.Single()),
                 EvalResult("x", "0", "int", fullName: null));
         }
+
+        [Fact]
+        public void MangledName_SimplifySynthesizedLocalName()
+        {
+            IDkmClrFullNameProvider2 fullNameProvider = new CSharpFormatter();
+            var inspectionContext = CreateDkmInspectionContext();
+            // The synthesized locals name should just become an empty string since it's compiler generated.
+            Assert.Equal(string.Empty, fullNameProvider.GetClrNameForLocalVariable(inspectionContext, null, default, default, new DkmClrLocalVariable("CS$<>8__locals0")));
+        }
+
+        [Fact]
+        public void MangledName_SimplifyThisProxyField()
+        {
+            var il = @"
+.class public C
+{
+  .field public object '<>4__this'
+}
+";
+            ImmutableArray<byte> assemblyBytes;
+            ImmutableArray<byte> pdbBytes;
+            CSharpTestBase.EmitILToArray(il, appendDefaultHeader: true, includePdb: false, assemblyBytes: out assemblyBytes, pdbBytes: out pdbBytes);
+            var assembly = ReflectionUtilities.Load(assemblyBytes);
+
+            var fieldToken = assembly.GetType("C").GetFields().First().MetadataToken;
+
+            IDkmClrFullNameProvider2 fullNameProvider = new CSharpFormatter();
+            var inspectionContext = CreateDkmInspectionContext();
+            // The stashed <>4__this should just become an empty string since it's compiler generated.
+            Assert.Equal(string.Empty, fullNameProvider.GetClrNameForField(inspectionContext, new DkmClrRuntimeInstance(assembly).Modules[0], fieldToken));
+        }
+
+        [Fact]
+        public void MangledName_SimplifyHoistedLocal()
+        {
+            var il = @"
+.class public C
+{
+  .field public object '<myClass>5__1'
+}
+";
+            ImmutableArray<byte> assemblyBytes;
+            ImmutableArray<byte> pdbBytes;
+            CSharpTestBase.EmitILToArray(il, appendDefaultHeader: true, includePdb: false, assemblyBytes: out assemblyBytes, pdbBytes: out pdbBytes);
+            var assembly = ReflectionUtilities.Load(assemblyBytes);
+
+            var fieldToken = assembly.GetType("C").GetFields().First().MetadataToken;
+
+            IDkmClrFullNameProvider2 fullNameProvider = new CSharpFormatter();
+            var inspectionContext = CreateDkmInspectionContext();
+            Assert.Equal("myClass", fullNameProvider.GetClrNameForField(inspectionContext, new DkmClrRuntimeInstance(assembly).Modules[0], fieldToken));
+        }
+
+        [Fact]
+        public void MangledName_SimplifyBackingField()
+        {
+            var il = @"
+.class public C
+{
+  .field public object '<StringProperty>k__BackingField'
+}
+";
+            ImmutableArray<byte> assemblyBytes;
+            ImmutableArray<byte> pdbBytes;
+            CSharpTestBase.EmitILToArray(il, appendDefaultHeader: true, includePdb: false, assemblyBytes: out assemblyBytes, pdbBytes: out pdbBytes);
+            var assembly = ReflectionUtilities.Load(assemblyBytes);
+
+            var fieldToken = assembly.GetType("C").GetFields().First().MetadataToken;
+
+            IDkmClrFullNameProvider2 fullNameProvider = new CSharpFormatter();
+            var inspectionContext = CreateDkmInspectionContext();
+            Assert.Equal("StringProperty", fullNameProvider.GetClrNameForField(inspectionContext, new DkmClrRuntimeInstance(assembly).Modules[0], fieldToken));
+        }
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrLocalVariable.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrLocalVariable.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+
+namespace Microsoft.VisualStudio.Debugger.Clr
+{
+    public class DkmClrLocalVariable
+    {
+        public string Name { get; }
+
+        internal DkmClrLocalVariable(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrMethodId.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrMethodId.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+
+using System;
+
+namespace Microsoft.VisualStudio.Debugger.Clr
+{
+    public struct DkmClrMethodId : IComparable<DkmClrMethodId>, IEquatable<DkmClrMethodId>
+    {
+        public int CompareTo(DkmClrMethodId other)
+        {
+            if (this.Token != other.Token)
+            {
+                if (this.Token < other.Token)
+                    return -1;
+                else
+                    return 1;
+            }
+            if (this.Version != other.Version)
+            {
+                if (this.Version < other.Version)
+                    return -1;
+                else
+                    return 1;
+            }
+            return 0;
+        }
+
+        public bool Equals(DkmClrMethodId other)
+        {
+            return (this.CompareTo(other) == 0);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is DkmClrMethodId && Equals((DkmClrMethodId)obj);
+        }
+
+        public static bool operator !=(DkmClrMethodId element0, DkmClrMethodId element1)
+        {
+            return element0.CompareTo(element1) != 0;
+        }
+
+        public static bool operator ==(DkmClrMethodId element0, DkmClrMethodId element1)
+        {
+            return element0.CompareTo(element1) == 0;
+        }
+
+        public static bool operator >(DkmClrMethodId element0, DkmClrMethodId element1)
+        {
+            return element0.CompareTo(element1) > 0;
+        }
+
+        public static bool operator <(DkmClrMethodId element0, DkmClrMethodId element1)
+        {
+            return element0.CompareTo(element1) < 0;
+        }
+
+        public static bool operator >=(DkmClrMethodId element0, DkmClrMethodId element1)
+        {
+            return element0.CompareTo(element1) >= 0;
+        }
+
+        public static bool operator <=(DkmClrMethodId element0, DkmClrMethodId element1)
+        {
+            return element0.CompareTo(element1) <= 0;
+        }
+        public override int GetHashCode()
+        {
+            return Token ^ ((int)Version);
+        }
+
+        public readonly int Token;
+
+        public readonly uint Version;
+
+        public DkmClrMethodId(int Token, uint Version)
+        {
+            this.Token = Token;
+            this.Version = Version;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrModuleInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrModuleInstance.cs
@@ -70,12 +70,12 @@ namespace Microsoft.VisualStudio.Debugger.Clr
             get { return _resolveTypeNameFailures; }
         }
 
-        public object GetMetaDataImport() => new MetaDataImportMock(Assembly);
+        public object GetMetaDataImport() => new MetadataImportMock(Assembly);
 
-        private class MetaDataImportMock : IMetadataImport
+        private class MetadataImportMock : IMetadataImport
         {
             private readonly Assembly _assembly;
-            public MetaDataImportMock(Assembly assembly)
+            public MetadataImportMock(Assembly assembly)
             {
                 _assembly = assembly;
             }
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.Debugger.Clr
                 return 1;
             }
 
-            #region IMetaDataImport - throws NotImplementedException
+            #region IMetadataImport - throws NotImplementedException
             void IMetadataImport.CloseEnum(IntPtr hEnum)
             {
                 throw new NotImplementedException();

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrModuleInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrModuleInstance.cs
@@ -10,12 +10,15 @@
 #endregion
 
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.MetadataReader;
 using Microsoft.VisualStudio.Debugger.Symbols;
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Adds;
+using System.Text;
 using System.Threading;
 
 namespace Microsoft.VisualStudio.Debugger.Clr
@@ -65,6 +68,365 @@ namespace Microsoft.VisualStudio.Debugger.Clr
         internal int ResolveTypeNameFailures
         {
             get { return _resolveTypeNameFailures; }
+        }
+
+        public object GetMetaDataImport() => new MetaDataImportMock(Assembly);
+
+        private class MetaDataImportMock : IMetadataImport
+        {
+            private readonly Assembly _assembly;
+            public MetaDataImportMock(Assembly assembly)
+            {
+                _assembly = assembly;
+            }
+
+            int IMetadataImport.GetFieldProps(int mb, out int mdTypeDef, StringBuilder szField, int cchField, out int pchField, out FieldAttributes pdwAttr, out EmbeddedBlobPointer ppvSigBlob, out int pcbSigBlob, out int pdwCPlusTypeFlab, out IntPtr ppValue, out int pcchValue)
+            {
+                mdTypeDef = default;
+                pchField = default;
+                pdwAttr = default;
+                ppvSigBlob = default;
+                pcbSigBlob = default;
+                pdwCPlusTypeFlab = default;
+                ppValue = default;
+                pcchValue = default;
+
+                // Iterate over all types in the assembly to find the field matching the token.
+                foreach (var type in _assembly.GetTypes())
+                {
+                    foreach (var field in type.GetFields(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                    {
+                        // Found a match.
+                        if (field.MetadataToken == mb)
+                        {
+                            var fieldName = field.Name;
+                            pchField = fieldName.Length;
+
+                            if (szField != null && cchField != 0)
+                            {
+                                if (cchField < pchField)
+                                {
+                                    return -1;
+                                }
+
+                                szField.Append(fieldName);
+                            }
+
+                            return 0;
+                        }
+                    }
+                }
+
+                return 1;
+            }
+
+            #region IMetaDataImport - throws NotImplementedException
+            void IMetadataImport.CloseEnum(IntPtr hEnum)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.CountEnum(HCORENUM hEnum, out int pulCount)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.ResetEnum(HCORENUM hEnum, int ulPos)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumTypeDefs(ref HCORENUM phEnum, out int rTypeDefs, uint cMax, out uint pcTypeDefs)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumInterfaceImpls(ref HCORENUM phEnum, int td, out int rImpls, int cMax, ref int pcImpls)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumTypeRefs(ref HCORENUM phEnum, int[] td, uint cMax, uint pcTypeRefs)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.FindTypeDefByName(string szTypeDef, int tkEnclosingClass, out int token)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetScopeProps(StringBuilder szName, int cchName, out int pchName, out Guid mvid)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetModuleFromScope(out int mdModule)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetTypeDefProps(int td, StringBuilder szTypeDef, int cchTypeDef, out int pchTypeDef, out TypeAttributes pdwTypeDefFlags, out int ptkExtends)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetInterfaceImplProps(int iiImpl, out int pClass, out int ptkIface)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetTypeRefProps(int tr, out int ptkResolutionScope, StringBuilder szName, int cchName, out int pchName)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.ResolveTypeRef(int tr, ref Guid riid, out object ppIScope)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumMembers(ref uint phEnum, uint cl, uint[] rMembers, uint cMax, out uint pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumMembersWithName(ref uint phEnum, uint cl, string szName, uint[] rMembers, uint cMax, ref uint pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumMethods(ref HCORENUM phEnum, int cl, out int mdMethodDef, int cMax, out int pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumMethodsWithName(ref HCORENUM phEnum, int cl, string szName, out int mdMethodDef, int cMax, out int pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumFields(ref HCORENUM phEnum, int cl, out int mdFieldDef, int cMax, out uint pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumFieldsWithName(ref uint phEnum, uint cl, string szName, uint[] rFields, uint cMax, out uint pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumParams(ref HCORENUM phEnum, int mdMethodDef, int[] rParams, int cMax, out uint pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumMemberRefs(ref uint phEnum, uint tkParent, uint[] rMemberRefs, uint cMax, out uint pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumMethodImpls(ref HCORENUM hEnum, Token typeDef, out Token methodBody, out Token methodDecl, int cMax, out int cTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumPermissionSets(ref HCORENUM hEnum, uint tk, uint dwActions, uint[] rPermission, ref uint cMax)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.FindMember(int typeDefToken, string szName, byte[] pvSigBlob, int cbSigBlob, out int memberDefToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.FindMethod(int typeDef, string szName, EmbeddedBlobPointer pvSigBlob, int cbSigBlob, out int methodDef)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.FindField(int typeDef, string szName, byte[] pvSigBlob, int cbSigBlob, out int fieldDef)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.FindMemberRef(int typeRef, string szName, byte[] pvSigBlob, int cbSigBlob, out int result)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetMethodProps(uint md, out int pClass, StringBuilder szMethod, int cchMethod, out uint pchMethod, out MethodAttributes pdwAttr, out EmbeddedBlobPointer ppvSigBlob, out uint pcbSigBlob, out uint pulCodeRVA, out uint pdwImplFlags)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetMemberRefProps(Token mr, out Token ptk, StringBuilder szMember, int cchMember, out uint pchMember, out EmbeddedBlobPointer ppvSigBlob, out uint pbSig)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumProperties(ref HCORENUM phEnum, int td, out int mdFieldDef, int cMax, out uint pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumEvents(ref HCORENUM phEnum, int td, out int mdFieldDef, int cMax, out uint pcEvents)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetEventProps(int ev, out int pClass, StringBuilder szEvent, int cchEvent, out int pchEvent, out int pdwEventFlags, out int ptkEventType, out int pmdAddOn, out int pmdRemoveOn, out int pmdFire, out int rmdOtherMethod, uint cMax, out uint pcOtherMethod)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumMethodSemantics(ref uint phEnum, uint mb, uint[] rEventProp, uint cMax, out uint pcEventProp)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetMethodSemantics(uint mb, uint tkEventProp, out uint pdwSemanticsFlags)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetClassLayout(int typeDef, out uint dwPackSize, COR_FIELD_OFFSET[] rFieldOffset, uint cMax, out uint cFieldOffset, out uint ulClassSize)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetFieldMarshal(int tk, out IntPtr ppvNativeType, out int pcbNativeType)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetRVA(int token, out uint rva, out uint flags)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetPermissionSetProps(uint pm, out uint pdwAction, out IntPtr ppvPermission, out int pcbPermission)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetSigFromToken(int token, out EmbeddedBlobPointer pSig, out int cbSig)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetModuleRefProps(int mur, StringBuilder szName, int cchName, out int pchName)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumModuleRefs(ref HCORENUM phEnum, out int mdModuleRef, int cMax, out uint pcModuleRefs)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetTypeSpecFromToken(Token typeSpec, out EmbeddedBlobPointer pSig, out int cbSig)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetNameFromToken(uint tk, string pszUtf8NamePtr)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumUnresolvedMethods(ref uint phEnum, uint[] rMethods, uint cMax, out uint pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetUserString(int stk, char[] szString, int cchString, out int pchString)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetPinvokeMap(uint tk, out uint pdwMappingFlags, StringBuilder szImportName, uint cchImportName, out uint pchImportName, out int pmrImportDLL)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumSignatures(ref uint phEnum, uint[] rSignatures, uint cmax, out uint pcSignatures)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumTypeSpecs(ref uint phEnum, uint[] rTypeSpecs, uint cmax, out uint pcTypeSpecs)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumUserStrings(ref uint phEnum, uint[] rStrings, uint cmax, out uint pcStrings)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetParamForMethodIndex(uint md, uint ulParamSeq, out uint pParam, out int ppd)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.EnumCustomAttributes(ref HCORENUM phEnum, int tk, int tkType, out Token mdCustomAttribute, uint cMax, out uint pcTokens)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetCustomAttributeProps(Token cv, out Token tkObj, out Token tkType, out EmbeddedBlobPointer blob, out int cbSize)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.FindTypeRef(int tkResolutionScope, string szName, out int typeRef)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetMemberProps(uint mb, out uint pClass, StringBuilder szMember, uint cchMember, out uint pchMember, out uint pdwAttr, out IntPtr ppvSigBlob, out uint pcbSigBlob, out uint pulCodeRVA, out uint pdwImplFlags, out uint pdwCPlusTypeFlag, out IntPtr ppValue, out uint pcchValue)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetPropertyProps(Token prop, out Token pClass, StringBuilder szProperty, int cchProperty, out int pchProperty, out PropertyAttributes pdwPropFlags, out EmbeddedBlobPointer ppvSig, out int pbSig, out int pdwCPlusTypeFlag, out UnusedIntPtr ppDefaultValue, out int pcchDefaultValue, out Token pmdSetter, out Token pmdGetter, out Token rmdOtherMethod, uint cMax, out uint pcOtherMethod)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetParamProps(int tk, out int pmd, out uint pulSequence, StringBuilder szName, uint cchName, out uint pchName, out uint pdwAttr, out uint pdwCPlusTypeFlag, out UnusedIntPtr ppValue, out uint pcchValue)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetCustomAttributeByName(int tkObj, string szName, out EmbeddedBlobPointer ppData, out uint pcbData)
+            {
+                throw new NotImplementedException();
+            }
+
+            bool IMetadataImport.IsValidToken(uint tk)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetNestedClassProps(int tdNestedClass, out int tdEnclosingClass)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.GetNativeCallConvFromSig(IntPtr pvSig, uint cbSig, out uint pCallConv)
+            {
+                throw new NotImplementedException();
+            }
+
+            int IMetadataImport.IsGlobal(uint pd, out int pbGlobal)
+            {
+                throw new NotImplementedException();
+            }
+
+            #endregion
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrRuntimeInstance.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrRuntimeInstance.cs
@@ -37,6 +37,9 @@ namespace Microsoft.VisualStudio.Debugger.Clr
         private readonly Dictionary<string, DkmClrObjectFavoritesInfo> _favoritesByTypeName;
         internal readonly GetMemberValueDelegate GetMemberValue;
 
+        internal DkmClrRuntimeInstance(Assembly assembly) : this(new[] { assembly })
+        { }
+
         internal DkmClrRuntimeInstance(
             Assembly[] assemblies,
             GetModuleDelegate getModule = null,

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmILRange.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmILRange.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+
+#endregion
+
+using System;
+
+namespace Microsoft.VisualStudio.Debugger.Clr
+{
+    public struct DkmILRange
+    {
+        public readonly uint StartOffset;
+
+        public readonly uint EndOffset;
+
+        public DkmILRange(uint StartOffset, uint EndOffset)
+        {
+            this.StartOffset = StartOffset;
+            this.EndOffset = EndOffset;
+        }
+    }
+}

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/IDkmClrFullNameProvider2.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/IDkmClrFullNameProvider2.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+#region Assembly Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+// References\Debugger\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll
+#endregion
+
+using System.Collections.ObjectModel;
+using Microsoft.VisualStudio.Debugger.Clr;
+using Microsoft.VisualStudio.Debugger.Evaluation;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
+
+namespace Microsoft.VisualStudio.Debugger.ComponentInterfaces
+{
+    public interface IDkmClrFullNameProvider2
+    {
+        string GetClrNameForLocalVariable(
+            DkmInspectionContext inspectionContext,
+            DkmClrModuleInstance moduleInstance,
+            DkmClrMethodId methodId,
+            DkmILRange ilRange,
+            DkmClrLocalVariable localVariable);
+
+        string GetClrNameForField(
+            DkmInspectionContext inspectionContext,
+            DkmClrModuleInstance moduleInstance,
+            int fieldToken);
+    }
+}

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -49,6 +49,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Return RemoveLeadingAndTrailingWhitespace(expression)
         End Function
 
+        ' TODO https://github.com/dotnet/roslyn/issues/60581
+        Friend Overrides Function GetOriginalLocalVariableName(name As String) As String
+            Return name
+        End Function
+
+        ' TODO Implement this VB. https://github.com/dotnet/roslyn/issues/60581
+        Friend Overrides Function GetOriginalFieldName(name As String) As String
+            Return name
+        End Function
+
         Private Shared Function RemoveComments(expression As String) As String
             ' Workaround for https://dev.azure.com/devdiv/DevDiv/_workitems/edit/847849
             ' Do not remove any comments that might be in a string. 


### PR DESCRIPTION
Resuming PR https://github.com/dotnet/roslyn/pull/50931

Issue:
- Debugger added IDkmClrFullNameProvider2 API with https://devdiv.visualstudio.com/DevDiv/_git/Concord/pullrequest/301518
- It is currently temporarily implement in Concord, needs to be implemented in Roslyn so implementation can be removed from Concord.

Changes:
1. Formatter:
- Implement IDkmClrFullNameProvider2. It has 2 methods, one to format local names and the other given field metadata.
- Currently only implemented for C#. I'm not that familiar with VB and the GeneratedNames stuff in VB needs some splitting and moving around to get working. Filed https://github.com/dotnet/roslyn/issues/60581 to implement in VB.

2. Unit tests:
- Add unit tests for the common cases of hoisted locals, synthesized locals, etc.

3. Versions.props:
- Update MicrosoftVSSDKVSDConfigToolVersion to a newer version which recognizes IDkmClrFullNameProvider2.
