### PR TITLE
Re-enable Code Definition Window integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeDefinitionWindow.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeDefinitionWindow.cs
@@ -19,7 +19,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [WpfTheory(Skip = "https://github.com/dotnet/roslyn/issues/60364")]
+        [WpfTheory]
         [CombinatorialData]
         public void CodeDefinitionWindowOpensMetadataAsSource(bool enableDecompilation)
         {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicCodeDefinitionWindow.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicCodeDefinitionWindow.cs
@@ -19,7 +19,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Basic
         {
         }
 
-        [WpfTheory(Skip = "https://github.com/dotnet/roslyn/issues/60364")]
+        [WpfTheory]
         [CombinatorialData]
         public void CodeDefinitionWindowOpensMetadataAsSource(bool enableDecompilation)
         {


### PR DESCRIPTION
The internal Visual Studio bug that broke this has been fixed, so this re-enables the tests.

Closes https://github.com/dotnet/roslyn/issues/60364