### PR TITLE
Allow code actions to retrieve options for any language

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -468,7 +468,7 @@ class Class
                     Assert.Equal(2, diagnostics.Where(d => d.Id == "CS0219").Count());
 
                     var options = CodeActionOptions.Default;
-                    var allFixes = (await fixService.GetFixesAsync(document, span, options, CancellationToken.None))
+                    var allFixes = (await fixService.GetFixesAsync(document, span, _ => options, CancellationToken.None))
                         .SelectMany(fixCollection => fixCollection.Fixes);
 
                     var cs0219Fixes = allFixes.Where(fix => fix.PrimaryDiagnostic.Id == "CS0219").ToArray();

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -659,7 +659,7 @@ namespace A
             var enabledDiagnostics = codeCleanupService.GetAllDiagnostics();
 
             var newDoc = await codeCleanupService.CleanupAsync(
-                document, enabledDiagnostics, new ProgressTracker(), options, formattingOptions, CancellationToken.None);
+                document, enabledDiagnostics, new ProgressTracker(), _ => options, formattingOptions, CancellationToken.None);
 
             var actual = await newDoc.GetTextAsync();
 

--- a/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 var workspace = document.Project.Solution.Workspace;
                 var supportsFeatureService = workspace.Services.GetRequiredService<ITextBufferSupportsFeatureService>();
 
-                var options = GlobalOptions.GetCodeActionOptions(document.Project.Language);
+                var options = GlobalOptions.GetCodeActionOptionsProvider();
 
                 var fixesTask = GetCodeFixesAsync(
                     state, supportsFeatureService, requestedActionCategories, workspace, document, range,

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     Func<string, IDisposable?> addOperationScope =
                         description => operationContext?.AddScope(allowCancellation: true, string.Format(EditorFeaturesResources.Gathering_Suggestions_0, description));
 
-                    var options = GlobalOptions.GetBlockingCodeActionOptions(document.Project.Language);
+                    var options = GlobalOptions.GetBlockingCodeActionOptionsProvider();
 
                     // We convert the code fixes and refactorings to UnifiedSuggestedActionSets instead of
                     // SuggestedActionSets so that we can share logic between local Roslyn and LSP.
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 SnapshotSpan range,
                 Func<string, IDisposable?> addOperationScope,
                 CodeActionRequestPriority priority,
-                CodeActionOptions options,
+                CodeActionOptionsProvider options,
                 CancellationToken cancellationToken)
             {
                 if (state.Target.Owner._codeFixService == null ||
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 TextSpan? selection,
                 Func<string, IDisposable?> addOperationScope,
                 CodeActionRequestPriority priority,
-                CodeActionOptions options,
+                CodeActionOptionsProvider options,
                 CancellationToken cancellationToken)
             {
                 if (!selection.HasValue)
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 ReferenceCountedDisposable<State> state,
                 Document document,
                 SnapshotSpan range,
-                CodeActionOptions options,
+                CodeActionOptionsProvider options,
                 CancellationToken cancellationToken)
             {
                 foreach (var order in Orderings)
@@ -458,7 +458,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             private async Task<string?> TryGetRefactoringSuggestedActionCategoryAsync(
                 Document document,
                 TextSpan? selection,
-                CodeActionOptions options,
+                CodeActionOptionsProvider options,
                 CancellationToken cancellationToken)
             {
                 using var state = _state.TryAddReference();
@@ -630,7 +630,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (document == null)
                     return null;
 
-                var options = GlobalOptions.GetCodeActionOptions(document.Project.Language);
+                var options = GlobalOptions.GetCodeActionOptionsProvider();
 
                 using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var linkedToken = linkedTokenSource.Token;

--- a/src/EditorFeatures/Core/CodeActions/CodeActionOptionsStorage.cs
+++ b/src/EditorFeatures/Core/CodeActions/CodeActionOptionsStorage.cs
@@ -32,5 +32,11 @@ namespace Microsoft.CodeAnalysis.CodeActions
             var cache = ImmutableDictionary<string, CodeActionOptions>.Empty;
             return language => ImmutableInterlocked.GetOrAdd(ref cache, language, (language, options) => GetCodeActionOptions(options, language), globalOptions);
         }
+
+        internal static CodeActionOptionsProvider GetBlockingCodeActionOptionsProvider(this IGlobalOptionService globalOptions)
+        {
+            var cache = ImmutableDictionary<string, CodeActionOptions>.Empty;
+            return language => ImmutableInterlocked.GetOrAdd(ref cache, language, (language, options) => GetBlockingCodeActionOptions(options, language), globalOptions);
+        }
     }
 }

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
             CodeActionParams request,
             CodeActionsCache codeActionsCache,
             Document document,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             ICodeFixService codeFixService,
             ICodeRefactoringService codeRefactoringService,
             CancellationToken cancellationToken)
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
             CodeActionsCache codeActionsCache,
             Document document,
             LSP.Range selection,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             ICodeFixService codeFixService,
             ICodeRefactoringService codeRefactoringService,
             CancellationToken cancellationToken)
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
 
         private static async ValueTask<ImmutableArray<UnifiedSuggestedActionSet>> GetActionSetsAsync(
             Document document,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             ICodeFixService codeFixService,
             ICodeRefactoringService codeRefactoringService,
             LSP.Range selection,

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/CodeActionResolveHandler.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/CodeActionResolveHandler.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var data = ((JToken)codeAction.Data!).ToObject<CodeActionResolveData>();
             Assumes.Present(data);
 
-            var options = _globalOptions.GetCodeActionOptions(document.Project.Language);
+            var options = _globalOptions.GetCodeActionOptionsProvider();
 
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
                 _codeActionsCache,

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/CodeActionsHandler.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/CodeActionsHandler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var document = context.Document;
             Contract.ThrowIfNull(document);
 
-            var options = _globalOptions.GetCodeActionOptions(document.Project.Language);
+            var options = _globalOptions.GetCodeActionOptionsProvider();
 
             var codeActions = await CodeActionHelpers.GetVSCodeActionsAsync(
                 request, _codeActionsCache, document, options, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/RunCodeActionHandler.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/RunCodeActionHandler.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var runRequest = ((JToken)request.Arguments.Single()).ToObject<CodeActionResolveData>();
             Assumes.Present(runRequest);
 
-            var options = _globalOptions.GetCodeActionOptions(document.Project.Language);
+            var options = _globalOptions.GetCodeActionOptionsProvider();
 
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
                 _codeActionsCache, document, runRequest.Range, options, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             var span = documentsWithSelections.Single().SelectedSpans.Single();
             var actions = ArrayBuilder<(CodeAction, TextSpan?)>.GetInstance();
             var document = workspace.CurrentSolution.GetDocument(documentsWithSelections.Single().Id);
-            var context = new CodeRefactoringContext(document, span, (a, t) => actions.Add((a, t)), parameters.codeActionOptions, CancellationToken.None);
+            var context = new CodeRefactoringContext(document, span, (a, t) => actions.Add((a, t)), _ => parameters.codeActionOptions, CancellationToken.None);
             await provider.ComputeRefactoringsAsync(context);
 
             var result = actions.Count > 0 ? new CodeRefactoring(provider, actions.ToImmutable()) : null;

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), project.Solution, _sharedState.IdeAnalyzerOptions);
 
             protected override CodeFixContext CreateCodeFixContext(Document document, TextSpan span, ImmutableArray<Diagnostic> diagnostics, Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix, CancellationToken cancellationToken)
