### PR TITLE
Delay symbol-search index updating until solution is fully loaded.

### DIFF
--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -46,7 +46,6 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
         // but we want to keep it alive until the VS is closed, so we don't dispose it.
         private ISymbolSearchUpdateEngine _lazyUpdateEngine;
 
-        private readonly VisualStudioWorkspaceImpl _workspace;
         private readonly SVsServiceProvider _serviceProvider;
         private readonly IPackageInstallerService _installerService;
 
@@ -61,13 +60,13 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             VisualStudioWorkspaceImpl workspace,
             IGlobalOptionService globalOptions,
             VSShell.SVsServiceProvider serviceProvider)
-            : base(globalOptions,
+            : base(threadingContext,
+                   globalOptions,
+                   workspace,
                    listenerProvider,
-                   threadingContext,
                    SymbolSearchGlobalOptions.Enabled,
                    ImmutableArray.Create(SymbolSearchOptionsStorage.SearchReferenceAssemblies, SymbolSearchOptionsStorage.SearchNuGetPackages))
         {
-            _workspace = workspace;
             _serviceProvider = serviceProvider;
             _installerService = workspace.Services.GetService<IPackageInstallerService>();
         }
@@ -103,7 +102,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
                 return _lazyUpdateEngine ??= await SymbolSearchUpdateEngineFactory.CreateEngineAsync(
-                    _workspace, _logService, cancellationToken).ConfigureAwait(false);
+                    Workspace, _logService, cancellationToken).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Potential fix for https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1513707

It appears as if some perf work we've done in our package (liek https://github.com/dotnet/roslyn/pull/60211 for example) has had some unintended consequences.  Specifically, because we've gotten better at moving things to the BG and getting out of hte package load codepath, this also means that we start running bg tasks earlier, which then consumes resources that competes with other VS components during important times like solution load.

Two cases of this are the Nuget-search-indexer (which pulls down an index from our servers) and the Nuget-package-scanner (which analyzes the current VS project structure to see what nuget packages and versions we're already referencing).  Neither of these need to start right away, and we can delay them until the solution is actually fully loaded.