### PR TITLE
Avoid using --blame-crash with CollectDumps

### DIFF
--- a/src/Tools/Source/RunTests/ITestExecutor.cs
+++ b/src/Tools/Source/RunTests/ITestExecutor.cs
@@ -16,8 +16,9 @@ namespace RunTests
         internal string? TestFilter { get; }
         internal bool IncludeHtml { get; }
         internal bool Retry { get; }
+        internal bool CollectDumps { get; }
 
-        internal TestExecutionOptions(string dotnetFilePath, ProcDumpInfo? procDumpInfo, string testResultsDirectory, string? testFilter, bool includeHtml, bool retry)
+        internal TestExecutionOptions(string dotnetFilePath, ProcDumpInfo? procDumpInfo, string testResultsDirectory, string? testFilter, bool includeHtml, bool retry, bool collectDumps)
         {
             DotnetFilePath = dotnetFilePath;
             ProcDumpInfo = procDumpInfo;
@@ -25,6 +26,7 @@ namespace RunTests
             TestFilter = testFilter;
             IncludeHtml = includeHtml;
             Retry = retry;
+            CollectDumps = collectDumps;
         }
     }
 

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -8,8 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -81,11 +79,19 @@ namespace RunTests
                 builder.AppendFormat($@" --logger {sep}html;LogFileName={GetResultsFilePath(assemblyInfo, "html")}{sep}");
             }
 
+            if (!Options.CollectDumps)
+            {
+                // The 'CollectDumps' option uses operating system features to collect dumps when a process crashes. We
+                // only enable the test executor blame feature in remaining cases, as the latter relies on ProcDump and
+                // interferes with automatic crash dump collection on Windows.
+                builder.Append(" --blame-crash");
+            }
+
             // The 25 minute timeout accounts for the fact that VSIX deployment and/or experimental hive reset and
             // configuration can take significant time (seems to vary from ~10 seconds to ~15 minutes), and the blame
             // functionality cannot separate this configuration overhead from the first test which will eventually run.
             // https://github.com/dotnet/roslyn/issues/59851
-            builder.Append(" --blame-crash --blame-hang-dump-type full --blame-hang-timeout 25minutes");
+            builder.Append(" --blame-hang-dump-type full --blame-hang-timeout 25minutes");
 
             return builder.ToString();
         }

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -386,7 +386,8 @@ namespace RunTests
                 testResultsDirectory: options.TestResultsDirectory,
                 testFilter: options.TestFilter,
                 includeHtml: options.IncludeHtml,
-                retry: options.Retry);
+                retry: options.Retry,
+                collectDumps: options.CollectDumps);
             return new ProcessTestExecutor(testExecutionOptions);
         }
 


### PR DESCRIPTION
This flag causes the test harness to attach ProcDump, which removes our ability to collect heap dumps on crash using Windows' built-in functionality.