### PR TITLE
Improve command-line parsing for linux

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1410,9 +1410,7 @@ class C
             Assert.Equal("blah", args.Win32Manifest);
         }
 
-        // The following test is failing in the Linux Debug test leg of CI.
-        // This issue is being tracked by https://github.com/dotnet/roslyn/issues/58077
-        [ConditionalFact(typeof(WindowsOrMacOSOnly))]
+        [Fact]
         public void ArgumentParsing()
         {
             var sdkDirectory = SdkDirectory;

--- a/src/Compilers/Core/Portable/InternalUtilities/FileNameUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FileNameUtilities.cs
@@ -170,10 +170,13 @@ namespace Roslyn.Utilities
                 return -1;
             }
 
+            // We don't want a "path" like `//langversion:?` to find `?` as the file name
+            bool ignoreVolumeSeparator = path.Length > 0 && path[0] is DirectorySeparatorChar or AltDirectorySeparatorChar;
+
             for (int i = path.Length - 1; i >= 0; i--)
             {
                 char ch = path[i];
-                if (ch == DirectorySeparatorChar || ch == AltDirectorySeparatorChar || ch == VolumeSeparatorChar)
+                if (ch == DirectorySeparatorChar || ch == AltDirectorySeparatorChar || (ch == VolumeSeparatorChar && !ignoreVolumeSeparator))
                 {
                     return i + 1;
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/58077

The problematic portion of the test was:
```
            parsedArgs = CSharpCommandLineParser.Script.Parse(new[] { "//langversion:?" }, WorkingDirectory, sdkDirectory);
            parsedArgs.Errors.Verify(
                // error CS2001: Source file '//langversion:?' could not be found.
                Diagnostic(ErrorCode.ERR_FileNotFound).WithArguments("//langversion:?").WithLocation(1, 1)
                );
```

When failing parse a command-line option, we fall back to treating it as a file path. We would parse it into a directory and a file name. Then use the file name as a pattern for searching the directory.
But with this input, we would find `?` as the file name, so we'd match any single character file in the root directory of the system.

Note: this fix doesn't make the test foolproof. It could still fail if a file named `langversion:1` was added to the root directory, but that seems unlikely to happen.