### PR TITLE
Fix crash when combining reordered arguments with params array

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -348,11 +348,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
+                // After we do https://github.com/dotnet/roslyn/issues/49602, this assert can be
+                // simplified to `argsToParamsOpt.IsDefault || argsToParamsOpt == lengthAfterRewriting`.
+                Debug.Assert(argsToParamsOpt.IsDefault
+                    || argsToParamsOpt.Length == lengthAfterRewriting
+                    // in expanded scenarios, lengthAfterRewriting can only be larger than argsToParamsOpt by 1--otherwise it will be the same size or smaller
+                    || (boundAttribute.ConstructorExpanded && lengthAfterRewriting - argsToParamsOpt.Length <= 1));
+
                 var constructorArgumentSourceIndices = ArrayBuilder<int>.GetInstance(lengthAfterRewriting);
                 constructorArgumentSourceIndices.Count = lengthAfterRewriting;
                 for (int argIndex = 0; argIndex < lengthAfterRewriting; argIndex++)
                 {
-                    int paramIndex = argsToParamsOpt.IsDefault ? argIndex : argsToParamsOpt[argIndex];
+                    int paramIndex = argsToParamsOpt.IsDefault || argIndex >= argsToParamsOpt.Length ? argIndex : argsToParamsOpt[argIndex];
                     constructorArgumentSourceIndices[paramIndex] = defaultArguments[argIndex] ? -1 : argIndex;
                 }
                 return constructorArgumentSourceIndices.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
@@ -807,6 +807,76 @@ class Program
         }
 
         [Fact]
+        [WorkItem(60572, "https://github.com/dotnet/roslyn/issues/60572")]
+        public void TestParamArrayWithReorderedArguments_01()
+        {
+            var source = @"
+using System;
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+class Attr : Attribute
+{
+    public Attr(bool b, int i, params object?[] parameters) { }
+}
+
+[Attr(i: 1, b: true)]
+[Attr(i: 1, b: true, parameters: ""a"")]
+class Program { }
+";
+            var comp = CreateCompilation(source, options: WithNullableEnable());
+            comp.VerifyDiagnostics();
+
+            var program = comp.GetMember<NamedTypeSymbol>("Program");
+            var attrs = program.GetAttributes();
+            Assert.Equal(2, attrs.Length);
+
+            var arguments0 = attrs[0].ConstructorArguments.ToArray();
+            Assert.Equal(3, arguments0.Length);
+            Assert.Equal(true, arguments0[0].Value);
+            Assert.Equal(1, arguments0[1].Value);
+            Assert.Empty(arguments0[2].Values);
+
+            var arguments1 = attrs[1].ConstructorArguments.ToArray();
+            Assert.Equal(3, arguments1.Length);
+            Assert.Equal(true, arguments1[0].Value);
+            Assert.Equal(1, arguments1[1].Value);
+            Assert.Equal("a", arguments1[2].Values.Single().Value);
+        }
+
+        [Fact]
+        [WorkItem(60572, "https://github.com/dotnet/roslyn/issues/60572")]
+        public void TestParamArrayWithReorderedArguments_02()
+        {
+            var source = @"
+using System;
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+class Attr : Attribute
+{
+    public Attr(bool b, int i, params object?[] parameters) { }
+}
+
+[Attr(i: 1, b: true, ""a"")]
+[Attr(i: 1, b: true, ""a"", ""b"")]
+class Program { }
+";
+            var comp = CreateCompilation(source, options: WithNullableEnable());
+            comp.VerifyDiagnostics(
+                // (10,7): error CS8323: Named argument 'i' is used out-of-position but is followed by an unnamed argument
+                // [Attr(i: 1, b: true, "a")]
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "i").WithArguments("i").WithLocation(10, 7),
+                // (11,7): error CS8323: Named argument 'i' is used out-of-position but is followed by an unnamed argument
+                // [Attr(i: 1, b: true, "a", "b")]
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "i").WithArguments("i").WithLocation(11, 7));
+
+            var program = comp.GetMember<NamedTypeSymbol>("Program");
+            var attrs = program.GetAttributes();
+            Assert.Equal(2, attrs.Length);
+            Assert.Empty(attrs[0].ConstructorArguments);
+            Assert.Empty(attrs[1].ConstructorArguments);
+        }
+
+        [Fact]
         [WorkItem(20741, "https://github.com/dotnet/roslyn/issues/20741")]
         public void TestNamedArgumentOnObjectParamsArgument()
         {


### PR DESCRIPTION
Fixes #60572 
https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1520536