### PR TITLE
File types binding

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -243,8 +243,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal virtual SyntaxTree AssociatedSyntaxTree => NextRequired.AssociatedSyntaxTree;
-
         /// <summary>
         /// Are we in a context where un-annotated types should be interpreted as non-null?
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -243,6 +243,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal virtual SyntaxTree AssociatedSyntaxTree => NextRequired.AssociatedSyntaxTree;
+
         /// <summary>
         /// Are we in a context where un-annotated types should be interpreted as non-null?
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFactory.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // more than 50 items added before getting collected.
             _binderCache = new ConcurrentCache<BinderCacheKey, Binder>(50);
 
-            _buckStopsHereBinder = new BuckStopsHereBinder(compilation);
+            _buckStopsHereBinder = new BuckStopsHereBinder(compilation, syntaxTree);
         }
 
         internal SyntaxTree SyntaxTree

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -410,6 +410,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // "Inconsistent accessibility: constraint type '{1}' is less accessible than '{0}'"
                 diagnostics.Add(ErrorCode.ERR_BadVisBound, location, containingSymbol, constraintType.Type);
             }
+
+            if (constraintType.Type.IsFileTypeOrUsesFileTypes() && !containingSymbol.ContainingType.IsFileTypeOrUsesFileTypes())
+            {
+                diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, location, constraintType.Type, containingSymbol);
+            }
+
             diagnostics.Add(location, useSiteInfo);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1308,8 +1308,14 @@ symIsHidden:;
 
         private bool IsInScopeOfAssociatedSyntaxTree(Symbol symbol)
         {
-            if (symbol is not SourceMemberContainerTypeSymbol { IsFile: true })
+            while (symbol is not null and not SourceMemberContainerTypeSymbol { IsFile: true })
             {
+                symbol = symbol.ContainingSymbol;
+            }
+
+            if (symbol is null)
+            {
+                // the passed-in symbol was not contained in a file type.
                 return true;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1310,7 +1310,7 @@ symIsHidden:;
         {
             while (symbol is not null and not SourceMemberContainerTypeSymbol { IsFile: true })
             {
-                symbol = symbol.ContainingSymbol;
+                symbol = symbol.ContainingType;
             }
 
             if (symbol is null)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1322,8 +1322,12 @@ symIsHidden:;
                 ? ((AliasSymbol)symbol).GetAliasTarget(basesBeingResolved)
                 : symbol;
 
+            if (unwrappedSymbol is SourceNamedTypeSymbol { IsFile: true } && !unwrappedSymbol.IsDefinedInSourceTree(this.AssociatedSyntaxTree, definedWithinSpan: null))
+            {
+                return LookupResult.Empty();
+            }
             // Check for symbols marked with 'Microsoft.CodeAnalysis.Embedded' attribute
-            if (!this.Compilation.SourceModule.Equals(unwrappedSymbol.ContainingModule) && unwrappedSymbol.IsHiddenByCodeAnalysisEmbeddedAttribute())
+            else if (!this.Compilation.SourceModule.Equals(unwrappedSymbol.ContainingModule) && unwrappedSymbol.IsHiddenByCodeAnalysisEmbeddedAttribute())
             {
                 return LookupResult.Empty();
             }

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -15,10 +15,18 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal class BuckStopsHereBinder : Binder
     {
-        internal BuckStopsHereBinder(CSharpCompilation compilation)
+        internal BuckStopsHereBinder(CSharpCompilation compilation, SyntaxTree? associatedSyntaxTree)
             : base(compilation)
         {
+            this.AssociatedSyntaxTree = associatedSyntaxTree;
         }
+
+        /// <summary>
+        /// In non-speculative scenarios, the syntax tree being bound.
+        /// In speculative scenarios, the syntax tree from the original compilation used as the speculation context.
+        /// PROTOTYPE(ft): what about in EE scenarios?
+        /// </summary>
+        internal readonly SyntaxTree? AssociatedSyntaxTree;
 
         internal override ImportChain? ImportChain
         {
@@ -49,9 +57,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return null;
         }
-
-        // PROTOTYPE(ft): should the return type be nullable?
-        internal override SyntaxTree AssociatedSyntaxTree => throw ExceptionUtilities.Unreachable;
 
         internal override uint LocalScopeDepth => Binder.ExternalScope;
 

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// In non-speculative scenarios, the syntax tree being bound.
         /// In speculative scenarios, the syntax tree from the original compilation used as the speculation context.
+        /// This is <see langword="null"/> in some scenarios, such as the binder used for <see cref="CSharpCompilation.Conversions" />
+        /// or the binder used to bind usings in <see cref="CSharpCompilation.UsingsFromOptionsAndDiagnostics"/>.
         /// PROTOTYPE(ft): what about in EE scenarios?
         /// </summary>
         internal readonly SyntaxTree? AssociatedSyntaxTree;

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -50,6 +50,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        // PROTOTYPE(ft): should the return type be nullable?
+        internal override SyntaxTree AssociatedSyntaxTree => throw ExceptionUtilities.Unreachable;
+
         internal override uint LocalScopeDepth => Binder.ExternalScope;
 
         protected override bool InExecutableBinder => false;

--- a/src/Compilers/CSharp/Portable/Binder/WithExternAndUsingAliasesBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithExternAndUsingAliasesBinder.cs
@@ -122,6 +122,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _declarationSyntax = declarationSyntax;
             }
 
+            // PROTOTYPE(ft): is this the right way to get a syntax tree for a binder chain?
+            internal override SyntaxTree AssociatedSyntaxTree => _declarationSyntax.SyntaxTree;
+
             internal sealed override ImmutableArray<AliasAndExternAliasDirective> ExternAliases
             {
                 get

--- a/src/Compilers/CSharp/Portable/Binder/WithExternAndUsingAliasesBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithExternAndUsingAliasesBinder.cs
@@ -122,9 +122,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _declarationSyntax = declarationSyntax;
             }
 
-            // PROTOTYPE(ft): is this the right way to get a syntax tree for a binder chain?
-            internal override SyntaxTree AssociatedSyntaxTree => _declarationSyntax.SyntaxTree;
-
             internal sealed override ImmutableArray<AliasAndExternAliasDirective> ExternAliases
             {
                 get

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7088,6 +7088,15 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ExpressionTreeContainsUTF8StringLiterals" xml:space="preserve">
     <value>An expression tree may not contain UTF8 string conversion or literal.</value>
   </data>
+  <data name="ERR_FileTypeDisallowedInSignature" xml:space="preserve">
+    <value>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</value>
+  </data>
+  <data name="ERR_FileTypeNoExplicitAccessibility" xml:space="preserve">
+    <value>File type '{0}' cannot use accessibility modifiers.</value>
+  </data>
+  <data name="ERR_FileTypeBase" xml:space="preserve">
+    <value>File type '{0}' cannot be used as a base type in non-file type '{1}'.</value>
+  </data>
   <data name="IDS_FeatureUnsignedRightShift" xml:space="preserve">
     <value>unsigned right shift</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7095,7 +7095,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>File type '{0}' cannot use accessibility modifiers.</value>
   </data>
   <data name="ERR_FileTypeBase" xml:space="preserve">
-    <value>File type '{0}' cannot be used as a base type in non-file type '{1}'.</value>
+    <value>File type '{0}' cannot be used as a base type of non-file type '{1}'.</value>
   </data>
   <data name="IDS_FeatureUnsignedRightShift" xml:space="preserve">
     <value>unsigned right shift</value>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.UsingsFromOptionsAndDiagnostics.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.UsingsFromOptionsAndDiagnostics.cs
@@ -34,7 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var diagnostics = new DiagnosticBag();
-                var usingsBinder = new InContainerBinder(compilation.GlobalNamespace, new BuckStopsHereBinder(compilation));
+                // PROTOTYPE(ft): should usings from compilation options be allowed to bring file types into scope?
+                // it doesn't seem to work for non-file types within the compilaton, so can probably do the same for file types.
+                var usingsBinder = new InContainerBinder(compilation.GlobalNamespace, new BuckStopsHereBinder(compilation, associatedSyntaxTree: null));
                 var boundUsings = ArrayBuilder<NamespaceOrTypeAndUsingDirective>.GetInstance();
                 var uniqueUsings = PooledHashSet<NamespaceOrTypeSymbol>.GetInstance();
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (_conversions == null)
                 {
-                    Interlocked.CompareExchange(ref _conversions, new BuckStopsHereBinder(this).Conversions, null);
+                    Interlocked.CompareExchange(ref _conversions, new BuckStopsHereBinder(this, associatedSyntaxTree: null).Conversions, null);
                 }
 
                 return _conversions;

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     "Why are we processing a documentation comment that is not attached to a member declaration?");
 
                 var nameDiagnostics = BindingDiagnosticBag.GetInstance(_diagnostics);
-                Binder binder = MakeNameBinder(isParameter, isTypeParameterRef, _memberSymbol, _compilation);
+                Binder binder = MakeNameBinder(isParameter, isTypeParameterRef, _memberSymbol, _compilation, originatingSyntax.SyntaxTree);
                 DocumentationCommentCompiler.BindName(attrSyntax, binder, _memberSymbol, ref _documentedParameters, ref _documentedTypeParameters, nameDiagnostics);
                 RecordBindingDiagnostics(nameDiagnostics, sourceLocation); // Respects DocumentationMode.
                 nameDiagnostics.Free();
@@ -545,9 +545,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // NOTE: We're not sharing code with the BinderFactory visitor, because we already have the
             // member symbol in hand, which makes things much easier.
-            private static Binder MakeNameBinder(bool isParameter, bool isTypeParameterRef, Symbol memberSymbol, CSharpCompilation compilation)
+            private static Binder MakeNameBinder(bool isParameter, bool isTypeParameterRef, Symbol memberSymbol, CSharpCompilation compilation, SyntaxTree syntaxTree)
             {
-                Binder binder = new BuckStopsHereBinder(compilation);
+                Binder binder = new BuckStopsHereBinder(compilation, syntaxTree);
 
                 // All binders should have a containing symbol.
                 Symbol containingSymbol = memberSymbol.ContainingSymbol;

--- a/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
@@ -238,8 +238,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 if ((object)thisDecl.Location.SourceTree != otherDecl.Location.SourceTree
-                    && (thisDecl.Modifiers & DeclarationModifiers.File) != 0
-                        || (otherDecl.Modifiers & DeclarationModifiers.File) != 0)
+                    && ((thisDecl.Modifiers & DeclarationModifiers.File) != 0
+                        || (otherDecl.Modifiers & DeclarationModifiers.File) != 0))
                 {
                     // declarations of 'file' types are only the same type if they are in the same file
                     return false;

--- a/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
@@ -237,6 +237,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
+                if (!thisDecl.Location.SourceTree.Equals(otherDecl.Location.SourceTree)
+                    && (thisDecl.Modifiers & DeclarationModifiers.File) != 0
+                        || (otherDecl.Modifiers & DeclarationModifiers.File) != 0)
+                {
+                    // declarations of 'file' types are only the same type if they are in the same file
+                    return false;
+                }
+
                 if (thisDecl._kind == DeclarationKind.Enum || thisDecl._kind == DeclarationKind.Delegate)
                 {
                     // oh, so close, but enums and delegates cannot be partial

--- a/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/SingleTypeDeclaration.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
-                if (!thisDecl.Location.SourceTree.Equals(otherDecl.Location.SourceTree)
+                if ((object)thisDecl.Location.SourceTree != otherDecl.Location.SourceTree
                     && (thisDecl.Modifiers & DeclarationModifiers.File) != 0
                         || (otherDecl.Modifiers & DeclarationModifiers.File) != 0)
                 {

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2069,6 +2069,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CannotBeConvertedToUTF8 = 9026,
         ERR_ExpressionTreeContainsUTF8StringLiterals = 9027,
 
+        // PROTOTYPE(ft): compress these before feature merge
+        ERR_FileTypeDisallowedInSignature = 9300,
+        ERR_FileTypeNoExplicitAccessibility = 9301,
+        ERR_FileTypeBase = 9302,
+
         #endregion
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private sealed class SyntheticBinderImpl : BuckStopsHereBinder
         {
             private readonly SyntheticBoundNodeFactory _factory;
-            internal SyntheticBinderImpl(SyntheticBoundNodeFactory factory) : base(factory.Compilation)
+            internal SyntheticBinderImpl(SyntheticBoundNodeFactory factory) : base(factory.Compilation, associatedSyntaxTree: null)
             {
                 _factory = factory;
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -179,6 +180,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             VisitNamedTypeWithoutNullability(symbol);
             AddNullableAnnotations(symbol);
+
+            if ((format.CompilerInternalOptions & SymbolDisplayCompilerInternalOptions.IncludeContainingFileForFileTypes) != 0
+                // PROTOTYPE(ft): public API?
+                && symbol.GetSymbol() is SourceMemberContainerTypeSymbol { IsFile: true } fileType)
+            {
+                var tree = symbol.DeclaringSyntaxReferences[0].SyntaxTree;
+                var fileDescription = tree.FilePath is { Length: not 0 } path
+                    ? Path.GetFileNameWithoutExtension(path)
+                    : $"<file {fileType.DeclaringCompilation.SyntaxTrees.IndexOf(tree)}>";
+
+                builder.Add(CreatePart(SymbolDisplayPartKind.Punctuation, symbol, "@"));
+                builder.Add(CreatePart(SymbolDisplayPartKind.ModuleName, symbol, fileDescription));
+            }
         }
 
         private void VisitNamedTypeWithoutNullability(INamedTypeSymbol symbol)

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var tree = symbol.DeclaringSyntaxReferences[0].SyntaxTree;
                 var fileDescription = tree.FilePath is { Length: not 0 } path
                     ? Path.GetFileNameWithoutExtension(path)
-                    : $"<file {fileType.DeclaringCompilation.SyntaxTrees.IndexOf(tree)}>";
+                    : $"<tree {fileType.DeclaringCompilation.SyntaxTrees.IndexOf(tree)}>";
 
                 builder.Add(CreatePart(SymbolDisplayPartKind.Punctuation, symbol, "@"));
                 builder.Add(CreatePart(SymbolDisplayPartKind.ModuleName, symbol, fileDescription));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
@@ -71,6 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             this.CheckEffectiveAccessibility(_lazyReturnType, _lazyParameters, diagnostics);
+            this.CheckFileTypeUsage(_lazyReturnType, _lazyParameters, diagnostics);
 
             if (_lazyIsVararg && (IsGenericMethod || ContainingType.IsGenericType || _lazyParameters.Length > 0 && _lazyParameters[_lazyParameters.Length - 1].IsParams))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -98,6 +98,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_BadVisDelegateReturn, delegateType.Locations[0], delegateType, invoke.ReturnType);
             }
 
+            var delegateTypeIsFile = delegateType.IsFileTypeOrUsesFileTypes();
+            if (!delegateTypeIsFile && invoke.ReturnType.IsFileTypeOrUsesFileTypes())
+            {
+                diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, delegateType.Locations[0], invoke.ReturnType, delegateType);
+            }
+
             for (int i = 0; i < invoke.Parameters.Length; i++)
             {
                 var parameterSymbol = invoke.Parameters[i];
@@ -105,6 +111,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     // Inconsistent accessibility: parameter type '{1}' is less accessible than delegate '{0}'
                     diagnostics.Add(ErrorCode.ERR_BadVisDelegateParam, delegateType.Locations[0], delegateType, parameterSymbol.Type);
+                }
+                else if (!delegateTypeIsFile && parameterSymbol.Type.IsFileTypeOrUsesFileTypes())
+                {
+                    diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, delegateType.Locations[0], parameterSymbol.Type, delegateType);
                 }
                 var parameterSyntax = syntax.ParameterList.Parameters[i];
                 if (parameterSyntax.ExclamationExclamationToken.Kind() == SyntaxKind.ExclamationExclamationToken)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -394,6 +394,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 result |= defaultAccess;
             }
+            else if ((result & DeclarationModifiers.File) != 0)
+            {
+                diagnostics.Add(ErrorCode.ERR_FileTypeNoExplicitAccessibility, Locations[0], this);
+            }
 
             if (missingPartial)
             {
@@ -775,6 +779,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal bool IsPartial => HasFlag(DeclarationModifiers.Partial);
 
         internal bool IsNew => HasFlag(DeclarationModifiers.New);
+
+        internal bool IsFile => HasFlag(DeclarationModifiers.File);
+
+        // PROTOTYPE(ft): decide if this is the right internal API
+        // we will probably need this when we mangle the symbol name
+        // internal SyntaxTree? AssociatedSyntaxTree => HasFlag(DeclarationModifiers.File) ? declaration.Declarations[0].Location.SourceTree : null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool HasFlag(DeclarationModifiers flag) => (_declModifiers & flag) != 0;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -782,9 +782,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal bool IsFile => HasFlag(DeclarationModifiers.File);
 
-        // PROTOTYPE(ft): decide if this is the right internal API
-        // we will probably need this when we mangle the symbol name
-        // internal SyntaxTree? AssociatedSyntaxTree => HasFlag(DeclarationModifiers.File) ? declaration.Declarations[0].Location.SourceTree : null;
+        /// <summary>If this symbol is only available within a single syntax tree, returns that syntax tree. Otherwise, returns null.</summary>
+        internal SyntaxTree? AssociatedSyntaxTree => IsFile ? declaration.Declarations[0].Location.SourceTree : null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool HasFlag(DeclarationModifiers flag) => (_declModifiers & flag) != 0;
@@ -1229,7 +1228,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private Dictionary<string, ImmutableArray<NamedTypeSymbol>> MakeTypeMembers(BindingDiagnosticBag diagnostics)
         {
             var symbols = ArrayBuilder<NamedTypeSymbol>.GetInstance();
-            var conflictDict = new Dictionary<(string, int), SourceNamedTypeSymbol>();
+            var conflictDict = new Dictionary<(string name, int arity, SyntaxTree? syntaxTree), SourceNamedTypeSymbol>();
             try
             {
                 foreach (var childDeclaration in declaration.Children)
@@ -1237,7 +1236,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var t = new SourceNamedTypeSymbol(this, childDeclaration, diagnostics);
                     this.CheckMemberNameDistinctFromType(t, diagnostics);
 
-                    var key = (t.Name, t.Arity);
+                    var key = (t.Name, t.Arity, t.AssociatedSyntaxTree);
                     SourceNamedTypeSymbol? other;
                     if (conflictDict.TryGetValue(key, out other))
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -46,7 +46,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         protected void TypeChecks(TypeSymbol type, BindingDiagnosticBag diagnostics)
         {
-            if (type.IsStatic)
+            if (type.IsFileTypeOrUsesFileTypes() && !ContainingType.IsFileTypeOrUsesFileTypes())
+            {
+                diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, this.ErrorLocation, type, ContainingType);
+            }
+            else if (type.IsStatic)
             {
                 // Cannot declare a variable of static type '{0}'
                 diagnostics.Add(ErrorCode.ERR_VarDeclIsStaticClass, this.ErrorLocation, type);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -286,7 +286,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (returnType.Type.IsFileTypeOrUsesFileTypes())
             {
                 diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, Locations[0], returnType.Type, ContainingType);
-                return;
             }
 
             foreach (var param in parameters)
@@ -294,7 +293,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (param.Type.IsFileTypeOrUsesFileTypes())
                 {
                     diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, Locations[0], param.Type, ContainingType);
-                    return;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -276,6 +276,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             diagnostics.Add(Locations[0], useSiteInfo);
         }
 
+        protected void CheckFileTypeUsage(TypeWithAnnotations returnType, ImmutableArray<ParameterSymbol> parameters, BindingDiagnosticBag diagnostics)
+        {
+            if (ContainingType.IsFileTypeOrUsesFileTypes())
+            {
+                return;
+            }
+
+            if (returnType.Type.IsFileTypeOrUsesFileTypes())
+            {
+                diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, Locations[0], returnType.Type, ContainingType);
+                return;
+            }
+
+            foreach (var param in parameters)
+            {
+                if (param.Type.IsFileTypeOrUsesFileTypes())
+                {
+                    diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, Locations[0], param.Type, ContainingType);
+                    return;
+                }
+            }
+        }
+
         protected void MakeFlags(
             MethodKind methodKind,
             DeclarationModifiers declarationModifiers,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     if (i.IsFileTypeOrUsesFileTypes() && !this.IsFileTypeOrUsesFileTypes())
                     {
-                        diagnostics.Add(ErrorCode.ERR_FileTypeBase, baseTypeLocation, i, this);
+                        diagnostics.Add(ErrorCode.ERR_FileTypeBase, interfaceLocations[i], i, this);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -384,6 +384,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // Inconsistent accessibility: base class '{1}' is less accessible than class '{0}'
                     diagnostics.Add(ErrorCode.ERR_BadVisBaseClass, baseTypeLocation, this, baseType);
                 }
+
+                if (baseType.IsFileTypeOrUsesFileTypes() && !this.IsFileTypeOrUsesFileTypes())
+                {
+                    diagnostics.Add(ErrorCode.ERR_FileTypeBase, baseTypeLocation, baseType, this);
+                }
             }
 
             var baseInterfacesRO = baseInterfaces.ToImmutableAndFree();
@@ -395,6 +400,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         // Inconsistent accessibility: base interface '{1}' is less accessible than interface '{0}'
                         diagnostics.Add(ErrorCode.ERR_BadVisBaseInterface, interfaceLocations[i], this, i);
+                    }
+
+                    if (i.IsFileTypeOrUsesFileTypes() && !this.IsFileTypeOrUsesFileTypes())
+                    {
+                        diagnostics.Add(ErrorCode.ERR_FileTypeBase, baseTypeLocation, i, this);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -374,7 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         switch (nts, other)
                         {
-                            case (SourceNamedTypeSymbol left, SourceNamedTypeSymbol right) when left.IsFileTypeInSeparateFileFrom(right) || right.IsFileTypeInSeparateFileFrom(left):
+                            case (SourceNamedTypeSymbol left, SourceNamedTypeSymbol right) when isFileTypeInSeparateFileFrom(left, right) || isFileTypeInSeparateFileFrom(right, left):
                                 // no error
                                 break;
                             case (SourceNamedTypeSymbol { IsPartial: true }, SourceNamedTypeSymbol { IsPartial: true }):
@@ -398,6 +398,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         }
                     }
                 }
+            }
+
+            static bool isFileTypeInSeparateFileFrom(SourceNamedTypeSymbol possibleFileType, SourceNamedTypeSymbol otherSymbol)
+            {
+                if (!possibleFileType.IsFile)
+                {
+                    return false;
+                }
+
+                var leftTree = possibleFileType.MergedDeclaration.Declarations[0].Location.SourceTree;
+                if (otherSymbol.MergedDeclaration.NameLocations.Any((loc, leftTree) => (object)loc.SourceTree == leftTree, leftTree))
+                {
+                    return false;
+                }
+
+                return true;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -374,7 +374,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         switch (nts, other)
                         {
-                            case (SourceNamedTypeSymbol left, SourceNamedTypeSymbol right) when isLeftAFileTypeInSeparateSourceTreeFromRight(left, right) || isLeftAFileTypeInSeparateSourceTreeFromRight(right, left):
+                            case (SourceNamedTypeSymbol left, SourceNamedTypeSymbol right) when left.IsFileTypeInSeparateFileFrom(right) || right.IsFileTypeInSeparateFileFrom(left):
                                 // no error
                                 break;
                             case (SourceNamedTypeSymbol { IsPartial: true }, SourceNamedTypeSymbol { IsPartial: true }):
@@ -383,24 +383,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             default:
                                 diagnostics.Add(ErrorCode.ERR_DuplicateNameInNS, symbol.Locations.FirstOrNone(), name, @namespace);
                                 break;
-                        }
-
-                        // prototype(ft): better name? better diagnostic?
-                        static bool isLeftAFileTypeInSeparateSourceTreeFromRight(SourceNamedTypeSymbol left, SourceNamedTypeSymbol right)
-                        {
-                            // no, left is not a file type.
-                            if (!left.IsFile)
-                            {
-                                return false;
-                            }
-
-                            var leftTree = left.MergedDeclaration.Declarations[0].Location.SourceTree;
-                            if (right.MergedDeclaration.NameLocations.Any((loc, leftTree) => (object)loc.SourceTree == leftTree, leftTree))
-                            {
-                                return false; // no, there's a declaration of 'right' in the same file as 'left'.
-                            }
-
-                            return true;
                         }
                     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -386,7 +386,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         }
 
                         // prototype(ft): better name? better diagnostic?
