### PR TITLE
Fix assertion failure for optional VB attribute with invalid type (Approach 2)

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
@@ -3401,12 +3401,12 @@ Bailout:
                binder.Compilation.GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(candidate.Candidate.UnderlyingSymbol.ContainingType, useSiteInfo) Then
 
                 Debug.Assert(Not argument.HasErrors)
-                If Not targetType.IsValidTypeForAttributeArgument(binder.Compilation) Then
-                    candidate.SetIllegalInAttribute()
-                Else
-                    Dim passedExpression As BoundExpression = binder.PassArgumentByVal(argument, conv, targetType, BindingDiagnosticBag.Discarded)
+                Dim passedExpression As BoundExpression = binder.PassArgumentByVal(argument, conv, targetType, BindingDiagnosticBag.Discarded)
 
-                    If Not passedExpression.IsConstant Then ' Trying to match native compiler behavior in Semantics::IsValidAttributeConstant
+                If Not passedExpression.IsConstant Then ' Trying to match native compiler behavior in Semantics::IsValidAttributeConstant
+                    If Not targetType.IsValidTypeForAttributeArgument(binder.Compilation) Then
+                        candidate.SetIllegalInAttribute()
+                    Else
                         Dim visitor As New Binder.AttributeExpressionVisitor(binder, passedExpression.HasErrors)
                         visitor.VisitExpression(passedExpression, BindingDiagnosticBag.Discarded)
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
@@ -3401,14 +3401,18 @@ Bailout:
                binder.Compilation.GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(candidate.Candidate.UnderlyingSymbol.ContainingType, useSiteInfo) Then
 
                 Debug.Assert(Not argument.HasErrors)
-                Dim passedExpression As BoundExpression = binder.PassArgumentByVal(argument, conv, targetType, BindingDiagnosticBag.Discarded)
+                If Not targetType.IsValidTypeForAttributeArgument(binder.Compilation) Then
+                    candidate.SetIllegalInAttribute()
+                Else
+                    Dim passedExpression As BoundExpression = binder.PassArgumentByVal(argument, conv, targetType, BindingDiagnosticBag.Discarded)
 
-                If Not passedExpression.IsConstant Then ' Trying to match native compiler behavior in Semantics::IsValidAttributeConstant
-                    Dim visitor As New Binder.AttributeExpressionVisitor(binder, passedExpression.HasErrors)
-                    visitor.VisitExpression(passedExpression, BindingDiagnosticBag.Discarded)
+                    If Not passedExpression.IsConstant Then ' Trying to match native compiler behavior in Semantics::IsValidAttributeConstant
+                        Dim visitor As New Binder.AttributeExpressionVisitor(binder, passedExpression.HasErrors)
+                        visitor.VisitExpression(passedExpression, BindingDiagnosticBag.Discarded)
 
-                    If visitor.HasErrors Then
-                        candidate.SetIllegalInAttribute()
+                        If visitor.HasErrors Then
+                            candidate.SetIllegalInAttribute()
+                        End If
                     End If
                 End If
             End If

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -4654,5 +4654,23 @@ End Namespace
                 Diagnostic(ERRID.ERR_BadAttributeConstructor1, "Command").WithArguments("a.Class1.CommandAttribute.FxCommand").WithLocation(20, 10),
                 Diagnostic(ERRID.ERR_RequiredConstExpr, "AddressOf UserInfo").WithLocation(20, 18))
         End Sub
+
+        <Fact>
+        Public Sub AttributeWithOptionalNullableParameter_NullIsPassed()
+            Dim code = "
+Imports System
+
+Class MyAttribute
+    Inherits Attribute
+    Public Sub New(Optional x As Integer? = 0)
+    End Sub
+End Class
+
+<My(Nothing)>
+Class C
+End Class
+"
+            CreateCompilation(code).VerifyDiagnostics()
+        End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests.vb
@@ -4670,7 +4670,8 @@ End Class
 Class C
 End Class
 "
-            CreateCompilation(code).VerifyDiagnostics()
+            CreateCompilation(code).VerifyDiagnostics(
+                Diagnostic(ERRID.ERR_BadAttributeConstructor1, "My").WithArguments("Integer?").WithLocation(10, 2))
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
A different fix for https://github.com/dotnet/roslyn/pull/60924