-                => new(document, span, diagnostics, registerCodeFix, _sharedState.CodeActionOptions, cancellationToken);
+                => new(document, span, diagnostics, registerCodeFix, _ => _sharedState.CodeActionOptions, cancellationToken);
 
             protected override FixAllContext CreateFixAllContext(
                 Document? document,

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                     diagnostic.Location.SourceSpan,
                     ImmutableArray.Create(diagnostic),
                     (a, d) => fixes.Add(new CodeFix(document.Project, a, d)),
-                    options,
+                    _ => options,
                     CancellationToken.None);
 
                 await fixer.RegisterCodeFixesAsync(context);

--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
             var document = project.Documents.Single();
             var unused = await fixService.GetMostSevereFixAsync(
-                document, TextSpan.FromBounds(0, 0), CodeActionRequestPriority.None, CodeActionOptions.Default, CancellationToken.None);
+                document, TextSpan.FromBounds(0, 0), CodeActionRequestPriority.None, _ => CodeActionOptions.Default, CancellationToken.None);
 
             var fixer1 = (MockFixer)fixers.Single().Value;
             var fixer2 = (MockFixer)reference.Fixer!;
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             // Verify that we do not crash when computing fixes.
             var options = CodeActionOptions.Default;
 
-            _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
+            _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), _ => options, CancellationToken.None);
 
             // Verify that code fix is invoked with both the diagnostics in the context,
             // i.e. duplicate diagnostics are not silently discarded by the CodeFixService.
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
             // Verify registered configuration code actions do not have duplicates.
             var options = CodeActionOptions.Default;
-            var fixCollections = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
+            var fixCollections = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), _ => options, CancellationToken.None);
             var codeActions = fixCollections.SelectMany(c => c.Fixes.Select(f => f.Action)).ToImmutableArray();
             Assert.Equal(7, codeActions.Length);
             var uniqueTitles = new HashSet<string>();
@@ -152,14 +152,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
             // Verify only analyzerWithFix is executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Normal'.
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                priority: CodeActionRequestPriority.Normal, options,
+                priority: CodeActionRequestPriority.Normal, _ => options,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(analyzerWithFix.ReceivedCallback);
             Assert.False(analyzerWithoutFix.ReceivedCallback);
 
             // Verify both analyzerWithFix and analyzerWithoutFix are executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Lowest'.
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                priority: CodeActionRequestPriority.Lowest, options,
+                priority: CodeActionRequestPriority.Lowest, _ => options,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(analyzerWithFix.ReceivedCallback);
             Assert.True(analyzerWithoutFix.ReceivedCallback);
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var options = CodeActionOptions.Default;
 
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                priority: CodeActionRequestPriority.Normal, options,
+                priority: CodeActionRequestPriority.Normal, _ => options,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(documentDiagnosticAnalyzer.ReceivedCallback);
         }
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
             document = project.Documents.Single();
             var options = CodeActionOptions.Default;
