### PR TITLE
Grab bag of UTF8 string support in IDE features

### DIFF
--- a/src/EditorFeatures/CSharp/BraceMatching/StringLiteralBraceMatcher.cs
+++ b/src/EditorFeatures/CSharp/BraceMatching/StringLiteralBraceMatcher.cs
@@ -34,11 +34,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
             {
                 if (token.IsKind(SyntaxKind.StringLiteralToken))
                 {
-                    return GetSimpleStringBraceMatchingResult(token, 1);
+                    return GetSimpleStringBraceMatchingResult(token, endTokenLength: 1);
                 }
                 else if (token.IsKind(SyntaxKind.UTF8StringLiteralToken))
                 {
-                    return GetSimpleStringBraceMatchingResult(token, 3);
+                    return GetSimpleStringBraceMatchingResult(token, endTokenLength: 3);
                 }
                 else if (token.IsKind(SyntaxKind.InterpolatedStringStartToken, SyntaxKind.InterpolatedVerbatimStringStartToken))
                 {

--- a/src/EditorFeatures/CSharp/BraceMatching/StringLiteralBraceMatcher.cs
+++ b/src/EditorFeatures/CSharp/BraceMatching/StringLiteralBraceMatcher.cs
@@ -34,18 +34,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
             {
                 if (token.IsKind(SyntaxKind.StringLiteralToken))
                 {
-                    if (token.IsVerbatimStringLiteral())
-                    {
-                        return new BraceMatchingResult(
-                            new TextSpan(token.SpanStart, 2),
-                            new TextSpan(token.Span.End - 1, 1));
-                    }
-                    else
-                    {
-                        return new BraceMatchingResult(
-                            new TextSpan(token.SpanStart, 1),
-                            new TextSpan(token.Span.End - 1, 1));
-                    }
+                    return GetSimpleStringBraceMatchingResult(token, 1);
+                }
+                else if (token.IsKind(SyntaxKind.UTF8StringLiteralToken))
+                {
+                    return GetSimpleStringBraceMatchingResult(token, 3);
                 }
                 else if (token.IsKind(SyntaxKind.InterpolatedStringStartToken, SyntaxKind.InterpolatedVerbatimStringStartToken))
                 {
@@ -64,6 +57,22 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.BraceMatching
             }
 
             return null;
+        }
+
+        private static BraceMatchingResult GetSimpleStringBraceMatchingResult(SyntaxToken token, int endTokenLength)
+        {
+            if (token.IsVerbatimStringLiteral())
+            {
+                return new BraceMatchingResult(
+                    new TextSpan(token.SpanStart, 2),
+                    new TextSpan(token.Span.End - endTokenLength, endTokenLength));
+            }
+            else
+            {
+                return new BraceMatchingResult(
+                    new TextSpan(token.SpanStart, 1),
+                    new TextSpan(token.Span.End - endTokenLength, endTokenLength));
+            }
         }
     }
 }

--- a/src/EditorFeatures/CSharp/TextStructureNavigation/CSharpTextStructureNavigatorProvider.cs
+++ b/src/EditorFeatures/CSharp/TextStructureNavigation/CSharpTextStructureNavigatorProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.TextStructureNavigation
             if (token.IsKind(SyntaxKind.UTF8MultiLineRawStringLiteralToken) || token.IsKind(SyntaxKind.UTF8SingleLineRawStringLiteralToken))
             {
                 // Skip past the u8 suffix
-                end -= 2;
+                end -= "u8".Length;
             }
 
             while (start < end && text[start] == '"')

--- a/src/EditorFeatures/CSharp/TextStructureNavigation/CSharpTextStructureNavigatorProvider.cs
+++ b/src/EditorFeatures/CSharp/TextStructureNavigation/CSharpTextStructureNavigatorProvider.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.TextStructureNavigation
             var start = 0;
             var end = text.Length;
 
