### PR TITLE
Handle unexpected keyword rather than identifier for lambda parameter name

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -13076,7 +13076,9 @@ tryAgain:
                     // Unparenthesized lambda case
                     // x => ...
                     // x!! => ...
-                    var identifier = this.ParseIdentifierToken();
+                    var identifier = (this.CurrentToken.Kind != SyntaxKind.IdentifierToken && this.PeekToken(1).Kind == SyntaxKind.EqualsGreaterThanToken) ?
+                        this.EatTokenAsKind(SyntaxKind.IdentifierToken) :
+                        this.ParseIdentifierToken();
 
                     ParseParameterNullCheck(out var exclamationExclamationToken, out var equalsToken);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -6311,6 +6311,26 @@ class A : Attribute { }
         }
 
         [Fact]
+        [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
+        public void KeywordParameterName()
+        {
+            var source =
+@"using System;
+class Program
+{
+    static void Main()
+    {
+        Action<int> a = int => { };
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,25): error CS1041: Identifier expected; 'int' is a keyword
+                //         Action<int> a = int => { };
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "int").WithArguments("", "int").WithLocation(6, 25));
+        }
+
+        [Fact]
         public void ParameterScope_NotInMethodAttributeNameOf()
         {
             var comp = CreateCompilation(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -6351,6 +6351,29 @@ class Program
         }
 
         [Fact]
+        [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
+        public void KeywordParameterName_03()
+        {
+            var source =
+@"using System;
+class Program
+{
+    static void Main()
+    {
+        Action<int> a = ref int => { };
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,21): error CS8171: Cannot initialize a by-value variable with a reference
+                //         Action<int> a = ref int => { };
+                Diagnostic(ErrorCode.ERR_InitializeByValueVariableWithReference, "a = ref int => { }").WithLocation(6, 21),
+                // (6,29): error CS1041: Identifier expected; 'int' is a keyword
+                //         Action<int> a = ref int => { };
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "int").WithArguments("", "int").WithLocation(6, 29));
+        }
+
+        [Fact]
         public void ParameterScope_NotInMethodAttributeNameOf()
         {
             var comp = CreateCompilation(@"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -6312,7 +6312,7 @@ class A : Attribute { }
 
         [Fact]
         [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
-        public void KeywordParameterName()
+        public void KeywordParameterName_01()
         {
             var source =
 @"using System;
@@ -6328,6 +6328,26 @@ class Program
                 // (6,25): error CS1041: Identifier expected; 'int' is a keyword
                 //         Action<int> a = int => { };
                 Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "int").WithArguments("", "int").WithLocation(6, 25));
+        }
+
+        [Fact]
+        [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
+        public void KeywordParameterName_02()
+        {
+            var source =
+@"using System;
+class Program
+{
+    static void Main()
+    {
+        Action<int> a = ref => { };
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,25): error CS1041: Identifier expected; 'ref' is a keyword
+                //         Action<int> a = ref => { };
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "ref").WithArguments("", "ref").WithLocation(6, 25));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -3203,25 +3203,6 @@ class C {
         [Fact]
         public void KeywordParameterName_07()
         {
-            string source = "public => { }";
-            UsingExpression(source,
-                // (1,1): error CS1525: Invalid expression term 'public'
-                // public => { }
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "public").WithArguments("public").WithLocation(1, 1),
-                // (1,1): error CS1073: Unexpected token 'public'
-                // public => { }
-                Diagnostic(ErrorCode.ERR_UnexpectedToken, "").WithArguments("public").WithLocation(1, 1));
-
-            M(SyntaxKind.IdentifierName);
-            {
-                M(SyntaxKind.IdentifierToken);
-            }
-            EOF();
-        }
-
-        [Fact]
-        public void KeywordParameterName_08()
-        {
             string source = "f = [A] int => { }";
             UsingExpression(source,
                 // (1,1): error CS1073: Unexpected token 'int'
@@ -3262,7 +3243,7 @@ class C {
         }
 
         [Fact]
-        public void KeywordParameterName_09()
+        public void KeywordParameterName_08()
         {
             string source = "var => { }";
             UsingExpression(source);
@@ -3284,7 +3265,7 @@ class C {
         }
 
         [Fact]
-        public void KeywordParameterName_10()
+        public void KeywordParameterName_09()
         {
             string source = "async => { }";
             UsingExpression(source);
@@ -3301,6 +3282,86 @@ class C {
                     N(SyntaxKind.OpenBraceToken);
                     N(SyntaxKind.CloseBraceToken);
                 }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void KeywordParameterName_10()
+        {
+            string source = "Action<object> a = public => { };";
+            var tree = UsingTree(source);
+            tree.GetDiagnostics().Verify(
+                // (1,20): error CS1525: Invalid expression term 'public'
+                // Action<object> a = public => { };
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "public").WithArguments("public").WithLocation(1, 20),
+                // (1,20): error CS1002: ; expected
+                // Action<object> a = public => { };
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "public").WithLocation(1, 20),
+                // (1,20): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+                // Action<object> a = public => { };
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "public").WithLocation(1, 20),
+                // (1,27): error CS1022: Type or namespace definition, or end-of-file expected
+                // Action<object> a = public => { };
+                Diagnostic(ErrorCode.ERR_EOFExpected, "=>").WithLocation(1, 27));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.LocalDeclarationStatement);
+                    {
+                        N(SyntaxKind.VariableDeclaration);
+                        {
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Action");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.ObjectKeyword);
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    M(SyntaxKind.IdentifierName);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                }
+                            }
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.IncompleteMember);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                }
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.EmptyStatement);
+                    {
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
             }
             EOF();
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -3203,6 +3203,25 @@ class C {
         [Fact]
         public void KeywordParameterName_07()
         {
+            string source = "public => { }";
+            UsingExpression(source,
+                // (1,1): error CS1525: Invalid expression term 'public'
+                // public => { }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "public").WithArguments("public").WithLocation(1, 1),
+                // (1,1): error CS1073: Unexpected token 'public'
+                // public => { }
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "").WithArguments("public").WithLocation(1, 1));
+
+            M(SyntaxKind.IdentifierName);
+            {
+                M(SyntaxKind.IdentifierToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void KeywordParameterName_08()
+        {
             string source = "f = [A] int => { }";
             UsingExpression(source,
                 // (1,1): error CS1073: Unexpected token 'int'
@@ -3243,7 +3262,7 @@ class C {
         }
 
         [Fact]
-        public void KeywordParameterName_08()
+        public void KeywordParameterName_09()
         {
             string source = "var => { }";
             UsingExpression(source);
@@ -3265,7 +3284,7 @@ class C {
         }
 
         [Fact]
-        public void KeywordParameterName_09()
+        public void KeywordParameterName_10()
         {
             string source = "async => { }";
             UsingExpression(source);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -3035,5 +3035,385 @@ class C {
             }
             EOF();
         }
+
+        [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
+        [InlineData(LanguageVersion.CSharp9)]
+        [InlineData(LanguageVersionFacts.CSharpNext)]
+        [Theory]
+        public void KeywordParameterName_01(LanguageVersion languageVersion)
+        {
+            string source = "int =>";
+            UsingExpression(source, TestOptions.Regular.WithLanguageVersion(languageVersion),
+                // (1,1): error CS1041: Identifier expected; 'int' is a keyword
+                // int =>
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "int").WithArguments("", "int").WithLocation(1, 1),
+                // (1,7): error CS1733: Expected expression
+                // int =>
+                Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(1, 7));
+
+            N(SyntaxKind.SimpleLambdaExpression);
+            {
+                M(SyntaxKind.Parameter);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                M(SyntaxKind.IdentifierName);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+            }
+            EOF();
+        }
+
+        [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
+        [InlineData(LanguageVersion.CSharp9)]
+        [InlineData(LanguageVersionFacts.CSharpNext)]
+        [Theory]
+        public void KeywordParameterName_02(LanguageVersion languageVersion)
+        {
+            string source = "ref => { }";
+            UsingExpression(source, TestOptions.Regular.WithLanguageVersion(languageVersion),
+                // (1,1): error CS1041: Identifier expected; 'ref' is a keyword
+                // ref => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "ref").WithArguments("", "ref").WithLocation(1, 1));
+
+            N(SyntaxKind.SimpleLambdaExpression);
+            {
+                M(SyntaxKind.Parameter);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
+        }
+
+        [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
+        [InlineData(LanguageVersion.CSharp9)]
+        [InlineData(LanguageVersionFacts.CSharpNext)]
+        [Theory]
+        public void KeywordParameterName_03(LanguageVersion languageVersion)
+        {
+            string source = "ref int => { }";
+            UsingExpression(source, TestOptions.Regular.WithLanguageVersion(languageVersion),
+                // (1,1): error CS1525: Invalid expression term 'ref'
+                // ref int => { }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref int => { }").WithArguments("ref").WithLocation(1, 1),
+                // (1,5): error CS1041: Identifier expected; 'int' is a keyword
+                // ref int => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "int").WithArguments("", "int").WithLocation(1, 5));
+
+            N(SyntaxKind.RefExpression);
+            {
+                N(SyntaxKind.RefKeyword);
+                N(SyntaxKind.SimpleLambdaExpression);
+                {
+                    M(SyntaxKind.Parameter);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.EqualsGreaterThanToken);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
+        [Fact]
+        public void KeywordParameterName_04()
+        {
+            string source = "delegate => { }";
+            UsingExpression(source,
+                // (1,1): error CS1041: Identifier expected; 'delegate' is a keyword
+                // delegate => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "delegate").WithArguments("", "delegate").WithLocation(1, 1));
+
+            N(SyntaxKind.SimpleLambdaExpression);
+            {
+                M(SyntaxKind.Parameter);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
+        }
+
+        [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
+        [Fact]
+        public void KeywordParameterName_05()
+        {
+            string source = "int !! =>";
+            UsingExpression(source,
+                // (1,1): error CS1041: Identifier expected; 'int' is a keyword
+                // int =>
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "int").WithArguments("", "int").WithLocation(1, 1),
+                // (1,7): error CS1733: Expected expression
+                // int =>
+                Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(1, 7));
+
+            M(SyntaxKind.IdentifierName);
+            {
+                M(SyntaxKind.IdentifierToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void KeywordParameterName_06()
+        {
+            string source = "static => { }";
+            UsingExpression(source,
+                // (1,8): error CS1001: Identifier expected
+                // static => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(1, 8));
+
+            N(SyntaxKind.SimpleLambdaExpression);
+            {
+                N(SyntaxKind.StaticKeyword);
+                M(SyntaxKind.Parameter);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void KeywordParameterName_07()
+        {
+            string source = "static int => { }";
+            UsingExpression(source,
+                // (1,1): error CS1525: Invalid expression term 'static'
+                // static int => { }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "static").WithArguments("static").WithLocation(1, 1),
+                // (1,1): error CS1073: Unexpected token 'static'
+                // static int => { }
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "").WithArguments("static").WithLocation(1, 1));
+
+            M(SyntaxKind.IdentifierName);
+            {
+                M(SyntaxKind.IdentifierToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void KeywordParameterName_08()
+        {
+            string source = "f = [A] int => { }";
+            UsingExpression(source,
+                // (1,1): error CS1073: Unexpected token 'int'
+                // f = [A] int => { }
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "f = [A]").WithArguments("int").WithLocation(1, 1),
+                // (1,5): error CS1525: Invalid expression term '['
+                // f = [A] int => { }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "[").WithArguments("[").WithLocation(1, 5));
+
+            N(SyntaxKind.SimpleAssignmentExpression);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "f");
+                }
+                N(SyntaxKind.EqualsToken);
+                N(SyntaxKind.ElementAccessExpression);
+                {
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.BracketedArgumentList);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Argument);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                            }
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void KeywordParameterName_09()
+        {
+            string source = "var => { }";
+            UsingExpression(source);
+
+            N(SyntaxKind.SimpleLambdaExpression);
+            {
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.IdentifierToken, "var");
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void KeywordParameterName_10()
+        {
+            string source = "async => { }";
+            UsingExpression(source);
+
+            N(SyntaxKind.SimpleLambdaExpression);
+            {
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.IdentifierToken, "async");
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void MissingParameterName_01()
+        {
+            string source = "=> { }";
+            UsingExpression(source,
+                // (1,1): error CS1001: Identifier expected
+                // => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(1, 1));
+
+            N(SyntaxKind.SimpleLambdaExpression);
+            {
+                M(SyntaxKind.Parameter);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void MissingParameterName_02()
+        {
+            string source = "[ => { }";
+            UsingExpression(source,
+                // (1,3): error CS1001: Identifier expected
+                // [ => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(1, 3),
+                // (1,3): error CS1001: Identifier expected
+                // [ => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(1, 3),
+                // (1,9): error CS1003: Syntax error, ']' expected
+                // [ => { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]", "").WithLocation(1, 9),
+                // (1,9): error CS1001: Identifier expected
+                // [ => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "").WithLocation(1, 9),
+                // (1,9): error CS1003: Syntax error, '=>' expected
+                // [ => { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("=>", "").WithLocation(1, 9),
+                // (1,9): error CS1733: Expected expression
+                // [ => { }
+                Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(1, 9));
+
+            N(SyntaxKind.SimpleLambdaExpression);
+            {
+                N(SyntaxKind.AttributeList);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    M(SyntaxKind.Attribute);
+                    {
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    M(SyntaxKind.CloseBracketToken);
+                }
+                M(SyntaxKind.Parameter);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                M(SyntaxKind.IdentifierName);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void MissingParameterName_03()
+        {
+            string source = "( => { }";
+            UsingExpression(source,
+                // (1,3): error CS1001: Identifier expected
+                // ( => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(1, 3),
+                // (1,9): error CS1026: ) expected
+                // ( => { }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(1, 9),
+                // (1,9): error CS1003: Syntax error, '=>' expected
+                // ( => { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("=>", "").WithLocation(1, 9),
+                // (1,9): error CS1733: Expected expression
+                // ( => { }
+                Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(1, 9));
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.EqualsGreaterThanToken);
+                M(SyntaxKind.IdentifierName);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+            }
+            EOF();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -3155,28 +3155,8 @@ class C {
             EOF();
         }
 
-        [WorkItem(60661, "https://github.com/dotnet/roslyn/issues/60661")]
         [Fact]
         public void KeywordParameterName_05()
-        {
-            string source = "int !! =>";
-            UsingExpression(source,
-                // (1,1): error CS1041: Identifier expected; 'int' is a keyword
-                // int =>
-                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "int").WithArguments("", "int").WithLocation(1, 1),
-                // (1,7): error CS1733: Expected expression
-                // int =>
-                Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(1, 7));
-
-            M(SyntaxKind.IdentifierName);
-            {
-                M(SyntaxKind.IdentifierToken);
-            }
-            EOF();
-        }
-
-        [Fact]
-        public void KeywordParameterName_06()
         {
             string source = "static => { }";
             UsingExpression(source,
@@ -3202,7 +3182,7 @@ class C {
         }
 
         [Fact]
-        public void KeywordParameterName_07()
+        public void KeywordParameterName_06()
         {
             string source = "static int => { }";
             UsingExpression(source,
@@ -3221,7 +3201,7 @@ class C {
         }
 
         [Fact]
-        public void KeywordParameterName_08()
+        public void KeywordParameterName_07()
         {
             string source = "f = [A] int => { }";
             UsingExpression(source,
@@ -3263,7 +3243,7 @@ class C {
         }
 
         [Fact]
-        public void KeywordParameterName_09()
+        public void KeywordParameterName_08()
         {
             string source = "var => { }";
             UsingExpression(source);
@@ -3285,7 +3265,7 @@ class C {
         }
 
         [Fact]
-        public void KeywordParameterName_10()
+        public void KeywordParameterName_09()
         {
             string source = "async => { }";
             UsingExpression(source);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -3289,6 +3289,86 @@ class C {
         [Fact]
         public void KeywordParameterName_10()
         {
+            string source = "(int) => { }";
+            UsingExpression(source,
+                // (1,5): error CS1001: Identifier expected
+                // (int) => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(1, 5));
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void KeywordParameterName_11()
+        {
+            string source = "(int, int) => { }";
+            UsingExpression(source,
+                // (1,5): error CS1001: Identifier expected
+                // (int, int) => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ",").WithLocation(1, 5),
+                // (1,10): error CS1001: Identifier expected
+                // (int, int) => { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(1, 10));
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void KeywordParameterName_12()
+        {
             string source = "Action<object> a = public => { };";
             var tree = UsingTree(source);
             tree.GetDiagnostics().Verify(


### PR DESCRIPTION
Fixes #60661