### PR TITLE
Fill out test plan for auto-default structs

### DIFF
--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -99,6 +99,7 @@ This document provides guidance for thinking about language interactions and tes
 - Switch expressions
 - With expressions (on record classes and on value types)
 - Nullability annotations (`?`, attributes) and analysis
+- Definite assignment analysis and auto-default struct fields
 - If you add a place an expression can appear in code, make sure `SpillSequenceSpiller` handles it. Test with a `switch` expression or `stackalloc` in that place.
 - If you add a new expression form that requires spilling, test it in the catch filter.
 - extension based Dispose, DisposeAsync, GetEnumerator, GetAsyncEnumerator, Deconstruct, GetAwaiter etc.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -1224,14 +1224,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (compilation.IsFeatureEnabled(MessageID.IDS_FeatureAutoDefaultStructs))
                 {
-                    Diagnostics.Add(ErrorCode.WRN_UseDefViolationThisSupportedVersion, node.Location, thisParameter.Name);
+                    Diagnostics.Add(ErrorCode.WRN_UseDefViolationThisSupportedVersion, node.Location);
                 }
                 else
                 {
                     Diagnostics.Add(
                         ErrorCode.ERR_UseDefViolationThisUnsupportedVersion,
                         node.Location,
-                        thisParameter.Name,
                         new CSharpRequiredLanguageVersion(MessageID.IDS_FeatureAutoDefaultStructs.RequiredVersion()));
                 }
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var F = new SyntheticBoundNodeFactory(method, body.Syntax, compilationState, diagnostics);
 
-            var builder = ArrayBuilder<BoundStatement>.GetInstance(implicitlyInitializedFields.Length + body.Statements.Length);
+            var builder = ArrayBuilder<BoundStatement>.GetInstance(implicitlyInitializedFields.Length);
             foreach (var field in implicitlyInitializedFields)
             {
                 builder.Add(
@@ -119,9 +119,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             F.Field(F.This(), field),
                             F.Default(field.Type))));
             }
-            builder.AddRange(body.Statements);
+            var initializations = F.HiddenSequencePoint(F.Block(builder.ToImmutableAndFree()));
 
-            return body.Update(body.Locals, body.LocalFunctions, builder.ToImmutableAndFree());
+            return body.Update(body.Locals, body.LocalFunctions, body.Statements.Insert(index: 0, initializations));
         }
 
         private static BoundBlock AppendImplicitReturn(BoundBlock body, MethodSymbol method, bool originalBodyNested)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (!implicitlyInitializedFields.IsDefault)
                     {
                         Debug.Assert(!implicitlyInitializedFields.IsEmpty);
+                        Debug.Assert(!originalBodyNested);
                         block = PrependImplicitInitializations(block, method, implicitlyInitializedFields, compilationState, diagnostics);
                     }
                     if (needsImplicitReturn)
@@ -107,21 +108,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(method.MethodKind == MethodKind.Constructor);
             Debug.Assert(method.ContainingType.IsStructType());
 
-            var syntax = body.Syntax;
-            var F = new SyntheticBoundNodeFactory(method, syntax, compilationState, diagnostics);
+            var F = new SyntheticBoundNodeFactory(method, body.Syntax, compilationState, diagnostics);
 
-            var builder = ArrayBuilder<BoundStatement>.GetInstance(implicitlyInitializedFields.Length + 1);
+            var builder = ArrayBuilder<BoundStatement>.GetInstance(implicitlyInitializedFields.Length + body.Statements.Length);
             foreach (var field in implicitlyInitializedFields)
             {
-                builder.Add(new BoundExpressionStatement(
-                    syntax,
-                    F.AssignmentExpression(
-                        F.Field(F.This(), field),
-                        F.Default(field.Type))));
+                builder.Add(
+                    F.ExpressionStatement(
+                        F.AssignmentExpression(
+                            F.Field(F.This(), field),
+                            F.Default(field.Type))));
             }
-            builder.Add(body);
+            builder.AddRange(body.Statements);
 
