### PR TITLE
Fix typo in Stack Trace Explorer text

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1879,7 +1879,7 @@ Additional information: {1}</value>
     <value>End of line</value>
   </data>
   <data name="Paste_valid_stack_trace" xml:space="preserve">
-    <value>Paste a valid stack trace to view and navigate it's values</value>
+    <value>Paste a stack trace to view and navigate its values</value>
     <comment>"Stack Trace" is a language term and should be kept the same. </comment>
   </data>
   <data name="Stack_Trace_Explorer" xml:space="preserve">

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1879,7 +1879,7 @@ Additional information: {1}</value>
     <value>End of line</value>
   </data>
   <data name="Paste_valid_stack_trace" xml:space="preserve">
-    <value>Paste a stack trace to view and navigate its values</value>
+    <value>Paste a stack trace to view and navigate its values.</value>
     <comment>"Stack Trace" is a language term and should be kept the same. </comment>
   </data>
   <data name="Stack_Trace_Explorer" xml:space="preserve">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">Pokud chcete zobrazit a procházet jeho hodnoty, vložte platné trasování zásobníku.</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">Pokud chcete zobrazit a procházet jeho hodnoty, vložte platné trasování zásobníku.</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">Pokud chcete zobrazit a procházet jeho hodnoty, vložte platné trasování zásobníku.</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">Fügen Sie eine gültige Stapelüberwachung ein, um ihre Werte anzuzeigen und durch sie zu navigieren.</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">Fügen Sie eine gültige Stapelüberwachung ein, um ihre Werte anzuzeigen und durch sie zu navigieren.</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">Fügen Sie eine gültige Stapelüberwachung ein, um ihre Werte anzuzeigen und durch sie zu navigieren.</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">Pegar un seguimiento de pila válido para ver y navegar sus valores</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">Pegar un seguimiento de pila válido para ver y navegar sus valores</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">Pegar un seguimiento de pila válido para ver y navegar sus valores</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">Collez une trace de pile valide pour afficher et parcourir ses valeurs</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">Collez une trace de pile valide pour afficher et parcourir ses valeurs</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">Collez une trace de pile valide pour afficher et parcourir ses valeurs</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">Incolla un'analisi dello stack valida per visualizzare e spostarti tra i relativi valori</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">Incolla un'analisi dello stack valida per visualizzare e spostarti tra i relativi valori</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">Incolla un'analisi dello stack valida per visualizzare e spostarti tra i relativi valori</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">有効なスタック トレースを貼り付けて、値を表示して移動します</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">有効なスタック トレースを貼り付けて、値を表示して移動します</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">有効なスタック トレースを貼り付けて、値を表示して移動します</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">유효한 스택 추적을 붙여넣어 해당 값을 보고 탐색합니다.</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">유효한 스택 추적을 붙여넣어 해당 값을 보고 탐색합니다.</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">유효한 스택 추적을 붙여넣어 해당 값을 보고 탐색합니다.</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">Wklej prawidłowy ślad stosu, aby wyświetlić jego wartościach i nawigować po nich</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">Wklej prawidłowy ślad stosu, aby wyświetlić jego wartościach i nawigować po nich</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">Wklej prawidłowy ślad stosu, aby wyświetlić jego wartościach i nawigować po nich</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">Cole um rastreamento de pilha válido para exibir e navegar pelos valores</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">Cole um rastreamento de pilha válido para exibir e navegar pelos valores</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">Cole um rastreamento de pilha válido para exibir e navegar pelos valores</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">Вставьте допустимую трассировку стека для просмотра ее значений и перехода к ним</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">Вставьте допустимую трассировку стека для просмотра ее значений и перехода к ним</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">Вставьте допустимую трассировку стека для просмотра ее значений и перехода к ним</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">Değerlerini görüntülemek ve gezinmek için geçerli bir yığın izlemesi yapıştırın</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">Değerlerini görüntülemek ve gezinmek için geçerli bir yığın izlemesi yapıştırın</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">Değerlerini görüntülemek ve gezinmek için geçerli bir yığın izlemesi yapıştırın</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">粘贴有效的堆栈跟踪以查看和导航其值</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">粘贴有效的堆栈跟踪以查看和导航其值</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">粘贴有效的堆栈跟踪以查看和导航其值</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a valid stack trace to view and navigate it's values</source>
-        <target state="translated">貼上有效的堆疊追蹤以檢視及瀏覽其值</target>
+        <source>Paste a stack trace to view and navigate its values</source>
+        <target state="needs-review-translation">貼上有效的堆疊追蹤以檢視及瀏覽其值</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>
       <trans-unit id="Paused_0_tasks_in_queue">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1008,7 +1008,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Paste_valid_stack_trace">
-        <source>Paste a stack trace to view and navigate its values</source>
+        <source>Paste a stack trace to view and navigate its values.</source>
         <target state="needs-review-translation">貼上有效的堆疊追蹤以檢視及瀏覽其值</target>
         <note>"Stack Trace" is a language term and should be kept the same. </note>
       </trans-unit>


### PR DESCRIPTION
Modify the text when a user needs to paste a stack trace to fix a typo and remove extra words. 