### PR TITLE
Fix up handling for partially written generics

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/GenericNamePartiallyWrittenSignatureHelpProviderTests.cs
@@ -41,6 +41,50 @@ class C
             await TestAsync(markup, expectedOrderedItems);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task NestedGenericUnterminatedWithAmbiguousShift()
+        {
+            var markup = @"
+class G<T> { };
+
+class C
+{
+    void Goo()
+    {
+        var x = G<G<G<int>>$$>
+
+        x = x;
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("G<T>", string.Empty, string.Empty, currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task NestedGenericUnterminatedWithAmbiguousUnsignedShift()
+        {
+            var markup = @"
+class G<T> { };
+
+class C
+{
+    void Goo()
+    {
+        var x = G<G<G<G<int>>>$$>
+
+        x = x;
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("G<T>", string.Empty, string.Empty, currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
         [WorkItem(544088, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544088")]
         [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public async Task DeclaringGenericTypeWith1ParameterUnterminated()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -110,13 +110,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                             break;
                         }
 
-                    case SyntaxKind.GreaterThanGreaterThanToken:
-                        stack++;
-                        goto case SyntaxKind.GreaterThanToken;
-
                     // fall through
                     case SyntaxKind.GreaterThanToken:
-                        stack++;
+                    case SyntaxKind.GreaterThanGreaterThanToken:
+                    case SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
+
+                        // FindTokenOnLeftOfPosition returns the token that we are contained in. This means in cases like
+                        // G<G<G<int>>$$> the compiler might have parsed that final >> as a shift operator. We want to only count the
+                        // number of >s to the left of where we actually are.
+                        if (token.Span.End <= position)
+                            stack += token.Span.Length;
+                        else
+                            stack += (position - token.Span.Start);
+
                         break;
 
                     case SyntaxKind.AsteriskToken:      // for int*


### PR DESCRIPTION
We have some code to handle partially written generics where it could be a type but the compiler is still parsing it as an expression based on context. This code needed updating for the new unsigned shift operator, but while doing and adding tests I discovered it was broken if you called it while you were in the middle of what the compiler parsed as a shift operator. This fixes that issue too.