-            return BoundBlock.SynthesizedNoLocals(syntax, builder.ToImmutableAndFree());
+            return body.Update(body.Locals, body.LocalFunctions, builder.ToImmutableAndFree());
         }
 
         private static BoundBlock AppendImplicitReturn(BoundBlock body, MethodSymbol method, bool originalBodyNested)

--- a/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/FlowDiagnosticTests.cs
@@ -1754,13 +1754,13 @@ struct Program
     // (20,17): error CS1620: Argument 1 must be passed with the 'out' keyword
     //         Goo(ref x3);
     Diagnostic(ErrorCode.ERR_BadArgRef, "x3").WithArguments("1", "out").WithLocation(20, 17),
-    // (15,17): error CS9013: Use of possibly unassigned auto-implemented property 'x1'. Consider updating to language version 'preview' to auto-default the property.
+    // (15,17): error CS9014: Use of possibly unassigned auto-implemented property 'x1'. Consider updating to language version 'preview' to auto-default the property.
     //         Goo(out x1);
     Diagnostic(ErrorCode.ERR_UseDefViolationPropertyUnsupportedVersion, "x1").WithArguments("x1", "preview").WithLocation(15, 17),
-    // (16,9): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+    // (16,9): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
     //         Goo(ref x1);
-    Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "Goo").WithArguments("this", "preview").WithLocation(16, 9),
-    // (17,17): error CS9013: Use of possibly unassigned auto-implemented property 'x2'. Consider updating to language version 'preview' to auto-default the property.
+    Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "Goo").WithArguments("preview").WithLocation(16, 9),
+    // (17,17): error CS9014: Use of possibly unassigned auto-implemented property 'x2'. Consider updating to language version 'preview' to auto-default the property.
     //         Goo(out x2);
     Diagnostic(ErrorCode.ERR_UseDefViolationPropertyUnsupportedVersion, "x2").WithArguments("x2", "preview").WithLocation(17, 17),
     // (6,20): warning CS0649: Field 'Program.S1.x' is never assigned to, and will always have its default value 0

--- a/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/LocalFunctions.cs
@@ -724,10 +724,10 @@ struct S
                 // (10,20): error CS1673: Anonymous methods, lambda expressions, query expressions, and local functions inside structs cannot access instance members of 'this'. Consider copying 'this' to a local variable outside the anonymous method, lambda expression, query expression, or local function and using the local instead.
                 //             s._x = _x;
                 Diagnostic(ErrorCode.ERR_ThisStructNotInAnonMeth, "_x").WithLocation(10, 20),
-                // (7,17): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                // (7,17): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
                 //         var s = this;
-                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "this").WithArguments("this", "preview").WithLocation(7, 17),
-                // (12,9): error CS9014: Use of possibly unassigned field '_x'. Consider updating to language version 'preview' to auto-default the field.
+                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "this").WithArguments("preview").WithLocation(7, 17),
+                // (12,9): error CS9015: Use of possibly unassigned field '_x'. Consider updating to language version 'preview' to auto-default the field.
                 //         Local();
                 Diagnostic(ErrorCode.ERR_UseDefViolationFieldUnsupportedVersion, "Local()").WithArguments("_x", "preview").WithLocation(12, 9),
                 // (5,12): error CS0171: Field 'S._x' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the field.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -7527,9 +7527,9 @@ record struct C
 
             var comp = CreateCompilation(src, parseOptions: TestOptions.Regular10);
             comp.VerifyDiagnostics(
-                // (8,13): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                // (8,13): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
                 //         _ = this with { X = 42 }; // 1
-                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "this").WithArguments("this", "preview").WithLocation(8, 13)
+                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "this").WithArguments("preview").WithLocation(8, 13)
                 );
 
             var verifier = CompileAndVerify(src, parseOptions: TestOptions.RegularNext);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -6982,9 +6982,9 @@ namespace MyNamespace
 }";
             CreateCompilation(text, parseOptions: TestOptions.Regular10).
                 VerifyDiagnostics(
-                // (17,17): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                // (17,17): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
                 //                 Goo();  // CS0188
-                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "Goo").WithArguments("this", "preview").WithLocation(17, 17),
+                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "Goo").WithArguments("preview").WithLocation(17, 17),
                 // (8,24): warning CS0649: Field 'MyClass.S.a' is never assigned to, and will always have its default value 0
                 //             public int a;
                 Diagnostic(ErrorCode.WRN_UnassignedInternalField, "a").WithArguments("MyNamespace.MyClass.S.a", "0").WithLocation(8, 24));
