### PR TITLE
Enable handling Modified -> Removed transitions in generator step tracking

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -917,6 +917,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             Assert.Equal(thirdValue, (int)transformNodeStep.Outputs[2].Value);
         }
 
+        [Fact]
+        public void Modified_Entry_Removing_Outputs_Records_Removed_Step_State()
+        {
+            ImmutableArray<int> values = ImmutableArray.Create(1, 2, 3);
+            var inputNode = new InputNode<ImmutableArray<int>>(_ => ImmutableArray.Create(values)).WithTrackingName("Input");
+            var transformNode = new TransformNode<ImmutableArray<int>, int>(inputNode, (arr, ct) => arr, name: "SelectMany");
+
+            DriverStateTable.Builder dstBuilder = GetBuilder(DriverStateTable.Empty, trackIncrementalGeneratorSteps: true);
+
+            List<IncrementalGeneratorRunStep> steps = new();
+
+            _ = dstBuilder.GetLatestStateTableForNode(transformNode);
+
+            values = ImmutableArray<int>.Empty;
+
+            // second time we'll see that the "Input" step is modified, but the outputs of the "SelectMany" step are removed.
+            dstBuilder = GetBuilder(dstBuilder.ToImmutable(), trackIncrementalGeneratorSteps: true);
+            var table = dstBuilder.GetLatestStateTableForNode(transformNode);
+
+            var step = Assert.Single(table.Steps);
+
+            var input = Assert.Single(step.Inputs);
+
+            Assert.Equal(IncrementalStepRunReason.Modified, input.Source.Outputs[input.OutputIndex].Reason);
+
+            Assert.All(step.Outputs, output =>
+            {
+                Assert.Equal(IncrementalStepRunReason.Removed, output.Reason);
+            });
+        }
+
         private void AssertTableEntries<T>(NodeStateTable<T> table, IList<(T Item, EntryState State, int OutputIndex)> expected)
         {
             int index = 0;

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -359,6 +359,7 @@ namespace Microsoft.CodeAnalysis
                     (EntryState.Modified, EntryState.Cached) => IncrementalStepRunReason.Unchanged,
                     (EntryState.Cached, EntryState.Cached) => IncrementalStepRunReason.Cached,
                     (EntryState.Removed, EntryState.Removed) => IncrementalStepRunReason.Removed,
+                    (EntryState.Modified, EntryState.Removed) => IncrementalStepRunReason.Removed,
                     _ => throw ExceptionUtilities.UnexpectedValue((inputState, outputState))
                 };
             }


### PR DESCRIPTION
Treat a Transform step where the input is modified such that the output is removed (possible in Where or SelectMany based steps) as a "Removed" output instead of treating it as unreachable.