### PR TITLE
Optimize allocations in batch queue processing

### DIFF
--- a/src/Dependencies/Collections/ImmutableSegmentedListExtensions.cs
+++ b/src/Dependencies/Collections/ImmutableSegmentedListExtensions.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Collections;
+
+#pragma warning disable RS0001 // Use 'SpecializedCollections.EmptyEnumerable()'
+
+namespace System.Linq
+{
+    /// <seealso cref="ImmutableArrayExtensions"/>
+    internal static class ImmutableSegmentedListExtensions
+    {
+        public static bool All<T>(this ImmutableSegmentedList<T> immutableList, Func<T, bool> predicate)
+        {
+            if (immutableList.IsDefault)
+                throw new ArgumentNullException(nameof(immutableList));
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            foreach (var item in immutableList)
+            {
+                if (!predicate(item))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public static bool Any<T>(this ImmutableSegmentedList<T> immutableList)
+        {
+            if (immutableList.IsDefault)
+                throw new ArgumentNullException(nameof(immutableList));
+
+            return !immutableList.IsEmpty;
+        }
+
+        public static bool Any<T>(this ImmutableSegmentedList<T>.Builder builder)
+        {
+            if (builder is null)
+                throw new ArgumentNullException(nameof(builder));
+
+            return builder.Count > 0;
+        }
+
+        public static bool Any<T>(this ImmutableSegmentedList<T> immutableList, Func<T, bool> predicate)
+        {
+            if (immutableList.IsDefault)
+                throw new ArgumentNullException(nameof(immutableList));
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            foreach (var item in immutableList)
+            {
+                if (predicate(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static T Last<T>(this ImmutableSegmentedList<T> immutableList)
+        {
+            // In the event of an empty list, generate the same exception
+            // that the linq extension method would.
+            return immutableList.Count > 0
+                ? immutableList[immutableList.Count - 1]
+                : Enumerable.Last(immutableList);
+        }
+
+        public static T Last<T>(this ImmutableSegmentedList<T>.Builder builder)
+        {
+            if (builder is null)
+                throw new ArgumentNullException(nameof(builder));
+
+            // In the event of an empty list, generate the same exception
+            // that the linq extension method would.
+            return builder.Count > 0
+                ? builder[builder.Count - 1]
+                : Enumerable.Last(builder);
+        }
+
+        public static T Last<T>(this ImmutableSegmentedList<T> immutableList, Func<T, bool> predicate)
+        {
+            if (immutableList.IsDefault)
+                throw new ArgumentNullException(nameof(immutableList));
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            for (var i = immutableList.Count - 1; i >= 0; i--)
+            {
+                if (predicate(immutableList[i]))
+                    return immutableList[i];
+            }
+
+            // Throw the same exception that LINQ would.
+            return Enumerable.Empty<T>().Last();
+        }
+
+        public static IEnumerable<TResult> Select<T, TResult>(this ImmutableSegmentedList<T> immutableList, Func<T, TResult> selector)
+        {
+            if (immutableList.IsDefault)
+                throw new ArgumentNullException(nameof(immutableList));
+            if (selector is null)
+                throw new ArgumentNullException(nameof(selector));
+
+            if (immutableList.IsEmpty)
+            {
+                return Enumerable.Empty<TResult>();
+            }
+            else
+            {
+                return Enumerable.Select(immutableList, selector);
+            }
+        }
+    }
+}

--- a/src/Dependencies/Collections/Microsoft.CodeAnalysis.Collections.projitems
+++ b/src/Dependencies/Collections/Microsoft.CodeAnalysis.Collections.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ImmutableSegmentedDictionary`2+ValueCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ImmutableSegmentedDictionary`2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ImmutableSegmentedList.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ImmutableSegmentedListExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ImmutableSegmentedList`1+Builder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ImmutableSegmentedList`1+Enumerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ImmutableSegmentedList`1+PrivateInterlocked.cs" />

--- a/src/EditorFeatures/Core.Wpf/BackgroundWorkIndicator/BackgroundWorkIndicatorContext.cs
+++ b/src/EditorFeatures/Core.Wpf/BackgroundWorkIndicator/BackgroundWorkIndicatorContext.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -187,10 +188,10 @@ internal partial class WpfBackgroundWorkIndicatorFactory
             }
         }
 
-        private ValueTask UpdateUIAsync(ImmutableArray<UIUpdateRequest> requests, CancellationToken cancellationToken)
+        private ValueTask UpdateUIAsync(ImmutableSegmentedList<UIUpdateRequest> requests, CancellationToken cancellationToken)
         {
-            Contract.ThrowIfTrue(requests.IsDefaultOrEmpty, "We must have gotten an actual request to process.");
-            Contract.ThrowIfTrue(requests.Length > 2, "At most we can have two requests in the queue (one to update, one to dismiss).");
+            Contract.ThrowIfTrue(requests.IsDefault || requests.IsEmpty, "We must have gotten an actual request to process.");
+            Contract.ThrowIfTrue(requests.Count > 2, "At most we can have two requests in the queue (one to update, one to dismiss).");
             Contract.ThrowIfFalse(
                 requests.Contains(UIUpdateRequest.DismissTooltip) || requests.Contains(UIUpdateRequest.UpdateTooltip),
                 "We didn't get an actual event we know about.");

--- a/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Classification/Syntactic/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -264,11 +265,11 @@ namespace Microsoft.CodeAnalysis.Classification
             /// the editor.  Calls to <see cref="ProcessChangesAsync"/> are serialized by <see cref="AsyncBatchingWorkQueue{TItem}"/>
             /// so we don't need to worry about multiple calls to this happening concurrently.
             /// </summary>
-            private async ValueTask ProcessChangesAsync(ImmutableArray<ITextSnapshot> snapshots, CancellationToken cancellationToken)
+            private async ValueTask ProcessChangesAsync(ImmutableSegmentedList<ITextSnapshot> snapshots, CancellationToken cancellationToken)
             {
                 // We have potentially heard about several changes to the subject buffer.  However
                 // we only need to process the latest once.
-                Contract.ThrowIfTrue(snapshots.IsDefaultOrEmpty);
+                Contract.ThrowIfTrue(snapshots.IsDefault || snapshots.IsEmpty);
                 var currentSnapshot = GetLatest(snapshots);
 
                 var classificationService = TryGetClassificationService(currentSnapshot);
@@ -299,10 +300,10 @@ namespace Microsoft.CodeAnalysis.Classification
 
                 return;
 
-                static ITextSnapshot GetLatest(ImmutableArray<ITextSnapshot> snapshots)
+                static ITextSnapshot GetLatest(ImmutableSegmentedList<ITextSnapshot> snapshots)
                 {
                     var latest = snapshots[0];
-                    for (var i = 1; i < snapshots.Length; i++)
+                    for (var i = 1; i < snapshots.Count; i++)
                     {
                         var snapshot = snapshots[i];
                         if (snapshot.Version.VersionNumber > latest.Version.VersionNumber)

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/References/FindUsagesLSPContext.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/References/FindUsagesLSPContext.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.ReferenceHighlighting;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.ErrorReporting;
@@ -345,7 +346,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.CustomProtocol
             return classifiedTextRuns.ToArray();
         }
 
-        private ValueTask ReportReferencesAsync(ImmutableArray<VSInternalReferenceItem> referencesToReport, CancellationToken cancellationToken)
+        private ValueTask ReportReferencesAsync(ImmutableSegmentedList<VSInternalReferenceItem> referencesToReport, CancellationToken cancellationToken)
         {
             // We can report outside of the lock here since _progress is thread-safe.
             _progress.Report(referencesToReport.ToArray());

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController_ModelComputation.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -21,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
         /// <summary>
         /// Starts a new task to compute the model based on the current text.
         /// </summary>
-        private async ValueTask<NavigationBarModel?> ComputeModelAndSelectItemAsync(ImmutableArray<bool> unused, CancellationToken cancellationToken)
+        private async ValueTask<NavigationBarModel?> ComputeModelAndSelectItemAsync(ImmutableSegmentedList<bool> unused, CancellationToken cancellationToken)
         {
             // Jump back to the UI thread to determine what snapshot the user is processing.
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -172,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _eventChangeQueue.AddWork(initialTags);
             }
 
-            private async ValueTask ProcessEventChangeAsync(ImmutableArray<bool> changes, CancellationToken cancellationToken)
+            private async ValueTask ProcessEventChangeAsync(ImmutableSegmentedList<bool> changes, CancellationToken cancellationToken)
             {
                 await _dataSource.ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_TagsChanged.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_TagsChanged.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
@@ -44,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             }
 
             private ValueTask ProcessTagsChangedAsync(
-                ImmutableArray<NormalizedSnapshotSpanCollection> snapshotSpans, CancellationToken cancellationToken)
+                ImmutableSegmentedList<NormalizedSnapshotSpanCollection> snapshotSpans, CancellationToken cancellationToken)
             {
                 var tagsChanged = this.TagsChanged;
                 if (tagsChanged == null)

--- a/src/Features/Core/Portable/Completion/Providers/CompletionUtilities.cs
+++ b/src/Features/Core/Portable/Completion/Providers/CompletionUtilities.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return false;
         }
 
-        public static ImmutableArray<Project> GetDistinctProjectsFromLatestSolutionSnapshot(ImmutableArray<Project> projects)
+        public static ImmutableArray<Project> GetDistinctProjectsFromLatestSolutionSnapshot(ImmutableSegmentedList<Project> projects)
         {
             if (projects.IsEmpty)
                 return ImmutableArray<Project>.Empty;

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionCacheServiceFactory.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionCacheServiceFactory.cs
@@ -5,10 +5,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -25,12 +24,12 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             = new();
 
         private readonly IAsynchronousOperationListenerProvider _listenerProvider;
-        private readonly Func<ImmutableArray<Project>, CancellationToken, ValueTask> _processBatchAsync;
+        private readonly Func<ImmutableSegmentedList<Project>, CancellationToken, ValueTask> _processBatchAsync;
         private readonly CancellationToken _disposalToken;
 
         protected AbstractImportCompletionCacheServiceFactory(
             IAsynchronousOperationListenerProvider listenerProvider,
-            Func<ImmutableArray<Project>, CancellationToken, ValueTask> processBatchAsync
+            Func<ImmutableSegmentedList<Project>, CancellationToken, ValueTask> processBatchAsync
             , CancellationToken disposalToken)
         {
             _listenerProvider = listenerProvider;

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -137,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             }
         }
 
-        public static async ValueTask BatchUpdateCacheAsync(ImmutableArray<Project> projects, CancellationToken cancellationToken)
+        public static async ValueTask BatchUpdateCacheAsync(ImmutableSegmentedList<Project> projects, CancellationToken cancellationToken)
         {
             var latestProjects = CompletionUtilities.GetDistinctProjectsFromLatestSolutionSnapshot(projects);
             foreach (var project in latestProjects)

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -108,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return new SerializableUnimportedExtensionMethods(items, isPartialResult, getSymbolsTicks, createItemsTicks, isRemote);
         }
 
-        public static async ValueTask BatchUpdateCacheAsync(ImmutableArray<Project> projects, CancellationToken cancellationToken)
+        public static async ValueTask BatchUpdateCacheAsync(ImmutableSegmentedList<Project> projects, CancellationToken cancellationToken)
         {
             var latestProjects = CompletionUtilities.GetDistinctProjectsFromLatestSolutionSnapshot(projects);
             foreach (var project in latestProjects)

--- a/src/Features/LanguageServer/Protocol/Features/TodoComments/TodoCommentsListener.cs
+++ b/src/Features/LanguageServer/Protocol/Features/TodoComments/TodoCommentsListener.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
@@ -143,7 +144,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
             => ValueTaskFactory.FromResult(_globalOptions.GetTodoCommentOptions());
 
         private ValueTask ProcessTodoCommentInfosAsync(
-            ImmutableArray<DocumentAndComments> docAndCommentsArray, CancellationToken cancellationToken)
+            ImmutableSegmentedList<DocumentAndComments> docAndCommentsArray, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -179,7 +180,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
         }
 
         private static void AddFilteredInfos(
-            ImmutableArray<DocumentAndComments> array,
+            ImmutableSegmentedList<DocumentAndComments> array,
             ArrayBuilder<DocumentAndComments> filteredArray)
         {
             using var _ = PooledHashSet<DocumentId>.GetInstance(out var seenDocumentIds);
@@ -187,7 +188,7 @@ namespace Microsoft.CodeAnalysis.TodoComments
             // Walk the list of todo comments in reverse, and skip any items for a document once
             // we've already seen it once.  That way, we're only reporting the most up to date
             // information for a document, and we're skipping the stale information.
-            for (var i = array.Length - 1; i >= 0; i--)
+            for (var i = array.Count - 1; i >= 0; i--)
             {
                 var info = array[i];
                 if (seenDocumentIds.Add(info.DocumentId))

--- a/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.DesignerAttribute;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
@@ -147,7 +148,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         }
 
         private async ValueTask NotifyProjectSystemAsync(
-            ImmutableArray<DesignerAttributeData> data, CancellationToken cancellationToken)
+            ImmutableSegmentedList<DesignerAttributeData> data, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -166,14 +167,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
-        private static void AddFilteredInfos(ImmutableArray<DesignerAttributeData> data, ArrayBuilder<DesignerAttributeData> filteredData)
+        private static void AddFilteredInfos(ImmutableSegmentedList<DesignerAttributeData> data, ArrayBuilder<DesignerAttributeData> filteredData)
         {
             using var _ = PooledHashSet<DocumentId>.GetInstance(out var seenDocumentIds);
 
             // Walk the list of designer items in reverse, and skip any items for a project once
             // we've already seen it once.  That way, we're only reporting the most up to date
             // information for a project, and we're skipping the stale information.
-            for (var i = data.Length - 1; i >= 0; i--)
+            for (var i = data.Count - 1; i >= 0; i--)
             {
                 var info = data[i];
                 if (seenDocumentIds.Add(info.DocumentId))

--- a/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Def/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -453,7 +454,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 return default;
             }
 
-            private ValueTask UpdateTableProgressAsync(ImmutableArray<(int current, int maximum)> nextBatch, CancellationToken _)
+            private ValueTask UpdateTableProgressAsync(ImmutableSegmentedList<(int current, int maximum)> nextBatch, CancellationToken _)
             {
                 if (!nextBatch.IsEmpty)
                 {

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -14,6 +14,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -455,7 +456,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
         }
 
         private ValueTask ProcessWorkQueueAsync(
-            ImmutableArray<(bool solutionChanged, ProjectId? changedProject)> workQueue, CancellationToken cancellationToken)
+            ImmutableSegmentedList<(bool solutionChanged, ProjectId? changedProject)> workQueue, CancellationToken cancellationToken)
         {
             ThisCanBeCalledOnAnyThread();
 
@@ -470,7 +471,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private async ValueTask ProcessWorkQueueWorkerAsync(
-            ImmutableArray<(bool solutionChanged, ProjectId? changedProject)> workQueue, CancellationToken cancellationToken)
+            ImmutableSegmentedList<(bool solutionChanged, ProjectId? changedProject)> workQueue, CancellationToken cancellationToken)
         {
             ThisCanBeCalledOnAnyThread();
 
@@ -519,7 +520,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
         }
 
         private void AddProjectsToProcess(
-            ImmutableArray<(bool solutionChanged, ProjectId? changedProject)> workQueue, Solution solution, HashSet<ProjectId> projectsToProcess)
+            ImmutableSegmentedList<(bool solutionChanged, ProjectId? changedProject)> workQueue, Solution solution, HashSet<ProjectId> projectsToProcess)
         {
             ThisCanBeCalledOnAnyThread();
 

--- a/src/VisualStudio/Core/Def/PdbSourceDocument/PdbSourceDocumentOutputWindowLogger.cs
+++ b/src/VisualStudio/Core/Def/PdbSourceDocument/PdbSourceDocumentOutputWindowLogger.cs
@@ -3,13 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PdbSourceDocument;
@@ -48,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.PdbSourceDocument
                 _cancellationTokenSource.Token);
         }
 
-        private async ValueTask ProcessLogMessagesAsync(ImmutableArray<string?> messages, CancellationToken cancellationToken)
+        private async ValueTask ProcessLogMessagesAsync(ImmutableSegmentedList<string?> messages, CancellationToken cancellationToken)
         {
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
@@ -50,12 +51,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 CancellationToken.None);
         }
 
-        private async ValueTask ProcessBatchAsync(ImmutableArray<WatcherOperation> workItems, CancellationToken cancellationToken)
+        private async ValueTask ProcessBatchAsync(ImmutableSegmentedList<WatcherOperation> workItems, CancellationToken cancellationToken)
         {
             var service = await _fileChangeService.ConfigureAwait(false);
 
             var prior = WatcherOperation.Empty;
-            for (var i = 0; i < workItems.Length; i++)
+            for (var i = 0; i < workItems.Count; i++)
             {
                 if (prior.TryCombineWith(workItems[i], out var combined))
                 {

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.BatchingDocumentCollection.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.BatchingDocumentCollection.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -377,7 +378,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
-            public async ValueTask ProcessRegularFileChangesAsync(ImmutableArray<string> filePaths)
+            public async ValueTask ProcessRegularFileChangesAsync(ImmutableSegmentedList<string> filePaths)
             {
                 using (await _project._gate.DisposableWaitAsync().ConfigureAwait(false))
                 {
@@ -387,7 +388,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         return;
                     }
 
-                    var documentsToChange = ArrayBuilder<(DocumentId, TextLoader)>.GetInstance(filePaths.Length);
+                    var documentsToChange = ArrayBuilder<(DocumentId, TextLoader)>.GetInstance(filePaths.Count);
 
                     foreach (var filePath in filePaths)
                     {

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -959,7 +960,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _fileChangesToProcess.AddWork(fullFilePath);
         }
 
-        private async ValueTask ProcessFileChangesAsync(ImmutableArray<string> filePaths, CancellationToken cancellationToken)
+        private async ValueTask ProcessFileChangesAsync(ImmutableSegmentedList<string> filePaths, CancellationToken cancellationToken)
         {
             await _sourceFiles.ProcessRegularFileChangesAsync(filePaths).ConfigureAwait(false);
             await _additionalFiles.ProcessRegularFileChangesAsync(filePaths).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/ProjectTelemetry/VisualStudioProjectTelemetryService.cs
+++ b/src/VisualStudio/Core/Def/ProjectTelemetry/VisualStudioProjectTelemetryService.cs
@@ -3,11 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectTelemetr
         }
 
         private async ValueTask NotifyTelemetryServiceAsync(
-            ImmutableArray<ProjectTelemetryData> infos, CancellationToken cancellationToken)
+            ImmutableSegmentedList<ProjectTelemetryData> infos, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -135,14 +135,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectTelemetr
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
-        private static void AddFilteredData(ImmutableArray<ProjectTelemetryData> infos, ArrayBuilder<ProjectTelemetryData> filteredInfos)
+        private static void AddFilteredData(ImmutableSegmentedList<ProjectTelemetryData> infos, ArrayBuilder<ProjectTelemetryData> filteredInfos)
         {
             using var _ = PooledHashSet<ProjectId>.GetInstance(out var seenProjectIds);
 
             // Walk the list of telemetry items in reverse, and skip any items for a project once
             // we've already seen it once.  That way, we're only reporting the most up to date
             // information for a project, and we're skipping the stale information.
-            for (var i = infos.Length - 1; i >= 0; i--)
+            for (var i = infos.Count - 1; i >= 0; i--)
             {
                 var info = infos[i];
                 if (seenProjectIds.Add(info.ProjectId))

--- a/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ProjectCodeModelFactory.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -71,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         internal IAsynchronousOperationListener Listener { get; }
 
         private async ValueTask ProcessNextDocumentBatchAsync(
-            ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken)
+            ImmutableSegmentedList<DocumentId> documentIds, CancellationToken cancellationToken)
         {
             // This logic preserves the previous behavior we had with IForegroundNotificationService.
             // Specifically, we don't run on the UI thread for more than 15ms at a time.  And once we 

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`0.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`0.cs
@@ -4,9 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Roslyn.Utilities
@@ -23,7 +23,7 @@ namespace Roslyn.Utilities
         {
         }
 
-        private static Func<ImmutableArray<VoidResult>, CancellationToken, ValueTask> Convert(Func<CancellationToken, ValueTask> processBatchAsync)
+        private static Func<ImmutableSegmentedList<VoidResult>, CancellationToken, ValueTask> Convert(Func<CancellationToken, ValueTask> processBatchAsync)
             => (items, ct) => processBatchAsync(ct);
 
         public void AddWork()

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`1.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`1.cs
@@ -4,9 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Roslyn.Utilities
@@ -16,7 +16,7 @@ namespace Roslyn.Utilities
     {
         public AsyncBatchingWorkQueue(
             TimeSpan delay,
-            Func<ImmutableArray<TItem>, CancellationToken, ValueTask> processBatchAsync,
+            Func<ImmutableSegmentedList<TItem>, CancellationToken, ValueTask> processBatchAsync,
             IAsynchronousOperationListener asyncListener,
             CancellationToken cancellationToken)
             : this(delay,
@@ -29,7 +29,7 @@ namespace Roslyn.Utilities
 
         public AsyncBatchingWorkQueue(
             TimeSpan delay,
-            Func<ImmutableArray<TItem>, CancellationToken, ValueTask> processBatchAsync,
+            Func<ImmutableSegmentedList<TItem>, CancellationToken, ValueTask> processBatchAsync,
             IEqualityComparer<TItem>? equalityComparer,
             IAsynchronousOperationListener asyncListener,
             CancellationToken cancellationToken)
@@ -37,7 +37,7 @@ namespace Roslyn.Utilities
         {
         }
 
-        private static Func<ImmutableArray<TItem>, CancellationToken, ValueTask<VoidResult>> Convert(Func<ImmutableArray<TItem>, CancellationToken, ValueTask> processBatchAsync)
+        private static Func<ImmutableSegmentedList<TItem>, CancellationToken, ValueTask<VoidResult>> Convert(Func<ImmutableSegmentedList<TItem>, CancellationToken, ValueTask> processBatchAsync)
             => async (items, ct) =>
             {
                 await processBatchAsync(items, ct).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
@@ -169,16 +169,14 @@ namespace Roslyn.Utilities
         {
             lock (_gate)
             {
-                var result = ArrayBuilder<TItem>.GetInstance();
-                result.AddRange(_nextBatch);
+                var result = _nextBatch.ToImmutableAndClear();
 
                 // mark there being no existing update task so that the next OOP notification will
                 // kick one off.
-                _nextBatch.Clear();
                 _uniqueItems.Clear();
                 _taskInFlight = false;
 
-                return result.ToImmutableAndFree();
+                return result;
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
@@ -4,10 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 
@@ -34,7 +33,7 @@ namespace Roslyn.Utilities
         /// <summary>
         /// Callback to actually perform the processing of the next batch of work.
         /// </summary>
-        private readonly Func<ImmutableArray<TItem>, CancellationToken, ValueTask<TResult>> _processBatchAsync;
+        private readonly Func<ImmutableSegmentedList<TItem>, CancellationToken, ValueTask<TResult>> _processBatchAsync;
         private readonly IAsynchronousOperationListener _asyncListener;
         private readonly CancellationToken _cancellationToken;
 
@@ -51,7 +50,7 @@ namespace Roslyn.Utilities
         /// <summary>
         /// Data added that we want to process in our next update task.
         /// </summary>
-        private readonly ArrayBuilder<TItem> _nextBatch = ArrayBuilder<TItem>.GetInstance();
+        private readonly ImmutableSegmentedList<TItem>.Builder _nextBatch = ImmutableSegmentedList.CreateBuilder<TItem>();
 
         /// <summary>
         /// Used if <see cref="_equalityComparer"/> is present to ensure only unique items are added to <see
@@ -76,7 +75,7 @@ namespace Roslyn.Utilities
 
         public AsyncBatchingWorkQueue(
             TimeSpan delay,
-            Func<ImmutableArray<TItem>, CancellationToken, ValueTask<TResult>> processBatchAsync,
+            Func<ImmutableSegmentedList<TItem>, CancellationToken, ValueTask<TResult>> processBatchAsync,
             IEqualityComparer<TItem>? equalityComparer,
             IAsynchronousOperationListener asyncListener,
             CancellationToken cancellationToken)
@@ -165,14 +164,15 @@ namespace Roslyn.Utilities
             return _processBatchAsync(GetNextBatchAndResetQueue(), _cancellationToken);
         }
 
-        private ImmutableArray<TItem> GetNextBatchAndResetQueue()
+        private ImmutableSegmentedList<TItem> GetNextBatchAndResetQueue()
         {
             lock (_gate)
             {
-                var result = _nextBatch.ToImmutableAndClear();
+                var result = _nextBatch.ToImmutable();
 
                 // mark there being no existing update task so that the next OOP notification will
                 // kick one off.
+                _nextBatch.Clear();
                 _uniqueItems.Clear();
                 _taskInFlight = false;
 

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         private static async ValueTask CacheClassificationsAsync(
-            ImmutableArray<(Document document, ClassificationType type, ClassificationOptions options)> documents,
+            ImmutableSegmentedList<(Document document, ClassificationType type, ClassificationOptions options)> documents,
             CancellationToken cancellationToken)
         {
             // Group all the requests by document (as we may have gotten many requests for the same document). Then,


### PR DESCRIPTION
* Avoid an unnecessary array copy (reduces allocations)
* Avoid the use of large object heap (reduces the time between allocation and successful collection by the GC)

Fixes [AB#1502196](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1502196)