### PR TITLE
Clean up IDiagnosticService extension methods

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/DiagnosticBucket.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticBucket.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal readonly struct DiagnosticBucket

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/IDiagnosticService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/IDiagnosticService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         /// <summary>
         /// Get current buckets storing our grouped diagnostics.  Specific buckets can be retrieved by calling <see
-        /// cref="IDiagnosticServiceExtensions.GetDiagnosticsAsync"/>.
+        /// cref="IDiagnosticServiceExtensions.GetPullDiagnosticsAsync(IDiagnosticService, DiagnosticBucket, bool, DiagnosticMode, CancellationToken)"/>.
         /// </summary>
         /// <param name="diagnosticMode">Option controlling if pull diagnostics are allowed for the client.  The
         /// <see cref="IDiagnosticService"/> only provides diagnostics for either push or pull purposes (but not both).
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         /// <summary>
         /// Get current buckets storing our grouped diagnostics.  Specific buckets can be retrieved by calling <see
-        /// cref="IDiagnosticServiceExtensions.GetDiagnosticsAsync"/>.
+        /// cref="IDiagnosticServiceExtensions.GetPushDiagnosticsAsync(IDiagnosticService, DiagnosticBucket, bool, DiagnosticMode, CancellationToken)"/>.
         /// </summary>
         /// <param name="diagnosticMode">Option controlling if pull diagnostics are allowed for the client.  The <see
         /// cref="IDiagnosticService"/> only provides diagnostics for either push or pull purposes (but not both).  If

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/IDiagnosticServiceExtensions.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/IDiagnosticServiceExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticMode diagnosticMode,
             CancellationToken cancellationToken)
         {
-            return GetDiagnosticsAsync(service, document.Project.Solution.Workspace, document.Project, document, includeSuppressedDiagnostics, forPullDiagnostics: false, diagnosticMode, cancellationToken);
+            return service.GetPushDiagnosticsAsync(document.Project.Solution.Workspace, document.Project.Id, document.Id, id: null, includeSuppressedDiagnostics, diagnosticMode, cancellationToken);
         }
 
         public static ValueTask<ImmutableArray<DiagnosticData>> GetPullDiagnosticsAsync(
@@ -35,40 +35,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticMode diagnosticMode,
             CancellationToken cancellationToken)
         {
-            return GetDiagnosticsAsync(service, document.Project.Solution.Workspace, document.Project, document, includeSuppressedDiagnostics, forPullDiagnostics: true, diagnosticMode, cancellationToken);
-        }
-
-        public static async ValueTask<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
-            this IDiagnosticService service,
-            Workspace workspace,
-            Project? project,
-            Document? document,
-            bool includeSuppressedDiagnostics,
-            bool forPullDiagnostics,
-            DiagnosticMode diagnosticMode,
-            CancellationToken cancellationToken)
-        {
-            Contract.ThrowIfTrue(document != null && document.Project != project);
-            Contract.ThrowIfTrue(project != null && project.Solution.Workspace != workspace);
-
-            using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var result);
-
-            var buckets = forPullDiagnostics
-                ? service.GetPullDiagnosticBuckets(workspace, project?.Id, document?.Id, diagnosticMode, cancellationToken)
-                : service.GetPushDiagnosticBuckets(workspace, project?.Id, document?.Id, diagnosticMode, cancellationToken);
-
-            foreach (var bucket in buckets)
-            {
-                Contract.ThrowIfFalse(workspace.Equals(bucket.Workspace));
-                Contract.ThrowIfFalse(document?.Id == bucket.DocumentId);
-
-                var diagnostics = forPullDiagnostics
-                    ? await service.GetPullDiagnosticsAsync(bucket, includeSuppressedDiagnostics, diagnosticMode, cancellationToken).ConfigureAwait(false)
-                    : await service.GetPushDiagnosticsAsync(bucket, includeSuppressedDiagnostics, diagnosticMode, cancellationToken).ConfigureAwait(false);
-                result.AddRange(diagnostics);
-            }
-
-            return result.ToImmutable();
+            return service.GetPullDiagnosticsAsync(document.Project.Solution.Workspace, document.Project.Id, document.Id, id: null, includeSuppressedDiagnostics, diagnosticMode, cancellationToken);
         }
     }
 }

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
@@ -114,12 +114,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Await waiter.ExpeditedWaitAsync()
 
             Dim diagnosticService = environment.ExportProvider.GetExportedValue(Of IDiagnosticService)
-            Dim diagnostics = Await diagnosticService.GetDiagnosticsAsync(
+            Dim diagnostics = Await diagnosticService.GetPushDiagnosticsAsync(
                 environment.Workspace,
-                project:=Nothing,
-                document:=Nothing,
+                projectId:=Nothing,
+                documentId:=Nothing,
+                id:=Nothing,
                 includeSuppressedDiagnostics:=True,
-                forPullDiagnostics:=False,
                 DiagnosticMode.Default,
                 CancellationToken.None)
             Return diagnostics


### PR DESCRIPTION
1. The GetPushDiagnostics/GetPullDiagnostics extension methods called a common helper method passing in a boolean, only for that common helper to switch on that boolean again.
2. The common helper worked via enumerating buckets and then calling other helpers to find diagnostics matching those buckets, when instead we can directly call the service and ask it for what we want.