### PR TITLE
Fixed adding a redundant blank line when suppressing with local attribute

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis.Diagnostics.CSharp;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ErrorLogger;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -981,10 +980,7 @@ class Class
 
         public abstract partial class CSharpGlobalSuppressMessageSuppressionTests : CSharpSuppressionTests
         {
-            protected sealed override int CodeActionIndex
-            {
-                get { return 1; }
-            }
+            protected sealed override int CodeActionIndex => 1;
 
             public class CompilerDiagnosticSuppressionTests : CSharpGlobalSuppressMessageSuppressionTests
             {
@@ -1073,7 +1069,7 @@ class Class
                 private class UserDiagnosticAnalyzer : DiagnosticAnalyzer
                 {
                     public static readonly DiagnosticDescriptor Descriptor =
-                        new DiagnosticDescriptor("InfoDiagnostic", "InfoDiagnostic", "InfoDiagnostic", "InfoDiagnostic", DiagnosticSeverity.Info, isEnabledByDefault: true);
+                        new("InfoDiagnostic", "InfoDiagnostic", "InfoDiagnostic", "InfoDiagnostic", DiagnosticSeverity.Info, isEnabledByDefault: true);
 
                     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
                     {
@@ -1218,7 +1214,7 @@ using System.Diagnostics.CodeAnalysis;
 ";
 
                     var lines = Regex.Split(expected, "\r?\n");
-                    Assert.False(string.IsNullOrWhiteSpace(lines[lines.Length - 2]));
+                    Assert.False(string.IsNullOrWhiteSpace(lines[^2]));
 
                     await TestAsync(
             @"
@@ -2069,10 +2065,7 @@ using System.Diagnostics.CodeAnalysis;
 
         public abstract class CSharpLocalSuppressMessageSuppressionTests : CSharpSuppressionTests
         {
-            protected sealed override int CodeActionIndex
-            {
-                get { return 2; }
-            }
+            protected sealed override int CodeActionIndex => 2;
 
             public class UserInfoDiagnosticSuppressionTests : CSharpLocalSuppressMessageSuppressionTests
             {
@@ -2081,13 +2074,7 @@ using System.Diagnostics.CodeAnalysis;
                     private readonly DiagnosticDescriptor _descriptor =
                         new("InfoDiagnostic", "InfoDiagnostic", "InfoDiagnostic", "InfoDiagnostic", DiagnosticSeverity.Info, isEnabledByDefault: true);
 
-                    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-                    {
-                        get
-                        {
-                            return ImmutableArray.Create(_descriptor);
-                        }
-                    }
+                    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_descriptor);
 
                     public override void Initialize(AnalysisContext context)
                         => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ClassDeclaration, SyntaxKind.NamespaceDeclaration, SyntaxKind.MethodDeclaration);
@@ -2402,6 +2389,75 @@ namespace ClassLibrary10
                     expected = expected.Replace("public void Method(int unused)", "[|public void Method(int unused)|]");
                     await TestMissingAsync(expected);
                 }
+
+                [WorkItem(47427, "https://github.com/dotnet/roslyn/issues/47427")]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                public async Task TestSuppressionOnMethodWithNoTrivia()
+                {
+                    var initial = @"
+using System;
+
+namespace ClassLibrary10
+{
+    public class Class1
+    {
+        int x;
+[|public void Method(int unused)|] { }
+    }
+}";
+                    var expected = $@"
+using System;
+
+namespace ClassLibrary10
+{{
+    public class Class1
+    {{
+        int x;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"")]
+        public void Method(int unused) {{ }}
+    }}
+}}";
+                    await TestAsync(initial, expected);
+
+                    // Also verify that the added attribute does indeed suppress the diagnostic.
+                    expected = expected.Replace("public void Method(int unused)", "[|public void Method(int unused)|]");
+                    await TestMissingAsync(expected);
+                }
+
+                [WorkItem(47427, "https://github.com/dotnet/roslyn/issues/47427")]
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                public async Task TestSuppressionOnMethodWithTriviaStartsOnTheSameLine()
+                {
+                    var initial = @"
+using System;
+
+namespace ClassLibrary10
+{
+    public class Class1
+    {
+        int x;
+        /*test*/[|public void Method(int unused)|] { }
+    }
+}";
+                    var expected = $@"
+using System;
+
+namespace ClassLibrary10
+{{
+    public class Class1
+    {{
+        int x;
+        /*test*/
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"")]
+        public void Method(int unused) {{ }}
+    }}
+}}";
+                    await TestAsync(initial, expected);
+
+                    // Also verify that the added attribute does indeed suppress the diagnostic.
+                    expected = expected.Replace("public void Method(int unused)", "[|public void Method(int unused)|]");
+                    await TestMissingAsync(expected);
+                }
             }
         }
 
