### PR TITLE
Ensure current OOP calls for the same solution-checksum can share the same OOP solution computation

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -372,7 +372,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         }
 
         [Fact]
-        public void TestRemoteWorkspaceCircularReferences()
+        public async Task TestRemoteWorkspaceCircularReferences()
         {
             using var tempRoot = new TempRoot();
 
@@ -399,7 +399,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var options = new SerializableOptionSet(optionService, ImmutableDictionary<OptionKey, object>.Empty, ImmutableHashSet<OptionKey>.Empty);
 
             // this shouldn't throw exception
-            remoteWorkspace.TrySetCurrentSolution(solutionInfo, workspaceVersion: 1, options, out var solution);
+            var solution = await remoteWorkspace.GetTestAccessor().TrySetCurrentSolutionAsync(solutionInfo, workspaceVersion: 1, options);
             Assert.NotNull(solution);
         }
 

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -399,7 +399,9 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var options = new SerializableOptionSet(optionService, ImmutableDictionary<OptionKey, object>.Empty, ImmutableHashSet<OptionKey>.Empty);
 
             // this shouldn't throw exception
-            var solution = await remoteWorkspace.GetTestAccessor().TrySetCurrentSolutionAsync(solutionInfo, workspaceVersion: 1, options);
+            var (solution, updated) = await remoteWorkspace.GetTestAccessor().TryUpdateWorkspaceAsync(
+                remoteWorkspace.GetTestAccessor().CreateSolutionFromInfoAndOptions(solutionInfo, options), workspaceVersion: 1);
+            Assert.True(updated);
             Assert.NotNull(solution);
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     var solution = await updater.CreateSolutionAsync(solutionChecksum).ConfigureAwait(false);
 
                     // if the solutionChecksum is for primary branch, update primary workspace cache with the solution
-                    return await TryUpdateAndReturnPrimarySolutionAsync(
+                    return await UpdateSolutionIfPossibleAsync(
                         workspaceVersion, fromPrimaryBranch, solution, cancellationToken).ConfigureAwait(false);
                 }
                 else
@@ -321,7 +321,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// <summary>
         /// Update if for primary solution and for version after what we've already stored in <see cref="_currentRemoteWorkspaceVersion"/>.
         /// </summary>
