### PR TITLE
Correctly set the TemplateSelector of inheritance margin.

### DIFF
--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml
@@ -23,6 +23,8 @@
         <!-- The image shown in the menu item, mark this is non-shared to make sure each menu item has its own image -->
         <imaging:CrispImage x:Key="NonSharedIcon" x:Shared="False" Moniker="{Binding ImageMoniker}"/>
 
+        <local:MenuItemContainerTemplateSelector x:Key="TemplateSelector"/>
+
         <!-- Style used to display a single target menu item -->
         <Style x:Key="TargetMenuItemStyle" TargetType="{x:Type MenuItem}">
             <Setter Property="Icon" Value="{StaticResource NonSharedIcon}"/>
@@ -148,8 +150,6 @@
                 </Setter.Value>
             </Setter>
         </Style>
-
-        <local:MenuItemContainerTemplateSelector x:Key="TemplateSelector"/>
 
         <!-- Style used to show the header  -->
         <Style x:Key="HeaderMenuItemStyle" TargetType="{x:Type MenuItem}">


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/60894
After this there is no problem when try to expand multiple members
![image](https://user-images.githubusercontent.com/24360909/164575876-c51e2fd7-7cca-4d8a-af39-ed3790f69627.png)

The reason is static resource must be declared first and then use : (

I think this is introduced back in this PR https://github.com/dotnet/roslyn/pull/56471