@@ -7032,9 +7032,9 @@ struct S
                 // (10,18): error CS0837: The first operand of an 'is' or 'as' operator may not be a lambda expression, anonymous method, or method group.
                 //         var b1 = F is Action;
                 Diagnostic(ErrorCode.ERR_LambdaInIsAs, "F is Action").WithLocation(10, 18),
-                // (10,18): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                // (10,18): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
                 //         var b1 = F is Action;
-                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "F").WithArguments("this", "preview").WithLocation(10, 18));
+                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "F").WithArguments("preview").WithLocation(10, 18));
 
             CreateCompilationWithMscorlib40AndSystemCore(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(
                 // (10,18): error CS0837: The first operand of an 'is' or 'as' operator may not be a lambda expression, anonymous method, or method group.
@@ -7066,9 +7066,9 @@ struct S
                 // (10,18): error CS0837: The first operand of an 'is' or 'as' operator may not be a lambda expression, anonymous method, or method group.
                 //         var b1 = this.F is Action;
                 Diagnostic(ErrorCode.ERR_LambdaInIsAs, "this.F is Action").WithLocation(10, 18),
-                // (10,18): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                // (10,18): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
                 //         var b1 = this.F is Action;
-                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "this").WithArguments("this", "preview").WithLocation(10, 18));
+                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "this").WithArguments("preview").WithLocation(10, 18));
 
             CreateCompilationWithMscorlib40AndSystemCore(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(
                 // (10,18): error CS0837: The first operand of an 'is' or 'as' operator may not be a lambda expression, anonymous method, or method group.
@@ -7099,9 +7099,9 @@ struct S
 }
 ";
             CreateCompilationWithMscorlib40AndSystemCore(source, parseOptions: TestOptions.Regular10).VerifyDiagnostics(
-                // (10,19): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                // (10,19): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
                 //         /*this.*/ Add(d);
-                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "Add").WithArguments("this", "preview").WithLocation(10, 19));
+                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "Add").WithArguments("preview").WithLocation(10, 19));
 
             var verifier = CompileAndVerify(source, new[] { CSharpRef }, parseOptions: TestOptions.RegularNext);
             verifier.VerifyDiagnostics();
@@ -7170,9 +7170,9 @@ struct S
 }
 ";
             CreateCompilationWithMscorlib40AndSystemCore(source, parseOptions: TestOptions.Regular10).VerifyDiagnostics(
-                // (10,9): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                // (10,9): error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
                 //         this.Add(d);
-                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "this").WithArguments("this", "preview").WithLocation(10, 9));
+                Diagnostic(ErrorCode.ERR_UseDefViolationThisUnsupportedVersion, "this").WithArguments("preview").WithLocation(10, 9));
 
             var verifier = CompileAndVerify(source, new[] { CSharpRef }, parseOptions: TestOptions.RegularNext);
             verifier.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -1653,9 +1653,11 @@ S3 { X = , Y = 3 }
 {
   // Code size       20 (0x14)
   .maxstack  2
+  // sequence point: <hidden>
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      ""object S3.<X>k__BackingField""
+  // sequence point: 3
   IL_0007:  ldarg.0
   IL_0008:  ldc.i4.3
   IL_0009:  box        ""int""

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -2757,7 +2757,7 @@ public struct S
 
         [Theory]
         [InlineData(LanguageVersion.CSharp10)]
-        [InlineData(LanguageVersion.Latest)]
+        [InlineData(LanguageVersionFacts.CSharpNext)]
         public void ImplicitlyInitializedFields_EmptyStruct(LanguageVersion languageVersion)
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -1621,29 +1621,33 @@ S3 { X = , Y = 3 }
 {
   // Code size       20 (0x14)
   .maxstack  2
+  // sequence point: <hidden>
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      ""object S1.Y""
+  // sequence point: public object X = 1;
   IL_0007:  ldarg.0
   IL_0008:  ldc.i4.1
   IL_0009:  box        ""int""
   IL_000e:  stfld      ""object S1.X""
   IL_0013:  ret
-}");
+}", sequencePoints: "S1..ctor", source: source);
 
             verifier.VerifyIL("S2..ctor", @"
 {
   // Code size       20 (0x14)
   .maxstack  2
+  // sequence point: <hidden>
   IL_0000:  ldarg.0
   IL_0001:  ldnull
   IL_0002:  stfld      ""object S2.<Y>k__BackingField""
+  // sequence point: 2
   IL_0007:  ldarg.0
   IL_0008:  ldc.i4.2
   IL_0009:  box        ""int""
   IL_000e:  stfld      ""object S2.<X>k__BackingField""
   IL_0013:  ret
-}");
+}", sequencePoints: "S2..ctor", source: source);
 
             verifier.VerifyIL("S3..ctor", @"
 {
@@ -1657,7 +1661,7 @@ S3 { X = , Y = 3 }
   IL_0009:  box        ""int""
   IL_000e:  stfld      ""object S3.<Y>k__BackingField""
   IL_0013:  ret
-}");
+}", sequencePoints: "S3..ctor", source: source);
         }
 
         [Fact]
