### PR TITLE
add more miscellaneous tests for checked operators

### DIFF
--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
@@ -555,6 +555,103 @@ public record [|R|]
 
                 await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, expected: expected, signaturesOnly: signaturesOnly);
             }
+
+            /// <summary>
+            /// This test must be updated when we switch to a new version of the decompiler that supports checked ops.
+            /// </summary>
+            [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+            [WorkItem(42986, "https://github.com/dotnet/roslyn/issues/42986")]
+            public async Task TestCheckedOperators(bool signaturesOnly)
+            {
+                var metadataSource = @"
+public class C
+{
+    public static explicit operator string(C x) => throw new System.Exception();
+
+    public static explicit operator checked string(C x) => throw new System.Exception();
+
+    public static C operator -(C x) => throw new System.Exception();
+
+    public static C operator checked -(C x) => throw new System.Exception();
+
+    public static C operator +(C x, C y) => throw new System.Exception();
+
+    public static C operator checked +(C x, C y) => throw new System.Exception();
+}";
+                var symbolName = "C";
+
+                var expected = signaturesOnly switch
+                {
+                    true => $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+// {CodeAnalysisResources.InMemoryAssembly}
+#endregion
+
+public class [|C|]
+{{
+    public C();
+
+    public static C operator +(C x, C y);
+    public static C operator checked +(C x, C y);
+    public static C operator -(C x);
+    public static C operator checked -(C x);
+
+    public static explicit operator string(C x);
+    public static explicit operator checked string(C x);
+}}",
+                    false => $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+// {CodeAnalysisResources.InMemoryAssembly}
+// Decompiled with ICSharpCode.Decompiler {ICSharpCodeDecompilerVersion}
+#endregion
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class [|C|]
+{{
+    public static explicit operator string(C x)
+    {{
+        throw new Exception();
+    }}
+
+    [SpecialName]
+    public static string op_CheckedExplicit(C x)
+    {{
+        throw new Exception();
+    }}
+
+    public static C operator -(C x)
+    {{
+        throw new Exception();
+    }}
+
+    [SpecialName]
+    public static C op_CheckedUnaryNegation(C x)
+    {{
+        throw new Exception();
+    }}
+
+    public static C operator +(C x, C y)
+    {{
+        throw new Exception();
+    }}
+
+    [SpecialName]
+    public static C op_CheckedAddition(C x, C y)
+    {{
+        throw new Exception();
+    }}
+}}
+#if false // {CSharpEditorResources.Decompilation_log}
+{string.Format(CSharpEditorResources._0_items_in_cache, 6)}
+------------------
+{string.Format(CSharpEditorResources.Resolve_0, "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")}
+{string.Format(CSharpEditorResources.Found_single_assembly_0, "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")}
+{string.Format(CSharpEditorResources.Load_from_0, "mscorlib.v4_6_1038_0.dll")}
+#endif",
+                };
+
+                await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, languageVersion: "Preview", metadataLanguageVersion: "Preview", expected: expected, signaturesOnly: signaturesOnly);
+            }
         }
     }
 }

--- a/src/EditorFeatures/Test2/NavigationBar/CSharpNavigationBarTests.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/CSharpNavigationBarTests.vb
@@ -306,5 +306,65 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 Item("C", Glyph.ClassInternal, children:={
                     Item("M(string? s, IEnumerable<string?> e)", Glyph.MethodPrivate)}))
         End Function
