### PR TITLE
Bump RichNav timeout to 260 min

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -23,7 +23,7 @@ jobs:
     demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   variables:
     EnableRichCodeNavigation: true
-  timeoutInMinutes: 200
+  timeoutInMinutes: 260
 
   steps:
     - task: PowerShell@2


### PR DESCRIPTION
The [RichNav build pipeline](https://dnceng.visualstudio.com/public/_build?definitionId=851&_a=summary) is timing out. This could be because we see an increase in msbuild output logs (232 => 235) so we need more time to index. 

This PR bumps the timeout up by an hour to see if that's enough time to process everything.