### PR TITLE
Correctly return E_NOTIMPL when asked for file code models for non-source

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             // Check that we know about this file!
             var documentId = State.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).Where(id => id.ProjectId == _projectId).FirstOrDefault();
-            if (documentId == null)
+            if (documentId == null || State.Workspace.CurrentSolution.GetDocument(documentId) == null)
             {
                 // Matches behavior of native (C#) implementation
                 throw Exceptions.ThrowENotImpl();

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/FileCodeModelTests.vb
@@ -1286,6 +1286,27 @@ class C
             End Using
         End Sub
 
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Sub RequestingCodeModelForAdditionalFileThrowsCorrectExceptionType()
+            Dim code =
+<Workspace>
+    <Project Language=<%= LanguageName %> CommonReferences="true">
+        <AdditionalDocument FilePath="Z:\Additional.txt"></AdditionalDocument>
+    </Project>
+</Workspace>
+
+            Using state = CreateCodeModelTestState(code)
+                Dim workspace = state.VisualStudioWorkspace
+                Dim projectCodeModelFactory = state.Workspace.GetService(Of ProjectCodeModelFactory)()
+                Dim projectCodeModel = projectCodeModelFactory.GetProjectCodeModel(workspace.CurrentSolution.ProjectIds.Single())
+
+                Assert.Throws(Of NotImplementedException)(
+                    Sub()
+                        projectCodeModel.GetOrCreateFileCodeModel("Z:\Additional.txt", parent:=Nothing)
+                    End Sub)
+            End Using
+        End Sub
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.CSharp

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
@@ -84,7 +84,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
                 Dim root = New ComHandle(Of EnvDTE.CodeModel, RootCodeModel)(RootCodeModel.Create(state, Nothing, project.Id))
 
-                result = New CodeModelTestState(workspace, state.Workspace, root, firstFileCodeModel.Value, state.CodeModelService)
+                result = New CodeModelTestState(workspace, state.Workspace, root, firstFileCodeModel, state.CodeModelService)
             Finally
                 If result Is Nothing Then
                     workspace.Dispose()

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestState.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestState.vb
@@ -14,14 +14,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         Public ReadOnly Workspace As TestWorkspace
         Private ReadOnly _visualStudioWorkspace As VisualStudioWorkspace
         Private ReadOnly _rootCodeModel As ComHandle(Of EnvDTE.CodeModel, RootCodeModel)
-        Private ReadOnly _fileCodeModel As ComHandle(Of EnvDTE80.FileCodeModel2, FileCodeModel)
+        Private ReadOnly _fileCodeModel As ComHandle(Of EnvDTE80.FileCodeModel2, FileCodeModel)?
         Private ReadOnly _codeModelService As ICodeModelService
 
         Public Sub New(
             workspace As TestWorkspace,
             visualStudioWorkspace As VisualStudioWorkspace,
             rootCodeModel As ComHandle(Of EnvDTE.CodeModel, RootCodeModel),
-            fileCodeModel As ComHandle(Of EnvDTE80.FileCodeModel2, FileCodeModel),
+            fileCodeModel As ComHandle(Of EnvDTE80.FileCodeModel2, FileCodeModel)?,
             codeModelService As ICodeModelService
         )
 
@@ -48,13 +48,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
 
         Public ReadOnly Property FileCodeModel As EnvDTE80.FileCodeModel2
             Get
-                Return _fileCodeModel.Handle
+                Return _fileCodeModel.Value.Handle
             End Get
         End Property
 
         Public ReadOnly Property FileCodeModelObject As FileCodeModel
             Get
-                Return _fileCodeModel.Object
+                Return _fileCodeModel.Value.Object
             End Get
         End Property
 


### PR DESCRIPTION
It appears the existing contract when the language service is asked for a file that we don't know about is to return E_NOTIMPL: this assumption is encoded in other places like https://github.com/dotnet/project-system/blob/aca656810125ee6be02c47a5195ddde008fe1ae5/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs#L70
In any case, we had a bug where if the caller asked about a file that happened to be an additional file, our check for the 
missing file would not return E_NOTIMPL and we'd throw other exceptions later.

Fixes https://developercommunity.visualstudio.com/t/Adding-strings-to-resx-file-pops-a-modal/1511601