@@ -2633,10 +2637,10 @@ public struct S
 {
   // Code size       11 (0xb)
   .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.0
-  IL_0002:  stfld      ""int S.x""
-  IL_0007:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldc.i4.0
+  IL_0003:  stfld      ""int S.x""
   IL_0008:  br.s       IL_000a
   IL_000a:  ret
 }
@@ -2679,10 +2683,10 @@ public struct S
 {
   // Code size       27 (0x1b)
   .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldnull
-  IL_0002:  stfld      ""System.Action S.E""
-  IL_0007:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldnull
+  IL_0003:  stfld      ""System.Action S.E""
   IL_0008:  ldarg.0
   IL_0009:  ldfld      ""System.Action S.E""
   IL_000e:  dup
@@ -2822,10 +2826,10 @@ public struct S2
 {
   // Code size       27 (0x1b)
   .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""S1 S2.S1""
-  IL_0006:  initobj    ""S1""
-  IL_000c:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldflda     ""S1 S2.S1""
+  IL_0007:  initobj    ""S1""
   IL_000d:  ldarg.0
   IL_000e:  ldflda     ""S1 S2.S1""
   IL_0013:  ldc.i4.s   42
@@ -2863,10 +2867,10 @@ public struct S
   // Code size       24 (0x18)
   .maxstack  2
   .locals init (bool V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldc.i4.0
-  IL_0002:  stfld      ""int S.X""
-  IL_0007:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldc.i4.0
+  IL_0003:  stfld      ""int S.X""
   IL_0008:  ldarg.1
   IL_0009:  stloc.0
   IL_000a:  ldloc.0
@@ -2913,10 +2917,10 @@ public struct S2
   // Code size       28 (0x1c)
   .maxstack  1
   .locals init (bool V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""S1 S2.S1""
-  IL_0006:  initobj    ""S1""
-  IL_000c:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldflda     ""S1 S2.S1""
+  IL_0007:  initobj    ""S1""
   IL_000d:  ldarg.1
   IL_000e:  stloc.0
   IL_000f:  ldloc.0
@@ -2957,20 +2961,61 @@ public struct S
 
             verifier.VerifyIL("S..ctor", @"
 {
-    // Code size       21 (0x15)
-    .maxstack  2
-    // sequence point: {
-    IL_0000:  nop
-    IL_0001:  ldarg.0
-    IL_0002:  ldc.i4.0
-    IL_0003:  stfld      ""int S.X""
-    // sequence point: X.ToString();
-    IL_0008:  ldarg.0
-    IL_0009:  ldflda     ""int S.X""
-    IL_000e:  call       ""string int.ToString()""
-    IL_0013:  pop
-    // sequence point: }
-    IL_0014:  ret
+  // Code size       21 (0x15)
+  .maxstack  2
+  // sequence point: {
+  IL_0000:  nop
+  // sequence point: <hidden>
+  IL_0001:  ldarg.0
+  IL_0002:  ldc.i4.0
+  IL_0003:  stfld      ""int S.X""
+  // sequence point: X.ToString();
+  IL_0008:  ldarg.0
+  IL_0009:  ldflda     ""int S.X""
+  IL_000e:  call       ""string int.ToString()""
+  IL_0013:  pop
+  // sequence point: }
+  IL_0014:  ret
+}
+",
+                sequencePoints: "S..ctor",
+                source: source);
+        }
+
+        [Fact]
+        public void ImplicitlyInitializedFields_SequencePoints_ExpressionBody()
+        {
+            var source = @"
+public struct S
+{
+    public int X;
+
+    public S()
+        => X.ToString();
+}";
+            var verifier = CompileAndVerify(source, options: TestOptions.DebugDll.WithSpecificDiagnosticOptions(ReportStructInitializationWarnings));
+            verifier.VerifyDiagnostics(
+                // (6,12): warning CS9022: Control is returned to caller before field 'S.X' is explicitly assigned, causing a preceding implicit assignment of 'default'.
+                //     public S()
+                Diagnostic(ErrorCode.WRN_UnassignedThisSupportedVersion, "S").WithArguments("S.X").WithLocation(6, 12),
+                // (7,12): warning CS9019: Field 'X' is read before being explicitly assigned, causing a preceding implicit assignment of 'default'.
+                //         => X.ToString();
+                Diagnostic(ErrorCode.WRN_UseDefViolationFieldSupportedVersion, "X").WithArguments("X").WithLocation(7, 12));
+
+            verifier.VerifyIL("S..ctor", @"
+{
+  // Code size       20 (0x14)
+  .maxstack  2
+  // sequence point: <hidden>
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  stfld      ""int S.X""
+  // sequence point: X.ToString()
+  IL_0007:  ldarg.0
+  IL_0008:  ldflda     ""int S.X""
+  IL_000d:  call       ""string int.ToString()""
+  IL_0012:  pop
+  IL_0013:  ret
 }
 ",
                 sequencePoints: "S..ctor",
@@ -3115,16 +3160,16 @@ public struct S<T>
 {
   // Code size       33 (0x21)
   .maxstack  2
-  IL_0000:  ldarg.0
-  IL_0001:  ldnull
-  IL_0002:  stfld      ""string S<T>.<AutoProp>k__BackingField""
-  IL_0007:  ldarg.0
-  IL_0008:  ldflda     ""T S<T>.TField""
-  IL_000d:  initobj    ""T""
-  IL_0013:  ldarg.0
-  IL_0014:  ldflda     ""SParameterless S<T>.Parameterless""
-  IL_0019:  initobj    ""SParameterless""
-  IL_001f:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldnull
+  IL_0003:  stfld      ""string S<T>.<AutoProp>k__BackingField""
+  IL_0008:  ldarg.0
+  IL_0009:  ldflda     ""T S<T>.TField""
+  IL_000e:  initobj    ""T""
+  IL_0014:  ldarg.0
+  IL_0015:  ldflda     ""SParameterless S<T>.Parameterless""
+  IL_001a:  initobj    ""SParameterless""
   IL_0020:  ret
 }
 ");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/WarningVersionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/WarningVersionTests.cs
@@ -629,9 +629,9 @@ public struct Struct
                 parseOptions: TestOptions.Regular10,
                 verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
-                // (6,22): warning CS8885: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                // (6,22): warning CS8885: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
                 //         Program p2 = this;
-                Diagnostic(ErrorCode.WRN_UseDefViolationThisUnsupportedVersion, "this").WithArguments("this", "preview").WithLocation(6, 22));
+                Diagnostic(ErrorCode.WRN_UseDefViolationThisUnsupportedVersion, "this").WithArguments("preview").WithLocation(6, 22));
             verifier.VerifyIL("Program..ctor", expectedIL);
 
             // C# 11+

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/WarningVersionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/WarningVersionTests.cs
@@ -143,10 +143,10 @@ public struct Struct
 {
   // Code size       14 (0xe)
   .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""Struct Program.<Property>k__BackingField""
-  IL_0006:  initobj    ""Struct""
-  IL_000c:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldflda     ""Struct Program.<Property>k__BackingField""
+  IL_0007:  initobj    ""Struct""
   IL_000d:  ret
 }
 ";
@@ -221,10 +221,10 @@ public struct Struct
 {
   // Code size       14 (0xe)
   .maxstack  1
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""Struct Program.Field""
-  IL_0006:  initobj    ""Struct""
-  IL_000c:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldflda     ""Struct Program.Field""
+  IL_0007:  initobj    ""Struct""
   IL_000d:  ret
 }
 ";
@@ -303,10 +303,10 @@ public struct Struct
   // Code size       28 (0x1c)
   .maxstack  1
   .locals init (Struct V_0) //s
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""Struct Program.Field""
-  IL_0006:  initobj    ""Struct""
-  IL_000c:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldflda     ""Struct Program.Field""
+  IL_0007:  initobj    ""Struct""
   IL_000d:  ldloca.s   V_0
   IL_000f:  constrained. ""Struct""
   IL_0015:  callvirt   ""string object.ToString()""
@@ -425,10 +425,10 @@ public struct Struct
   // Code size       33 (0x21)
   .maxstack  1
   .locals init (Struct V_0) //v2
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""Struct Program.<Property>k__BackingField""
-  IL_0006:  initobj    ""Struct""
-  IL_000c:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldflda     ""Struct Program.<Property>k__BackingField""
+  IL_0007:  initobj    ""Struct""
   IL_000d:  ldarg.0
   IL_000e:  call       ""readonly Struct Program.Property.get""
   IL_0013:  stloc.0
@@ -512,10 +512,10 @@ public struct Struct
   // Code size       33 (0x21)
   .maxstack  1
   .locals init (Struct V_0) //v2
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""Struct Program.Field""
-  IL_0006:  initobj    ""Struct""
-  IL_000c:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldflda     ""Struct Program.Field""
+  IL_0007:  initobj    ""Struct""
   IL_000d:  ldarg.0
   IL_000e:  ldfld      ""Struct Program.Field""
   IL_0013:  stloc.0
@@ -599,10 +599,10 @@ public struct Struct
   // Code size       33 (0x21)
   .maxstack  1
   .locals init (Program V_0) //p2
-  IL_0000:  ldarg.0
-  IL_0001:  ldflda     ""Struct Program.Field""
-  IL_0006:  initobj    ""Struct""
-  IL_000c:  nop
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  ldflda     ""Struct Program.Field""
+  IL_0007:  initobj    ""Struct""
   IL_000d:  ldarg.0
   IL_000e:  ldobj      ""Program""
   IL_0013:  stloc.0

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/WarningVersionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/WarningVersionTests.cs
@@ -653,9 +653,9 @@ public struct Struct
                 parseOptions: TestOptions.RegularNext,
                 verify: Verification.Skipped);
             verifier.VerifyDiagnostics(
-                // (6,22): warning CS9019: The 'this' object cannot be used before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.
+                // (6,22): warning CS9020: The 'this' object is read before all of its fields have been assigned, causing preceding implicit assignments of 'default' to non-explicitly assigned fields.
                 //         Program p2 = this;
-                Diagnostic(ErrorCode.WRN_UseDefViolationThisSupportedVersion, "this").WithArguments("this").WithLocation(6, 22));
+                Diagnostic(ErrorCode.WRN_UseDefViolationThisSupportedVersion, "this").WithLocation(6, 22));
             verifier.VerifyIL("Program..ctor", expectedIL);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -1103,5 +1103,49 @@ class Test
                 expected: LanguageVersion.Preview,
                 new CSharpParseOptions(LanguageVersion.CSharp8));
         }