-                        bool isLeftAFileTypeInSeparateSourceTreeFromRight(SourceNamedTypeSymbol left, SourceNamedTypeSymbol right)
+                        static bool isLeftAFileTypeInSeparateSourceTreeFromRight(SourceNamedTypeSymbol left, SourceNamedTypeSymbol right)
                         {
                             // no, left is not a file type.
                             if (!left.IsFile)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
@@ -46,6 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.SetReturnsVoid(_lazyReturnType.IsVoidType());
 
             this.CheckEffectiveAccessibility(_lazyReturnType, _lazyParameters, diagnostics);
+            this.CheckFileTypeUsage(_lazyReturnType, _lazyParameters, diagnostics);
 
             var location = locations[0];
             // Checks taken from MemberDefiner::defineMethod

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -438,6 +438,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add((this.IsIndexer ? ErrorCode.ERR_BadVisIndexerReturn : ErrorCode.ERR_BadVisPropertyType), Location, this, type.Type);
             }
 
+            if (type.Type.IsFileTypeOrUsesFileTypes() && !ContainingType.IsFileTypeOrUsesFileTypes())
+            {
+                diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, Location, type.Type, ContainingType);
+            }
+
             diagnostics.Add(Location, useSiteInfo);
 
             if (type.IsVoidType())
@@ -508,6 +513,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (!IsExplicitInterfaceImplementation && !this.IsNoMoreVisibleThan(param.Type, ref useSiteInfo))
                 {
                     diagnostics.Add(ErrorCode.ERR_BadVisIndexerParam, Location, this, param.Type);
+                }
+                else if (param.Type.IsFileTypeOrUsesFileTypes() && !this.ContainingType.IsFileTypeOrUsesFileTypes())
+                {
+                    diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, Location, param.Type, this.ContainingType);
                 }
                 else if (SetMethod is object && param.Name == ParameterSymbol.ValueParameterName)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -440,6 +440,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (type.Type.IsFileTypeOrUsesFileTypes() && !ContainingType.IsFileTypeOrUsesFileTypes())
             {
+                // PROTOTYPE(ft): should explicit interface implementations be allowed to use file types in signatures?
                 diagnostics.Add(ErrorCode.ERR_FileTypeDisallowedInSignature, Location, type.Type, ContainingType);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -873,7 +873,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SymbolDisplayFormat.TestFormat
                 .AddMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
                     | SymbolDisplayMiscellaneousOptions.IncludeNotNullableReferenceTypeModifier)
-                .WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.None);
+                .WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeContainingFileForFileTypes);
 
         internal virtual string GetDebuggerDisplay()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -451,7 +451,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Creates a new top-level binder that just contains the global imports for the compilation.
                 // The imports are required if a consumer of the scripting API is using a Task implementation 
                 // that uses extension methods.
-                Binder binder = WithUsingNamespacesAndTypesBinder.Create(compilation.GlobalImports, next: new BuckStopsHereBinder(compilation), withImportChainEntry: true);
+                Binder binder = WithUsingNamespacesAndTypesBinder.Create(compilation.GlobalImports, next: new BuckStopsHereBinder(compilation, syntax.SyntaxTree), withImportChainEntry: true);
                 binder = new InContainerBinder(compilation.GlobalNamespace, binder);
 
                 var ctor = _containingType.GetScriptConstructor();

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -451,7 +451,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Creates a new top-level binder that just contains the global imports for the compilation.
                 // The imports are required if a consumer of the scripting API is using a Task implementation 
                 // that uses extension methods.
-                Binder binder = WithUsingNamespacesAndTypesBinder.Create(compilation.GlobalImports, next: new BuckStopsHereBinder(compilation, syntax.SyntaxTree), withImportChainEntry: true);
+                Binder binder = WithUsingNamespacesAndTypesBinder.Create(compilation.GlobalImports, next: new BuckStopsHereBinder(compilation, null), withImportChainEntry: true);
                 binder = new InContainerBinder(compilation.GlobalNamespace, binder);
 
                 var ctor = _containingType.GetScriptConstructor();

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSimpleProgramEntryPointSymbol.cs
@@ -219,10 +219,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             CSharpCompilation compilation = DeclaringCompilation;
 
-            Binder result = new BuckStopsHereBinder(compilation);
+            var syntaxNode = SyntaxNode;
+            Binder result = new BuckStopsHereBinder(compilation, syntaxNode.SyntaxTree);
             var globalNamespace = compilation.GlobalNamespace;
             var declaringSymbol = (SourceNamespaceSymbol)compilation.SourceModule.GlobalNamespace;
-            var syntaxNode = SyntaxNode;
             result = WithExternAndUsingAliasesBinder.Create(declaringSymbol, syntaxNode, WithUsingNamespacesAndTypesBinder.Create(declaringSymbol, syntaxNode, result));
             result = new InContainerBinder(globalNamespace, result);
             result = new InContainerBinder(ContainingType, result);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1355,6 +1355,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type is SourceNamedTypeSymbol { IsPartial: true };
         }
 
+        public static bool IsFileTypeOrUsesFileTypes(this TypeSymbol type)
+        {
+            var foundType = type.VisitType(predicate: (type, input, _) => type is SourceMemberContainerTypeSymbol { IsFile: true }, arg: (object?)null);
+            return foundType is not null;
+        }
+
         public static bool IsPointerType(this TypeSymbol type)
         {
             return type is PointerTypeSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1361,6 +1361,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return foundType is not null;
         }
 
