### PR TITLE
Fixed crash when moving type from System namespace

### DIFF
--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -1343,5 +1343,29 @@ namespace B
                 Assert.Equal(expected, actualText);
             }
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.MoveToNamespace)]
+        [WorkItem(35507, "https://github.com/dotnet/roslyn/issues/35507")]
+        public Task MoveToNamespace_MoveTypeFromSystemNamespace()
+            => TestMoveToNamespaceAsync(
+@"namespace System
+{
+    [||]class A
+    {
+
+    }
+}",
+expectedMarkup: @"namespace {|Warning:Test|}
+{
+    [||]class A
+    {
+
+    }
+}",
+targetNamespace: "Test",
+expectedSymbolChanges: new Dictionary<string, string>()
+{
+    {"System.A", "Test.A" }
+});
     }
 }

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
@@ -186,20 +186,19 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
         private static async Task<ImmutableArray<ISymbol>> GetMemberSymbolsAsync(Document document, SyntaxNode container, CancellationToken cancellationToken)
         {
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
             switch (container)
             {
                 case TNamespaceDeclarationSyntax namespaceNode:
-                    var containerSymbol = (INamespaceSymbol)semanticModel.GetDeclaredSymbol(container, cancellationToken);
-                    return containerSymbol.GetMembers().Where(el => el.IsFromSource()).SelectAsArray(m => (ISymbol)m);
-
+                    var namespaceMembers = syntaxFacts.GetMembersOfBaseNamespaceDeclaration(namespaceNode);
+                    return namespaceMembers.SelectAsArray(member => semanticModel.GetDeclaredSymbol(member, cancellationToken));
                 case TCompilationUnitSyntax compilationUnit:
-                    var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
-                    var members = syntaxFacts.GetMembersOfCompilationUnit(compilationUnit);
+                    var compilationUnitMembers = syntaxFacts.GetMembersOfCompilationUnit(compilationUnit);
                     // We are trying to move a selected type from global namespace to the target namespace.
                     // This is supported if the selected type is the only member declared in the global namespace in this document.
                     // (See `TryAnalyzeNamedTypeAsync`)
-                    Debug.Assert(members.Count == 1);
-                    return members.SelectAsArray(member => semanticModel.GetDeclaredSymbol(member, cancellationToken));
+                    Debug.Assert(compilationUnitMembers.Count == 1);
+                    return compilationUnitMembers.SelectAsArray(member => semanticModel.GetDeclaredSymbol(member, cancellationToken));
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(container);

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
             {
                 case TNamespaceDeclarationSyntax namespaceNode:
                     var containerSymbol = (INamespaceSymbol)semanticModel.GetDeclaredSymbol(container, cancellationToken);
-                    return containerSymbol.GetMembers().SelectAsArray(m => (ISymbol)m);
+                    return containerSymbol.GetMembers().Where(el => el.IsFromSource()).SelectAsArray(m => (ISymbol)m);
 
                 case TCompilationUnitSyntax compilationUnit:
                     var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/35507