+
+        [Fact, WorkItem(60167, "https://github.com/dotnet/roslyn/issues/60167")]
+        public async Task UpgradeProjectForStructAutoDefaultError_1()
+        {
+            await TestLanguageVersionUpgradedAsync(@"
+struct Test
+{
+    public int X;
+    public [|Test|]() { }
+}",
+                expected: LanguageVersion.Preview,
+                new CSharpParseOptions(LanguageVersion.CSharp10));
+        }
+
+        [Fact, WorkItem(60167, "https://github.com/dotnet/roslyn/issues/60167")]
+        public async Task UpgradeProjectForStructAutoDefaultError_2()
+        {
+            await TestLanguageVersionUpgradedAsync(@"
+struct Test
+{
+    public int X;
+    public [|Test|]() { this.ToString(); }
+}",
+                expected: LanguageVersion.Preview,
+                new CSharpParseOptions(LanguageVersion.CSharp10));
+        }
+
+        [Fact, WorkItem(60167, "https://github.com/dotnet/roslyn/issues/60167")]
+        public async Task UpgradeProjectForStructAutoDefaultError_3()
+        {
+            await TestLanguageVersionUpgradedAsync(@"
+struct Test
+{
+    public int X { get; set; }
+    public [|Test|]() { this.ToString(); }
+}",
+                expected: LanguageVersion.Preview,
+                new CSharpParseOptions(LanguageVersion.CSharp10));
+        }
+
+        // warning CS8880: Auto-implemented property 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the property.
+        // warning CS8881: Field 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the field.
+        // warning CS8885: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -1142,10 +1142,5 @@ struct Test
                 expected: LanguageVersion.Preview,
                 new CSharpParseOptions(LanguageVersion.CSharp10));
         }
