### PR TITLE
Use dotnet bot instead of vslsnap for insertions

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -333,9 +333,9 @@ stages:
     - template: eng/pipelines/insert.yml
       parameters:
         buildUserName: "dn-bot@microsoft.com"
-        buildPassword: $(_DevDivInsertionAccessToken)
+        buildPassword: "$(_DevDivInsertionAccessToken)"
         componentUserName: "dn-bot@microsoft.com"
-        componentPassword: $(_DncEngInsertionAccessToken)
+        componentPassword: "$(_DncEngInsertionAccessToken)"
         componentBuildProjectName: internal
         sourceBranch: "$(ComponentBranchName)"
         publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-roslyn/items?path=eng/config/PublishData.json&api-version=6.0"

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -7,7 +7,6 @@ trigger:
     - release/dev17.*
     exclude:
     - release/dev17.0
-    - release/dev17.1
 pr: none
 
 resources:
@@ -55,7 +54,12 @@ variables:
   - name: _DevDivDropAccessToken
     value: $(dn-bot-devdiv-drop-rw-code-rw)
   - group: ManagedLanguageSecrets
-
+  - group: DotNet-Roslyn-Insertion-Variables
+  - name: _DevDivAccessToken
+    value: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
+  - name: _DncEngAccessToken
+    value: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
+    
   - name: BuildConfiguration
     value: release
   - name: Roslyn.GitHubEmail
@@ -328,8 +332,10 @@ stages:
 
     - template: eng/pipelines/insert.yml
       parameters:
-        clientId: $(ClientId)
-        clientSecret: $(ClientSecret)
+        buildUserName: "dn-bot@microsoft.com"
+        buildPassword: $(_DevDivAccessToken)
+        componentUserName: "dn-bot@microsoft.com"
+        componentPassword: $(_DncEngDropAccessToken)
         componentBuildProjectName: internal
         sourceBranch: "$(ComponentBranchName)"
         publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-roslyn/items?path=eng/config/PublishData.json&api-version=6.0"

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -55,9 +55,9 @@ variables:
     value: $(dn-bot-devdiv-drop-rw-code-rw)
   - group: ManagedLanguageSecrets
   - group: DotNet-Roslyn-Insertion-Variables
-  - name: _DevDivAccessToken
+  - name: _DevDivInsertionAccessToken
     value: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
-  - name: _DncEngAccessToken
+  - name: _DncEngInsertionAccessToken
     value: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
     
   - name: BuildConfiguration
@@ -333,9 +333,9 @@ stages:
     - template: eng/pipelines/insert.yml
       parameters:
         buildUserName: "dn-bot@microsoft.com"
-        buildPassword: $(_DevDivAccessToken)
+        buildPassword: $(_DevDivInsertionAccessToken)
         componentUserName: "dn-bot@microsoft.com"
-        componentPassword: $(_DncEngDropAccessToken)
+        componentPassword: $(_DncEngInsertionAccessToken)
         componentBuildProjectName: internal
         sourceBranch: "$(ComponentBranchName)"
         publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-roslyn/items?path=eng/config/PublishData.json&api-version=6.0"

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -53,12 +53,7 @@ variables:
   - group: DotNet-DevDiv-Insertion-Workflow-Variables
   - name: _DevDivDropAccessToken
     value: $(dn-bot-devdiv-drop-rw-code-rw)
-  - group: ManagedLanguageSecrets
   - group: DotNet-Roslyn-Insertion-Variables
-  - name: _DevDivInsertionAccessToken
-    value: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
-  - name: _DncEngInsertionAccessToken
-    value: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
     
   - name: BuildConfiguration
     value: release
@@ -333,9 +328,9 @@ stages:
     - template: eng/pipelines/insert.yml
       parameters:
         buildUserName: "dn-bot@microsoft.com"
-        buildPassword: "$(_DevDivInsertionAccessToken)"
+        buildPassword: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
         componentUserName: "dn-bot@microsoft.com"
-        componentPassword: "$(_DncEngInsertionAccessToken)"
+        componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
         componentBuildProjectName: internal
         sourceBranch: "$(ComponentBranchName)"
         publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-roslyn/items?path=eng/config/PublishData.json&api-version=6.0"

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -31,10 +31,6 @@ variables:
     value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
   - group: DotNet-Roslyn-Insertion-Variables
-  - name: _DevDivInsertionAccessToken
-    value: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
-  - name: _DncEngInsertionAccessToken
-    value: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
   # If the pipeline is running in DevDiv, the account has access to the VS drop storage.
@@ -232,9 +228,9 @@ stages:
         autoComplete: false
         insertToolset: ${{ parameters.InsertToolset }}
         buildUserName: "dn-bot@microsoft.com"
-        buildPassword: "$(_DevDivInsertionAccessToken)"
+        buildPassword: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
         componentUserName: "dn-bot@microsoft.com"
