### PR TITLE
Allow generating variable with contextual keyword name in return statements

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -9639,7 +9639,6 @@ class Class
         [InlineData("typevar")]
         [InlineData("when")]
         [InlineData("_")]
-        [InlineData("var")]
         [InlineData("or")]
         [InlineData("and")]
         [InlineData("not")]
@@ -9676,6 +9675,7 @@ $@"class C
         [InlineData("nameof")]
         [InlineData("async")]
         [InlineData("await")]
+        [InlineData("var")]
         public async Task TestContextualKeywordsThatCanProbablyStartSyntacticConstructs(string keyword)
         {
             await TestMissingInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -4079,18 +4079,6 @@ index: LocalIndex);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
-        public async Task TestLocalMissingForVar()
-        {
-            await TestMissingInRegularAndScriptAsync(
-@"class Program
-{
-    void Main()
-    {
-        var x = [|var|];
-    }");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
         public async Task TestOutLocal1()
         {
             await TestInRegularAndScriptAsync(
@@ -9623,7 +9611,6 @@ class Class
         [Theory]
         [InlineData("yield")]
         [InlineData("partial")]
-        [InlineData("from")]
         [InlineData("group")]
         [InlineData("join")]
         [InlineData("into")]
@@ -9650,9 +9637,6 @@ class Class
         [InlineData("param")]
         [InlineData("property")]
         [InlineData("typevar")]
-        [InlineData("nameof")]
-        [InlineData("async")]
-        [InlineData("await")]
         [InlineData("when")]
         [InlineData("_")]
         [InlineData("var")]
@@ -9665,7 +9649,7 @@ class Class
         [InlineData("managed")]
         [InlineData("unmanaged")]
         [InlineData("dynamic")]
-        public async Task TestContextualKeywordsInReturnStatement(string keyword)
+        public async Task TestContextualKeywordsThatDoNotProbablyStartSyntacticConstructs(string keyword)
         {
             await TestInRegularAndScriptAsync(
 $@"class C
@@ -9688,71 +9672,18 @@ $@"class C
 
         [WorkItem(27646, "https://github.com/dotnet/roslyn/issues/27646")]
         [Theory]
-        [InlineData("yield")]
-        [InlineData("partial")]
         [InlineData("from")]
-        [InlineData("group")]
-        [InlineData("join")]
-        [InlineData("into")]
-        [InlineData("let")]
-        [InlineData("by")]
-        [InlineData("where")]
-        [InlineData("select")]
-        [InlineData("get")]
-        [InlineData("set")]
-        [InlineData("add")]
-        [InlineData("remove")]
-        [InlineData("orderby")]
-        [InlineData("alias")]
-        [InlineData("on")]
-        [InlineData("equals")]
-        [InlineData("ascending")]
-        [InlineData("descending")]
-        [InlineData("assembly")]
-        [InlineData("module")]
-        [InlineData("type")]
-        [InlineData("global")]
-        [InlineData("field")]
-        [InlineData("method")]
-        [InlineData("param")]
-        [InlineData("property")]
-        [InlineData("typevar")]
         [InlineData("nameof")]
         [InlineData("async")]
         [InlineData("await")]
-        [InlineData("when")]
-        [InlineData("_")]
-        [InlineData("var")]
-        [InlineData("or")]
-        [InlineData("and")]
-        [InlineData("not")]
-        [InlineData("with")]
-        [InlineData("init")]
-        [InlineData("record")]
-        [InlineData("managed")]
-        [InlineData("unmanaged")]
-        [InlineData("dynamic")]
-        public async Task TestContextualKeywordsInYieldReturnStatement(string keyword)
+        public async Task TestContextualKeywordsThatCanProbablyStartSyntacticConstructs(string keyword)
         {
-            await TestInRegularAndScriptAsync(
-$@"using System.Collections.Generic;
-
-class C
+            await TestMissingInRegularAndScriptAsync(
+$@"class C
 {{
-    IEnumerable<int> M()
+    int M()
     {{
-        [|yield return {keyword}|];
-    }}
-}}",
-$@"using System.Collections.Generic;
-
-class C
-{{
-    private int {keyword};
-
-    IEnumerable<int> M()
-    {{
-        yield return {keyword};
+        [|return {keyword}|];
     }}
 }}");
         }

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -9706,5 +9706,23 @@ $@"class C
     }}
 }}");
         }
+
+        [WorkItem(27646, "https://github.com/dotnet/roslyn/issues/27646")]
+        [Theory]
+        [InlineData("from")]
+        [InlineData("nameof")]
+        [InlineData("async")]
+        [InlineData("await")]
+        [InlineData("var")]
+        public async Task TestContextualKeywordsThatCanProbablyStartSyntacticConstructs_Local(string keyword)
+        {
+            await TestMissingInRegularAndScriptAsync(
+$@"class Program
+{{
+    void Main()
+    {{
+        var x = [|{keyword}|];
+    }}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -37,11 +37,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateVariable
         internal override (DiagnosticAnalyzer?, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
             => (null, new CSharpGenerateVariableCodeFixProvider());
 
-        private readonly CodeStyleOption2<bool> onWithInfo = new CodeStyleOption2<bool>(true, NotificationOption2.Suggestion);
+        private readonly CodeStyleOption2<bool> onWithInfo = new(true, NotificationOption2.Suggestion);
 
         // specify all options explicitly to override defaults.
         private OptionsCollection ImplicitTypingEverywhere()
-            => new OptionsCollection(GetLanguage())
+            => new(GetLanguage())
             {
                 { CSharpCodeStyleOptions.VarElsewhere, onWithInfo },
                 { CSharpCodeStyleOptions.VarWhenTypeIsApparent, onWithInfo },
@@ -9617,6 +9617,73 @@ class Class
         }
     }
 }", index: Parameter);
+        }
+
+        [WorkItem(27646, "https://github.com/dotnet/roslyn/issues/27646")]
+        [Theory]
+        [InlineData("yield")]
+        [InlineData("partial")]
+        [InlineData("from")]
+        [InlineData("group")]
+        [InlineData("join")]
+        [InlineData("into")]
+        [InlineData("let")]
+        [InlineData("by")]
+        [InlineData("where")]
+        [InlineData("select")]
+        [InlineData("get")]
+        [InlineData("set")]
+        [InlineData("add")]
+        [InlineData("remove")]
+        [InlineData("orderby")]
+        [InlineData("alias")]
+        [InlineData("on")]
+        [InlineData("equals")]
+        [InlineData("ascending")]
+        [InlineData("descending")]
+        [InlineData("assembly")]
+        [InlineData("module")]
+        [InlineData("type")]
+        [InlineData("global")]
+        [InlineData("field")]
+        [InlineData("method")]
+        [InlineData("param")]
+        [InlineData("property")]
+        [InlineData("typevar")]
+        [InlineData("nameof")]
+        [InlineData("async")]
+        [InlineData("await")]
+        [InlineData("when")]
+        [InlineData("_")]
+        [InlineData("var")]
+        [InlineData("or")]
+        [InlineData("and")]
+        [InlineData("not")]
+        [InlineData("with")]
+        [InlineData("init")]
+        [InlineData("record")]
+        [InlineData("managed")]
+        [InlineData("unmanaged")]
+        [InlineData("dynamic")]
+        public async Task TestContextualKeywordsInReturnStatement(string keyword)
+        {
+            await TestInRegularAndScriptAsync(
+$@"class C
+{{
+    int M()
+    {{
+        [|return {keyword}|];
+    }}
+}}",
+$@"class C
+{{
+    private int {keyword};
+
+    int M()
+    {{
+        return {keyword};
+    }}
+}}");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -9685,5 +9685,76 @@ $@"class C
     }}
 }}");
         }
+
+        [WorkItem(27646, "https://github.com/dotnet/roslyn/issues/27646")]
+        [Theory]
+        [InlineData("yield")]
+        [InlineData("partial")]
+        [InlineData("from")]
+        [InlineData("group")]
+        [InlineData("join")]
+        [InlineData("into")]
+        [InlineData("let")]
+        [InlineData("by")]
+        [InlineData("where")]
+        [InlineData("select")]
+        [InlineData("get")]
+        [InlineData("set")]
+        [InlineData("add")]
+        [InlineData("remove")]
+        [InlineData("orderby")]
+        [InlineData("alias")]
+        [InlineData("on")]
+        [InlineData("equals")]
+        [InlineData("ascending")]
+        [InlineData("descending")]
+        [InlineData("assembly")]
+        [InlineData("module")]
+        [InlineData("type")]
+        [InlineData("global")]
+        [InlineData("field")]
+        [InlineData("method")]
+        [InlineData("param")]
+        [InlineData("property")]
+        [InlineData("typevar")]
+        [InlineData("nameof")]
+        [InlineData("async")]
+        [InlineData("await")]
+        [InlineData("when")]
+        [InlineData("_")]
+        [InlineData("var")]
+        [InlineData("or")]
+        [InlineData("and")]
+        [InlineData("not")]
+        [InlineData("with")]
+        [InlineData("init")]
+        [InlineData("record")]
+        [InlineData("managed")]
+        [InlineData("unmanaged")]
+        [InlineData("dynamic")]
+        public async Task TestContextualKeywordsInYieldReturnStatement(string keyword)
+        {
+            await TestInRegularAndScriptAsync(
+$@"using System.Collections.Generic;
+
+class C
+{{
+    IEnumerable<int> M()
+    {{
+        [|yield return {keyword}|];
+    }}
+}}",
+$@"using System.Collections.Generic;
+
+class C
+{{
+    private int {keyword};
+
+    IEnumerable<int> M()
+    {{
+        yield return {keyword};
+    }}
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -9648,7 +9648,7 @@ class Class
         [InlineData("managed")]
         [InlineData("unmanaged")]
         [InlineData("dynamic")]
-        public async Task TestContextualKeywordsThatDoNotProbablyStartSyntacticConstructs(string keyword)
+        public async Task TestContextualKeywordsThatDoNotProbablyStartSyntacticConstructs_ReturnStatement(string keyword)
         {
             await TestInRegularAndScriptAsync(
 $@"class C
@@ -9676,7 +9676,7 @@ $@"class C
         [InlineData("async")]
         [InlineData("await")]
         [InlineData("var")]
-        public async Task TestContextualKeywordsThatCanProbablyStartSyntacticConstructs(string keyword)
+        public async Task TestContextualKeywordsThatCanProbablyStartSyntacticConstructs_ReturnStatement(string keyword)
         {
             await TestMissingInRegularAndScriptAsync(
 $@"class C
@@ -9684,6 +9684,25 @@ $@"class C
     int M()
     {{
         [|return {keyword}|];
+    }}
+}}");
+        }
+
+        [WorkItem(27646, "https://github.com/dotnet/roslyn/issues/27646")]
+        [Theory]
+        [InlineData("from")]
+        [InlineData("nameof")]
+        [InlineData("async")]
+        [InlineData("await")]
+        [InlineData("var")]
+        public async Task TestContextualKeywordsThatCanProbablyStartSyntacticConstructs_OnTheirOwn(string keyword)
+        {
+            await TestMissingInRegularAndScriptAsync(
+$@"class C
+{{
+    int M()
+    {{
+        [|{keyword}|]
     }}
 }}");
         }

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
         }
 
         protected override bool IsExplicitInterfaceGeneration(SyntaxNode node)
-            => node.IsKind(SyntaxKind.PropertyDeclaration);
+            => node is PropertyDeclarationSyntax;
 
         protected override bool IsIdentifierNameGeneration(SyntaxNode node)
             => node.IsParentKind(SyntaxKind.ReturnStatement, SyntaxKind.YieldReturnStatement)

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -36,6 +36,16 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
 
         private static bool IsProbablySyntacticConstruct(SyntaxToken token)
         {
+            // Technically all C# contextual keywords are valid member names.
+            // However some of them start various syntactic constructs
+            // and we don't want to show "Generate <member name>" codefix for them:
+            // 1. "from" starts LINQ expression
+            // 2. "nameof" is probably nameof(some_name)
+            // 3. "async" can start a delegate declaration
+            // 4. "await" starts await expression
+            // 5. "var" is used in constructions like "var x = ..."
+            // The list can be expanded in the future if necessary
+            // This method tells if the given SyntaxToken is one of the cases above
             var contextualKind = SyntaxFacts.GetContextualKeywordKind(token.ValueText);
 
             return contextualKind is SyntaxKind.FromKeyword or

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.GenerateMember.GenerateVariable;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
@@ -30,10 +29,12 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
         }
 
         protected override bool IsExplicitInterfaceGeneration(SyntaxNode node)
-            => node is PropertyDeclarationSyntax;
+            => node.IsKind(SyntaxKind.PropertyDeclaration);
 
         protected override bool IsIdentifierNameGeneration(SyntaxNode node)
-            => node is IdentifierNameSyntax identifier && !identifier.Identifier.CouldBeKeyword();
+            => node.IsParentKind(SyntaxKind.ReturnStatement) ?
+                node.IsKind(SyntaxKind.IdentifierName) :
+                node is IdentifierNameSyntax identifierName && !identifierName.Identifier.CouldBeKeyword();
 
         protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
             => containingType.ContainingTypesOrSelfHasUnsafeKeyword();
@@ -69,7 +70,6 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
         {
             identifierToken = identifierName.Identifier;
             if (identifierToken.ValueText != string.Empty &&
-                !identifierName.IsVar &&
                 !IsProbablyGeneric(identifierName, cancellationToken))
             {
                 var memberAccess = identifierName.Parent as MemberAccessExpressionSyntax;

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -32,9 +32,9 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
             => node.IsKind(SyntaxKind.PropertyDeclaration);
 
         protected override bool IsIdentifierNameGeneration(SyntaxNode node)
-            => node.IsParentKind(SyntaxKind.ReturnStatement) ?
-                node.IsKind(SyntaxKind.IdentifierName) :
-                node is IdentifierNameSyntax identifierName && !identifierName.Identifier.CouldBeKeyword();
+            => node.IsParentKind(SyntaxKind.ReturnStatement, SyntaxKind.YieldReturnStatement)
+                ? node.IsKind(SyntaxKind.IdentifierName)
+                : node is IdentifierNameSyntax identifierName && !identifierName.Identifier.CouldBeKeyword();
 
         protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
             => containingType.ContainingTypesOrSelfHasUnsafeKeyword();

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -32,9 +32,17 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
             => node is PropertyDeclarationSyntax;
 
         protected override bool IsIdentifierNameGeneration(SyntaxNode node)
-            => node.IsParentKind(SyntaxKind.ReturnStatement, SyntaxKind.YieldReturnStatement)
-                ? node.IsKind(SyntaxKind.IdentifierName)
-                : node is IdentifierNameSyntax identifierName && !identifierName.Identifier.CouldBeKeyword();
+            => node is IdentifierNameSyntax identifierName && !IsProbablySyntacticConstruct(identifierName.Identifier);
+
+        private static bool IsProbablySyntacticConstruct(SyntaxToken token)
+        {
+            var contextualKind = SyntaxFacts.GetContextualKeywordKind(token.ValueText);
+
+            return contextualKind is SyntaxKind.FromKeyword or
+                                  SyntaxKind.NameOfKeyword or
+                                  SyntaxKind.AsyncKeyword or
+                                  SyntaxKind.AwaitKeyword;
+        }
 
         protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
             => containingType.ContainingTypesOrSelfHasUnsafeKeyword();

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -41,7 +41,8 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
             return contextualKind is SyntaxKind.FromKeyword or
                                   SyntaxKind.NameOfKeyword or
                                   SyntaxKind.AsyncKeyword or
-                                  SyntaxKind.AwaitKeyword;
+                                  SyntaxKind.AwaitKeyword or
+                                  SyntaxKind.VarKeyword;
         }
 
         protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/27646

Verified, that all this names are valid and do not break code after applying codefix