### PR TITLE
Make heading levels for warning waves documentation consistent

### DIFF
--- a/docs/compilers/CSharp/Warnversion Warning Waves.md
+++ b/docs/compilers/CSharp/Warnversion Warning Waves.md
@@ -17,7 +17,7 @@ The compiler shipped with .NET 7 (the C# 11 compiler) contains the following war
 |------------|-------------|
 | CS8981 | [Type names only containing lower-cased ascii characters may become reserved for the language](https://github.com/dotnet/roslyn/issues/56653) |
 
-# Warning level 6
+## Warning level 6
 
 The compiler shipped with .NET 6 (the C# 10 compiler) contains the following warnings which are reported only under `/warn:6` or higher.
 


### PR DESCRIPTION
Came here by chance and noticed the "Warning level 6" heading was larger :)

![image](https://user-images.githubusercontent.com/31348972/163189530-69837f3b-c7f2-4cd9-9ba0-549c78a3d752.png)
