### PR TITLE
Reenable concurrent OOP sync sharing.

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -90,8 +90,8 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var checksum = scope.Target.SolutionInfo.SolutionChecksum;
-            var solutionSyncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, checksum, CancellationToken.None).ConfigureAwait(false);
+            var checksum = scope.SolutionInfo.SolutionChecksum;
+            var solutionSyncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, checksum, CancellationToken.None).ConfigureAwait(false);
 
             await validator.VerifySynchronizationObjectInServiceAsync(solutionSyncObject).ConfigureAwait(false);
 
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             await validator.VerifyChecksumInServiceAsync(solutionObject.Attributes, WellKnownSynchronizationKind.SolutionAttributes).ConfigureAwait(false);
             await validator.VerifyChecksumInServiceAsync(solutionObject.Options, WellKnownSynchronizationKind.OptionSet).ConfigureAwait(false);
 
-            var projectsSyncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, solutionObject.Projects.Checksum, CancellationToken.None).ConfigureAwait(false);
+            var projectsSyncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, solutionObject.Projects.Checksum, CancellationToken.None).ConfigureAwait(false);
             await validator.VerifySynchronizationObjectInServiceAsync(projectsSyncObject).ConfigureAwait(false);
 
             Assert.Equal(0, solutionObject.Projects.Count);
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             var validator = new SerializationValidator(workspace.Services);
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            await validator.VerifySolutionStateSerializationAsync(solution, scope.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            await validator.VerifySolutionStateSerializationAsync(solution, scope.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
         }
 
         [Fact]
@@ -126,8 +126,8 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
-            var checksum = scope.Target.SolutionInfo.SolutionChecksum;
-            var solutionSyncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, checksum, CancellationToken.None).ConfigureAwait(false);
+            var checksum = scope.SolutionInfo.SolutionChecksum;
+            var solutionSyncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, checksum, CancellationToken.None).ConfigureAwait(false);
 
             await validator.VerifySynchronizationObjectInServiceAsync(solutionSyncObject).ConfigureAwait(false);
 
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             await validator.VerifyChecksumInServiceAsync(solutionObject.Attributes, WellKnownSynchronizationKind.SolutionAttributes);
             await validator.VerifyChecksumInServiceAsync(solutionObject.Options, WellKnownSynchronizationKind.OptionSet);
 
-            var projectSyncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, solutionObject.Projects.Checksum, CancellationToken.None).ConfigureAwait(false);
+            var projectSyncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, solutionObject.Projects.Checksum, CancellationToken.None).ConfigureAwait(false);
             await validator.VerifySynchronizationObjectInServiceAsync(projectSyncObject).ConfigureAwait(false);
 
             Assert.Equal(1, solutionObject.Projects.Count);
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var snapshot = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
-            await validator.VerifySolutionStateSerializationAsync(project.Solution, snapshot.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            await validator.VerifySolutionStateSerializationAsync(project.Solution, snapshot.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
         }
 
         [Fact]
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(document.Project.Solution, CancellationToken.None).ConfigureAwait(false);
-            var syncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, scope.Target.SolutionInfo.SolutionChecksum, CancellationToken.None).ConfigureAwait(false);
+            var syncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, scope.SolutionInfo.SolutionChecksum, CancellationToken.None).ConfigureAwait(false);
             var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(syncObject.Checksum).ConfigureAwait(false);
 
             await validator.VerifySynchronizationObjectInServiceAsync(syncObject).ConfigureAwait(false);
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(document.Project.Solution, CancellationToken.None).ConfigureAwait(false);
-            await validator.VerifySolutionStateSerializationAsync(document.Project.Solution, scope.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            await validator.VerifySolutionStateSerializationAsync(document.Project.Solution, scope.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
         }
 
         [Fact]
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var syncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, scope.Target.SolutionInfo.SolutionChecksum, CancellationToken.None).ConfigureAwait(false);
+            var syncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, scope.SolutionInfo.SolutionChecksum, CancellationToken.None).ConfigureAwait(false);
             var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(syncObject.Checksum).ConfigureAwait(false);
 
             await validator.VerifySynchronizationObjectInServiceAsync(syncObject).ConfigureAwait(false);
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            await validator.VerifySolutionStateSerializationAsync(solution, scope.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            await validator.VerifySolutionStateSerializationAsync(solution, scope.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
         }
 
         [Fact]
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(scope.Target.SolutionInfo.SolutionChecksum);
+            var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(scope.SolutionInfo.SolutionChecksum);
             await validator.VerifyAssetAsync(solutionObject).ConfigureAwait(false);
         }
 
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(scope.Target.SolutionInfo.SolutionChecksum);
+            var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(scope.SolutionInfo.SolutionChecksum);
             await validator.VerifyAssetAsync(solutionObject).ConfigureAwait(false);
         }
 
@@ -273,12 +273,12 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             using (var scope1 = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false))
             {
-                solutionId1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+                solutionId1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             }
 
             using (var scope2 = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false))
             {
-                solutionId2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+                solutionId2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             }
 
             // once pinned snapshot scope is released, there is no way to get back to asset.
@@ -311,26 +311,26 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var scope1 = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
 
             // recover solution from given snapshot
-            var recovered = await validator.GetSolutionAsync(scope1.Target).ConfigureAwait(false);
-            var solutionObject1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(scope1).ConfigureAwait(false);
+            var solutionObject1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
 
             // create new snapshot from recovered solution
             using var scope2 = await validator.AssetStorage.StoreAssetsAsync(recovered, CancellationToken.None).ConfigureAwait(false);
 
             // verify asset created by recovered solution is good
