### PR TITLE
Assume buffer is visible if we can't find any views for it at all

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Workspaces/WpfTextBufferVisibilityTracker.cs
+++ b/src/EditorFeatures/Core.Wpf/Workspaces/WpfTextBufferVisibilityTracker.cs
@@ -67,6 +67,10 @@ namespace Microsoft.CodeAnalysis.Workspaces
 
             var views = _associatedViewService.GetAssociatedTextViews(subjectBuffer).ToImmutableArrayOrEmpty();
 
+            // If we don't have any views at all, then assume the buffer is visible.
+            if (views.Length == 0)
+                return true;
+
             // if any of the views were *not* wpf text views, assume the buffer is visible.  We don't know how to
             // determine the visibility of this buffer.  While unlikely to happen, this is possible with VS's
             // extensibility model, which allows for a plugin to host an ITextBuffer in their own impl of an ITextView.

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -233,8 +233,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
 
             using var rightDisposable = rightTagger as IDisposable;
             // wait for diagnostics and taggers
-            await listenerProvider.WaitAllDispatcherOperationAndTasksAsync(workspace, FeatureAttribute.DiagnosticService);
-            await listenerProvider.WaitAllDispatcherOperationAndTasksAsync(workspace, FeatureAttribute.ErrorSquiggles);
+            await listenerProvider.WaitAllDispatcherOperationAndTasksAsync(
+                workspace, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles, FeatureAttribute.SolutionCrawler);
 
             // check left buffer
             var leftSnapshot = leftBuffer.CurrentSnapshot;

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -233,8 +233,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
 
             using var rightDisposable = rightTagger as IDisposable;
             // wait for diagnostics and taggers
-            await listenerProvider.WaitAllDispatcherOperationAndTasksAsync(
-                workspace, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles, FeatureAttribute.SolutionCrawler);
+            await listenerProvider.WaitAllDispatcherOperationAndTasksAsync(workspace, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles);
 
             // check left buffer
             var leftSnapshot = leftBuffer.CurrentSnapshot;

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -233,7 +233,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
 
             using var rightDisposable = rightTagger as IDisposable;
             // wait for diagnostics and taggers
-            await listenerProvider.WaitAllDispatcherOperationAndTasksAsync(workspace, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles);
+            await listenerProvider.WaitAllDispatcherOperationAndTasksAsync(workspace, FeatureAttribute.DiagnosticService);
+            await listenerProvider.WaitAllDispatcherOperationAndTasksAsync(workspace, FeatureAttribute.ErrorSquiggles);
 
             // check left buffer
             var leftSnapshot = leftBuffer.CurrentSnapshot;


### PR DESCRIPTION
There appears to be some sort of race/delay in unit tests around when a buffer becomes visible.  I can't figure out any way to force this to happen in tests.  SO i'm making our visbility service always return true for visbility for a buffer if we can't find a view for it.