+        public static bool IsFileTypeInSeparateFileFrom(this SourceNamedTypeSymbol possibleFileType, SourceNamedTypeSymbol otherSymbol)
+        {
+            if (!possibleFileType.IsFile)
+            {
+                return false;
+            }
+
+            var leftTree = possibleFileType.MergedDeclaration.Declarations[0].Location.SourceTree;
+            if (otherSymbol.MergedDeclaration.NameLocations.Any((loc, leftTree) => (object)loc.SourceTree == leftTree, leftTree))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         public static bool IsPointerType(this TypeSymbol type)
         {
             return type is PointerTypeSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1361,22 +1361,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return foundType is not null;
         }
 
-        public static bool IsFileTypeInSeparateFileFrom(this SourceNamedTypeSymbol possibleFileType, SourceNamedTypeSymbol otherSymbol)
-        {
-            if (!possibleFileType.IsFile)
-            {
-                return false;
-            }
-
-            var leftTree = possibleFileType.MergedDeclaration.Declarations[0].Location.SourceTree;
-            if (otherSymbol.MergedDeclaration.NameLocations.Any((loc, leftTree) => (object)loc.SourceTree == leftTree, leftTree))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
         public static bool IsPointerType(this TypeSymbol type)
         {
             return type is PointerTypeSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1357,7 +1357,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public static bool IsFileTypeOrUsesFileTypes(this TypeSymbol type)
         {
-            var foundType = type.VisitType(predicate: (type, input, _) => type is SourceMemberContainerTypeSymbol { IsFile: true }, arg: (object?)null);
+            var foundType = type.VisitType(predicate: (type, _, _) => type is SourceMemberContainerTypeSymbol { IsFile: true }, arg: (object?)null);
             return foundType is not null;
         }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -562,6 +562,21 @@
         <target state="translated">Obor názvů pro celý soubor musí předcházet všem ostatním členům v souboru.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Příkaz foreach nejde použít pro proměnné typu {0}, protože {0} neobsahuje veřejnou definici instance nebo rozšíření pro {1}. Měli jste v úmyslu await foreach místo foreach?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -562,6 +562,21 @@
         <target state="translated">Der Dateibereichsnamespace muss allen anderen Elementen in einer Datei vorangestellt sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Eine foreach-Anweisung kann nicht für Variablen vom Typ "{0}" verwendet werden, weil "{0}" keine öffentliche Instanz- oder Erweiterungsdefinition für "{1}" enthält. Meinten Sie "await foreach" statt "foreach"?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -562,6 +562,21 @@
         <target state="translated">El espacio de nombres con ámbito de archivo debe preceder a todos los demás miembros de un archivo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">La instrucción foreach no puede funcionar en variables de tipo "{0}" porque "{0}" no contiene ninguna definición de extensión o instancia pública para "{1}". ¿Quiso decir “await foreach” en lugar de “foreach”?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -562,6 +562,21 @@
         <target state="translated">Un espace de noms de portée de fichier doit précéder tous les autres membres d’un fichier.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">L'instruction foreach ne peut pas fonctionner sur des variables de type '{0}', car '{0}' ne contient pas de définition d'extension ou d'instance publique pour '{1}'. Vouliez-vous dire 'await foreach' plutôt que 'foreach' ?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -562,6 +562,21 @@
         <target state="translated">Lo spazio dei nomi con ambito file deve precedere tutti gli altri membri di un file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">L'istruzione foreach non può funzionare con variabili di tipo '{0}' perché '{0}' non contiene una definizione di istanza o estensione pubblica per '{1}'. Si intendeva 'await foreach' invece di 'foreach'?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -562,6 +562,21 @@
         <target state="translated">ファイルスコープの名前空間は、ファイル内の他のすべてのメンバーの前に指定する必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">'{0}' は '{1}' のパブリック インスタンスまたは拡張機能の定義を含んでいないため、型 '{0}' の変数に対して foreach ステートメントを使用することはできません。'foreach' ではなく 'await foreach' ですか?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -562,6 +562,21 @@
         <target state="translated">파일 범위 네임스페이스는 파일의 다른 모든 멤버보다 앞에 와야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">'{0}' 형식 변수에서 foreach 문을 수행할 수 없습니다. '{0}'에는 '{1}'의 공개 인스턴스 또는 확장 정의가 없기 때문입니다. 'foreach' 대신 'await foreach'를 사용하시겠습니까?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -562,6 +562,21 @@
         <target state="translated">Przestrzeń nazw z określonym zakresem plików musi poprzedzać wszystkie inne składowe w pliku.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Instrukcja foreach nie może operować na zmiennych typu „{0}”, ponieważ typ „{0}” nie zawiera publicznego wystąpienia lub definicji rozszerzenia dla elementu „{1}”. Czy planowano użyć instrukcji „await foreach”, a nie „foreach”?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -562,6 +562,21 @@
         <target state="translated">O namespace de escopo de arquivo deve preceder todos os outros membros em um arquivo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">A instrução foreach não pode operar em variáveis do tipo '{0}' porque '{0}' não contém uma definição de extensão ou de instância pública para '{1}'. Você quis dizer 'await foreach' em vez de 'foreach'?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -562,6 +562,21 @@
         <target state="translated">Пространство имен с файловой областью должно быть раньше всех остальных элементов в файле.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">Оператор foreach не работает с переменными типа "{0}", так как "{0}" не содержит открытое определение экземпляра или расширения для "{1}" Возможно, вы имели в виду "await foreach", а не "foreach"?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -562,6 +562,21 @@
         <target state="translated">Dosya kapsamlı ad alanı bir dosyadaki diğer tüm üyelerin önünde olmalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">'{0}', '{1}' için bir genel örnek veya uzantı tanımı içermediğinden foreach deyimi '{0}' türündeki değişkenler üzerinde çalışamaz. 'foreach' yerine 'await foreach' mi kullanmak istediniz?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -562,6 +562,21 @@
         <target state="translated">文件范围内的命名空间必须位于文件中所有其他成员之前。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">“{0}”不包含“{1}”的公共实例或扩展定义，因此 foreach 语句不能作用于“{0}”类型的变量。是否希望使用 "await foreach" 而非 "foreach"?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -562,6 +562,21 @@
         <target state="translated">以檔為範圍的命名空間必須在檔案中的所有其他成員之前。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_FileTypeBase">
+        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeDisallowedInSignature">
+        <source>File type '{0}' cannot be used in a member signature in non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used in a member signature in non-file type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_FileTypeNoExplicitAccessibility">
+        <source>File type '{0}' cannot use accessibility modifiers.</source>
+        <target state="new">File type '{0}' cannot use accessibility modifiers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ForEachMissingMemberWrongAsync">
         <source>foreach statement cannot operate on variables of type '{0}' because '{0}' does not contain a public instance or extension definition for '{1}'. Did you mean 'await foreach' rather than 'foreach'?</source>
         <target state="translated">因為 '{0}' 不包含 '{1}' 的公用執行個體或延伸模組定義，所以 foreach 陳述式無法在型別 '{0}' 的變數上運作。您指的是 'await foreach' 而不是 'foreach' 嗎?</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -563,8 +563,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeBase">
-        <source>File type '{0}' cannot be used as a base type in non-file type '{1}'.</source>
-        <target state="new">File type '{0}' cannot be used as a base type in non-file type '{1}'.</target>
+        <source>File type '{0}' cannot be used as a base type of non-file type '{1}'.</source>
+        <target state="new">File type '{0}' cannot be used as a base type of non-file type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_FileTypeDisallowedInSignature">

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
             var mscorlibRef = TestMetadata.Net40.mscorlib;
             var compilation = CSharpCompilation.Create("Test", references: new MetadataReference[] { mscorlibRef });
             var sys = compilation.GlobalNamespace.ChildNamespace("System");
-            Conversions c = new BuckStopsHereBinder(compilation).Conversions;
+            Conversions c = new BuckStopsHereBinder(compilation, associatedSyntaxTree: null).Conversions;
             var types = new TypeSymbol[]
             {
             sys.ChildType("Object"),
@@ -311,7 +311,7 @@ class C
 
             Assert.True(typeIntArrayWithCustomModifiers.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds: false));
 
-            var conv = new BuckStopsHereBinder(compilation).Conversions;
+            var conv = new BuckStopsHereBinder(compilation, associatedSyntaxTree: null).Conversions;
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 
             // no custom modifiers to custom modifiers

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -8,1699 +8,1698 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+public class FileModifierTests : CSharpTestBase
 {
-    public class FileModifierTests : CSharpTestBase
+    [Fact]
+    public void LangVersion()
     {
-        [Fact]
-        public void LangVersion()
-        {
-            var source = """
+        var source = """
+            file class C { }
+            """;
+
+        var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+        comp.VerifyDiagnostics(
+            // (1,12): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // file class C { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "C").WithArguments("file types").WithLocation(1, 12));
+
+        comp = CreateCompilation(source);
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Nested_01()
+    {
+        var source = """
+            class Outer
+            {
                 file class C { }
-                """;
-
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
-            comp.VerifyDiagnostics(
-                // (1,12): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                // file class C { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "C").WithArguments("file types").WithLocation(1, 12));
-
-            comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void Nested_01()
-        {
-            var source = """
-                class Outer
-                {
-                    file class C { }
-                }
-                """;
-
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
-            comp.VerifyDiagnostics(
-                // (3,16): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     file class C { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "C").WithArguments("file types").WithLocation(3, 16));
-
-            comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void Nested_02()
-        {
-            var source = """
-                file class Outer
-                {
-                    class C { }
-                }
-                """;
-
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
-            comp.VerifyDiagnostics(
-                // (1,12): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                // file class Outer
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "Outer").WithArguments("file types").WithLocation(1, 12));
-
-            comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void Nested_03()
-        {
-            var source = """
-                file class Outer
-                {
-                    file class C { }
-                }
-                """;
-
-            // PROTOTYPE(ft): determine whether an inner file class within a file class is an error or if it's just fine.
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
-            comp.VerifyDiagnostics(
-                // (1,12): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                // file class Outer
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "Outer").WithArguments("file types").WithLocation(1, 12),
-                // (3,16): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                //     file class C { }
-                Diagnostic(ErrorCode.ERR_FeatureInPreview, "C").WithArguments("file types").WithLocation(3, 16));
-
-            comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void Nested_04()
-        {
-            var source = """
-                file class Outer
-                {
-                    public class C { }
-                }
-
-                class D
-                {
-                    void M(Outer.C c) { } // 1
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (8,10): error CS9300: File type 'Outer.C' cannot be used in a member signature in non-file type 'D'.
-                //     void M(Outer.C c) { } // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("Outer.C", "D").WithLocation(8, 10));
-        }
-
-        [Fact]
-        public void Nested_05()
-        {
-            var source = """
-                file class Outer
-                {
-                    public class C
-                    {
-                        void M(Outer outer) { } // ok
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void Nested_06()
-        {
-            var source = """
-                class A1
-                {
-                    internal class A2 { }
-                }
-                file class B : A1
-                {
-                }
-                class C : B.A2 // ok: base type is bound as A1.A2
-                {
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void SameFileUse()
-        {
-            var source = """
-                using System;
-
-                file class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-
-                class Program
-                {
-                    static void Main()
-                    {
-                        C.M();
-                    }
-                }
-                """;
-
-            var verifier = CompileAndVerify(source, expectedOutput: "1");
-            verifier.VerifyDiagnostics();
-            // PROTOTYPE(ft): check metadata names
-        }
-
-        [Fact]
-        public void OtherFileUse()
-        {
-            var source1 = """
-                using System;
-
-                file class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-                """;
-
-            var source2 = """
-                class Program
-                {
-                    static void Main()
-                    {
-                        C.M(); // 1
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source1, source2 });
-            comp.VerifyDiagnostics(
-                // (5,9): error CS0103: The name 'C' does not exist in the current context
-                //         C.M(); // 1
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(5, 9));
-        }
-
-        [Theory]
-        [InlineData("file", "file")]
-        [InlineData("file", "")]
-        [InlineData("", "file")]
-        public void Duplication_01(string firstFileModifier, string secondFileModifier)
-        {
-            // A file type is allowed to have the same name as a non-file type from a different file.
-            // When both a file type and non-file type with the same name are in scope, the file type is preferred, since it's "more local".
-            var source1 = $$"""
-                using System;
-
-                {{firstFileModifier}} class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-                """;
-
-            var source2 = $$"""
-                using System;
-
-                {{secondFileModifier}} class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(2);
-                    }
-                }
-                """;
-
-            var main = """
-
-                class Program
-                {
-                    static void Main()
-                    {
-                        C.M();
-                    }
-                }
-                """;
-
-            // PROTOTYPE(ft): execute and check expectedOutput once name mangling is done
-            // expectedOutput: "1"
-            var comp = CreateCompilation(new[] { source1 + main, source2 });
-            verify();
-
-            // expectedOutput: "2"
-            comp = CreateCompilation(new[] { source1, source2 + main });
-            verify();
-
-            void verify()
-            {
-                comp.VerifyDiagnostics();
-
-                var cs = comp.GetMembers("C");
-                Assert.Equal(2, cs.Length);
-                Assert.Equal(comp.SyntaxTrees[0], cs[0].DeclaringSyntaxReferences.Single().SyntaxTree);
-                Assert.Equal(comp.SyntaxTrees[1], cs[1].DeclaringSyntaxReferences.Single().SyntaxTree);
             }
-        }
+            """;
 
-        [Fact]
-        public void Duplication_02()
-        {
-            // As a sanity check, demonstrate that non-file classes with the same name across different files are disallowed.
-            var source1 = """
-                using System;
+        var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+        comp.VerifyDiagnostics(
+            // (3,16): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     file class C { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "C").WithArguments("file types").WithLocation(3, 16));
 
-                class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-                """;
+        comp = CreateCompilation(source);
+        comp.VerifyDiagnostics();
+    }
 
-            var source2 = """
-                using System;
-
-                class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(2);
-                    }
-                }
-                """;
-
-            var main = """
-
-                class Program
-                {
-                    static void Main()
-                    {
-                        C.M();
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source1 + main, source2 });
-            verify();
-
-            comp = CreateCompilation(new[] { source1, source2 + main });
-            verify();
-
-            void verify()
+    [Fact]
+    public void Nested_02()
+    {
+        var source = """
+            file class Outer
             {
-                comp.VerifyDiagnostics(
-                    // (3,7): error CS0101: The namespace '<global namespace>' already contains a definition for 'C'
-                    // class C
-                    Diagnostic(ErrorCode.ERR_DuplicateNameInNS, "C").WithArguments("C", "<global namespace>").WithLocation(3, 7),
-                    // (5,24): error CS0111: Type 'C' already defines a member called 'M' with the same parameter types
-                    //     public static void M()
-                    Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M").WithArguments("M", "C").WithLocation(5, 24),
-                    // (14,11): error CS0121: The call is ambiguous between the following methods or properties: 'C.M()' and 'C.M()'
-                    //         C.M();
-                    Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M()", "C.M()").WithLocation(14, 11));
-
-                var cs = comp.GetMember("C");
-                var syntaxReferences = cs.DeclaringSyntaxReferences;
-                Assert.Equal(2, syntaxReferences.Length);
-                Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
-                Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
+                class C { }
             }
-        }
+            """;
 
-        [Fact]
-        public void Duplication_03()
+        var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+        comp.VerifyDiagnostics(
+            // (1,12): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // file class Outer
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "Outer").WithArguments("file types").WithLocation(1, 12));
+
+        comp = CreateCompilation(source);
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Nested_03()
+    {
+        var source = """
+            file class Outer
+            {
+                file class C { }
+            }
+            """;
+
+        // PROTOTYPE(ft): determine whether an inner file class within a file class is an error or if it's just fine.
+        var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+        comp.VerifyDiagnostics(
+            // (1,12): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // file class Outer
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "Outer").WithArguments("file types").WithLocation(1, 12),
+            // (3,16): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     file class C { }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "C").WithArguments("file types").WithLocation(3, 16));
+
+        comp = CreateCompilation(source);
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Nested_04()
+    {
+        var source = """
+            file class Outer
+            {
+                public class C { }
+            }
+
+            class D
+            {
+                void M(Outer.C c) { } // 1
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (8,10): error CS9300: File type 'Outer.C' cannot be used in a member signature in non-file type 'D'.
+            //     void M(Outer.C c) { } // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("Outer.C", "D").WithLocation(8, 10));
+    }
+
+    [Fact]
+    public void Nested_05()
+    {
+        var source = """
+            file class Outer
+            {
+                public class C
+                {
+                    void M(Outer outer) { } // ok
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Nested_06()
+    {
+        var source = """
+            class A1
+            {
+                internal class A2 { }
+            }
+            file class B : A1
+            {
+            }
+            class C : B.A2 // ok: base type is bound as A1.A2
+            {
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void SameFileUse()
+    {
+        var source = """
+            using System;
+
+            file class C
+            {
+                public static void M()
+                {
+                    Console.Write(1);
+                }
+            }
+
+            class Program
+            {
+                static void Main()
+                {
+                    C.M();
+                }
+            }
+            """;
+
+        var verifier = CompileAndVerify(source, expectedOutput: "1");
+        verifier.VerifyDiagnostics();
+        // PROTOTYPE(ft): check metadata names
+    }
+
+    [Fact]
+    public void OtherFileUse()
+    {
+        var source1 = """
+            using System;
+
+            file class C
+            {
+                public static void M()
+                {
+                    Console.Write(1);
+                }
+            }
+            """;
+
+        var source2 = """
+            class Program
+            {
+                static void Main()
+                {
+                    C.M(); // 1
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { source1, source2 });
+        comp.VerifyDiagnostics(
+            // (5,9): error CS0103: The name 'C' does not exist in the current context
+            //         C.M(); // 1
+            Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(5, 9));
+    }
+
+    [Theory]
+    [InlineData("file", "file")]
+    [InlineData("file", "")]
+    [InlineData("", "file")]
+    public void Duplication_01(string firstFileModifier, string secondFileModifier)
+    {
+        // A file type is allowed to have the same name as a non-file type from a different file.
+        // When both a file type and non-file type with the same name are in scope, the file type is preferred, since it's "more local".
+        var source1 = $$"""
+            using System;
+
+            {{firstFileModifier}} class C
+            {
+                public static void M()
+                {
+                    Console.Write(1);
+                }
+            }
+            """;
+
+        var source2 = $$"""
+            using System;
+
+            {{secondFileModifier}} class C
+            {
+                public static void M()
+                {
+                    Console.Write(2);
+                }
+            }
+            """;
+
+        var main = """
+
+            class Program
+            {
+                static void Main()
+                {
+                    C.M();
+                }
+            }
+            """;
+
+        // PROTOTYPE(ft): execute and check expectedOutput once name mangling is done
+        // expectedOutput: "1"
+        var comp = CreateCompilation(new[] { source1 + main, source2 });
+        verify();
+
+        // expectedOutput: "2"
+        comp = CreateCompilation(new[] { source1, source2 + main });
+        verify();
+
+        void verify()
         {
-            var source1 = """
-                using System;
-
-                partial class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-                """;
-
-            var source2 = """
-                partial class C
-                {
-                }
-                """;
-
-            var main = """
-                using System;
-
-                file class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(2);
-                    }
-                }
-
-                class Program
-                {
-                    static void Main()
-                    {
-                        C.M();
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source1, source2, main }); // expectedOutput: 2
             comp.VerifyDiagnostics();
 
             var cs = comp.GetMembers("C");
             Assert.Equal(2, cs.Length);
-
-            var c0 = cs[0];
-            Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: false });
-
-            var syntaxReferences = c0.DeclaringSyntaxReferences;
-            Assert.Equal(2, syntaxReferences.Length);
-            Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
-            Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
-
-            var c1 = cs[1];
-            Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
-            Assert.Equal(comp.SyntaxTrees[2], c1.DeclaringSyntaxReferences.Single().SyntaxTree);
+            Assert.Equal(comp.SyntaxTrees[0], cs[0].DeclaringSyntaxReferences.Single().SyntaxTree);
+            Assert.Equal(comp.SyntaxTrees[1], cs[1].DeclaringSyntaxReferences.Single().SyntaxTree);
         }
+    }
 
-        [Fact]
-        public void Duplication_04()
+    [Fact]
+    public void Duplication_02()
+    {
+        // As a sanity check, demonstrate that non-file classes with the same name across different files are disallowed.
+        var source1 = """
+            using System;
+
+            class C
+            {
+                public static void M()
+                {
+                    Console.Write(1);
+                }
+            }
+            """;
+
+        var source2 = """
+            using System;
+
+            class C
+            {
+                public static void M()
+                {
+                    Console.Write(2);
+                }
+            }
+            """;
+
+        var main = """
+
+            class Program
+            {
+                static void Main()
+                {
+                    C.M();
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { source1 + main, source2 });
+        verify();
+
+        comp = CreateCompilation(new[] { source1, source2 + main });
+        verify();
+
+        void verify()
         {
-            var source1 = """
-                using System;
-
-                class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-                """;
-
-            var main = """
-                using System;
-
-                file partial class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(Number);
-                    }
-                }
-
-                file partial class C
-                {
-                    private static int Number => 2;
-                }
-
-                class Program
-                {
-                    static void Main()
-                    {
-                        C.M();
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source1, main }); // expectedOutput: 2
-            comp.VerifyDiagnostics();
-
-            var cs = comp.GetMembers("C");
-            Assert.Equal(2, cs.Length);
-
-            var c0 = cs[0];
-            Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: false });
-            Assert.Equal(comp.SyntaxTrees[0], c0.DeclaringSyntaxReferences.Single().SyntaxTree);
-
-            var c1 = cs[1];
-            Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
-
-            var syntaxReferences = c1.DeclaringSyntaxReferences;
-            Assert.Equal(2, syntaxReferences.Length);
-            Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[0].SyntaxTree);
-            Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
-        }
-
-        [Theory]
-        [CombinatorialData]
-        public void Duplication_05(bool firstClassIsFile)
-        {
-            var source1 = $$"""
-                using System;
-
-                {{(firstClassIsFile ? "file " : "")}}partial class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-                """;
-
-            var main = """
-                using System;
-
-                file partial class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(2);
-                    }
-                }
-
-                class Program
-                {
-                    static void Main()
-                    {
-                        C.M();
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source1, main }); // expectedOutput: 2
-            comp.VerifyDiagnostics();
-
-            var cs = comp.GetMembers("C");
-            Assert.Equal(2, cs.Length);
-
-            var c0 = cs[0];
-            Assert.Equal(firstClassIsFile, ((SourceMemberContainerTypeSymbol)c0).IsFile);
-            Assert.Equal(comp.SyntaxTrees[0], c0.DeclaringSyntaxReferences.Single().SyntaxTree);
-
-            var c1 = cs[1];
-            Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
-            Assert.Equal(comp.SyntaxTrees[1], c1.DeclaringSyntaxReferences.Single().SyntaxTree);
-        }
-
-        [Fact]
-        public void Duplication_06()
-        {
-            var source1 = """
-                using System;
-
-                partial class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(Number);
-                    }
-                }
-                """;
-
-            var source2 = """
-                using System;
-
-                partial class C
-                {
-                    private static int Number => 1;
-                }
-
-                file class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(2);
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source1, source2 });
-            // PROTOTYPE(ft): should this diagnostic be more specific?
-            // the issue more precisely is that a definition for 'C' already exists in the current file--not that it's already in this namespace.
             comp.VerifyDiagnostics(
-                // (8,12): error CS0101: The namespace '<global namespace>' already contains a definition for 'C'
-                // file class C
-                Diagnostic(ErrorCode.ERR_DuplicateNameInNS, "C").WithArguments("C", "<global namespace>").WithLocation(8, 12));
-
-            var cs = comp.GetMembers("C");
-            Assert.Equal(2, cs.Length);
-
-            var c0 = cs[0];
-            Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: false });
-            var syntaxReferences = c0.DeclaringSyntaxReferences;
-            Assert.Equal(2, syntaxReferences.Length);
-            Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
-            Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
-
-            var c1 = cs[1];
-            Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
-            Assert.Equal(comp.SyntaxTrees[1], c1.DeclaringSyntaxReferences.Single().SyntaxTree);
-
-
-            comp = CreateCompilation(new[] { source2, source1 });
-            comp.VerifyDiagnostics(
+                // (3,7): error CS0101: The namespace '<global namespace>' already contains a definition for 'C'
+                // class C
+                Diagnostic(ErrorCode.ERR_DuplicateNameInNS, "C").WithArguments("C", "<global namespace>").WithLocation(3, 7),
                 // (5,24): error CS0111: Type 'C' already defines a member called 'M' with the same parameter types
                 //     public static void M()
                 Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M").WithArguments("M", "C").WithLocation(5, 24),
-                // (8,12): error CS0260: Missing partial modifier on declaration of type 'C'; another partial declaration of this type exists
-                // file class C
-                Diagnostic(ErrorCode.ERR_MissingPartial, "C").WithArguments("C").WithLocation(8, 12));
+                // (14,11): error CS0121: The call is ambiguous between the following methods or properties: 'C.M()' and 'C.M()'
+                //         C.M();
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M()", "C.M()").WithLocation(14, 11));
 
