### PR TITLE
Fix the color key for rename hint text at the bottom

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornment.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/InlineRenameAdornment.xaml
@@ -28,14 +28,12 @@
 
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
 
-            <SolidColorBrush x:Key="ForegroundText" Color="{DynamicResource {x:Static rename:InlineRenameColors.SystemCaptionTextColorKey}}"/>
-
             <Style TargetType="CheckBox">
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static rename:InlineRenameColors.CheckBoxTextBrushKey}}"/>
             </Style>
 
             <Style TargetType="TextBlock">
-                <Setter Property="Foreground" Value="{StaticResource ForegroundText}"/>
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static rename:InlineRenameColors.CheckBoxTextBrushKey}}"/>
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -113,7 +111,12 @@
                     Visibility="{Binding Path=ShowFileRename, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
             </StackPanel>
 
-            <TextBlock Text="{Binding ElementName=control, Path=SubmitText}" Foreground="LightGray" Margin="5, 5, 0, 0" FontStyle="Italic" />
+            <TextBlock 
+                Text="{Binding ElementName=control, Path=SubmitText}" 
+                Margin="5, 5, 0, 0" 
+                FontStyle="Italic"
+                Foreground="{DynamicResource {x:Static rename:InlineRenameColors.GrayTextKey}}"
+                />
     </StackPanel>
     </Border>
 </UserControl>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameColors.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameColors.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         // but in Visual Studio we will change these keys (since they are settable) to the keys for
         // the actual Visual Studio resource keys.
         //
-        // Each entry here should have a corresponding entry in DashboardColors.xaml to specify the
+        // Each entry here should have a corresponding entry in InlineRenameColors.xaml to specify the
         // default color.
 
         public static object SystemCaptionTextColorKey { get; set; } = "SystemCaptionTextColor";
@@ -21,5 +21,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public static object AccentBarColorKey { get; set; } = "AccentBarBrush";
         public static object ButtonStyleKey { get; set; } = "ButtonStyle";
         public static object ButtonBorderBrush { get; set; } = "ButtonBorderBrush";
+        public static object GrayTextKey { get; set; } = "GrayTextBrush";
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameColors.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameColors.xaml
@@ -12,5 +12,6 @@
     <SolidColorBrush x:Key="BackgroundBrush">LightGray</SolidColorBrush>
     <SolidColorBrush x:Key="AccentBarBrush">Blue</SolidColorBrush>
     <SolidColorBrush x:Key="ButtonBorderBrush">White</SolidColorBrush>
+    <SolidColorBrush x:Key="GrayTextBrush">Gray</SolidColorBrush>
     <Style TargetType="Button" x:Key="ButtonStyle" BasedOn="{StaticResource {x:Type Button}}"/>
 </ResourceDictionary>

--- a/src/VisualStudio/Core/Def/InlineRename/DashboardColorUpdater.cs
+++ b/src/VisualStudio/Core/Def/InlineRename/DashboardColorUpdater.cs
@@ -28,6 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InlineRename
             InlineRenameColors.BackgroundBrushKey = VsBrushes.CommandBarGradientBeginKey;
             InlineRenameColors.AccentBarColorKey = EnvironmentColors.FileTabInactiveDocumentBorderEdgeBrushKey;
             InlineRenameColors.ButtonStyleKey = VsResourceKeys.ButtonStyleKey;
+            InlineRenameColors.GrayTextKey = VsBrushes.GrayTextKey;
         }
     }
 }


### PR DESCRIPTION
Fixes #60734

![image](https://user-images.githubusercontent.com/475144/164114304-90bba21f-44fc-4caf-b1ab-cf84914ed8d6.png)
![image](https://user-images.githubusercontent.com/475144/164114400-9e171700-5d59-4f65-b89d-b436a4e731e8.png)

