### PR TITLE
Fix exceptions for non-VS hosting of Roslyn

### DIFF
--- a/src/Features/Core/Portable/PdbSourceDocument/PdbFileLocatorService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbFileLocatorService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
 
         public async Task<DocumentDebugInfoReader?> GetDocumentDebugInfoReaderAsync(string dllPath, bool useDefaultSymbolServers, TelemetryMessage telemetry, CancellationToken cancellationToken)
         {
-            var dllStream = IOUtilities.PerformIO(() => File.OpenRead(dllPath));
+            var dllStream = IOUtilities.PerformIO(() => ReadFileIfExists(dllPath));
             if (dllStream is null)
                 return null;
 
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
             try
             {
                 // Try to load the pdb file from disk, or embedded
-                if (peReader.TryOpenAssociatedPortablePdb(dllPath, pdbPath => File.OpenRead(pdbPath), out var pdbReaderProvider, out var pdbFilePath))
+                if (peReader.TryOpenAssociatedPortablePdb(dllPath, ReadFileIfExists, out var pdbReaderProvider, out var pdbFilePath))
                 {
                     Contract.ThrowIfNull(pdbReaderProvider);
 
@@ -126,6 +126,14 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
             }
 
             return result;
+
+            static FileStream? ReadFileIfExists(string fileName)
+            {
+                if (File.Exists(fileName))
+                    return File.OpenRead(fileName);
+
+                return null;
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
@@ -26,13 +26,13 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
         /// Lazy import ISourceLinkService because it can cause debugger 
         /// binaries to be eagerly loaded even if they are never used.
         /// </summary>
-        private readonly Lazy<ISourceLinkService?> _sourceLinkService;
+        private readonly Lazy<ISourceLinkService?>? _sourceLinkService;
         private readonly IPdbSourceDocumentLogger? _logger;
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code")]
         public PdbSourceDocumentLoaderService(
-            [Import(AllowDefault = true)] Lazy<ISourceLinkService?> sourceLinkService,
+            [Import(AllowDefault = true)] Lazy<ISourceLinkService?>? sourceLinkService,
             [Import(AllowDefault = true)] IPdbSourceDocumentLogger? logger)
         {
             _sourceLinkService = sourceLinkService;
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
 
         private async Task<SourceFileInfo?> TryGetSourceLinkFileAsync(SourceDocument sourceDocument, Encoding encoding, TelemetryMessage telemetry, bool useExtendedTimeout, CancellationToken cancellationToken)
         {
-            if (sourceDocument.SourceLinkUrl is null || _sourceLinkService.Value is null)
+            if (sourceDocument.SourceLinkUrl is null || _sourceLinkService?.Value is null)
                 return null;
 
             var timeout = useExtendedTimeout ? ExtendedSourceLinkTimeout : SourceLinkTimeout;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/60908

First chance exceptions are a little more noticeable in other IDEs.