+
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.NavigationBar), WorkItem(59458, "https://github.com/dotnet/roslyn/issues/59458")>
+        Public Async Function TestCheckedBinaryOperator(host As TestHost) As Task
+            Await AssertSelectedItemsAreAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class C
+{
+    public static C operator +(C x, C y) => throw new System.Exception();
+
+    public static C operator checked +(C x, C y) => throw new System.Exception();$$
+}
+                        </Document>
+                    </Project>
+                </Workspace>,
+                host,
+                Item("C", Glyph.ClassInternal), False,
+                Item("operator checked +(C x, C y)", Glyph.Operator), False)
+        End Function
+
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.NavigationBar), WorkItem(59458, "https://github.com/dotnet/roslyn/issues/59458")>
+        Public Async Function TestCheckedUnaryOperator(host As TestHost) As Task
+            Await AssertSelectedItemsAreAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class C
+{
+    public static C operator -(C x) => throw new System.Exception();
+
+    public static C operator checked -(C x) => throw new System.Exception();$$
+}
+                        </Document>
+                    </Project>
+                </Workspace>,
+                host,
+                Item("C", Glyph.ClassInternal), False,
+                Item("operator checked -(C x)", Glyph.Operator), False)
+        End Function
+
+        <Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.NavigationBar), WorkItem(59458, "https://github.com/dotnet/roslyn/issues/59458")>
+        Public Async Function TestCheckedCastOperator(host As TestHost) As Task
+            Await AssertSelectedItemsAreAsync(
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class C
+{
+    public static explicit operator string(C x) => throw new System.Exception();
+
+    public static explicit operator checked string(C x) => throw new System.Exception();$$
+}
+                        </Document>
+                    </Project>
+                </Workspace>,
+                host,
+                Item("C", Glyph.ClassInternal), False,
+                Item("explicit operator checked string(C x)", Glyph.Operator), False)
+        End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
+++ b/src/VisualStudio/Core/Test/ObjectBrowser/CSharp/ObjectBrowerTests.vb
@@ -1526,5 +1526,86 @@ namespace EditorFunctionalityHelper
             End Using
         End Sub
 
+        <WorkItem(59458, "https://github.com/dotnet/roslyn/issues/59458")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ObjectBrowser)>
+        Public Sub TestCheckedBinaryOperator()
+            Dim code =
+<Code>
+class C
+{
+    public static C operator +(C x, C y) => throw new System.Exception();
+
+    public static C operator checked +(C x, C y) => throw new System.Exception();
+}
+</Code>
+
+            Using state = CreateLibraryManager(GetWorkspaceDefinition(code))
+                Dim library = state.GetLibrary()
+
+                Dim list = library.GetProjectList()
+                list.VerifyNames("CSharpAssembly1")
+
+                list = list.GetTypeList(0)
+                list.VerifyNames("C")
+
+                list = list.GetMemberList(0)
+                list.VerifyNames(AddressOf IsImmediateMember, "operator +(C, C)", "operator checked +(C, C)")
+            End Using
+        End Sub
+
+        <WorkItem(59458, "https://github.com/dotnet/roslyn/issues/59458")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ObjectBrowser)>
+        Public Sub TestCheckedUnaryOperator()
+            Dim code =
+<Code>
+class C
+{
+    public static C operator -(C x) => throw new System.Exception();
+
+    public static C operator checked -(C x) => throw new System.Exception();
+}
+</Code>
+
+            Using state = CreateLibraryManager(GetWorkspaceDefinition(code))
+                Dim library = state.GetLibrary()
+
+                Dim list = library.GetProjectList()
+                list.VerifyNames("CSharpAssembly1")
+
+                list = list.GetTypeList(0)
+                list.VerifyNames("C")
+
+                list = list.GetMemberList(0)
+                list.VerifyNames(AddressOf IsImmediateMember, "operator -(C)", "operator checked -(C)")
+            End Using
+        End Sub
+
+        <WorkItem(59458, "https://github.com/dotnet/roslyn/issues/59458")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ObjectBrowser)>
+        Public Sub TestCheckedCastOperator()
+            Dim code =
+<Code>
+class C
+{
+    public static explicit operator string(C x) => throw new System.Exception();
+
+    public static explicit operator checked string(C x) => throw new System.Exception();$$
+}
+</Code>
+
+            Using state = CreateLibraryManager(GetWorkspaceDefinition(code))
+                Dim library = state.GetLibrary()
+
+                Dim list = library.GetProjectList()
+                list.VerifyNames("CSharpAssembly1")
+
+                list = list.GetTypeList(0)
+                list.VerifyNames("C")
+
+                list = list.GetMemberList(0)
+                list.VerifyNames(AddressOf IsImmediateMember, "explicit operator string(C)", "explicit operator checked string(C)")
+            End Using
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Navbar, object browser, and metadata as source tests for checked operators