### PR TITLE
Don't initialize the StackTraceExplorer tool window until it is invoked

### DIFF
--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -256,7 +256,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             await TaskScheduler.Default;
 
             await LoadInteractiveMenusAsync(cancellationToken).ConfigureAwait(true);
-            await LoadCallstackExplorerMenusAsync(cancellationToken).ConfigureAwait(true);
+            await LoadStackTraceExplorerMenusAsync(cancellationToken).ConfigureAwait(true);
 
             // Initialize keybinding reset detector
             await ComponentModel.DefaultExportProvider.GetExportedValue<KeybindingReset.KeybindingResetDetector>().InitializeAsync().ConfigureAwait(true);
@@ -284,7 +284,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
                 .ConfigureAwait(true);
         }
 
-        private async Task LoadCallstackExplorerMenusAsync(CancellationToken cancellationToken)
+        private async Task LoadStackTraceExplorerMenusAsync(CancellationToken cancellationToken)
         {
             // Obtain services and QueryInterface from the main thread
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerCommandHandler.cs
@@ -164,9 +164,6 @@ namespace Microsoft.VisualStudio.LanguageServices.StackTraceExplorer
 
             _instance = new(package);
 
-            // Initialize the window on startup
-            _instance.GetOrInitializeWindow();
-
             var menuCommandId = new CommandID(Guids.StackTraceExplorerCommandId, 0x0100);
             var menuItem = new MenuCommand(_instance.Execute, menuCommandId);
             menuCommandService.AddCommand(menuItem);


### PR DESCRIPTION
Fixes [AB#1524181](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1524181)

Tested locally and command invocation works as expected. The initialization was causing package loads while the Roslyn package was initializing. We can wait until needed, and likely those packages are loaded by then anyways. 