-            if (token.IsKind(SyntaxKind.UTF8MultiLineRawStringLiteralToken) || token.IsKind(SyntaxKind.UTF8SingleLineRawStringLiteralToken))
+            if (token.IsKind(SyntaxKind.UTF8MultiLineRawStringLiteralToken, SyntaxKind.UTF8SingleLineRawStringLiteralToken))
             {
                 // Skip past the u8 suffix
                 end -= "u8".Length;
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.TextStructureNavigation
 
         protected override TextExtent GetExtentOfWordFromToken(SyntaxToken token, SnapshotPoint position)
         {
-            if (token.Kind() is SyntaxKind.StringLiteralToken or SyntaxKind.UTF8StringLiteralToken && IsAtClosingQuote(token, position.Position))
+            if (token.IsKind(SyntaxKind.StringLiteralToken, SyntaxKind.UTF8StringLiteralToken) && IsAtClosingQuote(token, position.Position))
             {
                 // Special case to treat the closing quote of a string literal as a separate token.  This allows the
                 // cursor to stop during word navigation (Ctrl+LeftArrow, etc.) immediately before AND after the
@@ -104,8 +104,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.TextStructureNavigation
                 var span = new Span(position.Position, token.Span.End - position.Position);
                 return new TextExtent(new SnapshotSpan(position.Snapshot, span), isSignificant: true);
             }
-            else if (token.Kind() is SyntaxKind.SingleLineRawStringLiteralToken or SyntaxKind.MultiLineRawStringLiteralToken
-                or SyntaxKind.UTF8SingleLineRawStringLiteralToken or SyntaxKind.UTF8MultiLineRawStringLiteralToken)
+            else if (token.IsKind(SyntaxKind.SingleLineRawStringLiteralToken,
+                SyntaxKind.MultiLineRawStringLiteralToken,
+                SyntaxKind.UTF8SingleLineRawStringLiteralToken,
+                SyntaxKind.UTF8MultiLineRawStringLiteralToken))
             {
                 var delimiterStart = GetStartOfRawStringLiteralEndDelimiter(token);
                 return new TextExtent(new SnapshotSpan(position.Snapshot, Span.FromBounds(delimiterStart, token.Span.End)), isSignificant: true);

--- a/src/EditorFeatures/CSharp/TextStructureNavigation/CSharpTextStructureNavigatorProvider.cs
+++ b/src/EditorFeatures/CSharp/TextStructureNavigation/CSharpTextStructureNavigatorProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.TextStructureNavigation
 {
@@ -36,12 +37,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.TextStructureNavigation
             switch (token.Kind())
             {
                 case SyntaxKind.StringLiteralToken:
+                case SyntaxKind.UTF8StringLiteralToken:
                     // This, in combination with the override of GetExtentOfWordFromToken() below, treats the closing
                     // quote as a separate token.  This maintains behavior with VS2013.
                     return !IsAtClosingQuote(token, position);
 
                 case SyntaxKind.SingleLineRawStringLiteralToken:
                 case SyntaxKind.MultiLineRawStringLiteralToken:
+                case SyntaxKind.UTF8SingleLineRawStringLiteralToken:
+                case SyntaxKind.UTF8MultiLineRawStringLiteralToken:
                     {
                         // Like with normal string literals, treat the closing quotes as as the end of the string so that
                         // navigation ends there and doesn't go past them.
@@ -66,6 +70,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.TextStructureNavigation
             var text = token.ToString();
             var start = 0;
             var end = text.Length;
+
+            if (token.IsKind(SyntaxKind.UTF8MultiLineRawStringLiteralToken) || token.IsKind(SyntaxKind.UTF8SingleLineRawStringLiteralToken))
+            {
+                // Skip past the u8 suffix
+                end -= 2;
+            }
+
             while (start < end && text[start] == '"')
                 start++;
 
@@ -76,19 +87,25 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.TextStructureNavigation
         }
 
         private static bool IsAtClosingQuote(SyntaxToken token, int position)
-            => position == token.Span.End - 1 && token.Text[^1] == '"';
+            => token.Kind() switch
+            {
+                SyntaxKind.StringLiteralToken => position == token.Span.End - 1 && token.Text[^1] == '"',
+                SyntaxKind.UTF8StringLiteralToken => position == token.Span.End - 3 && token.Text is [.., '"', 'u' or 'U', '8'],
+                _ => throw ExceptionUtilities.Unreachable
+            };
 
         protected override TextExtent GetExtentOfWordFromToken(SyntaxToken token, SnapshotPoint position)
         {
-            if (token.Kind() == SyntaxKind.StringLiteralToken && IsAtClosingQuote(token, position.Position))
+            if (token.Kind() is SyntaxKind.StringLiteralToken or SyntaxKind.UTF8StringLiteralToken && IsAtClosingQuote(token, position.Position))
             {
                 // Special case to treat the closing quote of a string literal as a separate token.  This allows the
                 // cursor to stop during word navigation (Ctrl+LeftArrow, etc.) immediately before AND after the
                 // closing quote, just like it did in VS2013 and like it currently does for interpolated strings.
-                var span = new Span(position.Position, 1);
+                var span = new Span(position.Position, token.Span.End - position.Position);
                 return new TextExtent(new SnapshotSpan(position.Snapshot, span), isSignificant: true);
             }
-            else if (token.Kind() is SyntaxKind.SingleLineRawStringLiteralToken or SyntaxKind.MultiLineRawStringLiteralToken)
+            else if (token.Kind() is SyntaxKind.SingleLineRawStringLiteralToken or SyntaxKind.MultiLineRawStringLiteralToken
+                or SyntaxKind.UTF8SingleLineRawStringLiteralToken or SyntaxKind.UTF8MultiLineRawStringLiteralToken)
             {
                 var delimiterStart = GetStartOfRawStringLiteralEndDelimiter(token);
                 return new TextExtent(new SnapshotSpan(position.Snapshot, Span.FromBounds(delimiterStart, token.Span.End)), isSignificant: true);

--- a/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
+++ b/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
@@ -505,6 +505,123 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.BraceMatching
             await TestAsync(code, expected);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUTF8String1()
+        {
+            var code = @"public class C { string s = $$""Goo""u8; }";
+            var expected = @"public class C { string s = ""Goo[|""u8|]; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUTF8String2()
+        {
+            var code = @"public class C { string s = ""$$Goo""u8; }";
+            var expected = @"public class C { string s = ""Goo[|""u8|]; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUTF8String3()
+        {
+            var code = @"public class C { string s = ""Goo$$""u8; }";
+            var expected = @"public class C { string s = [|""|]Goo""u8; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUTF8String4()
+        {
+            var code = @"public class C { string s = ""Goo""$$u8; }";
+            var expected = @"public class C { string s = [|""|]Goo""u8; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUTF8String5()
+        {
+            var code = @"public class C { string s = ""Goo""u$$8; }";
+            var expected = @"public class C { string s = [|""|]Goo""u8; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestUTF8String6()
+        {
+            var code = @"public class C { string s = ""Goo""u8$$; }";
+            var expected = @"public class C { string s = [|""|]Goo""u8; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestVerbatimUTF8String1()
+        {
+            var code = @"public class C { string s = $$@""Goo""u8; }";
+            var expected = @"public class C { string s = @""Goo[|""u8|]; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestVerbatimUTF8String2()
+        {
+            var code = @"public class C { string s = @$$""Goo""u8; }";
+            var expected = @"public class C { string s = @""Goo[|""u8|]; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestVerbatimUTF8String3()
+        {
+            var code = @"public class C { string s = @""$$Goo""u8; }";
+            var expected = @"public class C { string s = @""Goo[|""u8|]; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestVerbatimUTF8String4()
+        {
+            var code = @"public class C { string s = @""Goo$$""u8; }";
+            var expected = @"public class C { string s = [|@""|]Goo""u8; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestVerbatimUTF8String5()
+        {
+            var code = @"public class C { string s = @""Goo""$$u8; }";
+            var expected = @"public class C { string s = [|@""|]Goo""u8; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestVerbatimUTF8String6()
+        {
+            var code = @"public class C { string s = @""Goo""u$$8; }";
+            var expected = @"public class C { string s = [|@""|]Goo""u8; }";
+
+            await TestAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
+        public async Task TestVerbatimUTF8String7()
+        {
+            var code = @"public class C { string s = @""Goo""u8$$; }";
+            var expected = @"public class C { string s = [|@""|]Goo""u8; }";
+
+            await TestAsync(code, expected);
+        }
+
         [WorkItem(7120, "https://github.com/dotnet/roslyn/issues/7120")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
         public async Task TestConditionalDirectiveWithSingleMatchingDirective()

--- a/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertToFileScopedNamespaceAnalyzerTests.cs
@@ -678,6 +678,102 @@ class C
         }
 
         [Fact]
+        public async Task TestConvertToFileScopedWithMultiLineRawString()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+[|namespace N|]
+{
+    class C
+    {
+        void M()
+        {
+            System.Console.WriteLine(""""""
+    a
+        b
+            c
+                d
+                    e
+    """""");
+        }
+    }
+}
+",
+                FixedCode = @"
+namespace $$N;
+
+class C
+{
+    void M()
+    {
+        System.Console.WriteLine(""""""
+    a
+        b
+            c
+                d
+                    e
+    """""");
+    }
+}
+",
+                LanguageVersion = LanguageVersion.Preview,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestConvertToFileScopedWithUTF8MultiLineRawString()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+[|namespace N|]
+{
+    class C
+    {
+        void M()
+        {
+            System.Console.WriteLine(""""""
+    a
+        b
+            c
+                d
+                    e
+    """"""u8);
+        }
+    }
+}
+",
+                FixedCode = @"
+namespace $$N;
+
+class C
+{
+    void M()
+    {
+        System.Console.WriteLine(""""""
+    a
+        b
+            c
+                d
+                    e
+    """"""u8);
+    }
+}
+",
+                LanguageVersion = LanguageVersion.Preview,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped }
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task TestConvertToFileScopedSingleLineNamespace1()
         {
             await new VerifyCS.Test

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -149,6 +149,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestMissingBeforeUTF8String()
+        {
+            TestNotHandled(
+@"class C
+{
+    void M()
+    {
+        var v = [||]""""u8;
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
         public void TestMissingBeforeInterpolatedString()
         {
             TestNotHandled(
@@ -266,6 +279,58 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestMissingAfterUTF8String_1()
+        {
+            TestNotHandled(
+@"class C
+{
+    void M()
+    {
+        var v = """"[||]u8;
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestMissingAfterUTF8String_2()
+        {
+            TestNotHandled(
+@"class C
+{
+    void M()
+    {
+        var v = """"u8[||];
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestMissingAfterUTF8String_3()
+        {
+            TestNotHandled(
+@"class C
+{
+    void M()
+    {
+        var v = """"u8[||]
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestMissingAfterUTF8String_4()
+        {
+            TestNotHandled(
+@"class C
+{
+    void M()
+    {
+        var v = $""""u8 [||]
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
         public void TestMissingInVerbatimString()
         {
             TestNotHandled(
@@ -274,6 +339,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     void M()
     {
         var v = @""a[||]b"";
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestMissingInUTF8VerbatimString()
+        {
+            TestNotHandled(
+@"class C
+{
+    void M()
+    {
+        var v = @""a[||]b""u8;
     }
 }");
         }
@@ -445,6 +523,48 @@ $""[||]"";
     {
         var v = ""now is "" +
             ""[||]the time"";
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestUTF8String_1()
+        {
+            TestHandled(
+@"class C
+{
+    void M()
+    {
+        var v = ""now is [||]the time""u8;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        var v = ""now is ""u8 +
+            ""[||]the time""u8;
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestUTF8String_2()
+        {
+            TestHandled(
+@"class C
+{
+    void M()
+    {
+        var v = ""now is [||]the time""U8;
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        var v = ""now is ""U8 +
+            ""[||]the time""U8;
     }
 }");
         }
@@ -942,6 +1062,21 @@ world
         var v = ${|#0:|}$""""""Hello[||]there
 world
 """""";
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestMissingInRawUTF8StringLiteral()
+        {
+            TestNotHandled(
+@"class C
+{
+    void M()
+    {
+        var v = """"""Hello[||]there
+world
+""""""u8;
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -331,6 +331,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestMissingAfterUTF8String_5()
+        {
+            TestNotHandled(
+@"class C
+{
+    void M()
+    {
+        var v = """"u[||]8;
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
         public void TestMissingInVerbatimString()
         {
             TestNotHandled(

--- a/src/EditorFeatures/CSharpTest/TextStructureNavigation/TextStructureNavigatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/TextStructureNavigation/TextStructureNavigatorTests.cs
@@ -250,6 +250,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TextStructureNavigation
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.TextStructureNavigator)]
+        public void UTF8String()
+        {
+            AssertExtent(
+                @"class Test { private string s1 = {|Significant:$$""|} () test  ""u8; }");
+
+            AssertExtent(
+                @"class Test { private string s1 = ""{|Insignificant:$$ |}() test  ""u8; }");
+
+            AssertExtent(
+                @"class Test { private string s1 = "" {|Significant:$$()|} test  ""u8; }");
+
+            AssertExtent(
+                @"class Test { private string s1 = "" () test{|Insignificant:$$  |}""u8; }");
+
+            AssertExtent(
+                @"class Test { private string s1 = "" () test  {|Significant:$$""u8|}; }");
+
+            AssertExtent(
+                @"class Test { private string s1 = "" () test  ""u8{|Significant:$$;|} }");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.TextStructureNavigator)]
         public void InterpolatedString1()
         {
             AssertExtent(
@@ -380,6 +402,45 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TextStructureNavigation
         World!
     :)
     {|Significant:""""$$""|};");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.TextStructureNavigator)]
+        public void TestUTF8RawStringDelimeter()
+        {
+            AssertExtent(
+                @"string s = """"""
+    Hello
+        World!
+    :)
+    {|Significant:$$""""""u8|};");
+
+            AssertExtent(
+                @"string s = """"""
+    Hello
+        World!
+    :)
+    {|Significant:""$$""""u8|};");
+
+            AssertExtent(
+                @"string s = """"""
+    Hello
+        World!
+    :)
+    {|Significant:""""$$""u8|};");
+
+            AssertExtent(
+    @"string s = """"""
+    Hello
+        World!
+    :)
+    {|Significant:""""""$$u8|};");
+
+            AssertExtent(
+    @"string s = """"""
+    Hello
+        World!
+    :)
+    {|Significant:""""""u$$8|};");
         }
 
         private static void TestNavigator(

--- a/src/Features/CSharp/Portable/SplitStringLiteral/SimpleStringSplitter.cs
+++ b/src/Features/CSharp/Portable/SplitStringLiteral/SimpleStringSplitter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SplitStringLiteral
 
             private bool CursorIsAfterQuotesInUTF8String()
             {
-                return _token.IsKind(SyntaxKind.UTF8StringLiteralToken) && CursorPosition >= _token.Span.End - 2;
+                return _token.IsKind(SyntaxKind.UTF8StringLiteralToken) && CursorPosition >= _token.Span.End - "u8".Length;
             }
 
             protected override SyntaxNode GetNodeToReplace() => _token.Parent;
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SplitStringLiteral
                 // If we're spliting a UTF8 string we need to keep the u8 suffix on the first part. We copy whatever
                 // the user had on the second part, for consistency.
                 var firstTokenSuffix = _token.Kind() == SyntaxKind.UTF8StringLiteralToken
-                    ? SourceText.GetSubText(TextSpan.FromBounds(_token.Span.End - 2, _token.Span.End)).ToString()
+                    ? SourceText.GetSubText(TextSpan.FromBounds(_token.Span.End - "u8".Length, _token.Span.End)).ToString()
                     : "";
 
                 var firstToken = SyntaxFactory.Token(

--- a/src/Features/CSharp/Portable/SplitStringLiteral/StringSplitter.cs
+++ b/src/Features/CSharp/Portable/SplitStringLiteral/StringSplitter.cs
@@ -60,7 +60,8 @@ namespace Microsoft.CodeAnalysis.CSharp.SplitStringLiteral
 
             var token = root.FindToken(position);
 
-            if (token.IsKind(SyntaxKind.StringLiteralToken))
+            if (token.IsKind(SyntaxKind.StringLiteralToken) ||
+                token.IsKind(SyntaxKind.UTF8StringLiteralToken))
             {
                 return new SimpleStringSplitter(
                     document, position, root,

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -133,6 +133,21 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
+            if (token.IsKind(SyntaxKind.UTF8StringLiteralToken) ||
+                token.IsKind(SyntaxKind.UTF8SingleLineRawStringLiteralToken) ||
+                token.IsKind(SyntaxKind.UTF8MultiLineRawStringLiteralToken))
+            {
+                text = Keyword("UTF8StringLiteral");
+                return true;
+            }
+
+            if (token.IsKind(SyntaxKind.SingleLineRawStringLiteralToken) ||
+                token.IsKind(SyntaxKind.MultiLineRawStringLiteralToken))
+            {
+                text = Keyword("RawStringLiteral");
+                return true;
+            }
+
             text = null;
             return false;
         }

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -987,7 +987,6 @@ class Program
 }", "UTF8StringLiteral_CSharpKeyword");
         }
 
-
         [WorkItem(46986, "https://github.com/dotnet/roslyn/issues/46986")]
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestVerbatimString()

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -942,6 +942,52 @@ class Program
 }", "$_CSharpKeyword");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestUTF8String()
+        {
+            await TestAsync(
+@"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var x = ""Hel[||]lo""u8;
+    }
+}", "UTF8StringLiteral_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestRawString()
+        {
+            await TestAsync(
+@"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var x = """"""Hel[||]lo"""""";
+    }
+}", "RawStringLiteral_CSharpKeyword");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
+        public async Task TestUTF8RawString()
+        {
+            await TestAsync(
+@"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var x = """"""Hel[||]lo""""""u8;
+    }
+}", "UTF8StringLiteral_CSharpKeyword");
+        }
+
+
         [WorkItem(46986, "https://github.com/dotnet/roslyn/issues/46986")]
         [Fact, Trait(Traits.Feature, Traits.Features.F1Help)]
         public async Task TestVerbatimString()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -417,7 +417,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 token = token.GetPreviousToken(includeSkipped: true, includeDirectives: true);
             }
 
-            if (token.Kind() is SyntaxKind.StringLiteralToken or SyntaxKind.SingleLineRawStringLiteralToken or SyntaxKind.MultiLineRawStringLiteralToken)
+            if (token.IsKind(SyntaxKind.StringLiteralToken,
+                             SyntaxKind.SingleLineRawStringLiteralToken,
+                             SyntaxKind.MultiLineRawStringLiteralToken,
+                             SyntaxKind.UTF8StringLiteralToken,
+                             SyntaxKind.UTF8SingleLineRawStringLiteralToken,
+                             SyntaxKind.UTF8MultiLineRawStringLiteralToken))
             {
                 var span = token.Span;
 


### PR DESCRIPTION
Fixes most of https://github.com/dotnet/roslyn/issues/60582
Relates to https://github.com/dotnet/roslyn/issues/58848

Also fixed a couple of raw string things that were missed. If the review is too annoying, each commit is a separate IDE feature.