### PR TITLE
Extract base class extracting generic type parameter now (#55871)

### DIFF
--- a/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
@@ -77,7 +77,8 @@ namespace Microsoft.CodeAnalysis.ExtractClass
                     _selectedType.DeclaredAccessibility,
                     _selectedType.GetSymbolModifiers(),
                     TypeKind.Class,
-                    extractClassOptions.TypeName);
+                    extractClassOptions.TypeName,
+                    typeParameters: ExtractTypeHelpers.GetRequiredTypeParametersForMembers(_selectedType, extractClassOptions.MemberAnalysisResults.Select(m => m.Member)));
 
                 var containingNamespaceDisplay = namespaceService.GetContainingNamespaceDisplay(
                     _selectedType,

--- a/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
@@ -208,6 +208,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     var property = member as IPropertySymbol;
                     return property.Parameters.Any(t => DoesTypeReferenceTypeParameter(t.Type, typeParameter, checkedTypes)) ||
                         DoesTypeReferenceTypeParameter(property.Type, typeParameter, checkedTypes);
+                case SymbolKind.Field:
+                    var field = member as IFieldSymbol;
+                    return DoesTypeReferenceTypeParameter(field.Type, typeParameter, checkedTypes);
                 default:
                     Debug.Assert(false, string.Format(FeaturesResources.Unexpected_interface_member_kind_colon_0, member.Kind.ToString()));
                     return false;


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/55871