### PR TITLE
Fix "top-level statements" feature name to match published name

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1938,6 +1938,6 @@ Additional information: {1}</value>
     <value>Always use default symbol servers for navigation</value>
   </data>
   <data name="Prefer_top_level_statements" xml:space="preserve">
-    <value>Prefer top level statements</value>
+    <value>Prefer top-level statements</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1078,8 +1078,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Prefer_top_level_statements">
-        <source>Prefer top level statements</source>
-        <target state="new">Prefer top level statements</target>
+        <source>Prefer top-level statements</source>
+        <target state="new">Prefer top-level statements</target>
         <note />
       </trans-unit>
       <trans-unit id="Prefer_tuple_swap">


### PR DESCRIPTION
Pointed out by SDK team.

Matches: https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/top-level-statements#:~:text=Top-level%20statements%20(C%23%20Programming%20Guide)%201%20Only%20one,point%20method.%20...%207%20C%23%20language%20specification.