-            var fixes = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
+            var fixes = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), _ => options, CancellationToken.None);
 
             if (exception)
             {
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager);
             var unused = await tuple.codeFixService.GetMostSevereFixAsync(
-                document, TextSpan.FromBounds(0, 0), CodeActionRequestPriority.None, CodeActionOptions.Default, CancellationToken.None);
+                document, TextSpan.FromBounds(0, 0), CodeActionRequestPriority.None, _ => CodeActionOptions.Default, CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(codefix));
             Assert.False(extensionManager.IsIgnored(codefix));
             Assert.True(errorReported);
@@ -692,7 +692,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var document = project.Documents.Single();
             var options = CodeActionOptions.Default;
 
-            return await fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
+            return await fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), _ => options, CancellationToken.None);
         }
 
         private sealed class NuGetCodeFixProvider : AbstractNuGetOrVsixCodeFixProvider

--- a/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
+++ b/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
             var document = project.Documents.Single();
             var options = CodeActionOptions.Default;
-            var refactorings = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
+            var refactorings = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), _ => options, CancellationToken.None);
 
             var stubRefactoringAction = refactorings.Single(refactoring => refactoring.CodeActions.FirstOrDefault().action?.Title == nameof(StubRefactoring));
             Assert.True(stubRefactoringAction is object);
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
             var document = project.Documents.Single();
             var extensionManager = (EditorLayerExtensionManager.ExtensionManager)document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
             var options = CodeActionOptions.Default;
-            var result = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), options, CancellationToken.None);
+            var result = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), _ => options, CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(codeRefactoring));
             Assert.False(extensionManager.IsIgnored(codeRefactoring));
 

--- a/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
+++ b/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 Dim fixes = Await codefixService.GetFixesAsync(
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                    options,
+                    Function(language) options,
                     CancellationToken.None)
 
                 Assert.Equal(0, fixes.Count())
@@ -93,7 +93,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 fixes = Await codefixService.GetFixesAsync(
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                    options,
+                    Function(language) options,
                     CancellationToken.None)
                 Assert.Equal(1, fixes.Count())
 
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 fixes = Await codefixService.GetFixesAsync(
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                    options,
+                    Function(language) options,
                     CancellationToken.None)
 
                 Assert.Equal(0, fixes.Count())
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 Dim fixes = Await codefixService.GetFixesAsync(
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                    options,
+                    Function(language) options,
                     CancellationToken.None)
 
                 Assert.Equal(0, fixes.Count())
@@ -170,7 +170,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                 fixes = Await codefixService.GetFixesAsync(
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
-                    options,
+                    Function(language) options,
                     CancellationToken.None)
 
                 Assert.Equal(0, fixes.Count())

--- a/src/EditorFeatures/Test2/SyncNamespaces/SyncNamespacesServiceTests.vb
+++ b/src/EditorFeatures/Test2/SyncNamespaces/SyncNamespacesServiceTests.vb
@@ -40,7 +40,7 @@ namespace Test.Namespace.App
                 Dim document = project.Documents.Single()
 
                 Dim syncService = project.GetLanguageService(Of ISyncNamespacesService)()
-                Dim newSolution = Await syncService.SyncNamespacesAsync(ImmutableArray.Create(project), CodeActionOptions.Default, CancellationToken.None)
+                Dim newSolution = Await syncService.SyncNamespacesAsync(ImmutableArray.Create(project), Function(language) CodeActionOptions.Default, CancellationToken.None)
 
                 Dim solutionChanges = workspace.CurrentSolution.GetChanges(newSolution)
 
@@ -76,7 +76,7 @@ namespace Test
                 Dim document = project.Documents.Single()
 
                 Dim syncService = project.GetLanguageService(Of ISyncNamespacesService)()
-                Dim newSolution = Await syncService.SyncNamespacesAsync(projects, CodeActionOptions.Default, CancellationToken.None)
+                Dim newSolution = Await syncService.SyncNamespacesAsync(projects, Function(language) CodeActionOptions.Default, CancellationToken.None)
 
                 Dim solutionChanges = workspace.CurrentSolution.GetChanges(newSolution)
                 Dim projectChanges = solutionChanges.GetProjectChanges().Single()
@@ -133,7 +133,7 @@ namespace Test2.Namespace.App
                 Dim project = projects(0)
 
                 Dim syncService = project.GetLanguageService(Of ISyncNamespacesService)()
-                Dim newSolution = Await syncService.SyncNamespacesAsync(projects, CodeActionOptions.Default, CancellationToken.None)
+                Dim newSolution = Await syncService.SyncNamespacesAsync(projects, Function(language) CodeActionOptions.Default, CancellationToken.None)
 
                 Dim solutionChanges = workspace.CurrentSolution.GetChanges(newSolution)
 
@@ -187,7 +187,7 @@ namespace Test2.Namespace.App
                 Dim document = project.Documents.Single()
 
                 Dim syncService = project.GetLanguageService(Of ISyncNamespacesService)()