-            var solutionObject2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var solutionObject2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             await validator.VerifyAssetAsync(solutionObject2).ConfigureAwait(false);
 
             // verify snapshots created from original solution and recovered solution are same
             validator.SolutionStateEqual(solutionObject1, solutionObject2);
 
             // recover new solution from recovered solution
-            var roundtrip = await validator.GetSolutionAsync(scope2.Target).ConfigureAwait(false);
+            var roundtrip = await validator.GetSolutionAsync(scope2).ConfigureAwait(false);
 
             // create new snapshot from round tripped solution
             using var scope3 = await validator.AssetStorage.StoreAssetsAsync(roundtrip, CancellationToken.None).ConfigureAwait(false);
             // verify asset created by round trip solution is good
-            var solutionObject3 = await validator.GetValueAsync<SolutionStateChecksums>(scope3.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var solutionObject3 = await validator.GetValueAsync<SolutionStateChecksums>(scope3.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             await validator.VerifyAssetAsync(solutionObject3).ConfigureAwait(false);
 
             // verify snapshots created from original solution and round trip solution are same.
@@ -348,14 +348,14 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var scope1 = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
 
             // recover solution from given snapshot
-            var recovered = await validator.GetSolutionAsync(scope1.Target).ConfigureAwait(false);
-            var solutionObject1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(scope1).ConfigureAwait(false);
+            var solutionObject1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
 
             // create new snapshot from recovered solution
             using var scope2 = await validator.AssetStorage.StoreAssetsAsync(recovered, CancellationToken.None).ConfigureAwait(false);
 
             // verify asset created by recovered solution is good
-            var solutionObject2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var solutionObject2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             await validator.VerifyAssetAsync(solutionObject2).ConfigureAwait(false);
 
             // verify snapshots created from original solution and recovered solution are same
@@ -363,12 +363,12 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             scope1.Dispose();
 
             // recover new solution from recovered solution
-            var roundtrip = await validator.GetSolutionAsync(scope2.Target).ConfigureAwait(false);
+            var roundtrip = await validator.GetSolutionAsync(scope2).ConfigureAwait(false);
 
             // create new snapshot from round tripped solution
             using var scope3 = await validator.AssetStorage.StoreAssetsAsync(roundtrip, CancellationToken.None).ConfigureAwait(false);
             // verify asset created by round trip solution is good
-            var solutionObject3 = await validator.GetValueAsync<SolutionStateChecksums>(scope3.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var solutionObject3 = await validator.GetValueAsync<SolutionStateChecksums>(scope3.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             await validator.VerifyAssetAsync(solutionObject3).ConfigureAwait(false);
 
             // verify snapshots created from original solution and round trip solution are same.
@@ -543,7 +543,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
             using var snapshot = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
 
-            var recovered = await validator.GetSolutionAsync(snapshot.Target).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(snapshot).ConfigureAwait(false);
             AssertEx.Equal(new[] { file1.Path, file2.Path }, recovered.GetProject(project.Id).AnalyzerReferences.Select(r => r.FullPath));
         }
 
@@ -563,7 +563,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             using var snapshot = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
             // this shouldn't throw
-            var recovered = await validator.GetSolutionAsync(snapshot.Target).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(snapshot).ConfigureAwait(false);
         }
 
         [Fact]
@@ -576,7 +576,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             using var snapshot = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
             // this shouldn't throw
-            var recovered = await validator.GetSolutionAsync(snapshot.Target).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(snapshot).ConfigureAwait(false);
         }
 
         [Fact, WorkItem(44791, "https://github.com/dotnet/roslyn/issues/44791")]
@@ -650,7 +650,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None);
             // recover solution from given snapshot
-            var recovered = await validator.GetSolutionAsync(scope.Target);
+            var recovered = await validator.GetSolutionAsync(scope);
 
             var compilation = await recovered.Projects.First().GetCompilationAsync(CancellationToken.None);
             var objectType = compilation.GetTypeByMetadataName("System.Object");
@@ -748,13 +748,13 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var checksum = scope.Target.SolutionInfo.SolutionChecksum;
+            var checksum = scope.SolutionInfo.SolutionChecksum;
             var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(checksum).ConfigureAwait(false);
 
             await validator.VerifyChecksumInServiceAsync(solutionObject.Attributes, WellKnownSynchronizationKind.SolutionAttributes);
             await validator.VerifyChecksumInServiceAsync(solutionObject.Options, WellKnownSynchronizationKind.OptionSet);
 
-            var recoveredSolution = await validator.GetSolutionAsync(scope.Target);
+            var recoveredSolution = await validator.GetSolutionAsync(scope);
 
             // option should be exactly same
             Assert.Equal(0, recoveredSolution.Options.GetChangedOptions(workspace.Options).Count());
@@ -764,7 +764,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             // checksum for recovered solution should be the same.
             using var recoveredScope = await validator.AssetStorage.StoreAssetsAsync(recoveredSolution, CancellationToken.None).ConfigureAwait(false);
-            var recoveredChecksum = recoveredScope.Target.SolutionInfo.SolutionChecksum;
+            var recoveredChecksum = recoveredScope.SolutionInfo.SolutionChecksum;
             Assert.Equal(checksum, recoveredChecksum);
         }
 

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -90,8 +90,8 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var checksum = scope.SolutionInfo.SolutionChecksum;
-            var solutionSyncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, checksum, CancellationToken.None).ConfigureAwait(false);
+            var checksum = scope.Target.SolutionInfo.SolutionChecksum;
+            var solutionSyncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, checksum, CancellationToken.None).ConfigureAwait(false);
 
             await validator.VerifySynchronizationObjectInServiceAsync(solutionSyncObject).ConfigureAwait(false);
 
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             await validator.VerifyChecksumInServiceAsync(solutionObject.Attributes, WellKnownSynchronizationKind.SolutionAttributes).ConfigureAwait(false);
             await validator.VerifyChecksumInServiceAsync(solutionObject.Options, WellKnownSynchronizationKind.OptionSet).ConfigureAwait(false);
 
