### PR TITLE
Fix TypeScript code actions and Xaml remove unused usings

### DIFF
--- a/src/EditorFeatures/Core/Organizing/OrganizeDocumentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Organizing/OrganizeDocumentCommandHandler.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Organizing
                 operationContext, _threadingContext);
             if (document != null)
             {
-                var formattingOptions = SyntaxFormattingOptions.FromDocumentAsync(document, cancellationToken).WaitAndGetResult(cancellationToken);
+                var formattingOptions = document.SupportsSyntaxTree ? SyntaxFormattingOptions.FromDocumentAsync(document, cancellationToken).WaitAndGetResult(cancellationToken) : null;
                 var newDocument = document.GetLanguageService<IRemoveUnnecessaryImportsService>().RemoveUnnecessaryImportsAsync(document, formattingOptions, cancellationToken).WaitAndGetResult(cancellationToken);
                 newDocument = Formatter.OrganizeImportsAsync(newDocument, cancellationToken).WaitAndGetResult(cancellationToken);
                 if (document != newDocument)

--- a/src/VisualStudio/Xaml/Impl/CodeFixes/RemoveUnnecessaryUsings/XamlRemoveUnnecessaryUsingsCodeFixProvider.cs
+++ b/src/VisualStudio/Xaml/Impl/CodeFixes/RemoveUnnecessaryUsings/XamlRemoveUnnecessaryUsingsCodeFixProvider.cs
@@ -55,8 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.CodeFixes.RemoveUnusedUsings
             Document document, CancellationToken cancellationToken)
         {
             var service = document.GetLanguageService<IRemoveUnnecessaryImportsService>();
-            var syntaxFormattingOptions = await SyntaxFormattingOptions.FromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
-            return await service.RemoveUnnecessaryImportsAsync(document, syntaxFormattingOptions, cancellationToken).ConfigureAwait(false);
+            return await service.RemoveUnnecessaryImportsAsync(document, formattingOptions: null, cancellationToken).ConfigureAwait(false);
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/VisualStudio/Xaml/Impl/Features/OrganizeImports/XamlRemoveUnnecessaryImportsService.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/OrganizeImports/XamlRemoveUnnecessaryImportsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Composition;
 using System.Threading;
@@ -27,11 +25,11 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.OrganizeImports
             _removeService = removeService;
         }
 
-        public Task<Document> RemoveUnnecessaryImportsAsync(Document document, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken)
+        public Task<Document> RemoveUnnecessaryImportsAsync(Document document, SyntaxFormattingOptions? formattingOptions, CancellationToken cancellationToken)
             => RemoveUnnecessaryImportsAsync(document, predicate: null, formattingOptions, cancellationToken: cancellationToken);
 
         public Task<Document> RemoveUnnecessaryImportsAsync(
-            Document document, Func<SyntaxNode, bool> predicate, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken)
+            Document document, Func<SyntaxNode, bool>? predicate, SyntaxFormattingOptions? formattingOptions, CancellationToken cancellationToken)
         {
             return _removeService.RemoveUnnecessaryNamespacesAsync(document, cancellationToken) ?? Task.FromResult(document);
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpRemoveUnnecessaryImportsService.cs
@@ -48,10 +48,12 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
 
         public override async Task<Document> RemoveUnnecessaryImportsAsync(
             Document document,
-            Func<SyntaxNode, bool> predicate,
-            SyntaxFormattingOptions formattingOptions,
+            Func<SyntaxNode, bool>? predicate,
+            SyntaxFormattingOptions? formattingOptions,
             CancellationToken cancellationToken)
         {
+            Contract.ThrowIfNull(formattingOptions);
+
             predicate ??= Functions<SyntaxNode>.True;
             using (Logger.LogBlock(FunctionId.Refactoring_RemoveUnnecessaryImports_CSharp, cancellationToken))
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,16 +20,16 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
     {
         protected abstract IUnnecessaryImportsProvider UnnecessaryImportsProvider { get; }
 
-        public Task<Document> RemoveUnnecessaryImportsAsync(Document document, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken)
+        public Task<Document> RemoveUnnecessaryImportsAsync(Document document, SyntaxFormattingOptions? formattingOptions, CancellationToken cancellationToken)
             => RemoveUnnecessaryImportsAsync(document, predicate: null, formattingOptions, cancellationToken);
 
-        public abstract Task<Document> RemoveUnnecessaryImportsAsync(Document fromDocument, Func<SyntaxNode, bool> predicate, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken);
+        public abstract Task<Document> RemoveUnnecessaryImportsAsync(Document fromDocument, Func<SyntaxNode, bool>? predicate, SyntaxFormattingOptions? formattingOptions, CancellationToken cancellationToken);
 
         protected static SyntaxToken StripNewLines(Document document, SyntaxToken token)
         {
-            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
-            var trimmedLeadingTrivia = token.LeadingTrivia.SkipWhile(t => syntaxFacts.IsEndOfLineTrivia(t)).ToList();
+            var trimmedLeadingTrivia = token.LeadingTrivia.SkipWhile(syntaxFacts.IsEndOfLineTrivia).ToList();
 
             // If the list ends with 3 newlines remove the last one until there's only 2 newlines to end the leading trivia.
             while (trimmedLeadingTrivia.Count >= 3 &&
@@ -66,8 +64,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
             return unnecessaryImports;
         }
 
-        bool IEqualityComparer<T>.Equals(T x, T y)
-            => x.Span == y.Span;
+        bool IEqualityComparer<T>.Equals(T? x, T? y)
+            => x?.Span == y?.Span;
 
         int IEqualityComparer<T>.GetHashCode(T obj)
             => obj.Span.GetHashCode();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/RemoveUnnecessaryImports/IRemoveUnnecessaryImportsService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/RemoveUnnecessaryImports/IRemoveUnnecessaryImportsService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +12,10 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
 {
     internal interface IRemoveUnnecessaryImportsService : ILanguageService
     {
-        Task<Document> RemoveUnnecessaryImportsAsync(Document document, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken);
-        Task<Document> RemoveUnnecessaryImportsAsync(Document fromDocument, Func<SyntaxNode, bool> predicate, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken);
+        /// <param name="formattingOptions">Null if the document does not support syntax trees.</param>
+        Task<Document> RemoveUnnecessaryImportsAsync(Document document, SyntaxFormattingOptions? formattingOptions, CancellationToken cancellationToken);
+
+        /// <param name="formattingOptions">Null if the document does not support syntax trees.</param>
+        Task<Document> RemoveUnnecessaryImportsAsync(Document fromDocument, Func<SyntaxNode, bool>? predicate, SyntaxFormattingOptions? formattingOptions, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicRemoveUnnecessaryImportsService.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicRemoveUnnecessaryImportsService.vb
@@ -33,6 +33,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryImports
                 formattingOptions As SyntaxFormattingOptions,
                 cancellationToken As CancellationToken) As Task(Of Document)
 
+            Contract.ThrowIfNull(formattingOptions)
+
             predicate = If(predicate, Functions(Of SyntaxNode).True)
             Using Logger.LogBlock(FunctionId.Refactoring_RemoveUnnecessaryImports_VisualBasic, cancellationToken)
 


### PR DESCRIPTION
TypeScript and Xaml can't retrieve Roslyn options.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1524587