### PR TITLE
Bump Humanizer.Core version to 2.14.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,7 +52,7 @@
     <BenchmarkDotNetDiagnosticsWindowsVersion>0.13.0</BenchmarkDotNetDiagnosticsWindowsVersion>
     <DiffPlexVersion>1.5.0</DiffPlexVersion>
     <FakeSignVersion>0.9.2</FakeSignVersion>
-    <HumanizerCoreVersion>2.2.0</HumanizerCoreVersion>
+    <HumanizerCoreVersion>2.14.1</HumanizerCoreVersion>
     <ICSharpCodeDecompilerVersion>7.1.0.6543</ICSharpCodeDecompilerVersion>
     <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
     <!--


### PR DESCRIPTION
Humanizer.Core v2.2.0 depends on an NETStandard.Library v1.6.1 which brings in potential component governance issues.