-                Dim newSolution = Await syncService.SyncNamespacesAsync(projects, CodeActionOptions.Default, CancellationToken.None)
+                Dim newSolution = Await syncService.SyncNamespacesAsync(projects, Function(language) CodeActionOptions.Default, CancellationToken.None)
 
                 Dim solutionChanges = workspace.CurrentSolution.GetChanges(newSolution)
                 Dim projectChanges = solutionChanges.GetProjectChanges().Single()
@@ -252,7 +252,7 @@ namespace Test2.Namespace
                 Dim document2 = project2.Documents.Single()
 
                 Dim syncService = project.GetLanguageService(Of ISyncNamespacesService)()
-                Dim newSolution = Await syncService.SyncNamespacesAsync(projects, CodeActionOptions.Default, CancellationToken.None)
+                Dim newSolution = Await syncService.SyncNamespacesAsync(projects, Function(language) CodeActionOptions.Default, CancellationToken.None)
 
                 Dim solutionChanges = workspace.CurrentSolution.GetChanges(newSolution)
                 Dim projectChanges = solutionChanges.GetProjectChanges().ToImmutableArray()

--- a/src/EditorFeatures/VisualBasicTest/Formatting/CodeCleanUpTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/CodeCleanUpTests.vb
@@ -365,7 +365,7 @@ End Class
                     document,
                     enabledDiagnostics,
                     New ProgressTracker,
-                    options,
+                    Function(language) options,
                     formattingOptions,
                     CancellationToken.None)
 

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementInterfaceCodeFixProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
 
             var actions = token.Parent.GetAncestorsOrThis<TypeSyntax>()
                                       .Where(_interfaceName)
-                                      .Select(n => service.GetCodeActions(document, context.Options.ImplementTypeOptions, model, n, cancellationToken))
+                                      .Select(n => service.GetCodeActions(document, context.Options(document.Project.Language).ImplementTypeOptions, model, n, cancellationToken))
                                       .FirstOrDefault(a => !a.IsEmpty);
 
             if (actions.IsDefaultOrEmpty)

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             var addImportService = document.GetRequiredLanguageService<IAddImportFeatureService>();
             var services = document.Project.Solution.Workspace.Services;
 