@@ -2417,12 +2473,7 @@ namespace ClassLibrary10
                     new("NoLocationDiagnostic", "NoLocationDiagnostic", "NoLocationDiagnostic", "NoLocationDiagnostic", DiagnosticSeverity.Info, isEnabledByDefault: true);
 
                 public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-                {
-                    get
-                    {
-                        return ImmutableArray.Create(Descriptor);
-                    }
-                }
+                    => ImmutableArray.Create(Descriptor);
 
                 public override void Initialize(AnalysisContext context)
                     => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ClassDeclaration);
@@ -2437,13 +2488,7 @@ namespace ClassLibrary10
                     new UserDiagnosticAnalyzer(), new CSharpSuppressionCodeFixProvider());
             }
 
-            protected override int CodeActionIndex
-            {
-                get
-                {
-                    return 0;
-                }
-            }
+            protected override int CodeActionIndex => 0;
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
             [WorkItem(1073825, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1073825")]

--- a/src/Features/CSharp/Portable/CodeFixes/Suppression/CSharpSuppressionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Suppression/CSharpSuppressionCodeFixProvider.cs
@@ -116,8 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Suppression
                     attributeName,
                     diagnostic,
                     isAssemblyAttribute: true,
-                    leadingTrivia: default,
-                    needsLeadingEndOfLine: true));
+                    leadingTrivia: default));
 
             if (isFirst && !newRoot.HasLeadingTrivia)
                 compilationRoot = compilationRoot.WithLeadingTrivia(SyntaxFactory.Comment(GlobalSuppressionsFileHeaderComment));
@@ -131,22 +130,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Suppression
             var memberNode = (MemberDeclarationSyntax)targetNode;
 
             SyntaxTriviaList leadingTriviaForAttributeList;
-            bool needsLeadingEndOfLine;
             if (!memberNode.GetAttributes().Any())
             {
                 leadingTriviaForAttributeList = memberNode.GetLeadingTrivia();
                 memberNode = memberNode.WithoutLeadingTrivia();
-                needsLeadingEndOfLine = !leadingTriviaForAttributeList.Any() || !IsEndOfLine(leadingTriviaForAttributeList.Last());
             }
             else
             {
                 leadingTriviaForAttributeList = default;
-                needsLeadingEndOfLine = true;
             }
 
             var attributeName = suppressMessageAttribute.GenerateNameSyntax();
             var attributeList = CreateAttributeList(
-                targetSymbol, attributeName, diagnostic, isAssemblyAttribute: false, leadingTrivia: leadingTriviaForAttributeList, needsLeadingEndOfLine: needsLeadingEndOfLine);
+                targetSymbol, attributeName, diagnostic, isAssemblyAttribute: false, leadingTrivia: leadingTriviaForAttributeList);
             return memberNode.AddAttributeLists(attributeList);
         }
 
@@ -155,8 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Suppression
             NameSyntax attributeName,
             Diagnostic diagnostic,
             bool isAssemblyAttribute,
-            SyntaxTriviaList leadingTrivia,
-            bool needsLeadingEndOfLine)
+            SyntaxTriviaList leadingTrivia)
         {
             var attributeArguments = CreateAttributeArguments(targetSymbol, diagnostic, isAssemblyAttribute);
 
@@ -174,15 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Suppression
                 attributeList = SyntaxFactory.AttributeList(attributes);
             }
 
-            var endOfLineTrivia = SyntaxFactory.ElasticCarriageReturnLineFeed;
-            var triviaList = SyntaxFactory.TriviaList();
-
-            if (needsLeadingEndOfLine)
-            {
-                triviaList = triviaList.Add(endOfLineTrivia);
-            }
-
-            return attributeList.WithLeadingTrivia(leadingTrivia.AddRange(triviaList));
+            return attributeList.WithLeadingTrivia(leadingTrivia);
         }
 
         private static AttributeArgumentListSyntax CreateAttributeArguments(ISymbol targetSymbol, Diagnostic diagnostic, bool isAssemblyAttribute)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/47427

As I've understood, there is always a formatting pass running after this codefix. I think, it is better to fully rely on it, rather than try to add new lines in the codefix ourselves. Otherwise it will be some code duplication. I had no tests broken, when deleted this peace of logic