### PR TITLE
Exclude System.Text.Encoding.CodePages from OptProf

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,15 +78,6 @@ jobs:
 
 - template: eng/pipelines/test-windows-job.yml
   parameters:
-    testRunName: 'Test Windows Desktop Spanish Release 32'
-    jobName: Test_Windows_Desktop_Spanish_Release_32
-    buildJobName: Build_Windows_Release
-    testArtifactName: Transport_Artifacts_Windows_Release
-    configuration: Release
-    testArguments: -testDesktop -test32 -helixQueueName Windows.10.Amd64.Server19H1.ES.Open
-
-- template: eng/pipelines/test-windows-job.yml
-  parameters:
     testRunName: 'Test Windows Desktop Release 64'
     jobName: Test_Windows_Desktop_Release_64
     buildJobName: Build_Windows_Release

--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -387,10 +387,6 @@
               "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
             },
             {
-              "filename": "/Contents/MSBuild/Current/Bin/Roslyn/System.Text.Encoding.CodePages.dll",
-              "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
-            },
-            {
               "filename": "/Contents/MSBuild/Current/Bin/Roslyn/Microsoft.CodeAnalysis.VisualBasic.dll",
               "testCases":[ "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
             },


### PR DESCRIPTION
@dibarbet This is to fix an OptProf profiling issue https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1515514
Once merged, we will need an 16.11 insertion with OptProf config update only (i.e. dotnet.roslyn.props file in VS)