-            var projectsSyncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, solutionObject.Projects.Checksum, CancellationToken.None).ConfigureAwait(false);
+            var projectsSyncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, solutionObject.Projects.Checksum, CancellationToken.None).ConfigureAwait(false);
             await validator.VerifySynchronizationObjectInServiceAsync(projectsSyncObject).ConfigureAwait(false);
 
             Assert.Equal(0, solutionObject.Projects.Count);
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             var validator = new SerializationValidator(workspace.Services);
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            await validator.VerifySolutionStateSerializationAsync(solution, scope.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            await validator.VerifySolutionStateSerializationAsync(solution, scope.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
         }
 
         [Fact]
@@ -126,8 +126,8 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
-            var checksum = scope.SolutionInfo.SolutionChecksum;
-            var solutionSyncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, checksum, CancellationToken.None).ConfigureAwait(false);
+            var checksum = scope.Target.SolutionInfo.SolutionChecksum;
+            var solutionSyncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, checksum, CancellationToken.None).ConfigureAwait(false);
 
             await validator.VerifySynchronizationObjectInServiceAsync(solutionSyncObject).ConfigureAwait(false);
 
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             await validator.VerifyChecksumInServiceAsync(solutionObject.Attributes, WellKnownSynchronizationKind.SolutionAttributes);
             await validator.VerifyChecksumInServiceAsync(solutionObject.Options, WellKnownSynchronizationKind.OptionSet);
 
-            var projectSyncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, solutionObject.Projects.Checksum, CancellationToken.None).ConfigureAwait(false);
+            var projectSyncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, solutionObject.Projects.Checksum, CancellationToken.None).ConfigureAwait(false);
             await validator.VerifySynchronizationObjectInServiceAsync(projectSyncObject).ConfigureAwait(false);
 
             Assert.Equal(1, solutionObject.Projects.Count);
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var snapshot = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
-            await validator.VerifySolutionStateSerializationAsync(project.Solution, snapshot.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            await validator.VerifySolutionStateSerializationAsync(project.Solution, snapshot.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
         }
 
         [Fact]
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(document.Project.Solution, CancellationToken.None).ConfigureAwait(false);
-            var syncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, scope.SolutionInfo.SolutionChecksum, CancellationToken.None).ConfigureAwait(false);
+            var syncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, scope.Target.SolutionInfo.SolutionChecksum, CancellationToken.None).ConfigureAwait(false);
             var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(syncObject.Checksum).ConfigureAwait(false);
 
             await validator.VerifySynchronizationObjectInServiceAsync(syncObject).ConfigureAwait(false);
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(document.Project.Solution, CancellationToken.None).ConfigureAwait(false);
-            await validator.VerifySolutionStateSerializationAsync(document.Project.Solution, scope.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            await validator.VerifySolutionStateSerializationAsync(document.Project.Solution, scope.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
         }
 
         [Fact]
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var syncObject = await validator.AssetStorage.GetAssetAsync(scope.SolutionInfo.ScopeId, scope.SolutionInfo.SolutionChecksum, CancellationToken.None).ConfigureAwait(false);
+            var syncObject = await validator.AssetStorage.GetAssetAsync(scope.Target.SolutionInfo.ScopeId, scope.Target.SolutionInfo.SolutionChecksum, CancellationToken.None).ConfigureAwait(false);
             var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(syncObject.Checksum).ConfigureAwait(false);
 
             await validator.VerifySynchronizationObjectInServiceAsync(syncObject).ConfigureAwait(false);
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            await validator.VerifySolutionStateSerializationAsync(solution, scope.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            await validator.VerifySolutionStateSerializationAsync(solution, scope.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
         }
 
         [Fact]
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(scope.SolutionInfo.SolutionChecksum);
+            var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(scope.Target.SolutionInfo.SolutionChecksum);
             await validator.VerifyAssetAsync(solutionObject).ConfigureAwait(false);
         }
 
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(scope.SolutionInfo.SolutionChecksum);
+            var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(scope.Target.SolutionInfo.SolutionChecksum);
             await validator.VerifyAssetAsync(solutionObject).ConfigureAwait(false);
         }
 
@@ -273,12 +273,12 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             using (var scope1 = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false))
             {
-                solutionId1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+                solutionId1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             }
 
             using (var scope2 = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false))
             {
-                solutionId2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+                solutionId2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             }
 
             // once pinned snapshot scope is released, there is no way to get back to asset.
@@ -311,26 +311,26 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var scope1 = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
 
             // recover solution from given snapshot
-            var recovered = await validator.GetSolutionAsync(scope1).ConfigureAwait(false);
-            var solutionObject1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(scope1.Target).ConfigureAwait(false);
+            var solutionObject1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
 
             // create new snapshot from recovered solution
             using var scope2 = await validator.AssetStorage.StoreAssetsAsync(recovered, CancellationToken.None).ConfigureAwait(false);
 
             // verify asset created by recovered solution is good
-            var solutionObject2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var solutionObject2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             await validator.VerifyAssetAsync(solutionObject2).ConfigureAwait(false);
 
             // verify snapshots created from original solution and recovered solution are same
             validator.SolutionStateEqual(solutionObject1, solutionObject2);
 
             // recover new solution from recovered solution
-            var roundtrip = await validator.GetSolutionAsync(scope2).ConfigureAwait(false);
+            var roundtrip = await validator.GetSolutionAsync(scope2.Target).ConfigureAwait(false);
 
             // create new snapshot from round tripped solution
             using var scope3 = await validator.AssetStorage.StoreAssetsAsync(roundtrip, CancellationToken.None).ConfigureAwait(false);
