### PR TITLE
Disable test TestPreviewDiagnosticTaggerInPreviewPane

### DIFF
--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
             Assert.Equal(SquigglesCount + 1, SquigglesCount + diagnosticsAndErrorsSpans.Item2.Length);
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/60863")]
         public async Task TestPreviewDiagnosticTaggerInPreviewPane()
         {
             // TODO: WPF required due to https://github.com/dotnet/roslyn/issues/46153


### PR DESCRIPTION
https://runfo.azurewebsites.net/search/tests/?q=started:~1+definition:roslyn-ci+name:TestPreviewDiagnosticTaggerInPreviewPane

I took a quick stab at fixing it locally, but it doesn't repro on my machine.  So disabling now to unblock PRs.

https://github.com/dotnet/roslyn/issues/60863