-            var searchOptions = context.Options.SearchOptions;
+            var searchOptions = context.Options(document.Project.Language).SearchOptions;
 
             var symbolSearchService = _symbolSearchService ?? services.GetRequiredService<ISymbolSearchService>();
 
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             var addImportOptions = new AddImportOptions(
                 searchOptions,
-                context.Options.HideAdvancedMembers,
+                context.Options(document.Project.Language).HideAdvancedMembers,
                 placement);
 
             var fixesForDiagnostic = await addImportService.GetFixesForDiagnosticsAsync(

--- a/src/Features/Core/Portable/AddPackage/AbstractAddPackageCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddPackage/AbstractAddPackageCodeFixProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.AddPackage
             var codeActions = ArrayBuilder<CodeAction>.GetInstance();
             if (symbolSearchService != null &&
                 installerService != null &&
-                context.Options.SearchOptions.SearchNuGetPackages &&
+                context.Options(document.Project.Language).SearchOptions.SearchNuGetPackages &&
                 installerService.IsEnabled(document.Project.Id))
             {
                 var packageSources = PackageSourceHelper.GetPackageSources(installerService.TryGetPackageSources());

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             var addMissingImportsService = document.GetLanguageService<IAddMissingImportsFeatureService>();
 
             var placement = await AddImportPlacementOptions.FromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
-            var options = new AddMissingImportsOptions(context.Options.HideAdvancedMembers, placement);
+            var options = new AddMissingImportsOptions(context.Options(document.Project.Language).HideAdvancedMembers, placement);
 
             var analysis = await addMissingImportsService.AnalyzeAsync(document, textSpan, options, cancellationToken).ConfigureAwait(false);
             if (!analysis.CanAddMissingImports)

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         public async Task<bool> HasRefactoringsAsync(
             Document document,
             TextSpan state,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             CancellationToken cancellationToken)
         {
             var extensionManager = document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             Document document,
             TextSpan state,
             CodeActionRequestPriority priority,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             Func<string, IDisposable?> addOperationScope,
             CancellationToken cancellationToken)
         {
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             CodeRefactoringProvider provider,
             CodeChangeProviderMetadata? providerMetadata,
             IExtensionManager extensionManager,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Features/Core/Portable/CodeRefactorings/ExtractMethod/AbstractExtractMethodCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ExtractMethod/AbstractExtractMethodCodeRefactoringProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.ExtractMethod
                 return;
             }
 
-            var options = context.Options.ExtractMethodOptions;
+            var options = context.Options(document.Project.Language).ExtractMethodOptions;
             var actions = await GetCodeActionsAsync(document, textSpan, options, cancellationToken).ConfigureAwait(false);
             context.RegisterRefactorings(actions);
         }

--- a/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
@@ -13,14 +13,14 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 {
     internal interface ICodeRefactoringService
     {
-        Task<bool> HasRefactoringsAsync(Document document, TextSpan textSpan, CodeActionOptions options, CancellationToken cancellationToken);
+        Task<bool> HasRefactoringsAsync(Document document, TextSpan textSpan, CodeActionOptionsProvider options, CancellationToken cancellationToken);
 
-        Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptions options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
+        Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
     }
 
     internal static class ICodeRefactoringServiceExtensions
     {
-        public static Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(this ICodeRefactoringService service, Document document, TextSpan state, CodeActionOptions options, CancellationToken cancellationToken)
+        public static Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(this ICodeRefactoringService service, Document document, TextSpan state, CodeActionOptionsProvider options, CancellationToken cancellationToken)
             => service.GetRefactoringsAsync(document, state, CodeActionRequestPriority.None, options, addOperationScope: _ => null, cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
                     return;
                 }
 
-                var hideAdvancedMembers = context.Options.HideAdvancedMembers;
+                var hideAdvancedMembers = context.Options(document.Project.Language).HideAdvancedMembers;
                 var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
                 var matchingTypes = await GetMatchingTypesAsync(document, semanticModel, node, hideAdvancedMembers, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/ImplementAbstractClass/AbstractImplementAbstractClassCodeFixProvider.cs
+++ b/src/Features/Core/Portable/ImplementAbstractClass/AbstractImplementAbstractClassCodeFixProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.ImplementAbstractClass
                 return;
 
             var data = await ImplementAbstractClassData.TryGetDataAsync(
-                document, classNode, GetClassIdentifier(classNode), context.Options.ImplementTypeOptions, cancellationToken).ConfigureAwait(false);
+                document, classNode, GetClassIdentifier(classNode), context.Options(document.Project.Language).ImplementTypeOptions, cancellationToken).ConfigureAwait(false);
             if (data == null)
                 return;
 

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
             // -    We believe spell-check should only compare what you have typed to what symbol would be offered here.
             var options = CompletionOptions.Default with
             {
-                HideAdvancedMembers = context.Options.HideAdvancedMembers,
+                HideAdvancedMembers = context.Options(document.Project.Language).HideAdvancedMembers,
                 SnippetsBehavior = SnippetsRule.NeverInclude,
                 ShowItemsFromUnimportedNamespaces = false,
                 TargetTypedCompletionFilter = false,

--- a/src/Features/Core/Portable/SyncNamespaces/AbstractSyncNamespacesSevice.cs
+++ b/src/Features/Core/Portable/SyncNamespaces/AbstractSyncNamespacesSevice.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.SyncNamespaces
         /// <inheritdoc/>
         public async Task<Solution> SyncNamespacesAsync(
             ImmutableArray<Project> projects,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             CancellationToken cancellationToken)
         {
             // all projects must be of the same language
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.SyncNamespaces
             Solution solution,
             CodeFixProvider codeFixProvider,
             ImmutableDictionary<Project, ImmutableArray<Diagnostic>> diagnosticsByProject,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             CancellationToken cancellationToken)
         {
             var diagnosticProvider = new DiagnosticProvider(diagnosticsByProject);
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.SyncNamespaces
                     codeActionEquivalenceKey: action?.EquivalenceKey!, // FixAllState supports null equivalence key. This should still be supported.
                     diagnosticIds: codeFixProvider.FixableDiagnosticIds,
                     fixAllDiagnosticProvider: diagnosticProvider,
-                    _ => options),
+                    options),
                 new ProgressTracker(),
                 cancellationToken);
         }

--- a/src/Features/Core/Portable/SyncNamespaces/ISyncNamespacesService.cs
+++ b/src/Features/Core/Portable/SyncNamespaces/ISyncNamespacesService.cs
@@ -16,6 +16,6 @@ namespace Microsoft.CodeAnalysis.SyncNamespaces
         /// This will update documents in the specified projects so that their namespace matches the RootNamespace
         /// and their relative folder path.
         /// </summary>
-        Task<Solution> SyncNamespacesAsync(ImmutableArray<Project> projects, CodeActionOptions options, CancellationToken cancellationToken);
+        Task<Solution> SyncNamespacesAsync(ImmutableArray<Project> projects, CodeActionOptionsProvider options, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Wrapping/AbstractWrappingCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/Wrapping/AbstractWrappingCodeRefactoringProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Wrapping
             var token = root.FindToken(position);
 
             var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var options = GetWrappingOptions(configOptions, context.Options);
+            var options = GetWrappingOptions(configOptions, context.Options(document.Project.Language));
 
             foreach (var node in token.GetRequiredParent().AncestorsAndSelf())
             {

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/AbstractCodeCleanupService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             Document document,
             EnabledDiagnosticOptions enabledDiagnostics,
             IProgressTracker progressTracker,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             SyntaxFormattingOptions formattingOptions,
             CancellationToken cancellationToken)
         {
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
 
         private async Task<Document> ApplyCodeFixesAsync(
             Document document, ImmutableArray<DiagnosticSet> enabledDiagnosticSets,
-            IProgressTracker progressTracker, CodeActionOptions options, CancellationToken cancellationToken)
+            IProgressTracker progressTracker, CodeActionOptionsProvider options, CancellationToken cancellationToken)
         {
             // Add a progress item for each enabled option we're going to fixup.
             progressTracker.AddItems(enabledDiagnosticSets.Length);
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
         }
 
         private async Task<Document> ApplyCodeFixesForSpecificDiagnosticIdsAsync(
-            Document document, ImmutableArray<string> diagnosticIds, IProgressTracker progressTracker, CodeActionOptions options, CancellationToken cancellationToken)
+            Document document, ImmutableArray<string> diagnosticIds, IProgressTracker progressTracker, CodeActionOptionsProvider options, CancellationToken cancellationToken)
         {
             foreach (var diagnosticId in diagnosticIds)
             {
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
             return document;
         }
 
-        private async Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, IProgressTracker progressTracker, CodeActionOptions options, CancellationToken cancellationToken)
+        private async Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, IProgressTracker progressTracker, CodeActionOptionsProvider options, CancellationToken cancellationToken)
         {
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var textSpan = new TextSpan(0, tree.Length);

--- a/src/Features/LanguageServer/Protocol/Features/CodeCleanup/ICodeCleanupService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeCleanup/ICodeCleanupService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
 {
     internal interface ICodeCleanupService : ILanguageService
     {
-        Task<Document> CleanupAsync(Document document, EnabledDiagnosticOptions enabledDiagnostics, IProgressTracker progressTracker, CodeActionOptions options, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken);
+        Task<Document> CleanupAsync(Document document, EnabledDiagnosticOptions enabledDiagnostics, IProgressTracker progressTracker, CodeActionOptionsProvider options, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken);
         EnabledDiagnosticOptions GetAllDiagnostics();
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         }
 
         public async Task<FirstFixResult> GetMostSevereFixAsync(
-            Document document, TextSpan range, CodeActionRequestPriority priority, CodeActionOptions options, CancellationToken cancellationToken)
+            Document document, TextSpan range, CodeActionRequestPriority priority, CodeActionOptionsProvider options, CancellationToken cancellationToken)
         {
             var (allDiagnostics, upToDate) = await _diagnosticService.TryGetDiagnosticsForSpanAsync(
                 document, range, GetShouldIncludeDiagnosticPredicate(document, priority),
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             Document document,
             TextSpan range,
             CodeActionRequestPriority priority,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             Func<string, IDisposable?> addOperationScope,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         }
 
         public async Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(
-            Document document, TextSpan range, string diagnosticId, CodeActionOptions options, CancellationToken cancellationToken)
+            Document document, TextSpan range, string diagnosticId, CodeActionOptionsProvider options, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             SortedDictionary<TextSpan, List<DiagnosticData>> spanToDiagnostics,
             bool fixAllForInSpan,
             CodeActionRequestPriority priority,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             Func<string, IDisposable?> addOperationScope,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
@@ -489,7 +489,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         }
 
         private static async Task<ImmutableArray<CodeFix>> GetCodeFixesAsync(
-            Document document, TextSpan span, CodeFixProvider fixer, CodeChangeProviderMetadata? fixerMetadata, CodeActionOptions options,
+            Document document, TextSpan span, CodeFixProvider fixer, CodeChangeProviderMetadata? fixerMetadata, CodeActionOptionsProvider options,
             ImmutableArray<Diagnostic> diagnostics,
             Dictionary<Diagnostic, PooledHashSet<string?>> uniqueDiagosticToEquivalenceKeysMap,
             Dictionary<(Diagnostic diagnostic, string? equivalenceKey), CodeFixProvider> diagnosticAndEquivalenceKeyToFixersMap,
@@ -574,7 +574,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             TextSpan diagnosticsSpan,
             IEnumerable<DiagnosticData> diagnostics,
             PooledHashSet<string> registeredConfigurationFixTitles,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             TCodeFixProvider fixer,
             Func<Diagnostic, bool> hasFix,
             Func<ImmutableArray<Diagnostic>, Task<ImmutableArray<CodeFix>>> getFixes,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             CancellationToken cancellationToken)
             where TCodeFixProvider : notnull
         {
@@ -666,11 +666,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                     fixes[0].Action.EquivalenceKey,
                     diagnosticIds,
                     diagnosticProvider,
-                    codeActionOptionsProvider: language =>
-                    {
-                        Contract.ThrowIfFalse(language == document.Project.Language);
-                        return options;
-                    });
+                    options);
 
                 supportedScopes = fixAllProviderInfo.SupportedScopes;
             }

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
@@ -16,28 +16,28 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 {
     internal interface ICodeFixService
     {
-        IAsyncEnumerable<CodeFixCollection> StreamFixesAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptions options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
+        IAsyncEnumerable<CodeFixCollection> StreamFixesAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
 
         /// <summary>
         /// Similar to <see cref="StreamFixesAsync"/> except that instead of streaming all results, this ends with the
         /// first.  This will also attempt to return a fix for an error first, but will fall back to any fix if that
         /// does not succeed.
         /// </summary>
-        Task<FirstFixResult> GetMostSevereFixAsync(Document document, TextSpan range, CodeActionRequestPriority priority, CodeActionOptions options, CancellationToken cancellationToken);
+        Task<FirstFixResult> GetMostSevereFixAsync(Document document, TextSpan range, CodeActionRequestPriority priority, CodeActionOptionsProvider options, CancellationToken cancellationToken);
 
-        Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CodeActionOptions options, CancellationToken cancellationToken);
+        Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CodeActionOptionsProvider options, CancellationToken cancellationToken);
         CodeFixProvider? GetSuppressionFixer(string language, IEnumerable<string> diagnosticIds);
     }
 
     internal static class ICodeFixServiceExtensions
     {
-        public static IAsyncEnumerable<CodeFixCollection> StreamFixesAsync(this ICodeFixService service, Document document, TextSpan range, CodeActionOptions options, CancellationToken cancellationToken)
+        public static IAsyncEnumerable<CodeFixCollection> StreamFixesAsync(this ICodeFixService service, Document document, TextSpan range, CodeActionOptionsProvider options, CancellationToken cancellationToken)
             => service.StreamFixesAsync(document, range, CodeActionRequestPriority.None, options, addOperationScope: _ => null, cancellationToken);
 
-        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, CodeActionOptions options, CancellationToken cancellationToken)
+        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, CodeActionOptionsProvider options, CancellationToken cancellationToken)
             => service.StreamFixesAsync(document, range, options, cancellationToken).ToImmutableArrayAsync(cancellationToken);
 