-        internal async ValueTask<Solution> TryUpdateAndReturnPrimarySolutionAsync(
+        internal async ValueTask<Solution> UpdateSolutionIfPossibleAsync(
             int workspaceVersion,
             bool fromPrimaryBranch,
             Solution solution,

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -109,6 +109,11 @@ namespace Microsoft.CodeAnalysis.Remote
         /// solution returned is only for legacy cases where we expose OOP to 2nd party clients who expect to be able to
         /// call through <see cref="RemoteWorkspaceManager.GetSolutionAsync"/> and who expose that statically to
         /// themselves.
+        /// <para>
+        /// During the life of the call to <paramref name="doWorkAsync"/> the solution corresponding to <paramref
+        /// name="solutionChecksum"/> will be kept alive and returned to any other concurrent calls to this method with
+        /// the same <paramref name="solutionChecksum"/>.
+        /// </para>
         /// </summary>
         public async ValueTask<(Solution solution, T result)> RunWithSolutionAsync<T>(
             AssetProvider assetProvider,

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -362,42 +362,40 @@ namespace Microsoft.CodeAnalysis.Remote
         private async ValueTask<Solution?> TrySetCurrentSolutionAsync(
             SolutionInfo solutionInfo, int workspaceVersion, bool fromPrimaryBranch, SerializableOptionSet options, CancellationToken cancellationToken)
         {
-            if (fromPrimaryBranch)
+            if (!fromPrimaryBranch)
+                return null;
+
+            using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    // we never move workspace backward
-                    if (workspaceVersion > _currentRemoteWorkspaceVersion)
-                    {
-                        _currentRemoteWorkspaceVersion = workspaceVersion;
+                // we never move workspace backward
+                if (workspaceVersion <= _currentRemoteWorkspaceVersion)
+                    return null;
 
-                        // clear previous solution data if there is one it is required by OnSolutionAdded
-                        ClearSolutionData();
+                _currentRemoteWorkspaceVersion = workspaceVersion;
 
-                        OnSolutionAdded(solutionInfo);
+                // clear previous solution data if there is one it is required by OnSolutionAdded
+                ClearSolutionData();
 
-                        // The call to SetOptions will ensure that the options get pushed into the remote IOptionService
-                        // store.  However, we still update our current solution with the options passed in.  This is
-                        // due to the fact that the option store will ignore any options it considered unchanged to what
-                        // it currently knows about.  This will prevent it from actually going and writing those
-                        // unchanged values into Solution.Options.  This is not a correctness issue, but it impacts how
-                        // checksums and syncing work in oop.  Currently, the checksum is based off Solution.Options and
-                        // the values loaded into it.  If one side has loaded a default value and the other has not,
-                        // then they will disagree on their checksum.  This ensures the remote side agrees with the
-                        // host.
-                        //
-                        // A better fix in the future is to make all options pure data and remove the general concept of
-                        // any part of the system eliding information about any options that have their 'default' value.
-                        // https://github.com/dotnet/roslyn/issues/55728
-                        this.SetCurrentSolution(this.CurrentSolution.WithOptions(options));
-                        SetOptions(options);
+                OnSolutionAdded(solutionInfo);
 
-                        return CurrentSolution;
-                    }
-                }
+                // The call to SetOptions will ensure that the options get pushed into the remote IOptionService
+                // store.  However, we still update our current solution with the options passed in.  This is
+                // due to the fact that the option store will ignore any options it considered unchanged to what
+                // it currently knows about.  This will prevent it from actually going and writing those
+                // unchanged values into Solution.Options.  This is not a correctness issue, but it impacts how
+                // checksums and syncing work in oop.  Currently, the checksum is based off Solution.Options and
+                // the values loaded into it.  If one side has loaded a default value and the other has not,
+                // then they will disagree on their checksum.  This ensures the remote side agrees with the
+                // host.
+                //
+                // A better fix in the future is to make all options pure data and remove the general concept of
+                // any part of the system eliding information about any options that have their 'default' value.
+                // https://github.com/dotnet/roslyn/issues/55728
+                this.SetCurrentSolution(this.CurrentSolution.WithOptions(options));
+                SetOptions(options);
+
+                return CurrentSolution;
             }
-
-            return null;
         }
 
         public TestAccessor GetTestAccessor()

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Remote
             var baseSolution = this.CurrentSolution;
 
             // Fast path if this solution checksum is for a solution we're already caching. This also avoids us then
-            // trying to actually mutate the workspace for the simple case of asking for the same thing the last calls
+            // trying to actually mutate the workspace for the simple case of asking for the same thing the last call
             // asked about.
             var tuple = await TryFastGetSolutionAndRunAsync().ConfigureAwait(false);
             if (tuple.solution != null)

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -381,12 +381,11 @@ namespace Microsoft.CodeAnalysis.Remote
                 // The call to SetOptions will ensure that the options get pushed into the remote IOptionService
                 // store.  However, we still update our current solution with the options passed in.  This is
                 // due to the fact that the option store will ignore any options it considered unchanged to what
-                // it currently knows about.  This will prevent it from actually going and writing those
-                // unchanged values into Solution.Options.  This is not a correctness issue, but it impacts how
-                // checksums and syncing work in oop.  Currently, the checksum is based off Solution.Options and
-                // the values loaded into it.  If one side has loaded a default value and the other has not,
-                // then they will disagree on their checksum.  This ensures the remote side agrees with the
-                // host.
+                // it currently knows about.  This will prevent it from actually going and writing those unchanged
+                // values into Solution.Options.  This is not a correctness issue, but it impacts how checksums and
+                // syncing work in oop.  Currently, the checksum is based off Solution.Options and the values
+                // loaded into it.  If one side has loaded a default value and the other has not, then they will
+                // disagree on their checksum.  This ensures the remote side agrees with the host.
                 //
                 // A better fix in the future is to make all options pure data and remove the general concept of
                 // any part of the system eliding information about any options that have their 'default' value.

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -102,6 +102,14 @@ namespace Microsoft.CodeAnalysis.Remote
                 cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Given an appropriate <paramref name="solutionChecksum"/>, gets or computes the corresponding <see
+        /// cref="Solution"/> snapshot for it, and then invokes <paramref name="doWorkAsync"/> with that snapshot.  That
+        /// snapshot and the result of <paramref name="doWorkAsync"/> are then returned from this method.  Note: the
+        /// solution returned is only for legacy cases where we expose OOP to 2nd party clients who expect to be able to
+        /// call through <see cref="RemoteWorkspaceManager.GetSolutionAsync"/> and who expose that statically to
+        /// themselves.
+        /// </summary>
         public async ValueTask<(Solution solution, T result)> RunWithSolutionAsync<T>(
             AssetProvider assetProvider,
             Checksum solutionChecksum,

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -346,8 +346,6 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 var oldSolution = this.CurrentSolution;
 
-                var isUpdate = oldSolution.Id == newSolution.Id && oldSolution.FilePath == newSolution.FilePath;
-
                 // if this wasn't from the primary branch, then we have nothing to do.  Just return the solution back for
                 // the caller.
                 //
@@ -360,7 +358,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 // if either solution id or file path changed, then we consider it as new solution. Otherwise,
                 // update the current solution in place.
 
-                if (!isUpdate)
+                var addingSolution = oldSolution.Id != newSolution.Id || oldSolution.FilePath != newSolution.FilePath;
+                if (addingSolution)
                 {
                     // We're not doing an update, we're moving to a new solution entirely.  Clear out the old one.
                     this.ClearSolutionData();
@@ -369,7 +368,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 newSolution = SetCurrentSolution(newSolution);
                 SetOptions(newSolution.Options);
                 _ = this.RaiseWorkspaceChangedEventAsync(
-                    isUpdate ? WorkspaceChangeKind.SolutionChanged : WorkspaceChangeKind.SolutionAdded, oldSolution, newSolution);
+                    addingSolution ? WorkspaceChangeKind.SolutionAdded : WorkspaceChangeKind.SolutionChanged, oldSolution, newSolution);
 
                 return (newSolution, updated: true);
             }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     {
                         // We're the first call that is asking about this checksum.  Create a lazy to compute it with a
                         // refcount of 1 (for 'us').
-                        tuple = (refCount: 1, new AsyncLazy<Solution>(
+                        tuple = (refCount: 1, AsyncLazy.Create(
                             c => ComputeSolutionAsync(assetProvider, solutionChecksum, workspaceVersion, fromPrimaryBranch, c), cacheResult: true));
                         _checksumToRefCountAndLazySolution.Add(solutionChecksum, tuple);
                     }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -361,7 +361,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 var addingSolution = oldSolution.Id != newSolution.Id || oldSolution.FilePath != newSolution.FilePath;
                 if (addingSolution)
                 {
-                    // We're not doing an update, we're moving to a new solution entirely.  Clear out the old one.
+                    // We're not doing an update, we're moving to a new solution entirely.  Clear out the old one. This
+                    // is necessary so that we clear out any open document information this workspace is tracking. Note:
+                    // this seems suspect as the remote workspace should not be tracking any open document state.
                     this.ClearSolutionData();
                 }
 

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -87,9 +87,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 return;
 
             // Do a no-op run.  This will still ensure that we compute and cache this checksum/solution pair for future
-            // callers. note we call directly into TrySlowGetSolutionAndRunAsync (skipping
-            // TryFastGetSolutionAndRunAsync) as we always want to cache the primary workspace we are being told about
-            // here.
+            // callers. note we call directly into SlowGetSolutionAndRunAsync (skipping TryFastGetSolutionAndRunAsync)
+            // as we always want to cache the primary workspace we are being told about here.
             await SlowGetSolutionAndRunAsync(
                 assetProvider,
                 solutionChecksum,

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Remote
             // callers. note we call directly into TrySlowGetSolutionAndRunAsync (skipping
             // TryFastGetSolutionAndRunAsync) as we always want to cache the primary workspace we are being told about
             // here.
-            await TrySlowGetSolutionAndRunAsync(
+            await SlowGetSolutionAndRunAsync(
                 assetProvider,
                 solutionChecksum,
                 workspaceVersion,
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
             // Wasn't the same as the last thing we cached, actually get the corresponding solution and run the
             // requested callback against it.
-            return await TrySlowGetSolutionAndRunAsync(
+            return await SlowGetSolutionAndRunAsync(
                 assetProvider, solutionChecksum, workspaceVersion, fromPrimaryBranch, doWorkAsync, cancellationToken).ConfigureAwait(false);
 
             async ValueTask<(Solution? solution, T result)> TryFastGetSolutionAndRunAsync()
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        private async ValueTask<(Solution solution, T result)> TrySlowGetSolutionAndRunAsync<T>(
+        private async ValueTask<(Solution solution, T result)> SlowGetSolutionAndRunAsync<T>(
             AssetProvider assetProvider,
             Checksum solutionChecksum,
             int workspaceVersion,

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -318,42 +318,6 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         /// <summary>
-        /// Update if for primary solution and for version after what we've already stored in <see cref="_currentRemoteWorkspaceVersion"/>.
-        /// </summary>
-        private async ValueTask<Solution> UpdateSolutionIfPossibleAsync(
-            int workspaceVersion,
-            bool fromPrimaryBranch,
-            Solution solution,
-            CancellationToken cancellationToken)
-        {
-            // if this wasn't from the primary branch, then we have nothing to do.  Just return the solution back for
-            // the caller.
-            if (!fromPrimaryBranch)
-                return solution;
-
-            using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
-            {
-                // we never move workspace backward
-                if (workspaceVersion <= _currentRemoteWorkspaceVersion)
-                    return solution;
-
-                _currentRemoteWorkspaceVersion = workspaceVersion;
-
-                var oldSolution = CurrentSolution;
-
-                var newSolution = SetCurrentSolution(solution);
-                _ = this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.SolutionChanged, oldSolution, newSolution);
-
-                SetOptions(newSolution.Options);
-
-                // Since we did successfully change the solution, return the actual final solution the workspace
-                // recorded (which will contain things like the real workspace version associated with this
-                // solution instance).
-                return this.CurrentSolution;
-            }
-        }
-
-        /// <summary>
         /// Adds an entire solution to the workspace, replacing any existing solution.  only do this for primary
         /// solution and for version after what we've already stored in <see cref="_currentRemoteWorkspaceVersion"/>. 
         /// </summary>
@@ -392,6 +356,42 @@ namespace Microsoft.CodeAnalysis.Remote
                 SetOptions(options);
 
                 return CurrentSolution;
+            }
+        }
+
+        /// <summary>
+        /// Update if for primary solution and for version after what we've already stored in <see cref="_currentRemoteWorkspaceVersion"/>.
+        /// </summary>
+        private async ValueTask<Solution> UpdateSolutionIfPossibleAsync(
+            int workspaceVersion,
+            bool fromPrimaryBranch,
+            Solution solution,
+            CancellationToken cancellationToken)
+        {
+            // if this wasn't from the primary branch, then we have nothing to do.  Just return the solution back for
+            // the caller.
+            if (!fromPrimaryBranch)
+                return solution;
+
+            using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
+            {
+                // we never move workspace backward
+                if (workspaceVersion <= _currentRemoteWorkspaceVersion)
+                    return solution;
+
+                _currentRemoteWorkspaceVersion = workspaceVersion;
+
+                var oldSolution = CurrentSolution;
+
+                var newSolution = SetCurrentSolution(solution);
+                _ = this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.SolutionChanged, oldSolution, newSolution);
+
+                SetOptions(newSolution.Options);
+
+                // Since we did successfully change the solution, return the actual final solution the workspace
+                // recorded (which will contain things like the real workspace version associated with this
+                // solution instance).
+                return this.CurrentSolution;
             }
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -122,9 +122,9 @@ namespace Microsoft.CodeAnalysis.Remote
             // Fast path if this solution checksum is for a solution we're already caching. This also avoids us then
             // trying to actually mutate the workspace for the simple case of asking for the same thing the last call
             // asked about.
-            var tuple = await TryFastGetSolutionAndRunAsync().ConfigureAwait(false);
-            if (tuple.solution != null)
-                return (tuple.solution, tuple.result);
+            var (solution, result) = await TryFastGetSolutionAndRunAsync().ConfigureAwait(false);
+            if (solution != null)
+                return (solution, result);
 
             // Wasn't the same as the last thing we cached, actually get the corresponding solution and run the
             // requested callback against it.

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
@@ -68,6 +68,11 @@ namespace Microsoft.CodeAnalysis.Remote
         public virtual RemoteWorkspace GetWorkspace()
             => _lazyPrimaryWorkspace.Value;
 
+        /// <summary>
+        /// Not ideal that we exposing the workspace solution, while not ensuring it stays alive for other calls using
+        /// the same <see cref="PinnedSolutionInfo.SolutionChecksum"/>). However, this is used by
+        /// Pythia/Razor/UnitTesting which all assume they can get that solution instance and use as desired by them.
+        /// </summary>
         public async ValueTask<Solution> GetSolutionAsync(ServiceBrokerClient client, PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken)
         {
             var assetSource = new SolutionAssetSource(client);

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs
@@ -68,12 +68,21 @@ namespace Microsoft.CodeAnalysis.Remote
         public virtual RemoteWorkspace GetWorkspace()
             => _lazyPrimaryWorkspace.Value;
 
-        public ValueTask<Solution> GetSolutionAsync(ServiceBrokerClient client, PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken)
+        public async ValueTask<Solution> GetSolutionAsync(ServiceBrokerClient client, PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken)
         {
             var assetSource = new SolutionAssetSource(client);
             var workspace = GetWorkspace();
             var assetProvider = workspace.CreateAssetProvider(solutionInfo, SolutionAssetCache, assetSource);
-            return workspace.GetSolutionAsync(assetProvider, solutionInfo.SolutionChecksum, solutionInfo.FromPrimaryBranch, solutionInfo.WorkspaceVersion, cancellationToken);
+
+            var (solution, result) = await workspace.RunWithSolutionAsync(
+                assetProvider,
+                solutionInfo.SolutionChecksum,
+                solutionInfo.WorkspaceVersion,
+                solutionInfo.FromPrimaryBranch,
+                static _ => ValueTaskFactory.FromResult(false),
+                cancellationToken).ConfigureAwait(false);
+
+            return solution;
         }
 
         private sealed class SimpleAssemblyLoader : IAssemblyLoader

--- a/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
@@ -81,17 +81,35 @@ namespace Microsoft.CodeAnalysis.Remote
         protected void Log(TraceEventType errorType, string message)
             => TraceLogger.TraceEvent(errorType, 0, $"{GetType()}: {message}");
 
-        protected ValueTask<Solution> GetSolutionAsync(PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken)
+        protected async ValueTask<T> RunWithSolutionAsync<T>(
+            PinnedSolutionInfo solutionInfo,
+            Func<Solution, ValueTask<T>> doWorkAsync,
+            CancellationToken cancellationToken)
         {
             var workspace = GetWorkspace();
             var assetProvider = workspace.CreateAssetProvider(solutionInfo, WorkspaceManager.SolutionAssetCache, SolutionAssetSource);
-            return workspace.GetSolutionAsync(assetProvider, solutionInfo.SolutionChecksum, solutionInfo.FromPrimaryBranch, solutionInfo.WorkspaceVersion, cancellationToken);
+            var (_, result) = await workspace.RunWithSolutionAsync(
+                assetProvider,
+                solutionInfo.SolutionChecksum,
+                solutionInfo.WorkspaceVersion,
+                solutionInfo.FromPrimaryBranch,
+                doWorkAsync,
+                cancellationToken).ConfigureAwait(false);
+
+            return result;
         }
 
         protected ValueTask<T> RunServiceAsync<T>(Func<CancellationToken, ValueTask<T>> implementation, CancellationToken cancellationToken)
         {
             WorkspaceManager.SolutionAssetCache.UpdateLastActivityTime();
             return RunServiceImplAsync(implementation, cancellationToken);
+        }
+
+        protected ValueTask<T> RunServiceWithSolutionAsync<T>(
+            PinnedSolutionInfo solutionInfo, Func<Solution, ValueTask<T>> implementation, CancellationToken cancellationToken)
+        {
+            return RunServiceAsync(
+                c => RunWithSolutionAsync(solutionInfo, implementation, c), cancellationToken);
         }
 
         internal static async ValueTask<T> RunServiceImplAsync<T>(Func<CancellationToken, ValueTask<T>> implementation, CancellationToken cancellationToken)
@@ -110,6 +128,23 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             WorkspaceManager.SolutionAssetCache.UpdateLastActivityTime();
             return RunServiceImplAsync(implementation, cancellationToken);
+        }
+
+        protected ValueTask RunServiceWithSolutionAsync(
+            PinnedSolutionInfo solutionInfo, Func<Solution, ValueTask> implementation, CancellationToken cancellationToken)
+        {
+            return RunServiceAsync(
+                async c =>
+                {
+                    await RunWithSolutionAsync(
+                        solutionInfo,
+                        async s =>
+                        {
+                            await implementation(s).ConfigureAwait(false);
+                            // bridge this void 'implementation' callback to the non-void type the underlying api needs.
+                            return false;
+                        }, c).ConfigureAwait(false);
+                }, cancellationToken);
         }
 
         internal static async ValueTask RunServiceImplAsync(Func<CancellationToken, ValueTask> implementation, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return RunServiceImplAsync(implementation, cancellationToken);
         }
 
-        protected ValueTask<T> RunServiceWithSolutionAsync<T>(
+        protected ValueTask<T> RunServiceAsync<T>(
             PinnedSolutionInfo solutionInfo, Func<Solution, ValueTask<T>> implementation, CancellationToken cancellationToken)
         {
             return RunServiceAsync(
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Remote
             return RunServiceImplAsync(implementation, cancellationToken);
         }
 
-        protected ValueTask RunServiceWithSolutionAsync(
+        protected ValueTask RunServiceAsync(
             PinnedSolutionInfo solutionInfo, Func<Solution, ValueTask> implementation, CancellationToken cancellationToken)
         {
             return RunServiceAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/BrokeredServiceBase.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         protected async ValueTask<T> RunWithSolutionAsync<T>(
             PinnedSolutionInfo solutionInfo,
-            Func<Solution, ValueTask<T>> doWorkAsync,
+            Func<Solution, ValueTask<T>> implementation,
             CancellationToken cancellationToken)
         {
             var workspace = GetWorkspace();
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 solutionInfo.SolutionChecksum,
                 solutionInfo.WorkspaceVersion,
                 solutionInfo.FromPrimaryBranch,
-                doWorkAsync,
+                implementation,
                 cancellationToken).ConfigureAwait(false);
 
             return result;

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeLensReferences/RemoteCodeLensReferencesService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeLensReferences/RemoteCodeLensReferencesService.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceLocationsAsync, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    return await RunServiceWithSolutionAsync(solutionInfo, async solution =>
+                    return await RunServiceAsync(solutionInfo, async solution =>
                     {
                         var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
                         if (syntaxNode == null)
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceMethodsAsync, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    return await RunServiceWithSolutionAsync(solutionInfo, async solution =>
+                    return await RunServiceAsync(solutionInfo, async solution =>
                     {
                         var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
                         if (syntaxNode == null)
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (Logger.LogBlock(FunctionId.CodeAnalysisService_GetFullyQualifiedName, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    return await RunServiceWithSolutionAsync(solutionInfo, async solution =>
+                    return await RunServiceAsync(solutionInfo, async solution =>
                     {
                         var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
                         if (syntaxNode == null)

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeLensReferences/RemoteCodeLensReferencesService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeLensReferences/RemoteCodeLensReferencesService.cs
@@ -43,18 +43,23 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (Logger.LogBlock(FunctionId.CodeAnalysisService_GetReferenceCountAsync, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-                    var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
-                    if (syntaxNode == null)
-                    {
-                        return null;
-                    }
+                    return await RunWithSolutionAsync(
+                        solutionInfo,
+                        async solution =>
+                        {
+                            var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
+                            if (syntaxNode == null)
+                            {
+                                return null;
+                            }
 
-                    return await CodeLensReferencesServiceFactory.Instance.GetReferenceCountAsync(
-                        solution,
-                        documentId,
-                        syntaxNode,
-                        maxResultCount,
+                            return await CodeLensReferencesServiceFactory.Instance.GetReferenceCountAsync(
+                                solution,
+                                documentId,
+                                syntaxNode,
+                                maxResultCount,
+                                cancellationToken).ConfigureAwait(false);
+                        },
                         cancellationToken).ConfigureAwait(false);
                 }
             }, cancellationToken);
@@ -66,15 +71,17 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceLocationsAsync, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-                    var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
-                    if (syntaxNode == null)
+                    return await RunServiceWithSolutionAsync(solutionInfo, async solution =>
                     {
-                        return null;
-                    }
+                        var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
+                        if (syntaxNode == null)
+                        {
+                            return null;
+                        }
 
-                    return await CodeLensReferencesServiceFactory.Instance.FindReferenceLocationsAsync(
-                        solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
+                        return await CodeLensReferencesServiceFactory.Instance.FindReferenceLocationsAsync(
+                            solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
+                    }, cancellationToken).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }
@@ -85,15 +92,17 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceMethodsAsync, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-                    var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
-                    if (syntaxNode == null)
+                    return await RunServiceWithSolutionAsync(solutionInfo, async solution =>
                     {
-                        return null;
-                    }
+                        var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
+                        if (syntaxNode == null)
+                        {
+                            return null;
+                        }
 
-                    return await CodeLensReferencesServiceFactory.Instance.FindReferenceMethodsAsync(
-                        solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
+                        return await CodeLensReferencesServiceFactory.Instance.FindReferenceMethodsAsync(
+                            solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
+                    }, cancellationToken).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }
@@ -104,15 +113,17 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (Logger.LogBlock(FunctionId.CodeAnalysisService_GetFullyQualifiedName, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-                    var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
-                    if (syntaxNode == null)
+                    return await RunServiceWithSolutionAsync(solutionInfo, async solution =>
                     {
-                        return null;
-                    }
+                        var syntaxNode = await TryFindNodeAsync(solution, documentId, textSpan, cancellationToken).ConfigureAwait(false);
+                        if (syntaxNode == null)
+                        {
+                            return null;
+                        }
 
-                    return await CodeLensReferencesServiceFactory.Instance.GetFullyQualifiedNameAsync(
-                        solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
+                        return await CodeLensReferencesServiceFactory.Instance.GetFullyQualifiedNameAsync(
+                            solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
+                    }, cancellationToken).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/ConvertTupleToStructCodeRefactoringProvider/RemoteConvertTupleToStructCodeRefactoringService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ConvertTupleToStructCodeRefactoringProvider/RemoteConvertTupleToStructCodeRefactoringService.cs
@@ -35,9 +35,8 @@ namespace Microsoft.CodeAnalysis.Remote
             bool isRecord,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = solution.GetDocument(documentId);
 
                 var service = document.GetLanguageService<IConvertTupleToStructCodeRefactoringProvider>();

--- a/src/Workspaces/Remote/ServiceHub/Services/ConvertTupleToStructCodeRefactoringProvider/RemoteConvertTupleToStructCodeRefactoringService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ConvertTupleToStructCodeRefactoringProvider/RemoteConvertTupleToStructCodeRefactoringService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Remote
             bool isRecord,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = solution.GetDocument(documentId);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/DependentTypeFinder/RemoteDependentTypeFinderService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DependentTypeFinder/RemoteDependentTypeFinderService.cs
@@ -34,10 +34,8 @@ namespace Microsoft.CodeAnalysis.Remote
             DependentTypesKind kind,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 var symbol = await typeAndProjectId.TryRehydrateAsync(solution, cancellationToken).ConfigureAwait(false);
 
                 if (symbol is not INamedTypeSymbol namedType)

--- a/src/Workspaces/Remote/ServiceHub/Services/DependentTypeFinder/RemoteDependentTypeFinderService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DependentTypeFinder/RemoteDependentTypeFinderService.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Remote
             DependentTypesKind kind,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var symbol = await typeAndProjectId.TryRehydrateAsync(solution, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -64,32 +64,35 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_CalculateDiagnosticsAsync, arguments.ProjectId.DebugName, cancellationToken))
                 {
-                    var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
+                    return await RunWithSolutionAsync(
+                        solutionInfo,
+                        async solution =>
+                        {
+                            var documentId = arguments.DocumentId;
+                            var projectId = arguments.ProjectId;
+                            var project = solution.GetProject(projectId);
+                            var document = arguments.DocumentId != null
+                                ? solution.GetTextDocument(arguments.DocumentId) ?? await solution.GetSourceGeneratedDocumentAsync(arguments.DocumentId, cancellationToken).ConfigureAwait(false)
+                                : null;
+                            var documentSpan = arguments.DocumentSpan;
+                            var documentAnalysisKind = arguments.DocumentAnalysisKind;
+                            var diagnosticComputer = new DiagnosticComputer(document, project, arguments.IdeOptions, documentSpan, documentAnalysisKind, _analyzerInfoCache);
 
-                    var documentId = arguments.DocumentId;
-                    var projectId = arguments.ProjectId;
-                    var project = solution.GetProject(projectId);
-                    var document = arguments.DocumentId != null
-                        ? solution.GetTextDocument(arguments.DocumentId) ?? await solution.GetSourceGeneratedDocumentAsync(arguments.DocumentId, cancellationToken).ConfigureAwait(false)
-                        : null;
-                    var documentSpan = arguments.DocumentSpan;
-                    var documentAnalysisKind = arguments.DocumentAnalysisKind;
-                    var diagnosticComputer = new DiagnosticComputer(document, project, arguments.IdeOptions, documentSpan, documentAnalysisKind, _analyzerInfoCache);
+                            var result = await diagnosticComputer.GetDiagnosticsAsync(
+                                arguments.AnalyzerIds,
+                                reportSuppressedDiagnostics: arguments.ReportSuppressedDiagnostics,
+                                logPerformanceInfo: arguments.LogPerformanceInfo,
+                                getTelemetryInfo: arguments.GetTelemetryInfo,
+                                cancellationToken).ConfigureAwait(false);
 
-                    var result = await diagnosticComputer.GetDiagnosticsAsync(
-                        arguments.AnalyzerIds,
-                        reportSuppressedDiagnostics: arguments.ReportSuppressedDiagnostics,
-                        logPerformanceInfo: arguments.LogPerformanceInfo,
-                        getTelemetryInfo: arguments.GetTelemetryInfo,
-                        cancellationToken).ConfigureAwait(false);
+                            // save log for debugging
+                            var diagnosticCount = result.Diagnostics.Sum(
+                                entry => entry.diagnosticMap.Syntax.Length + entry.diagnosticMap.Semantic.Length + entry.diagnosticMap.NonLocal.Length + entry.diagnosticMap.Other.Length);
 
-                    // save log for debugging
-                    var diagnosticCount = result.Diagnostics.Sum(
-                        entry => entry.diagnosticMap.Syntax.Length + entry.diagnosticMap.Semantic.Length + entry.diagnosticMap.NonLocal.Length + entry.diagnosticMap.Other.Length);
+                            Log(TraceEventType.Information, $"diagnostics: {diagnosticCount}, telemetry: {result.Telemetry.Length}");
 
-                    Log(TraceEventType.Information, $"diagnostics: {diagnosticCount}, telemetry: {result.Telemetry.Length}");
-
-                    return result;
+                            return result;
+                        }, cancellationToken).ConfigureAwait(false);
                 }
             }, cancellationToken);
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/DocumentHighlights/RemoteDocumentHighlightsService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DocumentHighlights/RemoteDocumentHighlightsService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Remote
             // that are not all the same language and might not exist in the OOP process
             // (like the JS parts of a .cshtml file). Filter them out here.  This will
             // need to be revisited if we someday support FAR between these languages.
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                 var documentsToSearch = await documentIdsToSearch.SelectAsArrayAsync(id => solution.GetDocumentAsync(id, includeSourceGenerated: true, cancellationToken)).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/DocumentHighlights/RemoteDocumentHighlightsService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DocumentHighlights/RemoteDocumentHighlightsService.cs
@@ -31,13 +31,12 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask<ImmutableArray<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
             PinnedSolutionInfo solutionInfo, DocumentId documentId, int position, ImmutableArray<DocumentId> documentIdsToSearch, HighlightingOptions options, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            // NOTE: In projection scenarios, we might get a set of documents to search
+            // that are not all the same language and might not exist in the OOP process
+            // (like the JS parts of a .cshtml file). Filter them out here.  This will
+            // need to be revisited if we someday support FAR between these languages.
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                // NOTE: In projection scenarios, we might get a set of documents to search
-                // that are not all the same language and might not exist in the OOP process
-                // (like the JS parts of a .cshtml file). Filter them out here.  This will
-                // need to be revisited if we someday support FAR between these languages.
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                 var documentsToSearch = await documentIdsToSearch.SelectAsArrayAsync(id => solution.GetDocumentAsync(id, includeSourceGenerated: true, cancellationToken)).ConfigureAwait(false);
                 var documentsToSearchSet = ImmutableHashSet.CreateRange(documentsToSearch.WhereNotNull());
@@ -47,7 +46,8 @@ namespace Microsoft.CodeAnalysis.Remote
                     document, position, documentsToSearchSet, options, cancellationToken).ConfigureAwait(false);
 
                 return result.SelectAsArray(SerializableDocumentHighlights.Dehydrate);
-            }, cancellationToken);
+            },
+            cancellationToken);
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.EditAndContinue.Contracts;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
@@ -68,9 +69,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<DebuggingSessionId> StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, ImmutableArray<DocumentId> captureMatchingDocuments, bool captureAllMatchingDocuments, bool reportDiagnostics, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var debuggerService = new ManagedEditAndContinueDebuggerService(_callback, callbackId);
                 var sessionId = await GetService().StartDebuggingSessionAsync(solution, debuggerService, captureMatchingDocuments, captureAllMatchingDocuments, reportDiagnostics, cancellationToken).ConfigureAwait(false);
                 return sessionId;
@@ -106,9 +106,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<ImmutableArray<DiagnosticData>> GetDocumentDiagnosticsAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId documentId, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
 
                 var diagnostics = await GetService().GetDocumentDiagnosticsAsync(document, CreateActiveStatementSpanProvider(callbackId), cancellationToken).ConfigureAwait(false);
@@ -121,10 +120,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<bool> HasChangesAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, string? sourceFilePath, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 return await GetService().HasChangesAsync(sessionId, solution, CreateActiveStatementSpanProvider(callbackId), sourceFilePath, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
@@ -135,10 +132,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public ValueTask<EmitSolutionUpdateResults.Data> EmitSolutionUpdateAsync(
             PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
                 var service = GetService();
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
 
                 try
                 {
@@ -186,9 +182,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<ImmutableArray<ImmutableArray<ActiveStatementSpan>>> GetBaseActiveStatementSpansAsync(PinnedSolutionInfo solutionInfo, DebuggingSessionId sessionId, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 return await GetService().GetBaseActiveStatementSpansAsync(sessionId, solution, documentIds, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
@@ -198,9 +193,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<ImmutableArray<ActiveStatementSpan>> GetAdjustedActiveStatementSpansAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, DocumentId documentId, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = await solution.GetRequiredTextDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
                 return await GetService().GetAdjustedActiveStatementSpansAsync(sessionId, document, CreateActiveStatementSpanProvider(callbackId), cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
@@ -211,9 +205,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<bool?> IsActiveStatementInExceptionRegionAsync(PinnedSolutionInfo solutionInfo, DebuggingSessionId sessionId, ManagedInstructionId instructionId, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 return await GetService().IsActiveStatementInExceptionRegionAsync(sessionId, solution, instructionId, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
@@ -223,9 +216,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<LinePositionSpan?> GetCurrentActiveStatementPositionAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, ManagedInstructionId instructionId, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 return await GetService().GetCurrentActiveStatementPositionAsync(sessionId, solution, CreateActiveStatementSpanProvider(callbackId), instructionId, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
@@ -235,10 +227,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask OnSourceFileUpdatedAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 // TODO: Non-C#/VB documents are not currently serialized to remote workspace.
                 // https://github.com/dotnet/roslyn/issues/47341
                 var document = solution.GetDocument(documentId);
@@ -246,6 +236,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 {
                     GetService().OnSourceFileUpdated(document);
                 }
+
+                return ValueTaskFactory.CompletedTask;
             }, cancellationToken);
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<DebuggingSessionId> StartDebuggingSessionAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, ImmutableArray<DocumentId> captureMatchingDocuments, bool captureAllMatchingDocuments, bool reportDiagnostics, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var debuggerService = new ManagedEditAndContinueDebuggerService(_callback, callbackId);
                 var sessionId = await GetService().StartDebuggingSessionAsync(solution, debuggerService, captureMatchingDocuments, captureAllMatchingDocuments, reportDiagnostics, cancellationToken).ConfigureAwait(false);
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<ImmutableArray<DiagnosticData>> GetDocumentDiagnosticsAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DocumentId documentId, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
 
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<bool> HasChangesAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, string? sourceFilePath, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 return await GetService().HasChangesAsync(sessionId, solution, CreateActiveStatementSpanProvider(callbackId), sourceFilePath, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public ValueTask<EmitSolutionUpdateResults.Data> EmitSolutionUpdateAsync(
             PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var service = GetService();
 
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<ImmutableArray<ImmutableArray<ActiveStatementSpan>>> GetBaseActiveStatementSpansAsync(PinnedSolutionInfo solutionInfo, DebuggingSessionId sessionId, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 return await GetService().GetBaseActiveStatementSpansAsync(sessionId, solution, documentIds, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<ImmutableArray<ActiveStatementSpan>> GetAdjustedActiveStatementSpansAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, DocumentId documentId, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = await solution.GetRequiredTextDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
                 return await GetService().GetAdjustedActiveStatementSpansAsync(sessionId, document, CreateActiveStatementSpanProvider(callbackId), cancellationToken).ConfigureAwait(false);
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<bool?> IsActiveStatementInExceptionRegionAsync(PinnedSolutionInfo solutionInfo, DebuggingSessionId sessionId, ManagedInstructionId instructionId, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 return await GetService().IsActiveStatementInExceptionRegionAsync(sessionId, solution, instructionId, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask<LinePositionSpan?> GetCurrentActiveStatementPositionAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, ManagedInstructionId instructionId, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 return await GetService().GetCurrentActiveStatementPositionAsync(sessionId, solution, CreateActiveStatementSpanProvider(callbackId), instructionId, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public ValueTask OnSourceFileUpdatedAsync(PinnedSolutionInfo solutionInfo, DocumentId documentId, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, solution =>
+            return RunServiceAsync(solutionInfo, solution =>
             {
                 // TODO: Non-C#/VB documents are not currently serialized to remote workspace.
                 // https://github.com/dotnet/roslyn/issues/47341

--- a/src/Workspaces/Remote/ServiceHub/Services/EncapsulateField/RemoteEncapsulateFieldService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EncapsulateField/RemoteEncapsulateFieldService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Remote
             bool updateReferences,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = solution.GetRequiredDocument(documentId);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/EncapsulateField/RemoteEncapsulateFieldService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EncapsulateField/RemoteEncapsulateFieldService.cs
@@ -35,9 +35,8 @@ namespace Microsoft.CodeAnalysis.Remote
             bool updateReferences,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = solution.GetRequiredDocument(documentId);
 
                 using var _ = ArrayBuilder<IFieldSymbol>.GetInstance(out var fields);

--- a/src/Workspaces/Remote/ServiceHub/Services/ExtensionMethodImportCompletion/RemoteExtensionMethodImportCompletionService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ExtensionMethodImportCompletion/RemoteExtensionMethodImportCompletionService.cs
@@ -40,9 +40,8 @@ namespace Microsoft.CodeAnalysis.Remote
             bool hideAdvancedMembers,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = solution.GetDocument(documentId)!;
                 var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var symbol = SymbolKey.ResolveString(receiverTypeSymbolKeyData, compilation, cancellationToken: cancellationToken).GetAnySymbol();
@@ -65,11 +64,11 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask WarmUpCacheAsync(PinnedSolutionInfo solutionInfo, ProjectId projectId, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var project = solution.GetRequiredProject(projectId);
                 ExtensionMethodImportCompletionHelper.WarmUpCacheInCurrentProcess(project);
+                return ValueTaskFactory.CompletedTask;
             }, cancellationToken);
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/ExtensionMethodImportCompletion/RemoteExtensionMethodImportCompletionService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ExtensionMethodImportCompletion/RemoteExtensionMethodImportCompletionService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Remote
             bool hideAdvancedMembers,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = solution.GetDocument(documentId)!;
                 var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask WarmUpCacheAsync(PinnedSolutionInfo solutionInfo, ProjectId projectId, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, solution =>
+            return RunServiceAsync(solutionInfo, solution =>
             {
                 var project = solution.GetRequiredProject(projectId);
                 ExtensionMethodImportCompletionHelper.WarmUpCacheInCurrentProcess(project);

--- a/src/Workspaces/Remote/ServiceHub/Services/FindUsages/RemoteFindUsagesService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/FindUsages/RemoteFindUsagesService.cs
@@ -36,9 +36,8 @@ namespace Microsoft.CodeAnalysis.Remote
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(symbolAndProjectId.ProjectId);
 
                 var symbol = await symbolAndProjectId.TryRehydrateAsync(
@@ -59,9 +58,8 @@ namespace Microsoft.CodeAnalysis.Remote
             SerializableSymbolAndProjectId symbolAndProjectId,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(symbolAndProjectId.ProjectId);
 
                 var symbol = await symbolAndProjectId.TryRehydrateAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/FindUsages/RemoteFindUsagesService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/FindUsages/RemoteFindUsagesService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Remote
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var project = solution.GetProject(symbolAndProjectId.ProjectId);
 
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Remote
             SerializableSymbolAndProjectId symbolAndProjectId,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var project = solution.GetProject(symbolAndProjectId.ProjectId);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
@@ -28,9 +28,8 @@ namespace Microsoft.CodeAnalysis.Remote
             ProjectId projectId,
             ImmutableArray<(SymbolKey symbolKey, int lineNumber)> symbolKeyAndLineNumbers,
             CancellationToken cancellationToken)
-            => RunServiceAsync(async cancellationToken =>
+            => RunServiceWithSolutionAsync(pinnedSolutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(pinnedSolutionInfo, cancellationToken).ConfigureAwait(false);
                 return await InheritanceMarginServiceHelper
                     .GetInheritanceMemberItemAsync(solution, projectId, symbolKeyAndLineNumbers, cancellationToken)
                     .ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ProjectId projectId,
             ImmutableArray<(SymbolKey symbolKey, int lineNumber)> symbolKeyAndLineNumbers,
             CancellationToken cancellationToken)
-            => RunServiceWithSolutionAsync(pinnedSolutionInfo, async solution =>
+            => RunServiceAsync(pinnedSolutionInfo, async solution =>
             {
                 return await InheritanceMarginServiceHelper
                     .GetInheritanceMemberItemAsync(solution, projectId, symbolKeyAndLineNumbers, cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ImmutableArray<PackageSource> packageSources,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = solution.GetDocument(documentId);
 
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ImmutableArray<PackageSource> packageSources,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = solution.GetDocument(documentId);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/MissingImportDiscovery/RemoteMissingImportDiscoveryService.cs
@@ -42,9 +42,8 @@ namespace Microsoft.CodeAnalysis.Remote
             ImmutableArray<PackageSource> packageSources,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = solution.GetDocument(documentId);
 
                 var service = document.GetLanguageService<IAddImportFeatureService>();
@@ -70,9 +69,8 @@ namespace Microsoft.CodeAnalysis.Remote
             ImmutableArray<PackageSource> packageSources,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = solution.GetDocument(documentId);
 
                 var service = document.GetLanguageService<IAddImportFeatureService>();

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Remote
             // pulled over from the host side to the remote side.  Once this completes, the next
             // call to SearchFullyLoadedDocumentAsync or SearchFullyLoadedProjectAsync will be
             // quick as very little will need to by sync'ed over.
-            return RunServiceWithSolutionAsync(solutionInfo, solution => ValueTaskFactory.CompletedTask, cancellationToken);
+            return RunServiceAsync(solutionInfo, solution => ValueTaskFactory.CompletedTask, cancellationToken);
         }
 
         public ValueTask SearchDocumentAsync(
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Remote
             RemoteServiceCallbackId callbackId,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = solution.GetRequiredDocument(documentId);
                 var callback = GetCallback(callbackId, cancellationToken);
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Remote
             RemoteServiceCallbackId callbackId,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var project = solution.GetRequiredProject(projectId);
                 var callback = GetCallback(callbackId, cancellationToken);
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Remote
             RemoteServiceCallbackId callbackId,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var project = solution.GetRequiredProject(projectId);
                 var callback = GetCallback(callbackId, cancellationToken);

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigateToSearch/RemoteNavigateToSearchService.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Storage;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -39,14 +40,11 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask HydrateAsync(PinnedSolutionInfo solutionInfo, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
-            {
-                // All we need to do is request the solution.  This will ensure that all assets are
-                // pulled over from the host side to the remote side.  Once this completes, the next
-                // call to SearchFullyLoadedDocumentAsync or SearchFullyLoadedProjectAsync will be
-                // quick as very little will need to by sync'ed over.
-                await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-            }, cancellationToken);
+            // All we need to do is request the solution.  This will ensure that all assets are
+            // pulled over from the host side to the remote side.  Once this completes, the next
+            // call to SearchFullyLoadedDocumentAsync or SearchFullyLoadedProjectAsync will be
+            // quick as very little will need to by sync'ed over.
+            return RunServiceWithSolutionAsync(solutionInfo, solution => ValueTaskFactory.CompletedTask, cancellationToken);
         }
 
         public ValueTask SearchDocumentAsync(
@@ -57,9 +55,8 @@ namespace Microsoft.CodeAnalysis.Remote
             RemoteServiceCallbackId callbackId,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = solution.GetRequiredDocument(documentId);
                 var callback = GetCallback(callbackId, cancellationToken);
 
@@ -77,9 +74,8 @@ namespace Microsoft.CodeAnalysis.Remote
             RemoteServiceCallbackId callbackId,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var project = solution.GetRequiredProject(projectId);
                 var callback = GetCallback(callbackId, cancellationToken);
 
@@ -98,9 +94,8 @@ namespace Microsoft.CodeAnalysis.Remote
             RemoteServiceCallbackId callbackId,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var project = solution.GetRequiredProject(projectId);
                 var callback = GetCallback(callbackId, cancellationToken);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigationBar/RemoteNavigationBarItemService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigationBar/RemoteNavigationBarItemService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask<ImmutableArray<SerializableNavigationBarItem>> GetItemsAsync(
             PinnedSolutionInfo solutionInfo, DocumentId documentId, bool supportsCodeGeneration, bool forceFrozenPartialSemanticsForCrossProcessOperations, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfNull(document);

--- a/src/Workspaces/Remote/ServiceHub/Services/NavigationBar/RemoteNavigationBarItemService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/NavigationBar/RemoteNavigationBarItemService.cs
@@ -27,10 +27,8 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask<ImmutableArray<SerializableNavigationBarItem>> GetItemsAsync(
             PinnedSolutionInfo solutionInfo, DocumentId documentId, bool supportsCodeGeneration, bool forceFrozenPartialSemanticsForCrossProcessOperations, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 var document = await solution.GetDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfNull(document);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
@@ -32,10 +32,8 @@ namespace Microsoft.CodeAnalysis.Remote
             ImmutableArray<SerializableSymbolAndProjectId> nonConflictSymbolIds,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 var symbol = await symbolAndProjectId.TryRehydrateAsync(
                     solution, cancellationToken).ConfigureAwait(false);
 
@@ -57,10 +55,8 @@ namespace Microsoft.CodeAnalysis.Remote
             SymbolRenameOptions options,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 var symbol = await symbolAndProjectId.TryRehydrateAsync(
                     solution, cancellationToken).ConfigureAwait(false);
 
@@ -80,9 +76,8 @@ namespace Microsoft.CodeAnalysis.Remote
             ImmutableArray<SerializableSymbolAndProjectId> nonConflictSymbolIds,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var nonConflictSymbols = await GetNonConflictSymbolsAsync(solution, nonConflictSymbolIds, cancellationToken).ConfigureAwait(false);
 
                 var rehydratedSet = await RenameLocations.TryRehydrateAsync(solution, renameLocationSet, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ImmutableArray<SerializableSymbolAndProjectId> nonConflictSymbolIds,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var symbol = await symbolAndProjectId.TryRehydrateAsync(
                     solution, cancellationToken).ConfigureAwait(false);
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Remote
             SymbolRenameOptions options,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var symbol = await symbolAndProjectId.TryRehydrateAsync(
                     solution, cancellationToken).ConfigureAwait(false);
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ImmutableArray<SerializableSymbolAndProjectId> nonConflictSymbolIds,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var nonConflictSymbols = await GetNonConflictSymbolsAsync(solution, nonConflictSymbolIds, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Remote
             bool isFullyLoaded,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var document = solution.GetDocument(documentId) ?? await solution.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfNull(document);

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
@@ -30,9 +30,8 @@ namespace Microsoft.CodeAnalysis.Remote
             bool isFullyLoaded,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var document = solution.GetDocument(documentId) ?? await solution.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
                 Contract.ThrowIfNull(document);
 
@@ -58,7 +57,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 }
 
                 return SerializableClassifiedSpans.Dehydrate(temp.ToImmutable());
-            }, cancellationToken);
+            },
+            cancellationToken);
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/StackTraceExplorer/RemoteStackTraceExplorerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/StackTraceExplorer/RemoteStackTraceExplorerService.cs
@@ -24,9 +24,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask<SerializableDefinitionItem?> TryFindDefinitionAsync(PinnedSolutionInfo solutionInfo, string frameString, StackFrameSymbolPart symbolPart, CancellationToken cancellationToken)
         {
-            return RunServiceAsync<SerializableDefinitionItem?>(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var result = await StackTraceAnalyzer.AnalyzeAsync(frameString, cancellationToken).ConfigureAwait(false);
                 if (result.ParsedFrames.Length != 1 || result.ParsedFrames[0] is not ParsedStackFrame parsedFrame)
                 {
@@ -36,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var definition = await StackTraceExplorerUtilities.GetDefinitionAsync(solution, parsedFrame.Root, symbolPart, cancellationToken).ConfigureAwait(false);
                 if (definition is null)
                 {
-                    return null;
+                    return (SerializableDefinitionItem?)null;
                 }
 
                 return SerializableDefinitionItem.Dehydrate(id: 0, definition);

--- a/src/Workspaces/Remote/ServiceHub/Services/StackTraceExplorer/RemoteStackTraceExplorerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/StackTraceExplorer/RemoteStackTraceExplorerService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask<SerializableDefinitionItem?> TryFindDefinitionAsync(PinnedSolutionInfo solutionInfo, string frameString, StackFrameSymbolPart symbolPart, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var result = await StackTraceAnalyzer.AnalyzeAsync(frameString, cancellationToken).ConfigureAwait(false);
                 if (result.ParsedFrames.Length != 1 || result.ParsedFrames[0] is not ParsedStackFrame parsedFrame)

--- a/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
@@ -41,10 +41,8 @@ namespace Microsoft.CodeAnalysis.Remote
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 var symbol = await symbolAndProjectIdArg.TryRehydrateAsync(
                     solution, cancellationToken).ConfigureAwait(false);
 
@@ -72,10 +70,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask FindLiteralReferencesAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, object value, TypeCode typeCode, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
                 var convertedType = System.Convert.ChangeType(value, typeCode);
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
 
                 var progressCallback = new FindLiteralReferencesProgressCallback(_callback, callbackId);
                 await SymbolFinder.FindLiteralReferencesInCurrentProcessAsync(
@@ -101,9 +98,8 @@ namespace Microsoft.CodeAnalysis.Remote
             SymbolFilter criteria,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(projectId);
 
                 using var query = SearchQuery.Create(name, searchKind);
@@ -122,9 +118,8 @@ namespace Microsoft.CodeAnalysis.Remote
             SymbolFilter criteria,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var result = await DeclarationFinder.FindSourceDeclarationsWithNormalQueryInCurrentProcessAsync(
                     solution, name, ignoreCase, criteria, cancellationToken).ConfigureAwait(false);
 
@@ -140,9 +135,8 @@ namespace Microsoft.CodeAnalysis.Remote
             SymbolFilter criteria,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(projectId);
 
                 var result = await DeclarationFinder.FindSourceDeclarationsWithNormalQueryInCurrentProcessAsync(
@@ -155,10 +149,8 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask<ImmutableArray<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithPatternAsync(
             PinnedSolutionInfo solutionInfo, string pattern, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 var result = await DeclarationFinder.FindSourceDeclarationsWithPatternInCurrentProcessAsync(
                     solution, pattern, criteria, cancellationToken).ConfigureAwait(false);
 
@@ -169,9 +161,8 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
             PinnedSolutionInfo solutionInfo, ProjectId projectId, string pattern, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(projectId);
 
                 var result = await DeclarationFinder.FindSourceDeclarationsWithPatternInCurrentProcessAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Remote
             FindReferencesSearchOptions options,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var symbol = await symbolAndProjectIdArg.TryRehydrateAsync(
                     solution, cancellationToken).ConfigureAwait(false);
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask FindLiteralReferencesAsync(PinnedSolutionInfo solutionInfo, RemoteServiceCallbackId callbackId, object value, TypeCode typeCode, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var convertedType = System.Convert.ChangeType(value, typeCode);
 
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Remote
             SymbolFilter criteria,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var project = solution.GetProject(projectId);
 
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Remote
             SymbolFilter criteria,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var result = await DeclarationFinder.FindSourceDeclarationsWithNormalQueryInCurrentProcessAsync(
                     solution, name, ignoreCase, criteria, cancellationToken).ConfigureAwait(false);
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.Remote
             SymbolFilter criteria,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var project = solution.GetProject(projectId);
 
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask<ImmutableArray<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithPatternAsync(
             PinnedSolutionInfo solutionInfo, string pattern, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var result = await DeclarationFinder.FindSourceDeclarationsWithPatternInCurrentProcessAsync(
                     solution, pattern, criteria, cancellationToken).ConfigureAwait(false);
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Remote
         public ValueTask<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
             PinnedSolutionInfo solutionInfo, ProjectId projectId, string pattern, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var project = solution.GetProject(projectId);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/Tagging/RemoteTaggerCompilationAvailableService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Tagging/RemoteTaggerCompilationAvailableService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Remote
             ProjectId projectId,
             CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 var project = solution.GetRequiredProject(projectId);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/Tagging/RemoteTaggerCompilationAvailableService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Tagging/RemoteTaggerCompilationAvailableService.cs
@@ -28,9 +28,8 @@ namespace Microsoft.CodeAnalysis.Remote
             ProjectId projectId,
             CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 var project = solution.GetRequiredProject(projectId);
 
                 await CompilationAvailableHelpers.ComputeCompilationInCurrentProcessAsync(project, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/UnusedReferences/RemoteUnusedReferenceAnalysisService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/UnusedReferences/RemoteUnusedReferenceAnalysisService.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask<ImmutableArray<ReferenceInfo>> GetUnusedReferencesAsync(PinnedSolutionInfo solutionInfo, string projectFilePath, string projectAssetsFilePath, ImmutableArray<ReferenceInfo> projectReferences, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 // Read specified references with dependency information from the project assets file.
                 var references = await ProjectAssetsFileReader.ReadReferencesAsync(projectReferences, projectAssetsFilePath).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/UnusedReferences/RemoteUnusedReferenceAnalysisService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/UnusedReferences/RemoteUnusedReferenceAnalysisService.cs
@@ -25,10 +25,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask<ImmutableArray<ReferenceInfo>> GetUnusedReferencesAsync(PinnedSolutionInfo solutionInfo, string projectFilePath, string projectAssetsFilePath, ImmutableArray<ReferenceInfo> projectReferences, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
-
                 // Read specified references with dependency information from the project assets file.
                 var references = await ProjectAssetsFileReader.ReadReferencesAsync(projectReferences, projectAssetsFilePath).ConfigureAwait(false);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/ValueTracking/RemoteValueTrackingService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ValueTracking/RemoteValueTrackingService.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask<ImmutableArray<SerializableValueTrackedItem>> TrackValueSourceAsync(PinnedSolutionInfo solutionInfo, TextSpan selection, DocumentId documentId, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 if (solution is null)
                 {
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask<ImmutableArray<SerializableValueTrackedItem>> TrackValueSourceAsync(PinnedSolutionInfo solutionInfo, SerializableValueTrackedItem previousTrackedItem, CancellationToken cancellationToken)
         {
-            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
+            return RunServiceAsync(solutionInfo, async solution =>
             {
                 if (solution is null)
                 {

--- a/src/Workspaces/Remote/ServiceHub/Services/ValueTracking/RemoteValueTrackingService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ValueTracking/RemoteValueTrackingService.cs
@@ -27,9 +27,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask<ImmutableArray<SerializableValueTrackedItem>> TrackValueSourceAsync(PinnedSolutionInfo solutionInfo, TextSpan selection, DocumentId documentId, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 if (solution is null)
                 {
                     throw new InvalidOperationException();
@@ -47,9 +46,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask<ImmutableArray<SerializableValueTrackedItem>> TrackValueSourceAsync(PinnedSolutionInfo solutionInfo, SerializableValueTrackedItem previousTrackedItem, CancellationToken cancellationToken)
         {
-            return RunServiceAsync(async cancellationToken =>
+            return RunServiceWithSolutionAsync(solutionInfo, async solution =>
             {
-                var solution = await GetSolutionAsync(solutionInfo, cancellationToken).ConfigureAwait(false);
                 if (solution is null)
                 {
                     throw new InvalidOperationException();


### PR DESCRIPTION
Sending out review for initial thoughts/feedback.

The general idea here is to setup our host/OOP communication to *avoid* teh following problem.

1. user makes edit on host, moving solution from Vn to Vn+1.  
2. immediately K features light up and call over to OOP to do work.
3. all features see that OOP has not sync'ed solution Vn+1 over and do the work to do just that, producing solution snapshots that may not share some state (for example the compilation-trackers for the last edited project.

To avoid this, this PR introduces a slightly different model for host-OOP calls.  Now, when the host calls into OOP for a paticular feature on a particular snapshot checksum, then OOP side creates a mapping from that checksum to the *async* computation for taht solution (an AsyncLazy), and it keeps it alive as long as that call is in flight.  If any other calls come in during that time and need that same solution, they will be given the same solution computation object back so that everything is shared across those calls.    This is done in a ref-counting fashion to ensure that as long as something is calling into oop that is working on that snapshot, the lazy for it will be kept alive and any concurrent calls will just get that and do no more extra work.

We still also keep track of hte last primary-workspace-solution, and the last-solution queried for, so that if a call gets either, and then returns, thne the next call can see those and potentially benefit from it.