### PR TITLE
Fix assertion failure for optional VB attribute with invalid type

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -767,7 +767,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                                     If Not conv.HasErrors Then
                                         ' BC30934: Conversion from '{0}' to '{1}' cannot occur in a constant expression used as an argument to an attribute.
-                                        Dim firstArgument As Object = If(conv.Operand.Type Is Nothing, "Nothing", conv.Operand.Type)
+                                        Dim firstArgument As Object = If(conv.Operand.Type Is Nothing, DirectCast("Nothing", Object), DirectCast(conv.Operand.Type, Object))
                                         ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, firstArgument, conv.Type)
                                     End If
                                     Return CreateErrorTypedConstant(node.Type)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -766,9 +766,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                    Not _binder.IsValidTypeForAttributeArgument(conv.Operand.Type) Then
 
                                     If Not conv.HasErrors Then
-                                        ' BC30934: Conversion from '{0}' to '{1}' cannot occur in a constant expression used as an argument to an attribute.
-                                        Dim firstArgument As Object = If(conv.Operand.Type Is Nothing, DirectCast("Nothing", Object), DirectCast(conv.Operand.Type, Object))
-                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, firstArgument, conv.Type)
+                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, conv.Operand.Type, conv.Type)
                                     End If
                                     Return CreateErrorTypedConstant(node.Type)
                                 Else
@@ -796,7 +794,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                    Not _binder.IsValidTypeForAttributeArgument(conv.Operand.Type) Then
 
                                     If Not conv.HasErrors Then
-                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, conv.Operand.Type, conv.Type)
+                                        ' BC30934: Conversion from '{0}' to '{1}' cannot occur in a constant expression used as an argument to an attribute.
+                                        Dim firstArgument As Object = If(conv.Operand.Type Is Nothing, DirectCast("Nothing", Object), DirectCast(conv.Operand.Type, Object))
+                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, firstArgument, conv.Type)
                                     End If
                                     Return CreateErrorTypedConstant(node.Type)
                                 Else

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -766,7 +766,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                    Not _binder.IsValidTypeForAttributeArgument(conv.Operand.Type) Then
 
                                     If Not conv.HasErrors Then
-                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, conv.Operand.Type, conv.Type)
+                                        ' BC30934: Conversion from '{0}' to '{1}' cannot occur in a constant expression used as an argument to an attribute.
+                                        Dim firstArgument As Object = If(conv.Operand.Type Is Nothing, "Nothing", conv.Operand.Type)
+                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, firstArgument, conv.Type)
                                     End If
                                     Return CreateErrorTypedConstant(node.Type)
                                 Else

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -795,8 +795,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                                     If Not conv.HasErrors Then
                                         ' BC30934: Conversion from '{0}' to '{1}' cannot occur in a constant expression used as an argument to an attribute.
-                                        Dim firstArgument As Object = If(conv.Operand.Type, _binder.Compilation.GetSpecialType(SpecialType.System_Object))
-                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, firstArgument, conv.Type)
+                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, If(conv.Operand.Type, _binder.Compilation.GetSpecialType(SpecialType.System_Object), conv.Type)
                                     End If
                                     Return CreateErrorTypedConstant(node.Type)
                                 Else

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -795,7 +795,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                                     If Not conv.HasErrors Then
                                         ' BC30934: Conversion from '{0}' to '{1}' cannot occur in a constant expression used as an argument to an attribute.
-                                        Dim firstArgument As Object = If(conv.Operand.Type Is Nothing, DirectCast("Nothing", Object), DirectCast(conv.Operand.Type, Object))
+                                        Dim firstArgument As Object = If(conv.Operand.Type, _binder.Compilation.GetSpecialType(SpecialType.System_Object))
                                         ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, firstArgument, conv.Type)
                                     End If
                                     Return CreateErrorTypedConstant(node.Type)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -795,7 +795,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                                     If Not conv.HasErrors Then
                                         ' BC30934: Conversion from '{0}' to '{1}' cannot occur in a constant expression used as an argument to an attribute.
-                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, If(conv.Operand.Type, _binder.Compilation.GetSpecialType(SpecialType.System_Object), conv.Type)
+                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, If(conv.Operand.Type, _binder.Compilation.GetSpecialType(SpecialType.System_Object), conv.Type))
                                     End If
                                     Return CreateErrorTypedConstant(node.Type)
                                 Else

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -795,7 +795,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                                     If Not conv.HasErrors Then
                                         ' BC30934: Conversion from '{0}' to '{1}' cannot occur in a constant expression used as an argument to an attribute.
-                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, If(conv.Operand.Type, _binder.Compilation.GetSpecialType(SpecialType.System_Object), conv.Type))
+                                        ReportDiagnostic(diagBag, conv.Operand.Syntax, ERRID.ERR_RequiredAttributeConstConversion2, If(conv.Operand.Type, _binder.Compilation.GetSpecialType(SpecialType.System_Object)), conv.Type)
                                     End If
                                     Return CreateErrorTypedConstant(node.Type)
                                 Else

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -4654,5 +4654,23 @@ End Namespace
                 Diagnostic(ERRID.ERR_BadAttributeConstructor1, "Command").WithArguments("a.Class1.CommandAttribute.FxCommand").WithLocation(20, 10),
                 Diagnostic(ERRID.ERR_RequiredConstExpr, "AddressOf UserInfo").WithLocation(20, 18))
         End Sub
+
+        <Fact>
+        Public Sub AttributeWithOptionalNullableParameter_NullIsPassed()
+            Dim code = "
+Imports System
+
+Class MyAttribute
+    Inherits Attribute
+    Public Sub New(Optional x As Integer? = 0)
+    End Sub
+End Class
+
+<My(Nothing)>
+Class C
+End Class
+"
+            CreateCompilation(code).VerifyDiagnostics()
+        End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -4670,8 +4670,12 @@ End Class
 Class C
 End Class
 "
-            CreateCompilation(code).VerifyDiagnostics(
-                Diagnostic(ERRID.ERR_BadAttributeConstructor1, "My").WithArguments("Integer?").WithLocation(10, 2))
+            CreateCompilation(code).AssertTheseDiagnostics(
+<expected><![CDATA[
+BC30045: Attribute constructor has a parameter of type 'Integer?', which is not an integral, floating-point or Enum type or one of Object, Char, String, Boolean, System.Type or 1-dimensional array of these types.
+<My(Nothing)>
+ ~~
+]]></expected>)
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -4670,7 +4670,8 @@ End Class
 Class C
 End Class
 "
-            CreateCompilation(code).VerifyDiagnostics()
+            CreateCompilation(code).VerifyDiagnostics(
+                Diagnostic(ERRID.ERR_BadAttributeConstructor1, "My").WithArguments("Integer?").WithLocation(10, 2))
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
cc @RikkiGibson @AlekseyTs 

I couldn't figure out a test with null `conv.Operand.Type` and a non-Discarded diagnostic bag.
I'm also not sure if this is the right fix. It could be debatable that `conv.Operand.Type` shouldn't be null in this code path maybe? See #60933 for the alternative fix