-        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptions options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken)
+        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken)
             => service.StreamFixesAsync(document, textSpan, priority, options, addOperationScope, cancellationToken).ToImmutableArrayAsync(cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             Document document,
             TextSpan selection,
             CodeActionRequestPriority priority,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             Func<string, IDisposable?> addOperationScope,
             CancellationToken cancellationToken)
         {
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             Document document,
             TextSpan selection,
             CodeActionRequestPriority priority,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             Func<string, IDisposable?> addOperationScope,
             bool filterOutsideSelection,
             CancellationToken cancellationToken)

--- a/src/Features/VisualBasic/Portable/ImplementInterface/VisualBasicImplementInterfaceCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/ImplementInterface/VisualBasicImplementInterfaceCodeFixProvider.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ImplementInterface
             Dim service = document.GetLanguageService(Of IImplementInterfaceService)()
             Dim actions = service.GetCodeActions(
                 document,
-                context.Options.ImplementTypeOptions,
+                context.Options(document.Project.Language).ImplementTypeOptions,
                 Await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(False),
                 typeNode,
                 cancellationToken)

--- a/src/Tools/ExternalAccess/OmniSharp/CodeActions/OmniSharpCodeFixContextFactory.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/CodeActions/OmniSharpCodeFixContextFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CodeActions
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
             OmniSharpCodeActionOptions options,
             CancellationToken cancellationToken)