-            var c = comp.GetMember("C");
-            // PROTOTYPE(ft): is it a problem that we consider this symbol a file type in this scenario?
-            Assert.True(c is SourceMemberContainerTypeSymbol { IsFile: true });
-            syntaxReferences = c.DeclaringSyntaxReferences;
-            Assert.Equal(3, syntaxReferences.Length);
-            Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
-            Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[1].SyntaxTree);
-            Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[2].SyntaxTree);
-        }
-
-        [Fact]
-        public void Duplication_07()
-        {
-            var source1 = """
-                using System;
-
-                file partial class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-                """;
-
-            var source2 = """
-                using System;
-
-                file partial class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(Number);
-                    }
-                }
-
-                file class C
-                {
-                    private static int Number => 2;
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source1, source2 });
-            comp.VerifyDiagnostics(
-                // (11,12): error CS0260: Missing partial modifier on declaration of type 'C'; another partial declaration of this type exists
-                // file class C
-                Diagnostic(ErrorCode.ERR_MissingPartial, "C").WithArguments("C").WithLocation(11, 12));
-
-            var cs = comp.GetMembers("C");
-            Assert.Equal(2, cs.Length);
-
-            var c0 = cs[0];
-            Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: true });
-            Assert.Equal(comp.SyntaxTrees[0], c0.DeclaringSyntaxReferences.Single().SyntaxTree);
-
-            var c1 = cs[1];
-            Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
-            var syntaxReferences = c1.DeclaringSyntaxReferences;
+            var cs = comp.GetMember("C");
+            var syntaxReferences = cs.DeclaringSyntaxReferences;
             Assert.Equal(2, syntaxReferences.Length);
-            Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[0].SyntaxTree);
+            Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
             Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
-
-
-            comp = CreateCompilation(new[] { source2, source1 });
-            comp.VerifyDiagnostics(
-                // (11,12): error CS0260: Missing partial modifier on declaration of type 'C'; another partial declaration of this type exists
-                // file class C
-                Diagnostic(ErrorCode.ERR_MissingPartial, "C").WithArguments("C").WithLocation(11, 12));
-
-            cs = comp.GetMembers("C");
-            Assert.Equal(2, cs.Length);
-
-            c0 = cs[0];
-            Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: true });
-            syntaxReferences = c0.DeclaringSyntaxReferences;
-            Assert.Equal(2, syntaxReferences.Length);
-            Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
-            Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[1].SyntaxTree);
-
-            c1 = cs[1];
-            Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
-            Assert.Equal(comp.SyntaxTrees[1], c1.DeclaringSyntaxReferences.Single().SyntaxTree);
         }
+    }
 
-        [Fact]
-        public void Duplication_08()
-        {
-            var source1 = """
-                partial class Outer
+    [Fact]
+    public void Duplication_03()
+    {
+        var source1 = """
+            using System;
+
+            partial class C
+            {
+                public static void M()
                 {
-                    file class C
-                    {
-                        public static void M() { }
-                    }
+                    Console.Write(1);
                 }
-                """;
+            }
+            """;
 
-            var source2 = """
-                partial class Outer
+        var source2 = """
+            partial class C
+            {
+            }
+            """;
+
+        var main = """
+            using System;
+
+            file class C
+            {
+                public static void M()
                 {
-                    file class C
-                    {
-                        public static void M() { }
-                    }
+                    Console.Write(2);
                 }
-                """;
+            }
 
-            var source3 = """
-                partial class Outer
+            class Program
+            {
+                static void Main()
                 {
-                    public class C
-                    {
-                        public static void M() { }
-                    }
+                    C.M();
                 }
-                """;
+            }
+            """;
 
-            var compilation = CreateCompilation(new[] { source1, source2, source3 });
-            compilation.VerifyDiagnostics();
+        var comp = CreateCompilation(new[] { source1, source2, main }); // expectedOutput: 2
+        comp.VerifyDiagnostics();
 
-            var classOuter = compilation.GetMember<NamedTypeSymbol>("Outer");
-            var cs = classOuter.GetMembers("C");
-            Assert.Equal(3, cs.Length);
-            Assert.True(cs[0] is SourceMemberContainerTypeSymbol { IsFile: true });
-            Assert.True(cs[1] is SourceMemberContainerTypeSymbol { IsFile: true });
-            Assert.True(cs[2] is SourceMemberContainerTypeSymbol { IsFile: false });
-        }
+        var cs = comp.GetMembers("C");
+        Assert.Equal(2, cs.Length);
 
-        [Fact]
-        public void Duplication_09()
-        {
-            var source1 = """
-                namespace NS
+        var c0 = cs[0];
+        Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: false });
+
+        var syntaxReferences = c0.DeclaringSyntaxReferences;
+        Assert.Equal(2, syntaxReferences.Length);
+        Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
+        Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
+
+        var c1 = cs[1];
+        Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
+        Assert.Equal(comp.SyntaxTrees[2], c1.DeclaringSyntaxReferences.Single().SyntaxTree);
+    }
+
+    [Fact]
+    public void Duplication_04()
+    {
+        var source1 = """
+            using System;
+
+            class C
+            {
+                public static void M()
                 {
-                    file class C
-                    {
-                        public static void M() { }
-                    }
+                    Console.Write(1);
                 }
-                """;
+            }
+            """;
 
-            var source2 = """
-                namespace NS
+        var main = """
+            using System;
+
+            file partial class C
+            {
+                public static void M()
                 {
-                    file class C
-                    {
-                        public static void M() { }
-                    }
+                    Console.Write(Number);
                 }
-                """;
+            }
 
