### PR TITLE
Run continuation to dispose of cancellation token source

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -178,6 +178,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 _requestTelemetryLogger,
                 combinedCancellationToken);
 
+            // Run a continuation to ensure the cts is disposed of.
+            // We pass in the queue's cancellation token to the continuation as we should dispose
+            // of the source even if the client cancels the request.
+            resultTask.ContinueWith((_) => combinedTokenSource.Dispose(), _cancelSource.Token, TaskContinuationOptions.None, TaskScheduler.Default);
+
             var didEnqueue = _queue.TryEnqueue((item, combinedCancellationToken));
 
             // If the queue has been shut down the enqueue will fail, so we just fault the task immediately.

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -179,9 +179,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 combinedCancellationToken);
 
             // Run a continuation to ensure the cts is disposed of.
-            // We pass in the queue's cancellation token to the continuation as we should dispose
-            // of the source even if the client cancels the request.
-            resultTask.ContinueWith((_) => combinedTokenSource.Dispose(), _cancelSource.Token, TaskContinuationOptions.None, TaskScheduler.Default);
+            // We pass CancellationToken.None as we always want to dispose of the source
+            // even when the request is cancelled or the queue is shutting down.
+            _ = resultTask.ContinueWith((_) => combinedTokenSource.Dispose(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
 
             var didEnqueue = _queue.TryEnqueue((item, combinedCancellationToken));
 

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // Run a continuation to ensure the cts is disposed of.
             // We pass CancellationToken.None as we always want to dispose of the source
             // even when the request is cancelled or the queue is shutting down.
-            _ = resultTask.ContinueWith((_) => combinedTokenSource.Dispose(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            _ = resultTask.ContinueWith(_ => combinedTokenSource.Dispose(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
 
             var didEnqueue = _queue.TryEnqueue((item, combinedCancellationToken));
 


### PR DESCRIPTION
resolves https://github.com/dotnet/roslyn/issues/60649

verified before/after that cancellationtokensource objects are not showing up in heap snapshot diffs on idle LSP polling requests