-            // verify asset created by rount trip solution is good
-            var solutionObject3 = await validator.GetValueAsync<SolutionStateChecksums>(scope3.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            // verify asset created by round trip solution is good
+            var solutionObject3 = await validator.GetValueAsync<SolutionStateChecksums>(scope3.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             await validator.VerifyAssetAsync(solutionObject3).ConfigureAwait(false);
 
             // verify snapshots created from original solution and round trip solution are same.
@@ -348,14 +348,14 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var scope1 = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
 
             // recover solution from given snapshot
-            var recovered = await validator.GetSolutionAsync(scope1).ConfigureAwait(false);
-            var solutionObject1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(scope1.Target).ConfigureAwait(false);
+            var solutionObject1 = await validator.GetValueAsync<SolutionStateChecksums>(scope1.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
 
             // create new snapshot from recovered solution
             using var scope2 = await validator.AssetStorage.StoreAssetsAsync(recovered, CancellationToken.None).ConfigureAwait(false);
 
             // verify asset created by recovered solution is good
-            var solutionObject2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            var solutionObject2 = await validator.GetValueAsync<SolutionStateChecksums>(scope2.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             await validator.VerifyAssetAsync(solutionObject2).ConfigureAwait(false);
 
             // verify snapshots created from original solution and recovered solution are same
@@ -363,12 +363,12 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             scope1.Dispose();
 
             // recover new solution from recovered solution
-            var roundtrip = await validator.GetSolutionAsync(scope2).ConfigureAwait(false);
+            var roundtrip = await validator.GetSolutionAsync(scope2.Target).ConfigureAwait(false);
 
             // create new snapshot from round tripped solution
             using var scope3 = await validator.AssetStorage.StoreAssetsAsync(roundtrip, CancellationToken.None).ConfigureAwait(false);
-            // verify asset created by rount trip solution is good
-            var solutionObject3 = await validator.GetValueAsync<SolutionStateChecksums>(scope3.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
+            // verify asset created by round trip solution is good
+            var solutionObject3 = await validator.GetValueAsync<SolutionStateChecksums>(scope3.Target.SolutionInfo.SolutionChecksum).ConfigureAwait(false);
             await validator.VerifyAssetAsync(solutionObject3).ConfigureAwait(false);
 
             // verify snapshots created from original solution and round trip solution are same.
@@ -543,7 +543,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
             using var snapshot = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
 
-            var recovered = await validator.GetSolutionAsync(snapshot).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(snapshot.Target).ConfigureAwait(false);
             AssertEx.Equal(new[] { file1.Path, file2.Path }, recovered.GetProject(project.Id).AnalyzerReferences.Select(r => r.FullPath));
         }
 
@@ -563,7 +563,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             using var snapshot = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
             // this shouldn't throw
-            var recovered = await validator.GetSolutionAsync(snapshot).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(snapshot.Target).ConfigureAwait(false);
         }
 
         [Fact]
@@ -576,7 +576,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             using var snapshot = await validator.AssetStorage.StoreAssetsAsync(project.Solution, CancellationToken.None).ConfigureAwait(false);
             // this shouldn't throw
-            var recovered = await validator.GetSolutionAsync(snapshot).ConfigureAwait(false);
+            var recovered = await validator.GetSolutionAsync(snapshot.Target).ConfigureAwait(false);
         }
 
         [Fact, WorkItem(44791, "https://github.com/dotnet/roslyn/issues/44791")]
@@ -650,7 +650,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None);
             // recover solution from given snapshot
-            var recovered = await validator.GetSolutionAsync(scope);
+            var recovered = await validator.GetSolutionAsync(scope.Target);
 
             var compilation = await recovered.Projects.First().GetCompilationAsync(CancellationToken.None);
             var objectType = compilation.GetTypeByMetadataName("System.Object");
@@ -748,13 +748,13 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var validator = new SerializationValidator(workspace.Services);
 
             using var scope = await validator.AssetStorage.StoreAssetsAsync(solution, CancellationToken.None).ConfigureAwait(false);
-            var checksum = scope.SolutionInfo.SolutionChecksum;
+            var checksum = scope.Target.SolutionInfo.SolutionChecksum;
             var solutionObject = await validator.GetValueAsync<SolutionStateChecksums>(checksum).ConfigureAwait(false);
 
             await validator.VerifyChecksumInServiceAsync(solutionObject.Attributes, WellKnownSynchronizationKind.SolutionAttributes);
             await validator.VerifyChecksumInServiceAsync(solutionObject.Options, WellKnownSynchronizationKind.OptionSet);
 
-            var recoveredSolution = await validator.GetSolutionAsync(scope);
+            var recoveredSolution = await validator.GetSolutionAsync(scope.Target);
 
             // option should be exactly same
             Assert.Equal(0, recoveredSolution.Options.GetChangedOptions(workspace.Options).Count());
@@ -764,7 +764,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
 
             // checksum for recovered solution should be the same.
             using var recoveredScope = await validator.AssetStorage.StoreAssetsAsync(recoveredSolution, CancellationToken.None).ConfigureAwait(false);
-            var recoveredChecksum = recoveredScope.SolutionInfo.SolutionChecksum;
+            var recoveredChecksum = recoveredScope.Target.SolutionInfo.SolutionChecksum;
             Assert.Equal(checksum, recoveredChecksum);
         }
 