-            var source3 = """
-                namespace NS
+            file partial class C
+            {
+                private static int Number => 2;
+            }
+
+            class Program
+            {
+                static void Main()
                 {
-                    public class C
-                    {
-                        public static void M() { }
-                    }
+                    C.M();
                 }
-                """;
+            }
+            """;
 
-            var compilation = CreateCompilation(new[] { source1, source2, source3 });
-            compilation.VerifyDiagnostics();
+        var comp = CreateCompilation(new[] { source1, main }); // expectedOutput: 2
+        comp.VerifyDiagnostics();
 
-            var namespaceNS = compilation.GetMember<NamespaceSymbol>("NS");
-            var cs = namespaceNS.GetMembers("C");
-            Assert.Equal(3, cs.Length);
-            Assert.True(cs[0] is SourceMemberContainerTypeSymbol { IsFile: true });
-            Assert.True(cs[1] is SourceMemberContainerTypeSymbol { IsFile: true });
-            Assert.True(cs[2] is SourceMemberContainerTypeSymbol { IsFile: false });
-        }
+        var cs = comp.GetMembers("C");
+        Assert.Equal(2, cs.Length);
 
-        [Fact]
-        public void SignatureUsage_01()
-        {
-            var source = """
+        var c0 = cs[0];
+        Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: false });
+        Assert.Equal(comp.SyntaxTrees[0], c0.DeclaringSyntaxReferences.Single().SyntaxTree);
+
+        var c1 = cs[1];
+        Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
+
+        var syntaxReferences = c1.DeclaringSyntaxReferences;
+        Assert.Equal(2, syntaxReferences.Length);
+        Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[0].SyntaxTree);
+        Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void Duplication_05(bool firstClassIsFile)
+    {
+        var source1 = $$"""
+            using System;
+
+            {{(firstClassIsFile ? "file " : "")}}partial class C
+            {
+                public static void M()
+                {
+                    Console.Write(1);
+                }
+            }
+            """;
+
+        var main = """
+            using System;
+
+            file partial class C
+            {
+                public static void M()
+                {
+                    Console.Write(2);
+                }
+            }
+
+            class Program
+            {
+                static void Main()
+                {
+                    C.M();
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { source1, main }); // expectedOutput: 2
+        comp.VerifyDiagnostics();
+
+        var cs = comp.GetMembers("C");
+        Assert.Equal(2, cs.Length);
+
+        var c0 = cs[0];
+        Assert.Equal(firstClassIsFile, ((SourceMemberContainerTypeSymbol)c0).IsFile);
+        Assert.Equal(comp.SyntaxTrees[0], c0.DeclaringSyntaxReferences.Single().SyntaxTree);
+
+        var c1 = cs[1];
+        Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
+        Assert.Equal(comp.SyntaxTrees[1], c1.DeclaringSyntaxReferences.Single().SyntaxTree);
+    }
+
+    [Fact]
+    public void Duplication_06()
+    {
+        var source1 = """
+            using System;
+
+            partial class C
+            {
+                public static void M()
+                {
+                    Console.Write(Number);
+                }
+            }
+            """;
+
+        var source2 = """
+            using System;
+
+            partial class C
+            {
+                private static int Number => 1;
+            }
+
+            file class C
+            {
+                public static void M()
+                {
+                    Console.Write(2);
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { source1, source2 });
+        // PROTOTYPE(ft): should this diagnostic be more specific?
+        // the issue more precisely is that a definition for 'C' already exists in the current file--not that it's already in this namespace.
+        comp.VerifyDiagnostics(
+            // (8,12): error CS0101: The namespace '<global namespace>' already contains a definition for 'C'
+            // file class C
+            Diagnostic(ErrorCode.ERR_DuplicateNameInNS, "C").WithArguments("C", "<global namespace>").WithLocation(8, 12));
+
+        var cs = comp.GetMembers("C");
+        Assert.Equal(2, cs.Length);
+
+        var c0 = cs[0];
+        Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: false });
+        var syntaxReferences = c0.DeclaringSyntaxReferences;
+        Assert.Equal(2, syntaxReferences.Length);
+        Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
+        Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
+
+        var c1 = cs[1];
+        Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
+        Assert.Equal(comp.SyntaxTrees[1], c1.DeclaringSyntaxReferences.Single().SyntaxTree);
+
+
+        comp = CreateCompilation(new[] { source2, source1 });
+        comp.VerifyDiagnostics(
+            // (5,24): error CS0111: Type 'C' already defines a member called 'M' with the same parameter types
+            //     public static void M()
+            Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M").WithArguments("M", "C").WithLocation(5, 24),
+            // (8,12): error CS0260: Missing partial modifier on declaration of type 'C'; another partial declaration of this type exists
+            // file class C
+            Diagnostic(ErrorCode.ERR_MissingPartial, "C").WithArguments("C").WithLocation(8, 12));
+
+        var c = comp.GetMember("C");
+        // PROTOTYPE(ft): is it a problem that we consider this symbol a file type in this scenario?
+        Assert.True(c is SourceMemberContainerTypeSymbol { IsFile: true });
+        syntaxReferences = c.DeclaringSyntaxReferences;
+        Assert.Equal(3, syntaxReferences.Length);
+        Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
+        Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[1].SyntaxTree);
+        Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[2].SyntaxTree);
+    }
+
+    [Fact]
+    public void Duplication_07()
+    {
+        var source1 = """
+            using System;
+
+            file partial class C
+            {
+                public static void M()
+                {
+                    Console.Write(1);
+                }
+            }
+            """;
+
+        var source2 = """
+            using System;
+
+            file partial class C
+            {
+                public static void M()
+                {
+                    Console.Write(Number);
+                }
+            }
+
+            file class C
+            {
+                private static int Number => 2;
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { source1, source2 });
+        comp.VerifyDiagnostics(
+            // (11,12): error CS0260: Missing partial modifier on declaration of type 'C'; another partial declaration of this type exists
+            // file class C
+            Diagnostic(ErrorCode.ERR_MissingPartial, "C").WithArguments("C").WithLocation(11, 12));
+
+        var cs = comp.GetMembers("C");
+        Assert.Equal(2, cs.Length);
+
+        var c0 = cs[0];
+        Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: true });
+        Assert.Equal(comp.SyntaxTrees[0], c0.DeclaringSyntaxReferences.Single().SyntaxTree);
+
+        var c1 = cs[1];
+        Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
+        var syntaxReferences = c1.DeclaringSyntaxReferences;
+        Assert.Equal(2, syntaxReferences.Length);
+        Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[0].SyntaxTree);
+        Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
+
+
+        comp = CreateCompilation(new[] { source2, source1 });
+        comp.VerifyDiagnostics(
+            // (11,12): error CS0260: Missing partial modifier on declaration of type 'C'; another partial declaration of this type exists
+            // file class C
+            Diagnostic(ErrorCode.ERR_MissingPartial, "C").WithArguments("C").WithLocation(11, 12));
+
+        cs = comp.GetMembers("C");
+        Assert.Equal(2, cs.Length);
+
+        c0 = cs[0];
+        Assert.True(c0 is SourceMemberContainerTypeSymbol { IsFile: true });
+        syntaxReferences = c0.DeclaringSyntaxReferences;
+        Assert.Equal(2, syntaxReferences.Length);
+        Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
+        Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[1].SyntaxTree);
+
+        c1 = cs[1];
+        Assert.True(c1 is SourceMemberContainerTypeSymbol { IsFile: true });
+        Assert.Equal(comp.SyntaxTrees[1], c1.DeclaringSyntaxReferences.Single().SyntaxTree);
+    }
+
+    [Fact]
+    public void Duplication_08()
+    {
+        var source1 = """
+            partial class Outer
+            {
                 file class C
                 {
+                    public static void M() { }
                 }
+            }
+            """;
 
-                class D
-                {
-                    public void M1(C c) { } // 1
-                    private void M2(C c) { } // 2
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (7,17): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     public void M1(C c) { } // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M1").WithArguments("C", "D").WithLocation(7, 17),
-                // (8,18): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     private void M2(C c) { } // 2
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M2").WithArguments("C", "D").WithLocation(8, 18));
-        }
-
-        [Fact]
-        public void SignatureUsage_02()
-        {
-            var source = """
+        var source2 = """
+            partial class Outer
+            {
                 file class C
                 {
+                    public static void M() { }
                 }
+            }
+            """;
 
-                class D
+        var source3 = """
+            partial class Outer
+            {
+                public class C
                 {
-                    public C M1() => new C(); // 1
-                    private C M2() => new C(); // 2
+                    public static void M() { }
                 }
-                """;
+            }
+            """;
 
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (7,14): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     public C M1() => new C(); // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M1").WithArguments("C", "D").WithLocation(7, 14),
-                // (8,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     private C M2() => new C(); // 2
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M2").WithArguments("C", "D").WithLocation(8, 15));
-        }
+        var compilation = CreateCompilation(new[] { source1, source2, source3 });
+        compilation.VerifyDiagnostics();
 
-        // PROTOTYPE(ft): report error on indexer parameters
-        // ensure that all cases where 'BadVis' errors are reported also check for 'file' mismatch
-        [Fact]
-        public void SignatureUsage_03()
-        {
-            var source = """
+        var classOuter = compilation.GetMember<NamedTypeSymbol>("Outer");
+        var cs = classOuter.GetMembers("C");
+        Assert.Equal(3, cs.Length);
+        Assert.True(cs[0] is SourceMemberContainerTypeSymbol { IsFile: true });
+        Assert.True(cs[1] is SourceMemberContainerTypeSymbol { IsFile: true });
+        Assert.True(cs[2] is SourceMemberContainerTypeSymbol { IsFile: false });
+    }
+
+    [Fact]
+    public void Duplication_09()
+    {
+        var source1 = """
+            namespace NS
+            {
                 file class C
                 {
+                    public static void M() { }
                 }
-                file delegate void D();
+            }
+            """;
 
-                public class E
-                {
-                    C field; // 1
-                    C property { get; set; } // 2
-                    object this[C c] { get => c; set { } } // 3
-                    event D @event; // 4
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (8,7): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E'.
-                //     C field; // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "field").WithArguments("C", "E").WithLocation(8, 7),
-                // (8,7): warning CS0169: The field 'E.field' is never used
-                //     C field; // 1
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "field").WithArguments("E.field").WithLocation(8, 7),
-                // (9,7): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E'.
-                //     C property { get; set; } // 2
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "property").WithArguments("C", "E").WithLocation(9, 7),
-                // (10,12): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E'.
-                //     object this[C c] { get => c; set { } } // 3
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "this").WithArguments("C", "E").WithLocation(10, 12),
-                // (11,13): error CS9300: File type 'D' cannot be used in a member signature in non-file type 'E'.
-                //     event D @event; // 4
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "@event").WithArguments("D", "E").WithLocation(11, 13),
-                // (11,13): warning CS0067: The event 'E.event' is never used
-                //     event D @event; // 4
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "@event").WithArguments("E.event").WithLocation(11, 13));
-        }
-
-        [Fact]
-        public void SignatureUsage_04()
-        {
-            var source = """
+        var source2 = """
+            namespace NS
+            {
                 file class C
                 {
-                    public class Inner { }
-                    public delegate void InnerDelegate();
+                    public static void M() { }
                 }
+            }
+            """;
 
-                public class E
+        var source3 = """
+            namespace NS
+            {
+                public class C
+                {
+                    public static void M() { }
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(new[] { source1, source2, source3 });
+        compilation.VerifyDiagnostics();
+
+        var namespaceNS = compilation.GetMember<NamespaceSymbol>("NS");
+        var cs = namespaceNS.GetMembers("C");
+        Assert.Equal(3, cs.Length);
+        Assert.True(cs[0] is SourceMemberContainerTypeSymbol { IsFile: true });
+        Assert.True(cs[1] is SourceMemberContainerTypeSymbol { IsFile: true });
+        Assert.True(cs[2] is SourceMemberContainerTypeSymbol { IsFile: false });
+    }
+
+    [Fact]
+    public void SignatureUsage_01()
+    {
+        var source = """
+            file class C
+            {
+            }
+
+            class D
+            {
+                public void M1(C c) { } // 1
+                private void M2(C c) { } // 2
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (7,17): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     public void M1(C c) { } // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M1").WithArguments("C", "D").WithLocation(7, 17),
+            // (8,18): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     private void M2(C c) { } // 2
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M2").WithArguments("C", "D").WithLocation(8, 18));
+    }
+
+    [Fact]
+    public void SignatureUsage_02()
+    {
+        var source = """
+            file class C
+            {
+            }
+
+            class D
+            {
+                public C M1() => new C(); // 1
+                private C M2() => new C(); // 2
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (7,14): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     public C M1() => new C(); // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M1").WithArguments("C", "D").WithLocation(7, 14),
+            // (8,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     private C M2() => new C(); // 2
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M2").WithArguments("C", "D").WithLocation(8, 15));
+    }
+
+    // PROTOTYPE(ft): report error on indexer parameters
+    // ensure that all cases where 'BadVis' errors are reported also check for 'file' mismatch
+    [Fact]
+    public void SignatureUsage_03()
+    {
+        var source = """
+            file class C
+            {
+            }
+            file delegate void D();
+
+            public class E
+            {
+                C field; // 1
+                C property { get; set; } // 2
+                object this[C c] { get => c; set { } } // 3
+                event D @event; // 4
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (8,7): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E'.
+            //     C field; // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "field").WithArguments("C", "E").WithLocation(8, 7),
+            // (8,7): warning CS0169: The field 'E.field' is never used
+            //     C field; // 1
+            Diagnostic(ErrorCode.WRN_UnreferencedField, "field").WithArguments("E.field").WithLocation(8, 7),
+            // (9,7): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E'.
+            //     C property { get; set; } // 2
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "property").WithArguments("C", "E").WithLocation(9, 7),
+            // (10,12): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E'.
+            //     object this[C c] { get => c; set { } } // 3
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "this").WithArguments("C", "E").WithLocation(10, 12),
+            // (11,13): error CS9300: File type 'D' cannot be used in a member signature in non-file type 'E'.
+            //     event D @event; // 4
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "@event").WithArguments("D", "E").WithLocation(11, 13),
+            // (11,13): warning CS0067: The event 'E.event' is never used
+            //     event D @event; // 4
+            Diagnostic(ErrorCode.WRN_UnreferencedEvent, "@event").WithArguments("E.event").WithLocation(11, 13));
+    }
+
+    [Fact]
+    public void SignatureUsage_04()
+    {
+        var source = """
+            file class C
+            {
+                public class Inner { }
+                public delegate void InnerDelegate();
+            }
+
+            public class E
+            {
+                C.Inner field; // 1
+                C.Inner property { get; set; } // 2
+                object this[C.Inner inner] { get => inner; set { } } // 3
+                event C.InnerDelegate @event; // 4
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (9,13): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E'.
+            //     C.Inner field; // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "field").WithArguments("C.Inner", "E").WithLocation(9, 13),
+            // (9,13): warning CS0169: The field 'E.field' is never used
+            //     C.Inner field; // 1
+            Diagnostic(ErrorCode.WRN_UnreferencedField, "field").WithArguments("E.field").WithLocation(9, 13),
+            // (10,13): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E'.
+            //     C.Inner property { get; set; } // 2
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "property").WithArguments("C.Inner", "E").WithLocation(10, 13),
+            // (11,12): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E'.
+            //     object this[C.Inner inner] { get => inner; set { } } // 3
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "this").WithArguments("C.Inner", "E").WithLocation(11, 12),
+            // (12,27): error CS9300: File type 'C.InnerDelegate' cannot be used in a member signature in non-file type 'E'.
+            //     event C.InnerDelegate @event; // 4
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "@event").WithArguments("C.InnerDelegate", "E").WithLocation(12, 27),
+            // (12,27): warning CS0067: The event 'E.event' is never used
+            //     event C.InnerDelegate @event; // 4
+            Diagnostic(ErrorCode.WRN_UnreferencedEvent, "@event").WithArguments("E.event").WithLocation(12, 27));
+    }
+
+    [Fact]
+    public void SignatureUsage_05()
+    {
+        var source = """
+            #pragma warning disable 67, 169 // unused event, field
+
+            file class C
+            {
+                public class Inner { }
+                public delegate void InnerDelegate();
+            }
+
+            file class D
+            {
+                public class Inner
+                {
+                    C.Inner field;
+                    C.Inner property { get; set; }
+                    object this[C.Inner inner] { get => inner; set { } }
+                    event C.InnerDelegate @event;
+                }
+            }
+
+            class E
+            {
+                public class Inner
                 {
                     C.Inner field; // 1
                     C.Inner property { get; set; } // 2
                     object this[C.Inner inner] { get => inner; set { } } // 3
                     event C.InnerDelegate @event; // 4
                 }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (9,13): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E'.
-                //     C.Inner field; // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "field").WithArguments("C.Inner", "E").WithLocation(9, 13),
-                // (9,13): warning CS0169: The field 'E.field' is never used
-                //     C.Inner field; // 1
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "field").WithArguments("E.field").WithLocation(9, 13),
-                // (10,13): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E'.
-                //     C.Inner property { get; set; } // 2
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "property").WithArguments("C.Inner", "E").WithLocation(10, 13),
-                // (11,12): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E'.
-                //     object this[C.Inner inner] { get => inner; set { } } // 3
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "this").WithArguments("C.Inner", "E").WithLocation(11, 12),
-                // (12,27): error CS9300: File type 'C.InnerDelegate' cannot be used in a member signature in non-file type 'E'.
-                //     event C.InnerDelegate @event; // 4
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "@event").WithArguments("C.InnerDelegate", "E").WithLocation(12, 27),
-                // (12,27): warning CS0067: The event 'E.event' is never used
-                //     event C.InnerDelegate @event; // 4
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "@event").WithArguments("E.event").WithLocation(12, 27));
-        }
-
-        [Fact]
-        public void SignatureUsage_05()
-        {
-            var source = """
-                #pragma warning disable 67, 169 // unused event, field
-
-                file class C
-                {
-                    public class Inner { }
-                    public delegate void InnerDelegate();
-                }
-
-                file class D
-                {
-                    public class Inner
-                    {
-                        C.Inner field;
-                        C.Inner property { get; set; }
-                        object this[C.Inner inner] { get => inner; set { } }
-                        event C.InnerDelegate @event;
-                    }
-                }
-
-                class E
-                {
-                    public class Inner
-                    {
-                        C.Inner field; // 1
-                        C.Inner property { get; set; } // 2
-                        object this[C.Inner inner] { get => inner; set { } } // 3
-                        event C.InnerDelegate @event; // 4
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (24,17): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E.Inner'.
-                //         C.Inner field; // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "field").WithArguments("C.Inner", "E.Inner").WithLocation(24, 17),
-                // (25,17): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E.Inner'.
-                //         C.Inner property { get; set; } // 2
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "property").WithArguments("C.Inner", "E.Inner").WithLocation(25, 17),
-                // (26,16): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E.Inner'.
-                //         object this[C.Inner inner] { get => inner; set { } } // 3
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "this").WithArguments("C.Inner", "E.Inner").WithLocation(26, 16),
-                // (27,31): error CS9300: File type 'C.InnerDelegate' cannot be used in a member signature in non-file type 'E.Inner'.
-                //         event C.InnerDelegate @event; // 4
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "@event").WithArguments("C.InnerDelegate", "E.Inner").WithLocation(27, 31));
-        }
-
-        [Fact]
-        public void SignatureUsage_06()
-        {
-            var source = """
-                file class C
-                {
-                }
-
-                delegate void Del1(C c); // 1
-                delegate C Del2(); // 2
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (5,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'Del1'.
-                // delegate void Del1(C c); // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "Del1").WithArguments("C", "Del1").WithLocation(5, 15),
-                // (6,12): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'Del2'.
-                // delegate C Del2(); // 2
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "Del2").WithArguments("C", "Del2").WithLocation(6, 12));
-        }
-
-        [Fact]
-        public void SignatureUsage_07()
-        {
-            var source = """
-                file class C
-                {
-                }
-
-                class D
-                {
-                    public static D operator +(D d, C c) => d; // 1
-                    public static C operator -(D d1, D d2) => new C(); // 2
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (7,30): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     public static D operator +(D d, C c) => d; // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "+").WithArguments("C", "D").WithLocation(7, 30),
-                // (8,30): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     public static C operator -(D d1, D d2) => new C(); // 2
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "-").WithArguments("C", "D").WithLocation(8, 30));
-        }
-
-        [Fact]
-        public void SignatureUsage_08()
-        {
-            var source = """
-                file class C
-                {
-                }
-
-                class D
-                {
-                    public D(C c) { } // 1
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (7,12): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     public D(C c) { } // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "D").WithArguments("C", "D").WithLocation(7, 12));
-        }
-
-        [Fact]
-        public void SignatureUsage_09()
-        {
-            var source = """
-                file class C
-                {
-                }
-
-                class D
-                {
-                    public C M(C c1, C c2) => c1; // 1, 2, 3
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (7,14): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     public C M(C c1, C c2) => c1; // 1, 2, 3
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("C", "D").WithLocation(7, 14),
-                // (7,14): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     public C M(C c1, C c2) => c1; // 1, 2, 3
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("C", "D").WithLocation(7, 14),
-                // (7,14): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
-                //     public C M(C c1, C c2) => c1; // 1, 2, 3
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("C", "D").WithLocation(7, 14));
-        }
-
-        [Fact]
-        public void AccessModifiers_01()
-        {
-            var source = """
-                public file class C { } // 1
-                file internal class D { } // 2
-                private file class E { } // 3, 4
-                file class F { } // ok
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (1,19): error CS9301: File type 'C' cannot use accessibility modifiers.
-                // public file class C { } // 1
-                Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "C").WithArguments("C").WithLocation(1, 19),
-                // (2,21): error CS9301: File type 'D' cannot use accessibility modifiers.
-                // file internal class D { } // 2
-                Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "D").WithArguments("D").WithLocation(2, 21),
-                // (3,20): error CS9301: File type 'E' cannot use accessibility modifiers.
-                // private file class E { } // 3, 4
-                Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "E").WithArguments("E").WithLocation(3, 20),
-                // (3,20): error CS1527: Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected
-                // private file class E { } // 3, 4
-                Diagnostic(ErrorCode.ERR_NoNamespacePrivate, "E").WithLocation(3, 20));
-        }
-
-        [Fact]
-        public void BaseClause_01()
-        {
-            var source = """
-                file class Base { }
-                class Derived1 : Base { } // 1
-                public class Derived2 : Base { } // 2, 3
-                file class Derived3 : Base { } // ok
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (2,7): error CS9301: File type 'Base' cannot be used as a base type of non-file type 'Derived1'.
-                // class Derived1 : Base { } // 1
-                Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived1").WithArguments("Base", "Derived1").WithLocation(2, 7),
-                // (3,14): error CS0060: Inconsistent accessibility: base class 'Base' is less accessible than class 'Derived2'
-                // public class Derived2 : Base { } // 2, 3
-                Diagnostic(ErrorCode.ERR_BadVisBaseClass, "Derived2").WithArguments("Derived2", "Base").WithLocation(3, 14),
-                // (3,14): error CS9301: File type 'Base' cannot be used as a base type of non-file type 'Derived2'.
-                // public class Derived2 : Base { } // 2, 3
-                Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived2").WithArguments("Base", "Derived2").WithLocation(3, 14));
-        }
-
-        [Fact]
-        public void BaseClause_02()
-        {
-            var source = """
-                file interface Interface { }
-
-                class Derived1 : Interface { } // ok
-                file class Derived2 : Interface { } // ok
-
-                interface Derived3 : Interface { } // 1
-                file interface Derived4 : Interface { } // ok
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (6,11): error CS9301: File type 'Interface' cannot be used as a base type of non-file type 'Derived3'.
-                // interface Derived3 : Interface { } // 1
-                Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived3").WithArguments("Interface", "Derived3").WithLocation(6, 11));
-        }
-
-        [Fact]
-        public void TypeArguments_01()
-        {
-            var source = """
-                file class C { }
-                class Container<T> { }
-                class Program
-                {
-                    Container<C> M() => new Container<C>(); // 1
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (5,18): error CS9300: File type 'Container<C>' cannot be used in a member signature in non-file type 'Program'.
-                //     Container<C> M() => new Container<C>(); // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("Container<C>", "Program").WithLocation(5, 18));
-        }
-
-        [Fact]
-        public void Constraints_01()
-        {
-            var source = """
-                file class C { }
-
-                file class D
-                {
-                    void M<T>(T t) where T : C { } // ok
-                }
-
-                class E
-                {
-                    void M<T>(T t) where T : C { } // 1
-                }
-                """;
-
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (10,30): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E.M<T>(T)'.
-                //     void M<T>(T t) where T : C { } // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "C").WithArguments("C", "E.M<T>(T)").WithLocation(10, 30));
-        }
-
-        [Fact]
-        public void PrimaryConstructor_01()
-        {
-            var source = """
-                file class C { }
-
-                record R1(C c); // 1
-                record struct R2(C c); // 2
-
-                file record R3(C c);
-                file record struct R4(C c);
-                """;
-
-            var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition });
-            comp.VerifyDiagnostics(
-                // (3,8): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'R1'.
-                // record R1(C c); // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "R1").WithArguments("C", "R1").WithLocation(3, 8),
-                // (3,8): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'R1'.
-                // record R1(C c); // 1
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "R1").WithArguments("C", "R1").WithLocation(3, 8),
-                // (4,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'R2'.
-                // record struct R2(C c); // 2
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "R2").WithArguments("C", "R2").WithLocation(4, 15),
-                // (4,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'R2'.
-                // record struct R2(C c); // 2
-                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "R2").WithArguments("C", "R2").WithLocation(4, 15)
-                );
-        }
-
-        [Fact]
-        public void Lambda_01()
-        {
-            var source = """
-                file class C { }
-
-                class Program
-                {
-                    void M()
-                    {
-                        var lambda = C (C c) => c; // ok
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition });
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void LocalFunction_01()
-        {
-            var source = """
-                file class C { }
-
-                class Program
-                {
-                    void M()
-                    {
-                        local(null!);
-                        C local(C c) => c; // ok
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition });
-            comp.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void AccessThroughNamespace_01()
-        {
-            var source = """
-                using System;
-
-                namespace NS
-                {
-                    file class C
-                    {
-                        public static void M() => Console.Write(1);
-                    }
-                }
-
-                class Program
-                {
-                    public static void Main()
-                    {
-                        NS.C.M();
-                    }
-                }
-                """;
-
-            var verifier = CompileAndVerify(new[] { source, IsExternalInitTypeDefinition }, expectedOutput: "1");
-            verifier.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void AccessThroughNamespace_02()
-        {
-            var source1 = """
-                using System;
-
-                class Outer
-                {
-                    file class C
-                    {
-                        public static void M()
-                        {
-                            Console.Write(1);
-                        }
-                    }
-                }
-                """;
-
-            var source2 = """
-                class Program
-                {
-                    static void Main()
-                    {
-                        Outer.C.M(); // 1
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source1, source2 });
-            comp.VerifyDiagnostics(
-                // (5,15): error CS0117: 'Outer' does not contain a definition for 'C'
-                //         Outer.C.M(); // 1
-                Diagnostic(ErrorCode.ERR_NoSuchMember, "C").WithArguments("Outer", "C").WithLocation(5, 15));
-        }
-
-        [Fact]
-        public void AccessThroughType_02()
-        {
-            var source1 = """
-                using System;
-
-                class Outer
-                {
-                    file class C
-                    {
-                        public static void M()
-                        {
-                            Console.Write(1);
-                        }
-                    }
-                }
-                """;
-
-            var source2 = """
-                class Program
-                {
-                    static void Main()
-                    {
-                        Outer.C.M(); // 1
-                    }
-                }
-                """;
-
-            var comp = CreateCompilation(new[] { source1, source2 });
-            comp.VerifyDiagnostics(
-                // (5,15): error CS0117: 'Outer' does not contain a definition for 'C'
-                //         Outer.C.M(); // 1
-                Diagnostic(ErrorCode.ERR_NoSuchMember, "C").WithArguments("Outer", "C").WithLocation(5, 15));
-        }
-
-        [Fact]
-        public void AccessThroughGlobalUsing_01()
-        {
-            var usings = """
-                global using NS;
-                """;
-
-            var source = """
-                using System;
-
-                namespace NS
-                {
-                    file class C
-                    {
-                        public static void M() => Console.Write(1);
-                    }
-                }
-
-                class Program
-                {
-                    public static void Main()
-                    {
-                        C.M();
-                    }
-                }
-                """;
-
-            var verifier = CompileAndVerify(new[] { usings, source, IsExternalInitTypeDefinition }, expectedOutput: "1");
-            verifier.VerifyDiagnostics();
-        }
-
-        [Theory]
-        [InlineData("file ")]
-        [InlineData("")]
-        public void AccessThroughGlobalUsing_02(string fileModifier)
-        {
-            var source = $$"""
-                using System;
-
-                namespace NS
-                {
-                    {{fileModifier}}class C
-                    {
-                        public static void M() => Console.Write(1);
-                    }
-                }
-
-                class Program
-                {
-                    public static void Main()
-                    {
-                        C.M(); // 1
-                    }
-                }
-                """;
-
-            var compilation = CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, options: TestOptions.DebugExe.WithUsings("NS"));
-            compilation.VerifyDiagnostics(
-                // (15,9): error CS0103: The name 'C' does not exist in the current context
-                //         C.M(); // 1
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(15, 9));
-        }
-
-        [Fact]
-        public void GlobalUsingStatic_01()
-        {
-            var source = """
-                global using static C;
-
-                file class C
-                {
-                    public static void M() { }
-                }
-                """;
-
-            var main = """
-                class Program
-                {
-                    public static void Main()
-                    {
-                        M();
-                    }
-                }
-                """;
-
-            // PROTOTYPE(ft): it should probably be an error to reference a file type in a global using static
-            var compilation = CreateCompilation(new[] { source, main });
-            compilation.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void UsingStatic_01()
-        {
-            var source = """
-                using System;
-                using static C;
-
-                file class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-
-                class Program
-                {
-                    public static void Main()
-                    {
-                        M();
-                    }
-                }
-                """;
-
-            var compilation = CompileAndVerify(source, expectedOutput: "1");
-            compilation.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void TypeShadowing()
-        {
-            var source = """
-                using System;
-
-                class Base
-                {
-                    internal class C
-                    {
-                        public static void M()
-                        {
-                            Console.Write(1);
-                        }
-                    }
-                }
-
-                class Derived : Base
-                {
-                    new file class C
-                    {
-                    }
-                }
-                """;
-
-            var main = """
-                class Program
-                {
-                    public static void Main()
-                    {
-                        Derived.C.M();
-                    }
-                }
-                """;
-
-            // 'Derived.C' is not actually accessible from 'Program', so we just bind to 'Base.C' and things work.
-            var compilation = CompileAndVerify(new[] { source, main }, expectedOutput: "1");
-            compilation.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void SemanticModel_01()
-        {
-            var source = """
-                file class C
-                {
-                    public static void M() { }
-                }
-
-                class Program
-                {
-                    public void M()
-                    {
-                        C.M();
-                    }
-                }
-                """;
-
-            var compilation = CreateCompilation(source);
-            compilation.VerifyDiagnostics();
-
-            var tree = compilation.SyntaxTrees[0];
-            var body = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Last().Body!;
-
-            var model = compilation.GetSemanticModel(tree, ignoreAccessibility: false);
-
-            var info = model.GetSymbolInfo(((ExpressionStatementSyntax)body.Statements.First()).Expression);
-            Assert.Equal(compilation.GetMember("C.M").GetPublicSymbol(), info.Symbol);
-
-            var classC = compilation.GetMember("C").GetPublicSymbol();
-            var symbols = model.LookupSymbols(body.OpenBraceToken.EndPosition, name: "C");
-            Assert.Equal(new[] { classC }, symbols);
-
-            symbols = model.LookupSymbols(body.OpenBraceToken.EndPosition);
-            Assert.Contains(classC, symbols);
-        }
-
-        [Fact]
-        public void SemanticModel_02()
-        {
-            var source = """
-                file class C
-                {
-                    public static void M() { }
-                }
-                """;
-
-            var main = """
-                class Program
-                {
-                    public void M()
-                    {
-                        C.M(); // 1
-                    }
-                }
-                """;
-
-            var compilation = CreateCompilation(new[] { source, main });
-            compilation.VerifyDiagnostics(
-                // (5,9): error CS0103: The name 'C' does not exist in the current context
-                //         C.M();
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(5, 9)
-                );
-
-            var tree = compilation.SyntaxTrees[1];
-            var body = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Last().Body!;
-
-            var model = compilation.GetSemanticModel(tree, ignoreAccessibility: false);
-
-            var info = model.GetSymbolInfo(((ExpressionStatementSyntax)body.Statements.First()).Expression);
-            Assert.Null(info.Symbol);
-            Assert.Empty(info.CandidateSymbols);
-            Assert.Equal(CandidateReason.None, info.CandidateReason);
-
-            var symbols = model.LookupSymbols(body.OpenBraceToken.EndPosition, name: "C");
-            Assert.Empty(symbols);
-
-            symbols = model.LookupSymbols(body.OpenBraceToken.EndPosition);
-            Assert.DoesNotContain(compilation.GetMember("C").GetPublicSymbol(), symbols);
-        }
-
-        [Fact]
-        public void Speculation_01()
-        {
-            var source = """
-                file class C
-                {
-                    public static void M() { }
-                }
-
-                class Program
-                {
-                    public void M()
-                    {
-
-                    }
-                }
-                """;
-
-            var compilation = CreateCompilation(source);
-            compilation.VerifyDiagnostics();
-
-            var tree = compilation.SyntaxTrees[0];
-            var body = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Last().Body!;
-
-            var model = compilation.GetSemanticModel(tree, ignoreAccessibility: false);
-
-            var newBody = body.AddStatements(SyntaxFactory.ParseStatement("C.M();"));
-            Assert.True(model.TryGetSpeculativeSemanticModel(position: body.OpenBraceToken.EndPosition, newBody, out var speculativeModel));
-            var info = speculativeModel!.GetSymbolInfo(((ExpressionStatementSyntax)newBody.Statements.First()).Expression);
-            Assert.Equal(compilation.GetMember("C.M").GetPublicSymbol(), info.Symbol);
-
-            var classC = compilation.GetMember("C").GetPublicSymbol();
-            var symbols = speculativeModel.LookupSymbols(newBody.OpenBraceToken.EndPosition, name: "C");
-            Assert.Equal(new[] { classC }, symbols);
-
-            symbols = speculativeModel.LookupSymbols(newBody.OpenBraceToken.EndPosition);
-            Assert.Contains(classC, symbols);
-        }
-
-        [Fact]
-        public void Speculation_02()
-        {
-            var source = """
-                file class C
-                {
-                    public static void M() { }
-                }
-                """;
-
-            var main = """
-                class Program
-                {
-                    public void M()
-                    {
-
-                    }
-                }
-                """;
-
-            var compilation = CreateCompilation(new[] { source, main });
-            compilation.VerifyDiagnostics();
-
-            var tree = compilation.SyntaxTrees[1];
-            var body = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Last().Body!;
-
-            var model = compilation.GetSemanticModel(tree, ignoreAccessibility: false);
-
-            var newBody = body.AddStatements(SyntaxFactory.ParseStatement("C.M();"));
-            Assert.True(model.TryGetSpeculativeSemanticModel(position: body.OpenBraceToken.EndPosition, newBody, out var speculativeModel));
-            var info = speculativeModel!.GetSymbolInfo(((ExpressionStatementSyntax)newBody.Statements.First()).Expression);
-            Assert.Null(info.Symbol);
-            Assert.Empty(info.CandidateSymbols);
-            Assert.Equal(CandidateReason.None, info.CandidateReason);
-
-            var symbols = speculativeModel.LookupSymbols(newBody.OpenBraceToken.EndPosition, name: "C");
-            Assert.Empty(symbols);
-
-            symbols = speculativeModel.LookupSymbols(newBody.OpenBraceToken.EndPosition);
-            Assert.DoesNotContain(compilation.GetMember("C").GetPublicSymbol(), symbols);
-        }
-
-        [Fact]
-        public void Cref_01()
-        {
-            var source = """
-                file class C
-                {
-                    public static void M() { }
-                }
-
-                class Program
-                {
-                    /// <summary>
-                    /// In the same file as <see cref="C"/>.
-                    /// </summary>
-                    public static void M()
-                    {
-
-                    }
-                }
-                """;
-
-            var compilation = CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose));
-            compilation.VerifyDiagnostics();
-        }
-
-        [Fact]
-        public void Cref_02()
-        {
-            var source = """
-                file class C
-                {
-                    public static void M() { }
-                }
-                """;
-
-            var main = """
-                class Program
-                {
-                    /// <summary>
-                    /// In a different file than <see cref="C"/>.
-                    /// </summary>
-                    public static void M()
-                    {
-
-                    }
-                }
-                """;
-
-            var compilation = CreateCompilation(new[] { source, main }, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose));
-            compilation.VerifyDiagnostics(
-                // (4,45): warning CS1574: XML comment has cref attribute 'C' that could not be resolved
-                //     /// In a different file than <see cref="C"/>.
-                Diagnostic(ErrorCode.WRN_BadXMLRef, "C").WithArguments("C").WithLocation(4, 45)
-                );
-        }
-
-        [Fact]
-        public void TopLevelStatements()
-        {
-            var source = """
-                using System;
-
-                C.M();
-
-                file class C
-                {
-                    public static void M()
-                    {
-                        Console.Write(1);
-                    }
-                }
-                """;
-
-            var verifier = CompileAndVerify(source, expectedOutput: "1");
-            verifier.VerifyDiagnostics();
-        }
-
-        // PROTOTYPE(ft): public API (INamedTypeSymbol.IsFile?)
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (24,17): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E.Inner'.
+            //         C.Inner field; // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "field").WithArguments("C.Inner", "E.Inner").WithLocation(24, 17),
+            // (25,17): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E.Inner'.
+            //         C.Inner property { get; set; } // 2
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "property").WithArguments("C.Inner", "E.Inner").WithLocation(25, 17),
+            // (26,16): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E.Inner'.
+            //         object this[C.Inner inner] { get => inner; set { } } // 3
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "this").WithArguments("C.Inner", "E.Inner").WithLocation(26, 16),
+            // (27,31): error CS9300: File type 'C.InnerDelegate' cannot be used in a member signature in non-file type 'E.Inner'.
+            //         event C.InnerDelegate @event; // 4
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "@event").WithArguments("C.InnerDelegate", "E.Inner").WithLocation(27, 31));
     }
+
+    [Fact]
+    public void SignatureUsage_06()
+    {
+        var source = """
+            file class C
+            {
+            }
+
+            delegate void Del1(C c); // 1
+            delegate C Del2(); // 2
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (5,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'Del1'.
+            // delegate void Del1(C c); // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "Del1").WithArguments("C", "Del1").WithLocation(5, 15),
+            // (6,12): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'Del2'.
+            // delegate C Del2(); // 2
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "Del2").WithArguments("C", "Del2").WithLocation(6, 12));
+    }
+
+    [Fact]
+    public void SignatureUsage_07()
+    {
+        var source = """
+            file class C
+            {
+            }
+
+            class D
+            {
+                public static D operator +(D d, C c) => d; // 1
+                public static C operator -(D d1, D d2) => new C(); // 2
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (7,30): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     public static D operator +(D d, C c) => d; // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "+").WithArguments("C", "D").WithLocation(7, 30),
+            // (8,30): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     public static C operator -(D d1, D d2) => new C(); // 2
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "-").WithArguments("C", "D").WithLocation(8, 30));
+    }
+
+    [Fact]
+    public void SignatureUsage_08()
+    {
+        var source = """
+            file class C
+            {
+            }
+
+            class D
+            {
+                public D(C c) { } // 1
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (7,12): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     public D(C c) { } // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "D").WithArguments("C", "D").WithLocation(7, 12));
+    }
+
+    [Fact]
+    public void SignatureUsage_09()
+    {
+        var source = """
+            file class C
+            {
+            }
+
+            class D
+            {
+                public C M(C c1, C c2) => c1; // 1, 2, 3
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (7,14): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     public C M(C c1, C c2) => c1; // 1, 2, 3
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("C", "D").WithLocation(7, 14),
+            // (7,14): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     public C M(C c1, C c2) => c1; // 1, 2, 3
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("C", "D").WithLocation(7, 14),
+            // (7,14): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+            //     public C M(C c1, C c2) => c1; // 1, 2, 3
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("C", "D").WithLocation(7, 14));
+    }
+
+    [Fact]
+    public void AccessModifiers_01()
+    {
+        var source = """
+            public file class C { } // 1
+            file internal class D { } // 2
+            private file class E { } // 3, 4
+            file class F { } // ok
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (1,19): error CS9301: File type 'C' cannot use accessibility modifiers.
+            // public file class C { } // 1
+            Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "C").WithArguments("C").WithLocation(1, 19),
+            // (2,21): error CS9301: File type 'D' cannot use accessibility modifiers.
+            // file internal class D { } // 2
+            Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "D").WithArguments("D").WithLocation(2, 21),
+            // (3,20): error CS9301: File type 'E' cannot use accessibility modifiers.
+            // private file class E { } // 3, 4
+            Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "E").WithArguments("E").WithLocation(3, 20),
+            // (3,20): error CS1527: Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected
+            // private file class E { } // 3, 4
+            Diagnostic(ErrorCode.ERR_NoNamespacePrivate, "E").WithLocation(3, 20));
+    }
+
+    [Fact]
+    public void BaseClause_01()
+    {
+        var source = """
+            file class Base { }
+            class Derived1 : Base { } // 1
+            public class Derived2 : Base { } // 2, 3
+            file class Derived3 : Base { } // ok
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (2,7): error CS9301: File type 'Base' cannot be used as a base type of non-file type 'Derived1'.
+            // class Derived1 : Base { } // 1
+            Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived1").WithArguments("Base", "Derived1").WithLocation(2, 7),
+            // (3,14): error CS0060: Inconsistent accessibility: base class 'Base' is less accessible than class 'Derived2'
+            // public class Derived2 : Base { } // 2, 3
+            Diagnostic(ErrorCode.ERR_BadVisBaseClass, "Derived2").WithArguments("Derived2", "Base").WithLocation(3, 14),
+            // (3,14): error CS9301: File type 'Base' cannot be used as a base type of non-file type 'Derived2'.
+            // public class Derived2 : Base { } // 2, 3
+            Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived2").WithArguments("Base", "Derived2").WithLocation(3, 14));
+    }
+
+    [Fact]
+    public void BaseClause_02()
+    {
+        var source = """
+            file interface Interface { }
+
+            class Derived1 : Interface { } // ok
+            file class Derived2 : Interface { } // ok
+
+            interface Derived3 : Interface { } // 1
+            file interface Derived4 : Interface { } // ok
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (6,11): error CS9301: File type 'Interface' cannot be used as a base type of non-file type 'Derived3'.
+            // interface Derived3 : Interface { } // 1
+            Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived3").WithArguments("Interface", "Derived3").WithLocation(6, 11));
+    }
+
+    [Fact]
+    public void TypeArguments_01()
+    {
+        var source = """
+            file class C { }
+            class Container<T> { }
+            class Program
+            {
+                Container<C> M() => new Container<C>(); // 1
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (5,18): error CS9300: File type 'Container<C>' cannot be used in a member signature in non-file type 'Program'.
+            //     Container<C> M() => new Container<C>(); // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("Container<C>", "Program").WithLocation(5, 18));
+    }
+
+    [Fact]
+    public void Constraints_01()
+    {
+        var source = """
+            file class C { }
+
+            file class D
+            {
+                void M<T>(T t) where T : C { } // ok
+            }
+
+            class E
+            {
+                void M<T>(T t) where T : C { } // 1
+            }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (10,30): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E.M<T>(T)'.
+            //     void M<T>(T t) where T : C { } // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "C").WithArguments("C", "E.M<T>(T)").WithLocation(10, 30));
+    }
+
+    [Fact]
+    public void PrimaryConstructor_01()
+    {
+        var source = """
+            file class C { }
+
+            record R1(C c); // 1
+            record struct R2(C c); // 2
+
+            file record R3(C c);
+            file record struct R4(C c);
+            """;
+
+        var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition });
+        comp.VerifyDiagnostics(
+            // (3,8): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'R1'.
+            // record R1(C c); // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "R1").WithArguments("C", "R1").WithLocation(3, 8),
+            // (3,8): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'R1'.
+            // record R1(C c); // 1
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "R1").WithArguments("C", "R1").WithLocation(3, 8),
+            // (4,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'R2'.
+            // record struct R2(C c); // 2
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "R2").WithArguments("C", "R2").WithLocation(4, 15),
+            // (4,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'R2'.
+            // record struct R2(C c); // 2
+            Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "R2").WithArguments("C", "R2").WithLocation(4, 15)
+            );
+    }
+
+    [Fact]
+    public void Lambda_01()
+    {
+        var source = """
+            file class C { }
+
+            class Program
+            {
+                void M()
+                {
+                    var lambda = C (C c) => c; // ok
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition });
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void LocalFunction_01()
+    {
+        var source = """
+            file class C { }
+
+            class Program
+            {
+                void M()
+                {
+                    local(null!);
+                    C local(C c) => c; // ok
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { source, IsExternalInitTypeDefinition });
+        comp.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void AccessThroughNamespace_01()
+    {
+        var source = """
+            using System;
+
+            namespace NS
+            {
+                file class C
+                {
+                    public static void M() => Console.Write(1);
+                }
+            }
+
+            class Program
+            {
+                public static void Main()
+                {
+                    NS.C.M();
+                }
+            }
+            """;
+
+        var verifier = CompileAndVerify(new[] { source, IsExternalInitTypeDefinition }, expectedOutput: "1");
+        verifier.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void AccessThroughNamespace_02()
+    {
+        var source1 = """
+            using System;
+
+            class Outer
+            {
+                file class C
+                {
+                    public static void M()
+                    {
+                        Console.Write(1);
+                    }
+                }
+            }
+            """;
+
+        var source2 = """
+            class Program
+            {
+                static void Main()
+                {
+                    Outer.C.M(); // 1
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { source1, source2 });
+        comp.VerifyDiagnostics(
+            // (5,15): error CS0117: 'Outer' does not contain a definition for 'C'
+            //         Outer.C.M(); // 1
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "C").WithArguments("Outer", "C").WithLocation(5, 15));
+    }
+
+    [Fact]
+    public void AccessThroughType_02()
+    {
+        var source1 = """
+            using System;
+
+            class Outer
+            {
+                file class C
+                {
+                    public static void M()
+                    {
+                        Console.Write(1);
+                    }
+                }
+            }
+            """;
+
+        var source2 = """
+            class Program
+            {
+                static void Main()
+                {
+                    Outer.C.M(); // 1
+                }
+            }
+            """;
+
+        var comp = CreateCompilation(new[] { source1, source2 });
+        comp.VerifyDiagnostics(
+            // (5,15): error CS0117: 'Outer' does not contain a definition for 'C'
+            //         Outer.C.M(); // 1
+            Diagnostic(ErrorCode.ERR_NoSuchMember, "C").WithArguments("Outer", "C").WithLocation(5, 15));
+    }
+
+    [Fact]
+    public void AccessThroughGlobalUsing_01()
+    {
+        var usings = """
+            global using NS;
+            """;
+
+        var source = """
+            using System;
+
+            namespace NS
+            {
+                file class C
+                {
+                    public static void M() => Console.Write(1);
+                }
+            }
+
+            class Program
+            {
+                public static void Main()
+                {
+                    C.M();
+                }
+            }
+            """;
+
+        var verifier = CompileAndVerify(new[] { usings, source, IsExternalInitTypeDefinition }, expectedOutput: "1");
+        verifier.VerifyDiagnostics();
+    }
+
+    [Theory]
+    [InlineData("file ")]
+    [InlineData("")]
+    public void AccessThroughGlobalUsing_02(string fileModifier)
+    {
+        var source = $$"""
+            using System;
+
+            namespace NS
+            {
+                {{fileModifier}}class C
+                {
+                    public static void M() => Console.Write(1);
+                }
+            }
+
+            class Program
+            {
+                public static void Main()
+                {
+                    C.M(); // 1
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(new[] { source, IsExternalInitTypeDefinition }, options: TestOptions.DebugExe.WithUsings("NS"));
+        compilation.VerifyDiagnostics(
+            // (15,9): error CS0103: The name 'C' does not exist in the current context
+            //         C.M(); // 1
+            Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(15, 9));
+    }
+
+    [Fact]
+    public void GlobalUsingStatic_01()
+    {
+        var source = """
+            global using static C;
+
+            file class C
+            {
+                public static void M() { }
+            }
+            """;
+
+        var main = """
+            class Program
+            {
+                public static void Main()
+                {
+                    M();
+                }
+            }
+            """;
+
+        // PROTOTYPE(ft): it should probably be an error to reference a file type in a global using static
+        var compilation = CreateCompilation(new[] { source, main });
+        compilation.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void UsingStatic_01()
+    {
+        var source = """
+            using System;
+            using static C;
+
+            file class C
+            {
+                public static void M()
+                {
+                    Console.Write(1);
+                }
+            }
+
+            class Program
+            {
+                public static void Main()
+                {
+                    M();
+                }
+            }
+            """;
+
+        var compilation = CompileAndVerify(source, expectedOutput: "1");
+        compilation.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void TypeShadowing()
+    {
+        var source = """
+            using System;
+
+            class Base
+            {
+                internal class C
+                {
+                    public static void M()
+                    {
+                        Console.Write(1);
+                    }
+                }
+            }
+
+            class Derived : Base
+            {
+                new file class C
+                {
+                }
+            }
+            """;
+
+        var main = """
+            class Program
+            {
+                public static void Main()
+                {
+                    Derived.C.M();
+                }
+            }
+            """;
+
+        // 'Derived.C' is not actually accessible from 'Program', so we just bind to 'Base.C' and things work.
+        var compilation = CompileAndVerify(new[] { source, main }, expectedOutput: "1");
+        compilation.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void SemanticModel_01()
+    {
+        var source = """
+            file class C
+            {
+                public static void M() { }
+            }
+
+            class Program
+            {
+                public void M()
+                {
+                    C.M();
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(source);
+        compilation.VerifyDiagnostics();
+
+        var tree = compilation.SyntaxTrees[0];
+        var body = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Last().Body!;
+
+        var model = compilation.GetSemanticModel(tree, ignoreAccessibility: false);
+
+        var info = model.GetSymbolInfo(((ExpressionStatementSyntax)body.Statements.First()).Expression);
+        Assert.Equal(compilation.GetMember("C.M").GetPublicSymbol(), info.Symbol);
+
+        var classC = compilation.GetMember("C").GetPublicSymbol();
+        var symbols = model.LookupSymbols(body.OpenBraceToken.EndPosition, name: "C");
+        Assert.Equal(new[] { classC }, symbols);
+
+        symbols = model.LookupSymbols(body.OpenBraceToken.EndPosition);
+        Assert.Contains(classC, symbols);
+    }
+
+    [Fact]
+    public void SemanticModel_02()
+    {
+        var source = """
+            file class C
+            {
+                public static void M() { }
+            }
+            """;
+
+        var main = """
+            class Program
+            {
+                public void M()
+                {
+                    C.M(); // 1
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(new[] { source, main });
+        compilation.VerifyDiagnostics(
+            // (5,9): error CS0103: The name 'C' does not exist in the current context
+            //         C.M();
+            Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(5, 9)
+            );
+
+        var tree = compilation.SyntaxTrees[1];
+        var body = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Last().Body!;
+
+        var model = compilation.GetSemanticModel(tree, ignoreAccessibility: false);
+
+        var info = model.GetSymbolInfo(((ExpressionStatementSyntax)body.Statements.First()).Expression);
+        Assert.Null(info.Symbol);
+        Assert.Empty(info.CandidateSymbols);
+        Assert.Equal(CandidateReason.None, info.CandidateReason);
+
+        var symbols = model.LookupSymbols(body.OpenBraceToken.EndPosition, name: "C");
+        Assert.Empty(symbols);
+
+        symbols = model.LookupSymbols(body.OpenBraceToken.EndPosition);
+        Assert.DoesNotContain(compilation.GetMember("C").GetPublicSymbol(), symbols);
+    }
+
+    [Fact]
+    public void Speculation_01()
+    {
+        var source = """
+            file class C
+            {
+                public static void M() { }
+            }
+
+            class Program
+            {
+                public void M()
+                {
+
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(source);
+        compilation.VerifyDiagnostics();
+
+        var tree = compilation.SyntaxTrees[0];
+        var body = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Last().Body!;
+
+        var model = compilation.GetSemanticModel(tree, ignoreAccessibility: false);
+
+        var newBody = body.AddStatements(SyntaxFactory.ParseStatement("C.M();"));
+        Assert.True(model.TryGetSpeculativeSemanticModel(position: body.OpenBraceToken.EndPosition, newBody, out var speculativeModel));
+        var info = speculativeModel!.GetSymbolInfo(((ExpressionStatementSyntax)newBody.Statements.First()).Expression);
+        Assert.Equal(compilation.GetMember("C.M").GetPublicSymbol(), info.Symbol);
+
+        var classC = compilation.GetMember("C").GetPublicSymbol();
+        var symbols = speculativeModel.LookupSymbols(newBody.OpenBraceToken.EndPosition, name: "C");
+        Assert.Equal(new[] { classC }, symbols);
+
+        symbols = speculativeModel.LookupSymbols(newBody.OpenBraceToken.EndPosition);
+        Assert.Contains(classC, symbols);
+    }
+
+    [Fact]
+    public void Speculation_02()
+    {
+        var source = """
+            file class C
+            {
+                public static void M() { }
+            }
+            """;
+
+        var main = """
+            class Program
+            {
+                public void M()
+                {
+
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(new[] { source, main });
+        compilation.VerifyDiagnostics();
+
+        var tree = compilation.SyntaxTrees[1];
+        var body = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Last().Body!;
+
+        var model = compilation.GetSemanticModel(tree, ignoreAccessibility: false);
+
+        var newBody = body.AddStatements(SyntaxFactory.ParseStatement("C.M();"));
+        Assert.True(model.TryGetSpeculativeSemanticModel(position: body.OpenBraceToken.EndPosition, newBody, out var speculativeModel));
+        var info = speculativeModel!.GetSymbolInfo(((ExpressionStatementSyntax)newBody.Statements.First()).Expression);
+        Assert.Null(info.Symbol);
+        Assert.Empty(info.CandidateSymbols);
+        Assert.Equal(CandidateReason.None, info.CandidateReason);
+
+        var symbols = speculativeModel.LookupSymbols(newBody.OpenBraceToken.EndPosition, name: "C");
+        Assert.Empty(symbols);
+
+        symbols = speculativeModel.LookupSymbols(newBody.OpenBraceToken.EndPosition);
+        Assert.DoesNotContain(compilation.GetMember("C").GetPublicSymbol(), symbols);
+    }
+
+    [Fact]
+    public void Cref_01()
+    {
+        var source = """
+            file class C
+            {
+                public static void M() { }
+            }
+
+            class Program
+            {
+                /// <summary>
+                /// In the same file as <see cref="C"/>.
+                /// </summary>
+                public static void M()
+                {
+
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(source, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose));
+        compilation.VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Cref_02()
+    {
+        var source = """
+            file class C
+            {
+                public static void M() { }
+            }
+            """;
+
+        var main = """
+            class Program
+            {
+                /// <summary>
+                /// In a different file than <see cref="C"/>.
+                /// </summary>
+                public static void M()
+                {
+
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(new[] { source, main }, parseOptions: TestOptions.RegularPreview.WithDocumentationMode(DocumentationMode.Diagnose));
+        compilation.VerifyDiagnostics(
+            // (4,45): warning CS1574: XML comment has cref attribute 'C' that could not be resolved
+            //     /// In a different file than <see cref="C"/>.
+            Diagnostic(ErrorCode.WRN_BadXMLRef, "C").WithArguments("C").WithLocation(4, 45)
+            );
+    }
+
+    [Fact]
+    public void TopLevelStatements()
+    {
+        var source = """
+            using System;
+
+            C.M();
+
+            file class C
+            {
+                public static void M()
+                {
+                    Console.Write(1);
+                }
+            }
+            """;
+
+        var verifier = CompileAndVerify(source, expectedOutput: "1");
+        verifier.VerifyDiagnostics();
+    }
+
+    // PROTOTYPE(ft): public API (INamedTypeSymbol.IsFile?)
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Xunit;
 
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        public void Nested()
+        public void Nested_01()
         {
             var source = """
                 class Outer
@@ -45,5 +46,605 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
         }
+
+        [Fact]
+        public void Nested_02()
+        {
+            var source = """
+                file class Outer
+                {
+                    class C { }
+                }
+                """;
+
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (1,12): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // file class Outer
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "Outer").WithArguments("file types").WithLocation(1, 12));
+
+            comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void Nested_03()
+        {
+            var source = """
+                file class Outer
+                {
+                    file class C { }
+                }
+                """;
+
+            // PROTOTYPE(ft): determine whether an inner file class within a file class is an error or if it's just fine.
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (1,12): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                // file class Outer
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "Outer").WithArguments("file types").WithLocation(1, 12),
+                // (3,16): error CS8652: The feature 'file types' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                //     file class C { }
+                Diagnostic(ErrorCode.ERR_FeatureInPreview, "C").WithArguments("file types").WithLocation(3, 16));
+
+            comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void SameFileUse()
+        {
+            var source = """
+                using System;
+
+                file class C
+                {
+                    public static void M()
+                    {
+                        Console.Write(1);
+                    }
+                }
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        C.M();
+                    }
+                }
+                """;
+
+            var verifier = CompileAndVerify(source, expectedOutput: "1");
+            verifier.VerifyDiagnostics();
+            // PROTOTYPE(ft): check metadata names
+        }
+
+        [Fact]
+        public void OtherFileUse()
+        {
+            var source1 = """
+                using System;
+
+                file class C
+                {
+                    public static void M()
+                    {
+                        Console.Write(1);
+                    }
+                }
+                """;
+
+            var source2 = """
+                class Program
+                {
+                    static void Main()
+                    {
+                        C.M(); // 1
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(new[] { source1, source2 });
+            comp.VerifyDiagnostics(
+                // (5,9): error CS0103: The name 'C' does not exist in the current context
+                //         C.M(); // 1
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "C").WithArguments("C").WithLocation(5, 9));
+        }
+
+        [Theory]
+        [InlineData("file", "file")]
+        [InlineData("file", "")]
+        [InlineData("", "file")]
+        public void Duplication_01(string firstFileModifier, string secondFileModifier)
+        {
+            // A file type is allowed to have the same name as a non-file type from a different file.
+            // When both a file type and non-file type with the same name are in scope, the file type is preferred, since it's "more local".
+            var source1 = $$"""
+                using System;
+
+                {{firstFileModifier}} class C
+                {
+                    public static void M()
+                    {
+                        Console.Write(1);
+                    }
+                }
+                """;
+
+            var source2 = $$"""
+                using System;
+
+                {{secondFileModifier}} class C
+                {
+                    public static void M()
+                    {
+                        Console.Write(2);
+                    }
+                }
+                """;
+
+            var main = """
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        C.M();
+                    }
+                }
+                """;
+
+            // PROTOTYPE(ft): execute and check expectedOutput once name mangling is done
+            // expectedOutput: "1"
+            var comp = CreateCompilation(new[] { source1 + main, source2 });
+            verify();
+
+            // expectedOutput: "2"
+            comp = CreateCompilation(new[] { source1, source2 + main });
+            verify();
+
+            void verify()
+            {
+                comp.VerifyDiagnostics();
+
+                var cs = comp.GetMembers("C");
+                Assert.Equal(2, cs.Length);
+                Assert.Equal(comp.SyntaxTrees[0], cs[0].DeclaringSyntaxReferences.Single().SyntaxTree);
+                Assert.Equal(comp.SyntaxTrees[1], cs[1].DeclaringSyntaxReferences.Single().SyntaxTree);
+            }
+        }
+
+        [Fact]
+        public void Duplication_02()
+        {
+            // As a sanity check, demonstrate that non-file classes with the same name across different files are disallowed.
+            var source1 = """
+                using System;
+
+                class C
+                {
+                    public static void M()
+                    {
+                        Console.Write(1);
+                    }
+                }
+                """;
+
+            var source2 = """
+                using System;
+
+                class C
+                {
+                    public static void M()
+                    {
+                        Console.Write(2);
+                    }
+                }
+                """;
+
+            var main = """
+
+                class Program
+                {
+                    static void Main()
+                    {
+                        C.M();
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(new[] { source1 + main, source2 });
+            verify();
+
+            comp = CreateCompilation(new[] { source1, source2 + main });
+            verify();
+
+            void verify()
+            {
+                comp.VerifyDiagnostics(
+                    // (3,7): error CS0101: The namespace '<global namespace>' already contains a definition for 'C'
+                    // class C
+                    Diagnostic(ErrorCode.ERR_DuplicateNameInNS, "C").WithArguments("C", "<global namespace>").WithLocation(3, 7),
+                    // (5,24): error CS0111: Type 'C' already defines a member called 'M' with the same parameter types
+                    //     public static void M()
+                    Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M").WithArguments("M", "C").WithLocation(5, 24),
+                    // (14,11): error CS0121: The call is ambiguous between the following methods or properties: 'C.M()' and 'C.M()'
+                    //         C.M();
+                    Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M()", "C.M()").WithLocation(14, 11));
+
+                var cs = comp.GetMember("C");
+                var syntaxReferences = cs.DeclaringSyntaxReferences;
+                Assert.Equal(2, syntaxReferences.Length);
+                Assert.Equal(comp.SyntaxTrees[0], syntaxReferences[0].SyntaxTree);
+                Assert.Equal(comp.SyntaxTrees[1], syntaxReferences[1].SyntaxTree);
+            }
+        }
+
+        [Fact]
+        public void SignatureUsage_01()
+        {
+            var source = """
+                file class C
+                {
+                }
+
+                class D
+                {
+                    public void M1(C c) { } // 1
+                    private void M2(C c) { } // 2
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,17): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+                //     public void M1(C c) { } // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M1").WithArguments("C", "D").WithLocation(7, 17),
+                // (8,18): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+                //     private void M2(C c) { } // 2
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M2").WithArguments("C", "D").WithLocation(8, 18));
+        }
+
+        [Fact]
+        public void SignatureUsage_02()
+        {
+            var source = """
+                file class C
+                {
+                }
+
+                class D
+                {
+                    public C M1() => new C(); // 1
+                    private C M2() => new C(); // 2
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,14): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+                //     public C M1() => new C(); // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M1").WithArguments("C", "D").WithLocation(7, 14),
+                // (8,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+                //     private C M2() => new C(); // 2
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M2").WithArguments("C", "D").WithLocation(8, 15));
+        }
+
+        // PROTOTYPE(ft): report error on indexer parameters
+        // ensure that all cases where 'BadVis' errors are reported also check for 'file' mismatch
+        [Fact]
+        public void SignatureUsage_03()
+        {
+            var source = """
+                file class C
+                {
+                }
+                file delegate void D();
+
+                public class E
+                {
+                    C field; // 1
+                    C property { get; set; } // 2
+                    object this[C c] { get => c; set { } } // 3
+                    event D @event; // 4
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (8,7): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E'.
+                //     C field; // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "field").WithArguments("C", "E").WithLocation(8, 7),
+                // (8,7): warning CS0169: The field 'E.field' is never used
+                //     C field; // 1
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "field").WithArguments("E.field").WithLocation(8, 7),
+                // (9,7): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E'.
+                //     C property { get; set; } // 2
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "property").WithArguments("C", "E").WithLocation(9, 7),
+                // (10,12): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E'.
+                //     object this[C c] { get => c; set { } } // 3
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "this").WithArguments("C", "E").WithLocation(10, 12),
+                // (11,13): error CS9300: File type 'D' cannot be used in a member signature in non-file type 'E'.
+                //     event D @event; // 4
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "@event").WithArguments("D", "E").WithLocation(11, 13),
+                // (11,13): warning CS0067: The event 'E.event' is never used
+                //     event D @event; // 4
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "@event").WithArguments("E.event").WithLocation(11, 13));
+        }
+
+        [Fact]
+        public void SignatureUsage_04()
+        {
+            var source = """
+                file class C
+                {
+                    public class Inner { }
+                    public delegate void InnerDelegate();
+                }
+
+                public class E
+                {
+                    C.Inner field; // 1
+                    C.Inner property { get; set; } // 2
+                    object this[C.Inner inner] { get => inner; set { } } // 3
+                    event C.InnerDelegate @event; // 4
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (9,13): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E'.
+                //     C.Inner field; // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "field").WithArguments("C.Inner", "E").WithLocation(9, 13),
+                // (9,13): warning CS0169: The field 'E.field' is never used
+                //     C.Inner field; // 1
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "field").WithArguments("E.field").WithLocation(9, 13),
+                // (10,13): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E'.
+                //     C.Inner property { get; set; } // 2
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "property").WithArguments("C.Inner", "E").WithLocation(10, 13),
+                // (11,12): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E'.
+                //     object this[C.Inner inner] { get => inner; set { } } // 3
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "this").WithArguments("C.Inner", "E").WithLocation(11, 12),
+                // (12,27): error CS9300: File type 'C.InnerDelegate' cannot be used in a member signature in non-file type 'E'.
+                //     event C.InnerDelegate @event; // 4
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "@event").WithArguments("C.InnerDelegate", "E").WithLocation(12, 27),
+                // (12,27): warning CS0067: The event 'E.event' is never used
+                //     event C.InnerDelegate @event; // 4
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "@event").WithArguments("E.event").WithLocation(12, 27));
+        }
+
+        [Fact]
+        public void SignatureUsage_05()
+        {
+            var source = """
+                #pragma warning disable 67, 169 // unused event, field
+
+                file class C
+                {
+                    public class Inner { }
+                    public delegate void InnerDelegate();
+                }
+
+                file class D
+                {
+                    public class Inner
+                    {
+                        C.Inner field;
+                        C.Inner property { get; set; }
+                        object this[C.Inner inner] { get => inner; set { } }
+                        event C.InnerDelegate @event;
+                    }
+                }
+
+                class E
+                {
+                    public class Inner
+                    {
+                        C.Inner field; // 1
+                        C.Inner property { get; set; } // 2
+                        object this[C.Inner inner] { get => inner; set { } } // 3
+                        event C.InnerDelegate @event; // 4
+                    }
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (24,17): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E.Inner'.
+                //         C.Inner field; // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "field").WithArguments("C.Inner", "E.Inner").WithLocation(24, 17),
+                // (25,17): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E.Inner'.
+                //         C.Inner property { get; set; } // 2
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "property").WithArguments("C.Inner", "E.Inner").WithLocation(25, 17),
+                // (26,16): error CS9300: File type 'C.Inner' cannot be used in a member signature in non-file type 'E.Inner'.
+                //         object this[C.Inner inner] { get => inner; set { } } // 3
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "this").WithArguments("C.Inner", "E.Inner").WithLocation(26, 16),
+                // (27,31): error CS9300: File type 'C.InnerDelegate' cannot be used in a member signature in non-file type 'E.Inner'.
+                //         event C.InnerDelegate @event; // 4
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "@event").WithArguments("C.InnerDelegate", "E.Inner").WithLocation(27, 31));
+        }
+
+        [Fact]
+        public void SignatureUsage_06()
+        {
+            var source = """
+                file class C
+                {
+                }
+
+                delegate void Del1(C c); // 1
+                delegate C Del2(); // 2
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (5,15): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'Del1'.
+                // delegate void Del1(C c); // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "Del1").WithArguments("C", "Del1").WithLocation(5, 15),
+                // (6,12): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'Del2'.
+                // delegate C Del2(); // 2
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "Del2").WithArguments("C", "Del2").WithLocation(6, 12));
+        }
+
+        [Fact]
+        public void SignatureUsage_07()
+        {
+            var source = """
+                file class C
+                {
+                }
+
+                class D
+                {
+                    public static D operator +(D d, C c) => d; // 1
+                    public static C operator -(D d1, D d2) => new C(); // 2
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,30): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+                //     public static D operator +(D d, C c) => d; // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "+").WithArguments("C", "D").WithLocation(7, 30),
+                // (8,30): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+                //     public static C operator -(D d1, D d2) => new C(); // 2
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "-").WithArguments("C", "D").WithLocation(8, 30));
+        }
+
+        [Fact]
+        public void SignatureUsage_08()
+        {
+            var source = """
+                file class C
+                {
+                }
+
+                class D
+                {
+                    public D(C c) { } // 1
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,12): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'D'.
+                //     public D(C c) { } // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "D").WithArguments("C", "D").WithLocation(7, 12));
+        }
+
+        [Fact]
+        public void AccessModifiers_01()
+        {
+            var source = """
+                public file class C { } // 1
+                file internal class D { } // 2
+                private file class E { } // 3, 4
+                file class F { } // ok
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (1,19): error CS9301: File type 'C' cannot use accessibility modifiers.
+                // public file class C { } // 1
+                Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "C").WithArguments("C").WithLocation(1, 19),
+                // (2,21): error CS9301: File type 'D' cannot use accessibility modifiers.
+                // file internal class D { } // 2
+                Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "D").WithArguments("D").WithLocation(2, 21),
+                // (3,20): error CS9301: File type 'E' cannot use accessibility modifiers.
+                // private file class E { } // 3, 4
+                Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "E").WithArguments("E").WithLocation(3, 20),
+                // (3,20): error CS1527: Elements defined in a namespace cannot be explicitly declared as private, protected, protected internal, or private protected
+                // private file class E { } // 3, 4
+                Diagnostic(ErrorCode.ERR_NoNamespacePrivate, "E").WithLocation(3, 20));
+        }
+
+        [Fact]
+        public void BaseClause_01()
+        {
+            var source = """
+                file class Base { }
+                class Derived1 : Base { } // 1
+                public class Derived2 : Base { } // 2, 3
+                file class Derived3 : Base { } // ok
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (2,7): error CS9301: File type 'Base' cannot be used as a base type in non-file type 'Derived1'.
+                // class Derived1 : Base { } // 1
+                Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived1").WithArguments("Base", "Derived1").WithLocation(2, 7),
+                // (3,14): error CS0060: Inconsistent accessibility: base class 'Base' is less accessible than class 'Derived2'
+                // public class Derived2 : Base { } // 2, 3
+                Diagnostic(ErrorCode.ERR_BadVisBaseClass, "Derived2").WithArguments("Derived2", "Base").WithLocation(3, 14),
+                // (3,14): error CS9301: File type 'Base' cannot be used as a base type in non-file type 'Derived2'.
+                // public class Derived2 : Base { } // 2, 3
+                Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived2").WithArguments("Base", "Derived2").WithLocation(3, 14));
+        }
+
+        [Fact]
+        public void BaseClause_02()
+        {
+            var source = """
+                file interface Interface { }
+
+                class Derived1 : Interface { } // ok
+                file class Derived2 : Interface { } // ok
+
+                interface Derived3 : Interface { } // 1
+                file interface Derived4 : Interface { } // ok
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,11): error CS9301: File type 'Interface' cannot be used as a base type in non-file type 'Derived3'.
+                // interface Derived3 : Interface { } // 1
+                Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived3").WithArguments("Interface", "Derived3").WithLocation(6, 11));
+        }
+
+        [Fact]
+        public void TypeArguments_01()
+        {
+            var source = """
+                file class C { }
+                class Container<T> { }
+                class Program
+                {
+                    Container<C> M() => new Container<C>(); // 1
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (5,18): error CS9300: File type 'Container<C>' cannot be used in a member signature in non-file type 'Program'.
+                //     Container<C> M() => new Container<C>(); // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M").WithArguments("Container<C>", "Program").WithLocation(5, 18));
+        }
+
+        [Fact]
+        public void Constraints_01()
+        {
+            var source = """
+                file class C { }
+
+                file class D
+                {
+                    void M<T>(T t) where T : C { } // ok
+                }
+
+                class E
+                {
+                    void M<T>(T t) where T : C { } // 1
+                }
+                """;
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (10,30): error CS9300: File type 'C' cannot be used in a member signature in non-file type 'E.M<T>(T)'.
+                //     void M<T>(T t) where T : C { } // 1
+                Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "C").WithArguments("C", "E.M<T>(T)").WithLocation(10, 30));
+        }
+
+        // PROTOTYPE(ft):
+        // ensure nested types within 'file' types are either disallowed or treated as implicitly 'file'
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -990,8 +990,6 @@ public class FileModifierTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_FileTypeDisallowedInSignature, "M2").WithArguments("C", "D").WithLocation(8, 15));
     }
 
-    // PROTOTYPE(ft): report error on indexer parameters
-    // ensure that all cases where 'BadVis' errors are reported also check for 'file' mismatch
     [Fact]
     public void SignatureUsage_03()
     {
@@ -1386,9 +1384,9 @@ public class FileModifierTests : CSharpTestBase
 
         var comp = CreateCompilation(source);
         comp.VerifyDiagnostics(
-            // (2,19): error CS9302: File type 'Interface' cannot be used as a base type of non-file type 'Derived'.
-            // partial interface Derived : Interface { } // 1
-            Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived").WithArguments("Interface", "Derived").WithLocation(2, 19));
+            // (3,19): error CS9302: File type 'I1' cannot be used as a base type of non-file type 'Derived'.
+            // partial interface Derived : I1 { } // 1
+            Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived").WithArguments("I1", "Derived").WithLocation(3, 19));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -1244,6 +1244,24 @@ public class FileModifierTests : CSharpTestBase
     }
 
     [Fact]
+    public void DuplicateModifiers_01()
+    {
+        var source = """
+            file file class C { } // 1
+            file readonly file struct D { } // 2
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (1,6): error CS1004: Duplicate 'file' modifier
+            // file file class C { } // 1
+            Diagnostic(ErrorCode.ERR_DuplicateModifier, "file").WithArguments("file").WithLocation(1, 6),
+            // (2,15): error CS1004: Duplicate 'file' modifier
+            // file readonly file struct D { } // 2
+            Diagnostic(ErrorCode.ERR_DuplicateModifier, "file").WithArguments("file").WithLocation(2, 15));
+    }
+
+    [Fact]
     public void BaseClause_01()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -1375,6 +1375,23 @@ public class FileModifierTests : CSharpTestBase
     }
 
     [Fact]