-        componentPassword: "$(_DncEngInsertionAccessToken)"
+        componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
         vsBranchName: ${{ parameters.VisualStudioBranchName }}
         titlePrefix: ${{ parameters.OptionalTitlePrefix }}
         sourceBranch: $(SourceBranchName)

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -31,9 +31,9 @@ variables:
     value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
   - group: DotNet-Roslyn-Insertion-Variables
-  - name: _DevDivAccessToken
+  - name: _DevDivInsertionAccessToken
     value: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
-  - name: _DncEngAccessToken
+  - name: _DncEngInsertionAccessToken
     value: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
@@ -232,9 +232,9 @@ stages:
         autoComplete: false
         insertToolset: ${{ parameters.InsertToolset }}
         buildUserName: "dn-bot@microsoft.com"
-        buildPassword: "$(_DevDivAccessToken)"
+        buildPassword: "$(_DevDivInsertionAccessToken)"
         componentUserName: "dn-bot@microsoft.com"
-        componentPassword: "$(_DncEngDropAccessToken)"
+        componentPassword: "$(_DncEngInsertionAccessToken)"
         vsBranchName: ${{ parameters.VisualStudioBranchName }}
         titlePrefix: ${{ parameters.OptionalTitlePrefix }}
         sourceBranch: $(SourceBranchName)

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -30,6 +30,11 @@ variables:
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
+  - group: DotNet-Roslyn-Insertion-Variables
+  - name: _DevDivAccessToken
+    value: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
+  - name: _DncEngAccessToken
+    value: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
   # If the pipeline is running in DevDiv, the account has access to the VS drop storage.
@@ -226,8 +231,10 @@ stages:
         createDraftPR: true
         autoComplete: false
         insertToolset: ${{ parameters.InsertToolset }}
-        clientId: $(ClientId)
-        clientSecret: $(ClientSecret)
+        buildUserName: "dn-bot@microsoft.com"
+        buildPassword: $(_DevDivAccessToken)
+        componentUserName: "dn-bot@microsoft.com"
+        componentPassword: $(_DncEngDropAccessToken)
         vsBranchName: ${{ parameters.VisualStudioBranchName }}
         titlePrefix: ${{ parameters.OptionalTitlePrefix }}
         sourceBranch: $(SourceBranchName)

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -232,9 +232,9 @@ stages:
         autoComplete: false
         insertToolset: ${{ parameters.InsertToolset }}
         buildUserName: "dn-bot@microsoft.com"
-        buildPassword: $(_DevDivAccessToken)
+        buildPassword: "$(_DevDivAccessToken)"
         componentUserName: "dn-bot@microsoft.com"
-        componentPassword: $(_DncEngDropAccessToken)
+        componentPassword: "$(_DncEngDropAccessToken)"
         vsBranchName: ${{ parameters.VisualStudioBranchName }}
         titlePrefix: ${{ parameters.OptionalTitlePrefix }}
         sourceBranch: $(SourceBranchName)

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -178,7 +178,7 @@ steps:
         -updateAssemblyVersions "(default)" `
         -updateCoreXTLibraries "(default)" `
         -visualStudioBranchName "$(Template.VSBranchName)" `
-        -writePullRequest "prid.txt" `
+        -writePullRequest "prid.txt"
     displayName: 'Run OneOffInsertion.ps1'
 
   - script: 'echo. && echo. && type "prid.txt" && echo. && echo.'

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -12,10 +12,15 @@ parameters:
     type: string
     default: ''
 
-  - name: clientId
+  - name: buildUserName
     type: string
-  - name: clientSecret
+  - name: buildPassword
     type: string
+  - name: componentUserName
+    type: string
+  - name: componentPassword
+    type: string
+  
   - name: publishDataURI
     type: string
   - name: publishDataAccessToken
@@ -148,8 +153,10 @@ steps:
         -autoComplete "$(Template.AutoComplete)" `
         -buildQueueName "$(Build.DefinitionName)" `
         -cherryPick "(default)" `
-        -clientId "${{ parameters.clientId }}" `
-        -clientSecret "${{ parameters.clientSecret }}" `
+        -userName "${{ parameters.buildUserName }}" `
+        -password "${{ parameters.buildPassword }}" `
+        -componentUserName "${{ parameters.componentUserName }}" `
+        -componentPassword "${{ parameters.componentPassword }}" `
         -componentAzdoUri "$(Template.ComponentAzdoUri)" `
         -componentProjectName "$(Template.ComponentProjectName)" `
         -componentName "Roslyn" `


### PR DESCRIPTION
Stacking on top of https://github.com/dotnet/roslyn/pull/60907 with slightly different changes.  This one looks to have worked (only failed due to inserting an older build into main b/c of no config for custom branch) 

https://dev.azure.com/dnceng/internal/_build/results?buildId=1733697&view=logs&j=7ae71e7c-d4fe-51ea-64cd-240849b77ab1&t=e2756d63-0606-58d5-0f0d-91c79a5ba922