-            => new(document, span, diagnostics, registerCodeFix, options.GetCodeActionOptions(), cancellationToken);
+            => new(document, span, diagnostics, registerCodeFix, _ => options.GetCodeActionOptions(), cancellationToken);
 
         public static CodeRefactoringContext CreateCodeRefactoringContext(
             Document document,
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CodeActions
             Action<CodeAction, TextSpan?> registerRefactoring,
             OmniSharpCodeActionOptions options,
             CancellationToken cancellationToken)
-            => new(document, span, registerRefactoring, options.GetCodeActionOptions(), cancellationToken);
+            => new(document, span, registerRefactoring, _ => options.GetCodeActionOptions(), cancellationToken);
 
         public static FixAllContext CreateFixAllContext(
             Document? document,

--- a/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
+++ b/src/VisualStudio/Core/Def/CodeCleanup/AbstractCodeCleanUpFixer.cs
@@ -355,7 +355,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
             var formattingOptions = await SyntaxFormattingOptions.FromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
 
             return await codeCleanupService.CleanupAsync(
-                document, enabledDiagnostics, progressTracker, ideOptions, formattingOptions, cancellationToken).ConfigureAwait(false);
+                document, enabledDiagnostics, progressTracker, _ => ideOptions, formattingOptions, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/SyncNamespaces/SyncNamespacesCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/SyncNamespaces/SyncNamespacesCommandHandler.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SyncNamespaces
             }
 
             var syncService = projects[0].GetRequiredLanguageService<ISyncNamespacesService>();
-            var options = _globalOptions.GetCodeActionOptions(projects[0].Language);
+            var options = _globalOptions.GetCodeActionOptionsProvider();
 
             Solution? solution = null;
             var status = _threadOperationExecutor.Execute(ServicesVSResources.Sync_Namespaces, ServicesVSResources.Updating_namspaces, allowCancellation: true, showProgress: true, (operationContext) =>

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -16,7 +16,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     /// <summary>
     /// Context for code fixes provided by a <see cref="CodeFixProvider"/>.
     /// </summary>
+#pragma warning disable CS0612 // Type or member is obsolete
     public readonly struct CodeFixContext : ITypeScriptCodeFixContext
+#pragma warning restore
     {
         private readonly Document _document;
         private readonly TextSpan _span;
@@ -45,8 +47,17 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
 
-        internal readonly CodeActionOptions Options;
-        bool ITypeScriptCodeFixContext.IsBlocking => Options.IsBlocking;
+        /// <summary>
+        /// IDE supplied options to use for settings not specified in the corresponding editorconfig file.
+        /// </summary>
+        /// <remarks>
+        /// Provider to allow code fix to update documents across multiple projects that differ in language (and hence language specific options).
+        /// </remarks>
+        internal readonly CodeActionOptionsProvider Options;
+
+        [Obsolete]
+        bool ITypeScriptCodeFixContext.IsBlocking
+            => Options("TypeScript").IsBlocking;
 
         /// <summary>
         /// Creates a code fix context to be passed into <see cref="CodeFixProvider.RegisterCodeFixesAsync(CodeFixContext)"/> method.
@@ -75,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                    span,
                    VerifyDiagnosticsArgument(diagnostics, span),
                    registerCodeFix ?? throw new ArgumentNullException(nameof(registerCodeFix)),
-                   CodeActionOptions.Default,
+                   _ => CodeActionOptions.Default,
                    cancellationToken)
         {
         }
@@ -100,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                    (diagnostic ?? throw new ArgumentNullException(nameof(diagnostic))).Location.SourceSpan,
                    ImmutableArray.Create(diagnostic),
                    registerCodeFix ?? throw new ArgumentNullException(nameof(registerCodeFix)),
-                   CodeActionOptions.Default,
+                   _ => CodeActionOptions.Default,
                    cancellationToken)
         {
         }
