### PR TITLE
Update csc.dll path in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,7 +56,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/src/Compilers/CSharp/csc/bin/Debug/netcoreapp2.1/csc.dll",
+      "program": "${workspaceFolder}/artifacts/bin/csc/Debug/net6.0/csc.dll",
       "args": [],
       "cwd": "${workspaceFolder}/src/Compilers/CSharp/csc",
       // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console


### PR DESCRIPTION
I actually was able to repro a compilation scenario starting from a binlog, making a response file, and launching in VS Code, so yay. I just had to update this path.