+    public void BaseClause_05()
+    {
+        var source = """
+            interface I2 { }
+            file interface I1 { }
+            partial interface Derived : I1 { } // 1
+            partial interface Derived : I2 { }
+            """;
+
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (2,19): error CS9302: File type 'Interface' cannot be used as a base type of non-file type 'Derived'.
+            // partial interface Derived : Interface { } // 1
+            Diagnostic(ErrorCode.ERR_FileTypeBase, "Derived").WithArguments("Interface", "Derived").WithLocation(2, 19));
+    }
+
+    [Fact]
     public void InterfaceImplementation_01()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/FileModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/FileModifierParsingTests.cs
@@ -475,7 +475,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             UsingNode($$"""
                 public file {{SyntaxFacts.GetText(typeKeyword)}} C { }
-                """);
+                """,
+                expectedBindingDiagnostics: new[]
+                {
+                    // (1,20): error CS9301: File type 'C' cannot use accessibility modifiers.
+                    // public file {{SyntaxFacts.GetText(typeKeyword)}} C { }
+                    Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "C").WithArguments("C")
+                });
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxFacts.GetBaseTypeDeclarationKind(typeKeyword));
@@ -502,7 +508,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             UsingNode($$"""
                 file public {{SyntaxFacts.GetText(typeKeyword)}} C { }