-
-        // warning CS8880: Auto-implemented property 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the property.
-        // warning CS8881: Field 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the field.
-        // warning CS8885: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
-
     }
 }

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -53,11 +53,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
                 "CS8967", // error CS8967: Newlines inside a non-verbatim interpolated string are not supported in C# 8.0. Please use language version preview or greater.
 
                 "CS0171", // error CS0171: Field 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the field.
-                "CS0188", // error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                "CS0188", // error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
                 "CS0843", // error CS0843: Auto-implemented property 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the property.
                 "CS8880", // warning CS8880: Auto-implemented property 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the property.
                 "CS8881", // warning CS8881: Field 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the field.
-                "CS8885", // warning CS8885: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                "CS8885", // warning CS8885: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'preview' to auto-default the unassigned fields.
             });
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -51,6 +51,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
                 "CS8704", // error CS8704: 'Test1' does not implement interface member 'I1.M1()'. 'Test1.M1()' cannot implicitly implement a non-public member in C# 9.0. Please use language version 'preview' or greater.
                 "CS8957", // error CS8957: Conditional expression is not valid in language version '8.0' because a common type was not found between 'int' and '<null>'. To use a target-typed conversion, upgrade to language version '9.0' or greater.
                 "CS8967", // error CS8967: Newlines inside a non-verbatim interpolated string are not supported in C# 8.0. Please use language version preview or greater.
+
+                "CS0171", // error CS0171: Field 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the field.
+                "CS0188", // error CS0188: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
+                "CS0843", // error CS0843: Auto-implemented property 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the property.
+                "CS8880", // warning CS8880: Auto-implemented property 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the property.
+                "CS8881", // warning CS8881: Field 'S.Test1' must be fully assigned before control is returned to the caller. Consider updating to language version 'preview' to auto-default the field.
+                "CS8885", // warning CS8885: The 'this' object cannot be used before all of its fields have been assigned. Consider updating to language version 'this' to auto-default the unassigned fields.
             });
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;


### PR DESCRIPTION
Closes #60167 (test plan)

I'm not sure how to test the LangVersion warnings here, as it requires having a struct with private reference type fields in another assembly, but I did test it manually. [langversion-warning](https://user-images.githubusercontent.com/5833655/163487584-c630a767-e733-4078-ac58-51d9a0bc05be.gif)

I manually verified in the debugger that changing an auto-defaulted field's value, then dragging to the `{` of the constructor, causes default to get written to the field again. [auto-default-debugger](https://user-images.githubusercontent.com/5833655/163485843-6160b0a5-cb09-47c3-a7a0-a2ab221da08e.gif)