--- a/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/SimpleAssetSource.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Remote.Testing
         }
 
         public ValueTask<ImmutableArray<(Checksum, object)>> GetAssetsAsync(
-            int serviceId, ISet<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
+            int scopeId, ISet<Checksum> checksums, ISerializerService deserializerService, CancellationToken cancellationToken)
         {
             var results = new List<(Checksum, object)>();
 

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                await invocation(rental.Service, scope.SolutionInfo, cancellationToken).ConfigureAwait(false);
+                await invocation(rental.Service, scope.Target.SolutionInfo, cancellationToken).ConfigureAwait(false);
                 return true;
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                return await invocation(rental.Service, scope.SolutionInfo, cancellationToken).ConfigureAwait(false);
+                return await invocation(rental.Service, scope.Target.SolutionInfo, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
             {
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                await invocation(rental.Service, scope.SolutionInfo, cancellationToken).ConfigureAwait(false);
+                await invocation(rental.Service, scope.Target.SolutionInfo, cancellationToken).ConfigureAwait(false);
                 return true;
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                return await invocation(rental.Service, scope.SolutionInfo, cancellationToken).ConfigureAwait(false);
+                return await invocation(rental.Service, scope.Target.SolutionInfo, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
             {
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                await invocation(rental.Service, scope.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
+                await invocation(rental.Service, scope.Target.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
 
                 return true;
             }
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                return await invocation(rental.Service, scope.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
+                return await invocation(rental.Service, scope.Target.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
             {
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                await invocation(rental.Service, scope.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
+                await invocation(rental.Service, scope.Target.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
 
                 return true;
             }
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                return await invocation(rental.Service, scope.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
+                return await invocation(rental.Service, scope.Target.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
             {
@@ -330,7 +330,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 return await InvokeStreamingServiceAsync(
                     rental.Service,
-                    (service, pipeWriter, cancellationToken) => invocation(service, scope.SolutionInfo, pipeWriter, cancellationToken),
+                    (service, pipeWriter, cancellationToken) => invocation(service, scope.Target.SolutionInfo, pipeWriter, cancellationToken),
                     reader,
                     cancellationToken).ConfigureAwait(false);
             }
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 return await InvokeStreamingServiceAsync(
                     rental.Service,
-                    (service, pipeWriter, cancellationToken) => invocation(service, scope.SolutionInfo, pipeWriter, cancellationToken),
+                    (service, pipeWriter, cancellationToken) => invocation(service, scope.Target.SolutionInfo, pipeWriter, cancellationToken),
                     reader,
                     cancellationToken).ConfigureAwait(false);
             }

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                await invocation(rental.Service, scope.Target.SolutionInfo, cancellationToken).ConfigureAwait(false);
+                await invocation(rental.Service, scope.SolutionInfo, cancellationToken).ConfigureAwait(false);
                 return true;
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                return await invocation(rental.Service, scope.Target.SolutionInfo, cancellationToken).ConfigureAwait(false);
+                return await invocation(rental.Service, scope.SolutionInfo, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
             {
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                await invocation(rental.Service, scope.Target.SolutionInfo, cancellationToken).ConfigureAwait(false);
+                await invocation(rental.Service, scope.SolutionInfo, cancellationToken).ConfigureAwait(false);
                 return true;
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                return await invocation(rental.Service, scope.Target.SolutionInfo, cancellationToken).ConfigureAwait(false);
+                return await invocation(rental.Service, scope.SolutionInfo, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
             {
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                await invocation(rental.Service, scope.Target.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
+                await invocation(rental.Service, scope.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
 
                 return true;
             }
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(solution, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                return await invocation(rental.Service, scope.Target.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
+                return await invocation(rental.Service, scope.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
             {
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                await invocation(rental.Service, scope.Target.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
+                await invocation(rental.Service, scope.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
 
                 return true;
             }
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using var scope = await _solutionAssetStorage.StoreAssetsAsync(project, cancellationToken).ConfigureAwait(false);
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
-                return await invocation(rental.Service, scope.Target.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
+                return await invocation(rental.Service, scope.SolutionInfo, _callbackHandle.Id, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (ReportUnexpectedException(exception, cancellationToken))
             {
@@ -330,7 +330,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 return await InvokeStreamingServiceAsync(
                     rental.Service,
-                    (service, pipeWriter, cancellationToken) => invocation(service, scope.Target.SolutionInfo, pipeWriter, cancellationToken),
+                    (service, pipeWriter, cancellationToken) => invocation(service, scope.SolutionInfo, pipeWriter, cancellationToken),
                     reader,
                     cancellationToken).ConfigureAwait(false);
             }
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 using var rental = await RentServiceAsync(cancellationToken).ConfigureAwait(false);
                 return await InvokeStreamingServiceAsync(
                     rental.Service,
-                    (service, pipeWriter, cancellationToken) => invocation(service, scope.Target.SolutionInfo, pipeWriter, cancellationToken),
+                    (service, pipeWriter, cancellationToken) => invocation(service, scope.SolutionInfo, pipeWriter, cancellationToken),
                     reader,
                     cancellationToken).ConfigureAwait(false);
             }

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -54,11 +54,13 @@ namespace Microsoft.CodeAnalysis.Remote
             cancellationToken.ThrowIfCancellationRequested();
             var mustNotCancelToken = CancellationToken.None;
 
-            // Work around the lack of async stream writing in ObjectWriter, which is required when writing to the RPC pipe.
-            // Run two tasks - the first synchronously writes to a local pipe and the second asynchronosly transfers the data to the RPC pipe.
+            // Work around the lack of async stream writing in ObjectWriter, which is required when writing to the RPC
+            // pipe. Run two tasks - the first synchronously writes to a local pipe and the second asynchronously
+            // transfers the data to the RPC pipe.
             //
-            // Configure the pipe to never block on write (waiting for the reader to read). This prevents deadlocks but might result in more
-            // (non-contiguous) memory allocated for the underlying buffers. The amount of memory is bounded by the total size of the serialized assets.
+            // Configure the pipe to never block on write (waiting for the reader to read). This prevents deadlocks but
+            // might result in more (non-contiguous) memory allocated for the underlying buffers. The amount of memory
+            // is bounded by the total size of the serialized assets.
             var localPipe = new Pipe(RemoteHostAssetSerialization.PipeOptionsWithUnlimitedWriterBuffer);
 
             var task1 = Task.Run(() =>

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -9,22 +9,22 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class SolutionAssetStorage
     {
-        internal readonly struct Scope : IDisposable
+        internal class Scope : IDisposable
         {
-            private readonly SolutionAssetStorage _storages;
+            private readonly SolutionAssetStorage _storage;
+
+            public readonly Checksum Checksum;
             public readonly PinnedSolutionInfo SolutionInfo;
 
-            public Scope(SolutionAssetStorage storages, PinnedSolutionInfo solutionInfo)
+            public Scope(SolutionAssetStorage storage, Checksum checksum, PinnedSolutionInfo solutionInfo)
             {
-                _storages = storages;
+                _storage = storage;
+                Checksum = checksum;
                 SolutionInfo = solutionInfo;
             }
 
             public void Dispose()
-            {
-                Contract.ThrowIfFalse(_storages._solutionStates.TryRemove(SolutionInfo.ScopeId, out var entry));
-                entry.ReplicationContext.Dispose();
-            }
+                => _storage.DisposeScope(this);
         }
     }
 }

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class SolutionAssetStorage
     {
-        internal class Scope : IDisposable
+        internal sealed class Scope : IDisposable
         {
             private readonly SolutionAssetStorage _storage;
 

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -110,13 +110,13 @@ namespace Microsoft.CodeAnalysis.Remote
                 // Note: we cannot assume the checksum mapping even has a mapping for this checksum, or that if it has a
                 // mapping that it points to this scope.  Specifically we may get the following sequences of steps:
                 //
-                //  1. Feature A creates and stores a scope-I associated with checksum X.  Scope-I will have a refcount of 1.
-                //  2. Feature A finishes their work and disposes the scope.  This will drop the refcount of the scope-I to 0.
-                //  3. Concurrently, feature B calls in to get a scope for checksum X.  THey see the mapping from that checksum to
-                //     scope with refcount 0.  They then remove that mapping and create a new mapping from checksum X to scope-J.
-                //  4a. Scope-I's Dispose then gets run and calls into this method.  Due to '3' the checksum now points at scope-J.
-                //  4b. Alternatively, Scope-J gets refcounted to 0, gets Disposed and then gets removed as well from the mapping
-                //      Scope-I's Dispose then calls into this and sees nothing at all.
+                //  1. Feature-A creates and stores a Scope-I associated with Checksum-X.  Scope-I will have a ref-count of 1.
+                //  2. Feature-A finishes their work and disposes the scope.  This will drop the ref-count of Scope-I to 0.
+                //  3. Concurrently, Feature-B calls in to get a scope for checksum X.  They see the mapping from that checksum to
+                //     Scope-I with ref-count 0.  They then remove that mapping and create a new mapping from Checksum-X to Scope-J.
+                //  4. Alternate 1: Scope-I's Dispose then gets run and calls into this method.  Due to '3' the checksum now points at Scope-J.
+                //  4. Alternate 2:, Scope-J gets refcounted to 0 by Feature-B, gets Dispose()'d and then gets removed
+                //     as well from the mapping. Scope-I's Dispose then calls into this and sees nothing at all.
                 if (_checksumToScope.TryGetValue(scope.Checksum, out var currentScopeMapping) &&
                     currentScopeMapping.Target?.SolutionInfo.ScopeId == scope.SolutionInfo.ScopeId)
                 {

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -70,9 +70,6 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     Contract.ThrowIfTrue(refCountAndScope.refCount <= 0);
 
-                    // Found a matching scope for this checksum.  See if we can up the refcount on it (i.e. it didn't
-                    // concurrently drop to 0 just before this on another thread.  If so, we're all good and the scope
-                    // can be shared.
                     refCountAndScope.refCount++;
                     _checksumToRefCountedScope[checksum] = refCountAndScope;
                     return refCountAndScope.scope;

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -23,6 +23,25 @@ namespace Microsoft.CodeAnalysis.Remote
         private static int s_scopeId = 1;
 
         /// <summary>
+        /// Lock over mutable state in this type.  Note: We could consider making this a SemaphoreSlim if the locking
+        /// proves to be a problem. However, it would greatly complicate the implementation and consumption side due to
+        /// the pattern around <c>await using</c> as well as <see cref="ReferenceCountedDisposable{T}"/> not supporting
+        /// <see cref="IAsyncDisposable"/>.
+        /// </summary>
+        private readonly object _gate = new();
+
+        /// <summary>
+        /// Mapping from operation checksum to the scope for the syncing operation that we've created for it.
+        /// Ref-counted so that if we have many concurrent calls going out from the host to the OOP side that we share
+        /// the same storage here so that all OOP calls can safely call back into us and get the assets they need, even
+        /// if individual calls get canceled.
+        /// </summary>
+        /// <remarks>
+        /// Accessed across many threads.  Lock this type itself to quickly update it.
+        /// </remarks>
+        private readonly Dictionary<Checksum, ReferenceCountedDisposable<Scope>> _checksumToScope = new();
+
+        /// <summary>
         /// Map from solution checksum scope id to its associated <see cref="SolutionState"/>.
         /// </summary>
         private readonly ConcurrentDictionary<int, (SolutionState Solution, SolutionReplicationContext ReplicationContext)> _solutionStates = new(concurrencyLevel: 2, capacity: 10);
@@ -33,33 +52,85 @@ namespace Microsoft.CodeAnalysis.Remote
         /// <summary>
         /// Adds given snapshot into the storage. This snapshot will be available within the returned <see cref="Scope"/>.
         /// </summary>
-        internal ValueTask<Scope> StoreAssetsAsync(Solution solution, CancellationToken cancellationToken)
+        internal ValueTask<ReferenceCountedDisposable<Scope>> StoreAssetsAsync(Solution solution, CancellationToken cancellationToken)
             => StoreAssetsAsync(solution, projectId: null, cancellationToken);
 
         /// <summary>
         /// Adds given snapshot into the storage. This snapshot will be available within the returned <see cref="Scope"/>.
         /// </summary>
-        internal ValueTask<Scope> StoreAssetsAsync(Project project, CancellationToken cancellationToken)
+        internal ValueTask<ReferenceCountedDisposable<Scope>> StoreAssetsAsync(Project project, CancellationToken cancellationToken)
             => StoreAssetsAsync(project.Solution, project.Id, cancellationToken);
 
-        private async ValueTask<Scope> StoreAssetsAsync(Solution solution, ProjectId? projectId, CancellationToken cancellationToken)
+        private async ValueTask<ReferenceCountedDisposable<Scope>> StoreAssetsAsync(Solution solution, ProjectId? projectId, CancellationToken cancellationToken)
         {
             var solutionState = solution.State;
-            var solutionChecksum = projectId == null
+            var checksum = projectId == null
                 ? await solutionState.GetChecksumAsync(cancellationToken).ConfigureAwait(false)
                 : await solutionState.GetChecksumAsync(projectId, cancellationToken).ConfigureAwait(false);
-            var context = SolutionReplicationContext.Create();
 
-            var id = Interlocked.Increment(ref s_scopeId);
-            var solutionInfo = new PinnedSolutionInfo(
-                id,
-                fromPrimaryBranch: solutionState.BranchId == solutionState.Workspace.PrimaryBranchId,
-                solutionState.WorkspaceVersion,
-                solutionChecksum);
+            lock (_gate)
+            {
+                if (_checksumToScope.TryGetValue(checksum, out var refCountedScope))
+                {
+                    // Found a matching scope for this checksum.  See if we can up the refcount on it (i.e. it didn't
+                    // concurrently drop to 0 just before this on another thread.  If so, we're all good and the scope
+                    // can be shared.
+                    var result = refCountedScope.TryAddReference();
+                    if (result != null)
+                        return result;
 
-            Contract.ThrowIfFalse(_solutionStates.TryAdd(id, (solutionState, context)));
+                    // Otherwise scope's refcount has dropped to zero externally, but we still got a concurrent call to
+                    // do an operation with the same checksum.  We have to recreate a scope at this point.  Explicitly
+                    // remove teh mapping here as we're going to update it below.  Note: when the scope itself calls
+                    // back into us to clean it will check to ensure that the mapping still points to it, so there's no
+                    // risk of both paths racing with each other.
+                    Contract.ThrowIfFalse(_checksumToScope.Remove(checksum));
+                }
 
-            return new Scope(this, solutionInfo);
+                var id = Interlocked.Increment(ref s_scopeId);
+                var solutionInfo = new PinnedSolutionInfo(
+                    id,
+                    fromPrimaryBranch: solutionState.BranchId == solutionState.Workspace.PrimaryBranchId,
+                    solutionState.WorkspaceVersion,
+                    checksum);
+
+                Contract.ThrowIfFalse(_solutionStates.TryAdd(id, (solutionState, SolutionReplicationContext.Create())));
+
+                refCountedScope = new ReferenceCountedDisposable<Scope>(new Scope(this, checksum, solutionInfo));
+                _checksumToScope.Add(checksum, refCountedScope);
+
+                return refCountedScope;
+            }
+        }
+
+        private void DisposeScope(Scope scope)
+        {
+            lock (_gate)
+            {
+                // See if the checksum mapping is still pointing at this scope.  Definitely remove it in that scope has
+                // been disposed and should not be used by anyone anymore.
+                //
+                // Note: we cannot assume the checksum mapping even has a mapping for this checksum, or that if it has a
+                // mapping that it points to this scope.  Specifically we may get the following sequences of steps:
+                //
+                //  1. Feature A creates and stores a scope-I associated with checksum X.  Scope-I will have a refcount of 1.
+                //  2. Feature A finishes their work and disposes the scope.  This will drop the refcount of the scope-I to 0.
+                //  3. Concurrently, feature B calls in to get a scope for checksum X.  THey see the mapping from that checksum to
+                //     scope with refcount 0.  They then remove that mapping and create a new mapping from checksum X to scope-J.
+                //  4a. Scope-I's Dispose then gets run and calls into this method.  Due to '3' the checksum now points at scope-J.
+                //  4b. Alternatively, Scope-J gets refcounted to 0, gets Disposed and then gets removed as well from the mapping
+                //      Scope-I's Dispose then calls into this and sees nothing at all.
+                if (_checksumToScope.TryGetValue(scope.Checksum, out var currentScopeMapping) &&
+                    currentScopeMapping.Target?.SolutionInfo.ScopeId == scope.SolutionInfo.ScopeId)
+                {
+                    Contract.ThrowIfFalse(_checksumToScope.Remove(scope.Checksum));
+                }
+            }
+
+            // We know at this point that absolutely no operations are in flight corresponding to this scope id.  So we
+            // can also remove it from the states map.
+            Contract.ThrowIfFalse(_solutionStates.TryRemove(scope.SolutionInfo.ScopeId, out var entry));
+            entry.ReplicationContext.Dispose();
         }
 
         /// <summary>

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -36,9 +36,6 @@ namespace Microsoft.CodeAnalysis.Remote
         /// the same storage here so that all OOP calls can safely call back into us and get the assets they need, even
         /// if individual calls get canceled.
         /// </summary>
-        /// <remarks>
-        /// Accessed across many threads.  Lock this type itself to quickly update it.
-        /// </remarks>
         private readonly Dictionary<Checksum, ReferenceCountedDisposable<Scope>> _checksumToScope = new();
 
         /// <summary>

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 Contract.ThrowIfTrue(refCount <= 0);
                 refCount--;
 
-                // If our refcount is still above 0, then just update the map and return.  NOthing else to do at this point.
+                // If our refcount is still above 0, then just update the map and return.  Nothing else to do at this point.
                 if (refCount > 0)
                 {
                     _checksumToRefCountedScope[checksum] = (refCount, scope);

--- a/src/Workspaces/Remote/Core/SolutionAssetStorageProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorageProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Remote
         [ExportWorkspaceServiceFactory(typeof(ISolutionAssetStorageProvider)), Shared]
         internal sealed class Factory : IWorkspaceServiceFactory
         {
-            private readonly SolutionAssetStorage _storage = new SolutionAssetStorage();
+            private readonly SolutionAssetStorage _storage = new();
 
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -20,14 +20,15 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal sealed class AssetProvider : AbstractAssetProvider
     {
+        public readonly int ScopeId;
+
         private readonly ISerializerService _serializerService;
-        private readonly int _scopeId;
         private readonly SolutionAssetCache _assetCache;
         private readonly IAssetSource _assetSource;
 
         public AssetProvider(int scopeId, SolutionAssetCache assetCache, IAssetSource assetSource, ISerializerService serializerService)
         {
-            _scopeId = scopeId;
+            ScopeId = scopeId;
             _assetCache = assetCache;
             _assetSource = assetSource;
             _serializerService = serializerService;
@@ -159,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 return ImmutableArray<(Checksum, object)>.Empty;
             }
 
-            return await _assetSource.GetAssetsAsync(_scopeId, checksums, _serializerService, cancellationToken).ConfigureAwait(false);
+            return await _assetSource.GetAssetsAsync(ScopeId, checksums, _serializerService, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -43,7 +43,6 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         private int _currentRemoteWorkspaceVersion = -1;
 
-#if SHARE_SOLUTIONS_ACROSS_CONCURRENT_CALLS
         /// <summary>
         /// Mapping from solution checksum to to the solution computed for it.  This is used so that we can hold a
         /// solution around as long as the checksum for it is being used in service of some feature operation (e.g.
@@ -51,7 +50,6 @@ namespace Microsoft.CodeAnalysis.Remote
         /// share the computation of that particular solution and avoid duplicated concurrent work.
         /// </summary>
         private readonly Dictionary<Checksum, (int refCount, AsyncLazy<Solution> lazySolution)> _checksumToRefCountAndLazySolution = new();
-#endif
 
         // internal for testing purposes.
         internal RemoteWorkspace(HostServices hostServices, string? workspaceKind)
@@ -191,13 +189,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 await DecrementLazySolutionRefcountAsync().ConfigureAwait(false);
             }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
             async ValueTask<AsyncLazy<Solution>> GetLazySolutionAndIncrementRefCountAsync()
             {
-#if !SHARE_SOLUTIONS_ACROSS_CONCURRENT_CALLS
-                return
-                    AsyncLazy.Create(c => ComputeSolutionAsync(assetProvider, solutionChecksum, workspaceVersion, fromPrimaryBranch, c), cacheResult: true);
-#else
                 using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
                 {
                     if (_checksumToRefCountAndLazySolution.TryGetValue(solutionChecksum, out var tuple))
@@ -219,7 +212,6 @@ namespace Microsoft.CodeAnalysis.Remote
 
                     return tuple.lazySolution;
                 }
-#endif
             }
 
             async ValueTask SetLastRequestedSolutionAsync(Solution solution)
@@ -236,9 +228,6 @@ namespace Microsoft.CodeAnalysis.Remote
 
             async ValueTask DecrementLazySolutionRefcountAsync()
             {
-#if !SHARE_SOLUTIONS_ACROSS_CONCURRENT_CALLS
-                return;
-#else
                 // We use CancellationToken.None here as we have to ensure the refcount is decremented, or else we will
                 // have a memory leak.  This should hopefully not ever be an issue as we only ever hold this gate for
                 // very short periods of time in order to set do basic operations on our state.
@@ -258,9 +247,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         _checksumToRefCountAndLazySolution[solutionChecksum] = (refCount, lazySolution);
                     }
                 }
-#endif
             }
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         }
 
         /// <summary>


### PR DESCRIPTION
The new design pushes the concurrency detection to the host instead.  On hte host side, we look to see if we're concurrently making feature requests for the same solution checksums.  If so, those concurrent features share the same PinnedSolutionInfo and Scope objects (in a ref counted fashion so that they stay alive as long as any of the requests is still in flight).

Then, on the OOP side, we just have a mapping from ScopeId to the in-flight operation to sync it.  Any OOP operations that then are working on the same scope-Id (which means they're sharing the same pinned info on the host side) can then share teh same sync operation on the OOP side.

This is safe as hte host side can only clean up if all concurrent features on the same checksum cancel/finish.  Only then does the pinned scope on the host side go away.  But tahts' ok as all the features on the OOP side that might care are themselves cancelled/finished.

Note: @dibarbet  suggested a nice simplification where we no longer use scope-ids, but instead use solution-checksums.  That change will come in a follow-up PR to keep things simple here.