@@ -110,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             TextSpan span,
             ImmutableArray<Diagnostic> diagnostics,
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             CancellationToken cancellationToken)
         {
             Debug.Assert(diagnostics.Any(d => d.Location.SourceSpan == span));
@@ -201,6 +212,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         }
     }
 
+    [Obsolete]
     internal interface ITypeScriptCodeFixContext
     {
         bool IsBlocking { get; }

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchFixAllProvider.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             foreach (var diagnostic in orderedDiagnostics)
             {
                 var document = solution.GetRequiredDocument(diagnostic.Location.SourceTree!);
-                var options = fixAllContext.State.CodeActionOptionsProvider(document.Project.Language) with { IsBlocking = false };
+                var options = new CodeActionOptionsProvider(language => fixAllContext.State.CodeActionOptionsProvider(language) with { IsBlocking = false });
 
                 cancellationToken.ThrowIfCancellationRequested();
                 tasks.Add(Task.Run(async () =>

--- a/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
@@ -12,7 +12,9 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
     /// <summary>
     /// Context for code refactorings provided by a <see cref="CodeRefactoringProvider"/>.
     /// </summary>
+#pragma warning disable CS0612 // Type or member is obsolete
     public readonly struct CodeRefactoringContext : ITypeScriptCodeRefactoringContext
+#pragma warning restore
     {
         /// <summary>
         /// Document corresponding to the <see cref="CodeRefactoringContext.Span"/> to refactor.
@@ -29,8 +31,11 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         /// </summary>
         public CancellationToken CancellationToken { get; }
 
-        internal readonly CodeActionOptions Options;
-        bool ITypeScriptCodeRefactoringContext.IsBlocking => Options.IsBlocking;
+        internal readonly CodeActionOptionsProvider Options;
+
+        [Obsolete]
+        bool ITypeScriptCodeRefactoringContext.IsBlocking
+            => Options("TypeScript").IsBlocking;
 
         private readonly Action<CodeAction, TextSpan?> _registerRefactoring;
 
@@ -42,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             TextSpan span,
             Action<CodeAction> registerRefactoring,
             CancellationToken cancellationToken)
-            : this(document, span, (action, textSpan) => registerRefactoring(action), CodeActionOptions.Default, cancellationToken)
+            : this(document, span, (action, textSpan) => registerRefactoring(action), _ => CodeActionOptions.Default, cancellationToken)
         { }
 
         /// <summary>
@@ -52,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             Document document,
             TextSpan span,
             Action<CodeAction, TextSpan?> registerRefactoring,
-            CodeActionOptions options,
+            CodeActionOptionsProvider options,
             CancellationToken cancellationToken)
         {
             // NOTE/TODO: Don't make this overload public & obsolete the `Action<CodeAction> registerRefactoring`
@@ -99,6 +104,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         }
     }
 
+    [Obsolete]
     internal interface ITypeScriptCodeRefactoringContext
     {
         bool IsBlocking { get; }

--- a/src/Workspaces/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCodeFixContextExtensions.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCodeFixContextExtensions.cs
@@ -2,16 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeRefactorings;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
     internal static class VSTypeScriptCodeFixContextExtensions
     {
         public static bool IsBlocking(this CodeFixContext context)
+#pragma warning disable CS0612 // Type or member is obsolete
             => ((ITypeScriptCodeFixContext)context).IsBlocking;
+#pragma warning restore
+
+        public static bool IsBlocking(this CodeRefactoringContext context)
+#pragma warning disable CS0612 // Type or member is obsolete
+            => ((ITypeScriptCodeRefactoringContext)context).IsBlocking;
+#pragma warning restore
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/SyntaxEditorBasedCodeFixProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/SyntaxEditorBasedCodeFixProvider.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 #if CODE_STYLE
             var optionsProvider = s_codeStyleOptionsProvider;
 #else
-            var optionsProvider = new CodeActionOptionsProvider(_ => context.Options);
+            var optionsProvider = context.Options;
 #endif
             var diagnostics = ImmutableArray.Create(diagnostic ?? context.Diagnostics[0]);
 


### PR DESCRIPTION
Use a provider delegate instead of directly passing the options. This allows code actions that might need to update files in multiple projects to retrieve the language-specific options for each file.