-                """);
+                """,
+                expectedBindingDiagnostics: new[]
+                {
+                    // (1,19): error CS9301: File type 'C' cannot use accessibility modifiers.
+                    // file public {{SyntaxFacts.GetText(typeKeyword)}} C { }
+                    Diagnostic(ErrorCode.ERR_FileTypeNoExplicitAccessibility, "C").WithArguments("C")
+                });
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxFacts.GetBaseTypeDeclarationKind(typeKeyword));

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/FileModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/FileModifierParsingTests.cs
@@ -2448,6 +2448,84 @@ public class FileModifierParsingTests : ParsingTests
     }
 
     [Fact]
+    public void TopLevelVariable_04()
+    {
+        // PROTOTYPE(ft): this should parse and compile without errors
+        // we will share a common solution with 'required' and 'scoped' here.
+        UsingNode("""
+            bool file;
+            file = true;
+            """,
+            expectedParsingDiagnostics: new[]
+            {
+                // (2,1): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+                // file = true;
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "file").WithLocation(2, 1),
+                // (2,6): error CS1525: Invalid expression term '='
+                // file = true;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(2, 6)
+            },
+            expectedBindingDiagnostics: new[]
+            {
+                // (1,6): warning CS0168: The variable 'file' is declared but never used
+                // bool file;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "file").WithArguments("file").WithLocation(1, 6),
+                // (2,1): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+                // file = true;
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "file").WithLocation(2, 1),
+                // (2,6): error CS1525: Invalid expression term '='
+                // file = true;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(2, 6)
+            });
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.GlobalStatement);
+            {
+                N(SyntaxKind.LocalDeclarationStatement);
+                {
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.BoolKeyword);
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "file");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+            }
+            N(SyntaxKind.IncompleteMember);
+            {
+                N(SyntaxKind.FileKeyword);
+            }
+            N(SyntaxKind.GlobalStatement);
+            {
+                N(SyntaxKind.ExpressionStatement);
+                {
+                    N(SyntaxKind.SimpleAssignmentExpression);
+                    {
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        N(SyntaxKind.EqualsToken);
+                        N(SyntaxKind.TrueLiteralExpression);
+                        {
+                            N(SyntaxKind.TrueKeyword);
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
     public void LambdaReturn()
     {
         UsingNode("""

--- a/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/SymbolDisplayCompilerInternalOptions.cs
@@ -62,5 +62,10 @@ namespace Microsoft.CodeAnalysis
         /// Display `System.[U]IntPtr` instead of `n[u]int`.
         /// </summary>
         UseNativeIntegerUnderlyingType = 1 << 7,
+
+        /// <summary>
+        /// Display `MyType@File.cs` instead of `MyType`.
+        /// </summary>
+        IncludeContainingFileForFileTypes = 1 << 8,
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/EEMethodBinder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/EEMethodBinder.cs
@@ -44,7 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var substitutedSourceMethod = method.SubstitutedSourceMethod;
             _parameterOffset = substitutedSourceMethod.IsStatic ? 0 : 1;
             _targetParameters = method.Parameters;
-            _sourceBinder = new InMethodBinder(substitutedSourceMethod, new BuckStopsHereBinder(next.Compilation));
+            // PROTOTYPE(ft): add tests and adjust implementation to allow EE to access file types
+            _sourceBinder = new InMethodBinder(substitutedSourceMethod, new BuckStopsHereBinder(next.Compilation, associatedSyntaxTree: null));
         }
 
         internal override void LookupSymbolsInSingleBinder(LookupResult result, string name, int arity, ConsList<TypeSymbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -706,7 +706,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 @namespace = @namespace.ContainingNamespace;
             }
 
-            Binder binder = new BuckStopsHereBinder(compilation);
+            // PROTOTYPE(ft): add tests and adjust implementation to allow EE to access file types
+            Binder binder = new BuckStopsHereBinder(compilation, associatedSyntaxTree: null);
             var hasImports = !importRecordGroups.IsDefaultOrEmpty;
             var numImportStringGroups = hasImports ? importRecordGroups.Length : 0;
             var currentStringGroup = numImportStringGroups - 1;


### PR DESCRIPTION
Related to #60819 

**I recommend disabling whitespace diffs when reviewing.**

Implements the following sections of the spec (dotnet/csharplang#6011):

> No accessibility modifiers can be used in combination with `file` on a type.

> `file` types can only appear in signatures or as base types of other `file` types

@jcouv @cston for review

I'm particularly wondering if the way I'm doing lookup, and the way I'm getting the "associated syntax tree" from a binder, is correct.