### PR TITLE
Add support to inheritance margin to disambiguate same-named items.

### DIFF
--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         public readonly string DisplayName;
 
         /// <summary>
-        /// The language of the symbol.  Used to disambiguate results when multiple targets have the same name.
+        /// The language of the symbol. Used to disambiguate results when multiple targets have the same name.
         /// </summary>
         public readonly string LanguageName;
 

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
@@ -44,13 +44,19 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         /// </summary>
         public readonly string? ProjectName;
 
+        /// <summary>
+        /// The glyph for source language.
+        /// </summary>
+        public readonly Glyph LanguageGlyph;
+
         public InheritanceTargetItem(
             InheritanceRelationship relationToMember,
             DefinitionItem.DetachedDefinitionItem definitionItem,
             Glyph glyph,
             string displayName,
             string languageName,
-            string? projectName)
+            string? projectName,
+            Glyph languageGlyph)
         {
             RelationToMember = relationToMember;
             DefinitionItem = definitionItem;
@@ -58,6 +64,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             DisplayName = displayName;
             LanguageName = languageName;
             ProjectName = projectName;
+            LanguageGlyph = languageGlyph;
         }
 
         public static async ValueTask<InheritanceTargetItem> ConvertAsync(
@@ -75,7 +82,8 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 serializableItem.Glyph,
                 serializableItem.DisplayName,
                 serializableItem.LanguageName,
-                serializableItem.ProjectName);
+                serializableItem.ProjectName,
+                serializableItem.LanguageGlyph);
         }
     }
 }

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
@@ -33,16 +33,24 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         /// </summary>
         public readonly string DisplayName;
 
+        /// <summary>
+        /// Name of the project the symbol is defined in (if known).  Used to disambiguate results when multiple targets
+        /// have the same name.
+        /// </summary>
+        public readonly string? ProjectName;
+
         public InheritanceTargetItem(
             InheritanceRelationship relationToMember,
             DefinitionItem.DetachedDefinitionItem definitionItem,
             Glyph glyph,
-            string displayName)
+            string displayName,
+            string? projectName)
         {
             RelationToMember = relationToMember;
             DefinitionItem = definitionItem;
             Glyph = glyph;
             DisplayName = displayName;
+            ProjectName = projectName;
         }
 
         public static async ValueTask<InheritanceTargetItem> ConvertAsync(
@@ -58,7 +66,8 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 serializableItem.RelationToMember,
                 definitionItem.Detach(),
                 serializableItem.Glyph,
-                serializableItem.DisplayName);
+                serializableItem.DisplayName,
+                serializableItem.ProjectName);
         }
     }
 }

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
@@ -34,8 +34,13 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         public readonly string DisplayName;
 
         /// <summary>
+        /// The language of the symbol.  Used to disambiguate results when multiple targets have the same name..
+        /// </summary>
+        public readonly string LanguageName;
+
+        /// <summary>
         /// Name of the project the symbol is defined in (if known).  Used to disambiguate results when multiple targets
-        /// have the same name.
+        /// have the same name and same language.
         /// </summary>
         public readonly string? ProjectName;
 
@@ -44,12 +49,14 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             DefinitionItem.DetachedDefinitionItem definitionItem,
             Glyph glyph,
             string displayName,
+            string languageName,
             string? projectName)
         {
             RelationToMember = relationToMember;
             DefinitionItem = definitionItem;
             Glyph = glyph;
             DisplayName = displayName;
+            LanguageName = languageName;
             ProjectName = projectName;
         }
 
@@ -67,6 +74,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 definitionItem.Detach(),
                 serializableItem.Glyph,
                 serializableItem.DisplayName,
+                serializableItem.LanguageName,
                 serializableItem.ProjectName);
         }
     }

--- a/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
+++ b/src/EditorFeatures/Core/InheritanceMargin/InheritanceTargetItem.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         public readonly string DisplayName;
 
         /// <summary>
-        /// The language of the symbol.  Used to disambiguate results when multiple targets have the same name..
+        /// The language of the symbol.  Used to disambiguate results when multiple targets have the same name.
         /// </summary>
         public readonly string LanguageName;
 

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
                 .Select(info => TestInheritanceTargetItem.Create(info, testWorkspace))
                 .OrderBy(target => target.TargetSymbolName)
                 .ToImmutableArray();
-            var sortedActualTargets = actualItem.TargetItems.OrderBy(target => target.DisplayName)
+            var sortedActualTargets = actualItem.TargetItems.OrderBy(t => t.DisplayName).ThenBy(t => t.LanguageName).ThenBy(t => t.ProjectName ?? "")
                 .ToImmutableArray();
             for (var i = 0; i < expectedTargets.Length; i++)
             {
@@ -106,6 +106,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
         {
             Assert.Equal(expectedTarget.TargetSymbolName, actualTarget.DisplayName);
             Assert.Equal(expectedTarget.RelationshipToMember, actualTarget.RelationToMember);
+
+            if (expectedTarget.LanguageName != null)
+                Assert.Equal(expectedTarget.LanguageName, actualTarget.LanguageName);
 
             if (expectedTarget.IsInMetadata)
             {
@@ -196,15 +199,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
             public readonly ImmutableArray<string> LocationTags;
             public readonly InheritanceRelationship Relationship;
             public readonly bool InMetadata;
+            public readonly string? LanguageName;
 
             public TargetInfo(
                 string targetSymbolDisplayName,
                 string locationTag,
-                InheritanceRelationship relationship)
+                InheritanceRelationship relationship,
+                string? languageName = null)
             {
                 TargetSymbolDisplayName = targetSymbolDisplayName;
                 LocationTags = ImmutableArray.Create(locationTag);
                 Relationship = relationship;
+                LanguageName = languageName;
                 InMetadata = false;
             }
 
@@ -236,17 +242,20 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
             public readonly InheritanceRelationship RelationshipToMember;
             public readonly ImmutableArray<DocumentSpan> DocumentSpans;
             public readonly bool IsInMetadata;
+            public readonly string? LanguageName;
 
             public TestInheritanceTargetItem(
                 string targetSymbolName,
                 InheritanceRelationship relationshipToMember,
-                 ImmutableArray<DocumentSpan> documentSpans,
-                  bool isInMetadata)
+                ImmutableArray<DocumentSpan> documentSpans,
+                bool isInMetadata,
+                string? languageName)
             {
                 TargetSymbolName = targetSymbolName;
                 RelationshipToMember = relationshipToMember;
                 DocumentSpans = documentSpans;
                 IsInMetadata = isInMetadata;
+                LanguageName = languageName;
             }
 
             public static TestInheritanceTargetItem Create(
@@ -259,7 +268,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
                         targetInfo.TargetSymbolDisplayName,
                         targetInfo.Relationship,
                         ImmutableArray<DocumentSpan>.Empty,
-                        isInMetadata: true);
+                        isInMetadata: true,
+                        targetInfo.LanguageName);
                 }
                 else
                 {
@@ -287,7 +297,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
                         targetInfo.TargetSymbolDisplayName,
                         targetInfo.Relationship,
                         builder.ToImmutable(),
-                        isInMetadata: false);
+                        isInMetadata: false,
+                        targetInfo.LanguageName);
                 }
             }
         }
@@ -1966,6 +1977,66 @@ public partial class {|target3:Bar|}
                 (markup2, LanguageNames.CSharp),
                 new[] { itemForBar44, itemForFooInMarkup1 },
                 new[] { itemForIBar, itemForFooInMarkup2 });
+        }
+
+        [Fact]
+        public Task TestSameNameSymbolInDifferentLanguageProjects()
+        {
+            var markup1 = @"
+        using MyNamespace;
+        namespace BarNs
+        {
+            public class {|target1:Bar|} : IBar
+            {
+            }
+        }";
+
+            var markup2 = @"
+        Namespace MyNamespace
+            Public Interface {|target2:IBar|}
+            End Interface
+
+            Public Class {|target3:Bar|}
+                Implements IBar
+            End Class
+        End Namespace";
+
+            var itemForBarInMarkup1 = new TestInheritanceMemberItem(
+                lineNumber: 5,
+                memberName: "class Bar",
+                targets: ImmutableArray.Create(new TargetInfo(
+                    targetSymbolDisplayName: "IBar",
+                    locationTag: "target2",
+                    relationship: InheritanceRelationship.ImplementedInterface)));
+
+            var itemForIBar = new TestInheritanceMemberItem(
+                lineNumber: 3,
+                memberName: "Interface IBar",
+                targets: ImmutableArray.Create(
+                    new TargetInfo(
+                        targetSymbolDisplayName: "Bar",
+                        locationTag: "target1",
+                        relationship: InheritanceRelationship.ImplementingType,
+                        languageName: LanguageNames.CSharp),
+                    new TargetInfo(
+                        targetSymbolDisplayName: "Bar",
+                        locationTag: "target3",
+                        relationship: InheritanceRelationship.ImplementingType,
+                        languageName: LanguageNames.VisualBasic)));
+
+            var itemForBarInMarkup2 = new TestInheritanceMemberItem(
+                lineNumber: 6,
+                memberName: "Class Bar",
+                targets: ImmutableArray.Create(new TargetInfo(
+                    targetSymbolDisplayName: "IBar",
+                    locationTag: "target2",
+                    relationship: InheritanceRelationship.ImplementedInterface)));
+
+            return VerifyInDifferentProjectsAsync(
+                (markup1, LanguageNames.CSharp),
+                (markup2, LanguageNames.VisualBasic),
+                new[] { itemForBarInMarkup1 },
+                new[] { itemForIBar, itemForBarInMarkup2 });
         }
     }
 }

--- a/src/Features/Core/Portable/DocumentIdSpan.cs
+++ b/src/Features/Core/Portable/DocumentIdSpan.cs
@@ -15,21 +15,21 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal readonly struct DocumentIdSpan
     {
-        private readonly Workspace _workspace;
-        private readonly DocumentId _documentId;
+        public readonly Workspace Workspace;
+        public readonly DocumentId DocumentId;
         public readonly TextSpan SourceSpan;
 
         public DocumentIdSpan(DocumentSpan documentSpan)
         {
-            _workspace = documentSpan.Document.Project.Solution.Workspace;
-            _documentId = documentSpan.Document.Id;
+            Workspace = documentSpan.Document.Project.Solution.Workspace;
+            DocumentId = documentSpan.Document.Id;
             SourceSpan = documentSpan.SourceSpan;
         }
 
         public async Task<DocumentSpan?> TryRehydrateAsync(CancellationToken cancellationToken)
         {
-            var solution = _workspace.CurrentSolution;
-            var document = await solution.GetDocumentAsync(_documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            var solution = Workspace.CurrentSolution;
+            var document = await solution.GetDocumentAsync(DocumentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
             return document == null ? null : new DocumentSpan(document, SourceSpan);
         }
     }

--- a/src/Features/Core/Portable/DocumentIdSpan.cs
+++ b/src/Features/Core/Portable/DocumentIdSpan.cs
@@ -15,21 +15,21 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal readonly struct DocumentIdSpan
     {
-        public readonly Workspace Workspace;
-        public readonly DocumentId DocumentId;
+        private readonly Workspace _workspace;
+        private readonly DocumentId _documentId;
         public readonly TextSpan SourceSpan;
 
         public DocumentIdSpan(DocumentSpan documentSpan)
         {
-            Workspace = documentSpan.Document.Project.Solution.Workspace;
-            DocumentId = documentSpan.Document.Id;
+            _workspace = documentSpan.Document.Project.Solution.Workspace;
+            _documentId = documentSpan.Document.Id;
             SourceSpan = documentSpan.SourceSpan;
         }
 
         public async Task<DocumentSpan?> TryRehydrateAsync(CancellationToken cancellationToken)
         {
-            var solution = Workspace.CurrentSolution;
-            var document = await solution.GetDocumentAsync(DocumentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+            var solution = _workspace.CurrentSolution;
+            var document = await solution.GetDocumentAsync(_documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
             return document == null ? null : new DocumentSpan(document, SourceSpan);
         }
     }

--- a/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginServiceHelpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginServiceHelpers.cs
@@ -367,8 +367,8 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
             var displayName = targetSymbol.ToDisplayString(s_displayFormat);
 
-            var projectName = definition.SourceSpans.Length > 0
-                ? definition.SourceSpans[0].Document.Project.State.NameAndFlavor.name
+            var projectState = definition.SourceSpans.Length > 0
+                ? definition.SourceSpans[0].Document.Project.State
                 : null;
 
             return new SerializableInheritanceTargetItem(
@@ -378,7 +378,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 targetSymbol.GetGlyph(),
                 displayName,
                 targetSymbol.Language,
-                projectName);
+                projectState?.NameAndFlavor.name ?? projectState?.Name);
         }
 
         private static ImmutableArray<ISymbol> GetImplementedSymbolsForTypeMember(

--- a/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginServiceHelpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginServiceHelpers.cs
@@ -367,12 +367,18 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
             var displayName = targetSymbol.ToDisplayString(s_displayFormat);
 
+            var projectName = definition.SourceSpans.Length > 0
+                ? definition.SourceSpans[0].Document.Project.State.NameAndFlavor.name
+                : null;
+
             return new SerializableInheritanceTargetItem(
                 inheritanceRelationship,
                 // Id is used by FAR service for caching, it is not used in inheritance margin
                 SerializableDefinitionItem.Dehydrate(id: 0, definition),
                 targetSymbol.GetGlyph(),
-                displayName);
+                displayName,
+                targetSymbol.Language,
+                projectName);
         }
 
         private static ImmutableArray<ISymbol> GetImplementedSymbolsForTypeMember(

--- a/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginServiceHelpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginServiceHelpers.cs
@@ -371,6 +371,13 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 ? definition.SourceSpans[0].Document.Project.State
                 : null;
 
+            var languageGlyph = targetSymbol.Language switch
+            {
+                LanguageNames.CSharp => Glyph.CSharpFile,
+                LanguageNames.VisualBasic => Glyph.BasicFile,
+                _ => throw ExceptionUtilities.UnexpectedValue(targetSymbol.Language),
+            };
+
             return new SerializableInheritanceTargetItem(
                 inheritanceRelationship,
                 // Id is used by FAR service for caching, it is not used in inheritance margin
@@ -378,7 +385,8 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 targetSymbol.GetGlyph(),
                 displayName,
                 targetSymbol.Language,
-                projectState?.NameAndFlavor.name ?? projectState?.Name);
+                projectState?.NameAndFlavor.name ?? projectState?.Name,
+                languageGlyph);
         }
 
         private static ImmutableArray<ISymbol> GetImplementedSymbolsForTypeMember(

--- a/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceTargetItem.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceTargetItem.cs
@@ -23,6 +23,9 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         public readonly string DisplayName;
 
         [DataMember(Order = 4)]
+        public readonly string LanguageName;
+
+        [DataMember(Order = 5)]
         public readonly string? ProjectName;
 
         public SerializableInheritanceTargetItem(
@@ -30,6 +33,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             SerializableDefinitionItem definitionItem,
             Glyph glyph,
             string displayName,
+            string languageName,
             string? projectName)
         {
             RelationToMember = relationToMember;
@@ -37,6 +41,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             Glyph = glyph;
             DisplayName = displayName;
             ProjectName = projectName;
+            LanguageName = languageName;
         }
     }
 }

--- a/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceTargetItem.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceTargetItem.cs
@@ -28,13 +28,17 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         [DataMember(Order = 5)]
         public readonly string? ProjectName;
 
+        [DataMember(Order = 6)]
+        public readonly Glyph LanguageGlyph;
+
         public SerializableInheritanceTargetItem(
             InheritanceRelationship relationToMember,
             SerializableDefinitionItem definitionItem,
             Glyph glyph,
             string displayName,
             string languageName,
-            string? projectName)
+            string? projectName,
+            Glyph languageGlyph)
         {
             RelationToMember = relationToMember;
             DefinitionItem = definitionItem;
@@ -42,6 +46,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             DisplayName = displayName;
             ProjectName = projectName;
             LanguageName = languageName;
+            LanguageGlyph = languageGlyph;
         }
     }
 }

--- a/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceTargetItem.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/SerializableInheritanceTargetItem.cs
@@ -22,16 +22,21 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         [DataMember(Order = 3)]
         public readonly string DisplayName;
 
+        [DataMember(Order = 4)]
+        public readonly string? ProjectName;
+
         public SerializableInheritanceTargetItem(
             InheritanceRelationship relationToMember,
             SerializableDefinitionItem definitionItem,
             Glyph glyph,
-            string displayName)
+            string displayName,
+            string? projectName)
         {
             RelationToMember = relationToMember;
             DefinitionItem = definitionItem;
             Glyph = glyph;
             DisplayName = displayName;
+            ProjectName = projectName;
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             {
                 if (action.NestedCodeActions.Length > 0)
                 {
-                    _ = ArrayBuilder<IUnifiedSuggestedAction>.GetInstance(action.NestedCodeActions.Length, out var unifiedNestedActions);
+                    using var _ = ArrayBuilder<IUnifiedSuggestedAction>.GetInstance(action.NestedCodeActions.Length, out var unifiedNestedActions);
                     foreach (var nestedAction in action.NestedCodeActions)
                     {
                         var unifiedNestedAction = await GetUnifiedSuggestedActionAsync(nestedAction, fix).ConfigureAwait(false);

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -164,24 +164,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             foreach (var target in targets)
             {
                 var targetsWithSameName = nameToTargets[target.DisplayName];
+                // Two or more items with the same name. Try to disambiguate them based on their languages and their project name.
                 if (targetsWithSameName.Count >= 2)
                 {
-                    // Two or more items with the same name.  Try to disambiguate them based on their languages if
-                    // they're all distinct, or their project name if they're not.
-                    var distinctLanguageCount = targetsWithSameName.Select(t => t.LanguageName).Distinct().Count();
-                    if (distinctLanguageCount == targetsWithSameName.Count)
-                    {
-                        builder.Add(TargetMenuItemViewModel.Create(
-                            target, string.Format(ServicesVSResources._0_1, target.DisplayName, target.LanguageName)));
-                        continue;
-                    }
+                    var displayName = target.ProjectName != null
+                        ? string.Format(ServicesVSResources._0_1, target.DisplayName, target.ProjectName)
+                        : target.DisplayName;
 
-                    if (target.ProjectName != null)
-                    {
-                        builder.Add(TargetMenuItemViewModel.Create(
-                            target, string.Format(ServicesVSResources._0_1, target.DisplayName, target.ProjectName)));
-                        continue;
-                    }
+                    builder.Add(DisambiguousTargetMenuItemViewModel.CreateWithSourceLanguageGlyph(
+                        target, displayName));
+                    continue;
                 }
 
                 builder.Add(TargetMenuItemViewModel.Create(target, target.DisplayName));

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -164,16 +164,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             foreach (var target in targets)
             {
                 var targetsWithSameName = nameToTargets[target.DisplayName];
-                // Two or more items with the same name. Try to disambiguate them based on their languages and their project name.
                 if (targetsWithSameName.Count >= 2)
                 {
-                    var displayName = target.ProjectName != null
-                        ? string.Format(ServicesVSResources._0_1, target.DisplayName, target.ProjectName)
-                        : target.DisplayName;
+                    // Two or more items with the same name.  Try to disambiguate them based on their languages if
+                    // they're all distinct, or their project name if they're not.
+                    var distinctLanguageCount = targetsWithSameName.Select(t => t.LanguageName).Distinct().Count();
+                    if (distinctLanguageCount == targetsWithSameName.Count)
+                    {
+                        builder.Add(DisambiguousTargetMenuItemViewModel.CreateWithSourceLanguageGlyph(target));
+                        continue;
+                    }
 
-                    builder.Add(DisambiguousTargetMenuItemViewModel.CreateWithSourceLanguageGlyph(
-                        target, displayName));
-                    continue;
+                    if (target.ProjectName != null)
+                    {
+                        builder.Add(TargetMenuItemViewModel.Create(
+                            target, string.Format(ServicesVSResources._0_1, target.DisplayName, target.ProjectName)));
+                        continue;
+                    }
                 }
 
                 builder.Add(TargetMenuItemViewModel.Create(target, target.DisplayName));

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -101,6 +101,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             var nameToTargets = s_pool.Allocate();
             try
             {
+                // Create a mapping from display name to all targets with that name.  This will allow us to determine if
+                // there may be multiple results with the same name, so we can disambiguate them with additional
+                // information later on when we create the items.
                 foreach (var target in targets)
                     nameToTargets.Add(target.DisplayName, target);
 

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -104,10 +104,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                 foreach (var target in targets)
                     nameToTargets.Add(target.DisplayName, target);
 
-                return targets.OrderBy(target => target.DisplayName)
-                    .GroupBy(target => target.RelationToMember)
-                    .SelectMany(grouping => CreateMenuItemsWithHeader(grouping.Key, grouping, nameToTargets))
-                    .ToImmutableArray();
+                return targets.OrderBy(t => t.DisplayName).ThenBy(t => t.LanguageName).ThenBy(t => t.ProjectName ?? "")
+                              .GroupBy(t => t.RelationToMember)
+                              .SelectMany(g => CreateMenuItemsWithHeader(g.Key, g, nameToTargets))
+                              .ToImmutableArray();
             }
             finally
             {
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             IEnumerable<InheritanceTargetItem> targets,
             MultiDictionary<string, InheritanceTargetItem> nameToTargets)
         {
-            using var _ = CodeAnalysis.PooledObjects.ArrayBuilder<MenuItemViewModel>.GetInstance(out var builder);
+            using var _ = ArrayBuilder<MenuItemViewModel>.GetInstance(out var builder);
             var displayContent = relationship switch
             {
                 InheritanceRelationship.ImplementedInterface => ServicesVSResources.Implemented_interfaces,
@@ -169,14 +169,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                     if (distinctLanguageCount == targetsWithSameName.Count)
                     {
                         builder.Add(TargetMenuItemViewModel.Create(
-                            target, string.Format(FeaturesResources._0_1, target.DisplayName, target.LanguageName)));
+                            target, string.Format(ServicesVSResources._0_1, target.DisplayName, target.LanguageName)));
                         continue;
                     }
 
                     if (target.ProjectName != null)
                     {
                         builder.Add(TargetMenuItemViewModel.Create(
-                            target, string.Format(FeaturesResources._0_1, target.DisplayName, target.ProjectName)));
+                            target, string.Format(ServicesVSResources._0_1, target.DisplayName, target.ProjectName)));
                         continue;
                     }
                 }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             // For multiple members, check if all the targets have the same inheritance relationship.
             // If so, then don't add the header, because it is already indicated by the margin.
             // Otherwise, add the Header.
-            return members.SelectAsArray(m => (MenuItemViewModel)MemberMenuItemViewModel.CreateWithHeaderInTargets(m));
+            return members.SelectAsArray(MemberMenuItemViewModel.CreateWithHeaderInTargets).CastArray<MenuItemViewModel>();
         }
 
         public static ImmutableArray<MenuItemViewModel> CreateMenuItemsWithHeader(

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/DisambiguousTargetMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/DisambiguousTargetMenuItemViewModel.cs
@@ -41,18 +41,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         public static DisambiguousTargetMenuItemViewModel CreateWithSourceLanguageGlyph(
             InheritanceTargetItem target)
         {
-            var languageGlyph = target.LanguageName switch
-            {
-                LanguageNames.CSharp => Glyph.CSharpFile,
-                LanguageNames.VisualBasic => Glyph.BasicFile,
-                _ => throw ExceptionUtilities.UnexpectedValue(target.LanguageName),
-            };
-
             return new(
                 target.DisplayName,
                 target.Glyph.GetImageMoniker(),
                 target.DefinitionItem,
-                languageGlyph.GetImageMoniker());
+                target.LanguageGlyph.GetImageMoniker());
         }
     }
 }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/DisambiguousTargetMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/DisambiguousTargetMenuItemViewModel.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Wpf;
+using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.InheritanceMargin;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph;
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph
+{
+    /// <summary>
+    /// The View Model would be used when there are multiple targets with same name in the group.
+    /// It contains an addtional image moniker represents the source language in the UI.
+    /// </summary>
+    internal class DisambiguousTargetMenuItemViewModel : TargetMenuItemViewModel
+    {
+        /// <summary>
+        /// Icon represets the source language of this target.
+        /// </summary>
+        public ImageMoniker LanguageMoniker { get; }
+
+        // Internal for testing purpose
+        internal DisambiguousTargetMenuItemViewModel(
+            string displayContent,
+            ImageMoniker imageMoniker,
+            DefinitionItem.DetachedDefinitionItem definitionItem,
+            ImageMoniker languageMoniker) : base(displayContent, imageMoniker, definitionItem)
+        {
+            LanguageMoniker = languageMoniker;
+        }
+
+        public static DisambiguousTargetMenuItemViewModel CreateWithSourceLanguageGlyph(
+            InheritanceTargetItem target, string displayContent)
+        {
+            var languageGlyph = target.LanguageName switch
+            {
+                LanguageNames.CSharp => Glyph.CSharpFile,
+                LanguageNames.VisualBasic => Glyph.BasicFile,
+                _ => throw ExceptionUtilities.UnexpectedValue(target.LanguageName),
+            };
+
+            return new(
+                displayContent,
+                target.Glyph.GetImageMoniker(),
+                target.DefinitionItem,
+                languageGlyph.GetImageMoniker());
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/DisambiguousTargetMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/DisambiguousTargetMenuItemViewModel.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         }
 
         public static DisambiguousTargetMenuItemViewModel CreateWithSourceLanguageGlyph(
-            InheritanceTargetItem target, string displayContent)
+            InheritanceTargetItem target)
         {
             var languageGlyph = target.LanguageName switch
             {
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             };
 
             return new(
-                displayContent,
+                target.DisplayName,
                 target.Glyph.GetImageMoniker(),
                 target.DefinitionItem,
                 languageGlyph.GetImageMoniker());

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/HeaderMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/HeaderMenuItemViewModel.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
     /// </summary>
     internal class HeaderMenuItemViewModel : MenuItemViewModel
     {
-        public HeaderMenuItemViewModel(string displayContent, ImageMoniker imageMoniker, string automationName)
-            : base(displayContent, imageMoniker, automationName)
+        public HeaderMenuItemViewModel(string displayContent, ImageMoniker imageMoniker)
+            : base(displayContent, imageMoniker)
         {
         }
     }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml
@@ -22,11 +22,60 @@
     <ContextMenu.Resources>
         <!-- The image shown in the menu item, mark this is non-shared to make sure each menu item has its own image -->
         <imaging:CrispImage x:Key="NonSharedIcon" x:Shared="False" Moniker="{Binding ImageMoniker}"/>
-
         <local:MenuItemContainerTemplateSelector x:Key="TemplateSelector"/>
 
         <!-- Style used to display a single target menu item -->
         <Style x:Key="TargetMenuItemStyle" TargetType="{x:Type MenuItem}">
+            <Setter Property="Icon" Value="{StaticResource NonSharedIcon}"/>
+            <Setter Property="Header" Value="{Binding  DisplayContent}"/>
+            <Setter Property="AutomationProperties.Name" Value="{Binding AutomationName}"/>
+            <Setter Property="IsCheckable" Value="False"/>
+            <EventSetter Event="Click" Handler="TargetMenuItem_OnClick"/>
+            <Setter Property="HorizontalContentAlignment" Value="{Binding Path=HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+            <Setter Property="VerticalContentAlignment" Value="{Binding Path=VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <!-- Style copied from editor -->
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarTextActiveBrushKey}}"/>
+            <Setter Property="DockPanel.Dock" Value="Top"/>
+            <Setter Property="Padding" Value="0,2,0,2"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type MenuItem}">
+                        <Grid SnapsToDevicePixels="true" Background="Transparent" MinHeight="22">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup"/>
+                                <ColumnDefinition Width="23" SharedSizeGroup="MenuItemExpanderColumnGroup"/>
+                            </Grid.ColumnDefinitions>
+
+                            <Rectangle Name="Bg" Stroke="Transparent" Fill="Transparent" StrokeThickness="0" Grid.ColumnSpan="5"/>
+                            <ContentPresenter Grid.Column="0" x:Name="Icon" Margin="22,1,4,1" Width="16" Height="16" VerticalAlignment="Center"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding MenuItem.Icon}" />
+                            <ContentPresenter Grid.Column="1" ContentSource="Header" Margin="4,1,4,1"
+                                                VerticalAlignment="Center" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                            <TextBlock Grid.Column="2" Text="{TemplateBinding MenuItem.InputGestureText}" Margin="{TemplateBinding MenuItem.Padding}" VerticalAlignment="Center"/>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="Icon" Value="{x:Null}">
+                                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed"/>
+                            </Trigger>
+                            <Trigger Property="IsHighlighted" Value="true">
+                                <Setter TargetName="Bg" Property="Fill" Value="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarMenuItemMouseOverBrushKey}}"/>
+                                <Setter TargetName="Bg" Property="Stroke" Value="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarMenuItemMouseOverBorderBrushKey}}"/>
+                                <Setter Property="TextElement.Foreground" Value="{DynamicResource {x:Static vsui:EnvironmentColors.CommandBarMenuItemMouseOverTextBrushKey}}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="false">
+                                <Setter Property="Foreground" Value="{DynamicResource {x:Static vsfx:VsBrushes.CommandBarTextInactiveKey}}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Style used to display a single target menu item -->
+        <Style x:Key="DisambiguatingTargetMenuItemStyle" TargetType="{x:Type MenuItem}">
             <Setter Property="Icon" Value="{StaticResource NonSharedIcon}"/>
             <Setter Property="Header" Value="{Binding  DisplayContent}"/>
             <Setter Property="AutomationProperties.Name" Value="{Binding AutomationName}"/>
@@ -44,20 +93,20 @@
                     <ControlTemplate TargetType="{x:Type MenuItem}">
                         <Grid SnapsToDevicePixels="true" Background="Transparent" MinHeight="22">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="LanguageIconColumnGroup"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="LanguageIconColumnGroup"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup"/>
                                 <ColumnDefinition Width="23" SharedSizeGroup="MenuItemExpanderColumnGroup"/>
                             </Grid.ColumnDefinitions>
 
-                            <Rectangle Name="Bg" Stroke="Transparent" Fill="Transparent" StrokeThickness="0" Grid.ColumnSpan="5"/>
+                            <Rectangle Name="Bg" Stroke="Transparent" Fill="Transparent" StrokeThickness="0" Grid.ColumnSpan="6"/>
 
-                            <imaging:CrispImage Grid.Column="0" x:Name="LanguageIcon" Margin="22,1,1,1" Width="16" Height="16" VerticalAlignment="Center"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Moniker="{Binding LanguageMoniker}" />
-
-                            <ContentPresenter Grid.Column="1" x:Name="Icon" Margin="1,1,4,1" Width="16" Height="16" VerticalAlignment="Center"
+                            <ContentPresenter Grid.Column="0" x:Name="Icon" Margin="22,1,4,1" Width="16" Height="16" VerticalAlignment="Center"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding MenuItem.Icon}" />
+
+                            <imaging:CrispImage Grid.Column="1" x:Name="LanguageIcon" Margin="1,1,4,1" Width="16" Height="16" VerticalAlignment="Center"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Moniker="{Binding LanguageMoniker}" />
 
                             <ContentPresenter Grid.Column="2" ContentSource="Header" Margin="4,1,4,1"
                                                 VerticalAlignment="Center" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
@@ -191,6 +240,12 @@
         <!-- The key is referenced from code behind -->
         <DataTemplate x:Key="TargetMenuItemTemplate" DataType="{x:Type local:TargetMenuItemViewModel}">
             <MenuItem Style="{StaticResource TargetMenuItemStyle}"/>
+        </DataTemplate>
+
+        <!-- DataTemplate for inheritance target in the context menu -->
+        <!-- The key is referenced from code behind -->
+        <DataTemplate x:Key="DisambiguatingTargetMenuItemTemplate" DataType="{x:Type local:DisambiguousTargetMenuItemViewModel}">
+            <MenuItem Style="{StaticResource DisambiguatingTargetMenuItemStyle}"/>
         </DataTemplate>
     </ContextMenu.Resources>
 

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml
@@ -44,6 +44,7 @@
                     <ControlTemplate TargetType="{x:Type MenuItem}">
                         <Grid SnapsToDevicePixels="true" Background="Transparent" MinHeight="22">
                             <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="LanguageIconColumnGroup"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIconColumnGroup"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup"/>
@@ -51,11 +52,16 @@
                             </Grid.ColumnDefinitions>
 
                             <Rectangle Name="Bg" Stroke="Transparent" Fill="Transparent" StrokeThickness="0" Grid.ColumnSpan="5"/>
-                            <ContentPresenter Grid.Column="0" x:Name="Icon" Margin="22,1,4,1" Width="16" Height="16" VerticalAlignment="Center"
+
+                            <imaging:CrispImage Grid.Column="0" x:Name="LanguageIcon" Margin="22,1,1,1" Width="16" Height="16" VerticalAlignment="Center"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Moniker="{Binding LanguageMoniker}" />
+
+                            <ContentPresenter Grid.Column="1" x:Name="Icon" Margin="1,1,4,1" Width="16" Height="16" VerticalAlignment="Center"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding MenuItem.Icon}" />
-                            <ContentPresenter Grid.Column="1" ContentSource="Header" Margin="4,1,4,1"
+
+                            <ContentPresenter Grid.Column="2" ContentSource="Header" Margin="4,1,4,1"
                                                 VerticalAlignment="Center" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <TextBlock Grid.Column="2" Text="{TemplateBinding MenuItem.InputGestureText}" Margin="{TemplateBinding MenuItem.Padding}" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="3" Text="{TemplateBinding MenuItem.InputGestureText}" Margin="{TemplateBinding MenuItem.Padding}" VerticalAlignment="Center"/>
                         </Grid>
                         <ControlTemplate.Triggers>
                             <Trigger Property="Icon" Value="{x:Null}">

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginContextMenu.xaml
@@ -74,7 +74,7 @@
             </Setter>
         </Style>
 
-        <!-- Style used to display a single target menu item -->
+        <!-- Style used to display a target menu item with a language icon -->
         <Style x:Key="DisambiguatingTargetMenuItemStyle" TargetType="{x:Type MenuItem}">
             <Setter Property="Icon" Value="{StaticResource NonSharedIcon}"/>
             <Setter Property="Header" Value="{Binding  DisplayContent}"/>
@@ -100,7 +100,7 @@
                                 <ColumnDefinition Width="23" SharedSizeGroup="MenuItemExpanderColumnGroup"/>
                             </Grid.ColumnDefinitions>
 
-                            <Rectangle Name="Bg" Stroke="Transparent" Fill="Transparent" StrokeThickness="0" Grid.ColumnSpan="6"/>
+                            <Rectangle Name="Bg" Stroke="Transparent" Fill="Transparent" StrokeThickness="0" Grid.ColumnSpan="5"/>
 
                             <ContentPresenter Grid.Column="0" x:Name="Icon" Margin="22,1,4,1" Width="16" Height="16" VerticalAlignment="Center"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding MenuItem.Icon}" />

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginGlyphViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginGlyphViewModel.cs
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                 var member = tag.MembersOnLine[0];
 
                 var automationName = string.Format(ServicesVSResources._0_is_inherited, member.DisplayTexts.JoinText());
-                var menuItemViewModels = InheritanceMarginHelpers.CreateMenuItemViewModelsForSingleMember(member.TargetItems);
+                var menuItemViewModels = InheritanceMarginHelpers.CreateModelsForTargetItems(member.TargetItems);
                 return new InheritanceMarginGlyphViewModel(tag, classificationTypeMap, classificationFormatMap, automationName, scaleFactor, menuItemViewModels);
             }
             else

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/MemberMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/MemberMenuItemViewModel.cs
@@ -7,7 +7,9 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.CodeAnalysis.InheritanceMargin;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph
@@ -35,26 +37,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         public MemberMenuItemViewModel(
             string displayContent,
             ImageMoniker imageMoniker,
-            string automationName,
-            ImmutableArray<MenuItemViewModel> targets) : base(displayContent, imageMoniker, automationName)
+            ImmutableArray<MenuItemViewModel> targets) : base(displayContent, imageMoniker)
         {
             Targets = targets;
         }
 
         public static MemberMenuItemViewModel CreateWithHeaderInTargets(InheritanceMarginItem member)
-        {
-            var displayName = member.DisplayTexts.JoinText();
-            var targetsByRelationship = member.TargetItems
-                .OrderBy(item => item.DisplayName)
-                .GroupBy(target => target.RelationToMember)
-                .SelectMany(grouping => InheritanceMarginHelpers.CreateMenuItemsWithHeader(grouping.Key, grouping))
-                .ToImmutableArray();
-
-            return new MemberMenuItemViewModel(
-                displayName,
+            => new(
+                member.DisplayTexts.JoinText(),
                 member.Glyph.GetImageMoniker(),
-                displayName,
-                targetsByRelationship);
-        }
+                InheritanceMarginHelpers.CreateModelsForTargetItems(member.TargetItems));
     }
 }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/MenuItemContainerTemplateSelector.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/MenuItemContainerTemplateSelector.cs
@@ -21,9 +21,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                 return (DataTemplate)parentItemsControl.FindResource("HeaderMenuItemTemplate");
             }
 
+            if (item is DisambiguousTargetMenuItemViewModel)
+            {
+                // Template for DisambiguatingTargetMenuItemTemplate, which contains one more icon than the common TargetMenuItemTemplate.
+                return (DataTemplate)parentItemsControl.FindResource("DisambiguatingTargetMenuItemTemplate");
+            }
+
             if (item is TargetMenuItemViewModel)
             {
-                // Template for Target
+                // Template for a common target
                 return (DataTemplate)parentItemsControl.FindResource("TargetMenuItemTemplate");
             }
 

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/MenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/MenuItemViewModel.cs
@@ -23,11 +23,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         /// </summary>
         public string AutomationName { get; }
 
-        protected MenuItemViewModel(string displayContent, ImageMoniker imageMoniker, string automationName)
+        protected MenuItemViewModel(string displayContent, ImageMoniker imageMoniker)
         {
             ImageMoniker = imageMoniker;
             DisplayContent = displayContent;
-            AutomationName = automationName;
+            AutomationName = displayContent;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
@@ -32,17 +32,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             DefinitionItem = definitionItem;
         }
 
-        public static TargetMenuItemViewModel Create(InheritanceTargetItem target, bool includeProjectName)
+        public static TargetMenuItemViewModel Create(InheritanceTargetItem target, string displayContent)
             => new(
-                GetDisplayContent(target, includeProjectName),
+                displayContent,
                 target.Glyph.GetImageMoniker(),
                 target.DefinitionItem);
-
-        private static string GetDisplayContent(InheritanceTargetItem target, bool includeProjectName)
-        {
-            return includeProjectName && target.ProjectName != null
-                ? string.Format(FeaturesResources._0_1, target.DisplayName, target.ProjectName)
-                : target.DisplayName;
-        }
     }
 }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.InheritanceMargin;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph
 {
@@ -23,19 +24,33 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         /// </summary>
         public DefinitionItem.DetachedDefinitionItem DefinitionItem { get; }
 
+        public ImageMoniker LanguageMoniker { get; }
+
         // Internal for testing purpose
         internal TargetMenuItemViewModel(
             string displayContent,
             ImageMoniker imageMoniker,
-            DefinitionItem.DetachedDefinitionItem definitionItem) : base(displayContent, imageMoniker)
+            DefinitionItem.DetachedDefinitionItem definitionItem,
+            ImageMoniker languageMoniker) : base(displayContent, imageMoniker)
         {
             DefinitionItem = definitionItem;
+            LanguageMoniker = languageMoniker;
         }
 
         public static TargetMenuItemViewModel Create(InheritanceTargetItem target, string displayContent)
-            => new(
+        {
+            var languageGlyph = target.LanguageName switch
+            {
+                LanguageNames.CSharp => Glyph.CSharpFile,
+                LanguageNames.VisualBasic => Glyph.BasicFile,
+                _ => throw ExceptionUtilities.UnexpectedValue(target.LanguageName),
+            };
+
+            return new(
                 displayContent,
                 target.Glyph.GetImageMoniker(),
-                target.DefinitionItem);
+                target.DefinitionItem,
+                languageGlyph.GetImageMoniker());
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Drawing;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.InheritanceMargin;
@@ -23,21 +27,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         internal TargetMenuItemViewModel(
             string displayContent,
             ImageMoniker imageMoniker,
-            string automationName,
-            DefinitionItem.DetachedDefinitionItem definitionItem) : base(displayContent, imageMoniker, automationName)
+            DefinitionItem.DetachedDefinitionItem definitionItem) : base(displayContent, imageMoniker)
         {
             DefinitionItem = definitionItem;
         }
 
-        public static TargetMenuItemViewModel Create(InheritanceTargetItem target)
-        {
-            var displayContent = target.DisplayName;
-            var imageMoniker = target.Glyph.GetImageMoniker();
-            return new TargetMenuItemViewModel(
-                displayContent,
-                imageMoniker,
-                displayContent,
+        public static TargetMenuItemViewModel Create(InheritanceTargetItem target, bool includeProjectName)
+            => new(
+                GetDisplayContent(target, includeProjectName),
+                target.Glyph.GetImageMoniker(),
                 target.DefinitionItem);
+
+        private static string GetDisplayContent(InheritanceTargetItem target, bool includeProjectName)
+        {
+            return includeProjectName && target.ProjectName != null
+                ? string.Format(FeaturesResources._0_1, target.DisplayName, target.ProjectName)
+                : target.DisplayName;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/TargetMenuItemViewModel.cs
@@ -24,33 +24,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         /// </summary>
         public DefinitionItem.DetachedDefinitionItem DefinitionItem { get; }
 
-        public ImageMoniker LanguageMoniker { get; }
-
         // Internal for testing purpose
         internal TargetMenuItemViewModel(
             string displayContent,
             ImageMoniker imageMoniker,
-            DefinitionItem.DetachedDefinitionItem definitionItem,
-            ImageMoniker languageMoniker) : base(displayContent, imageMoniker)
+            DefinitionItem.DetachedDefinitionItem definitionItem) : base(displayContent, imageMoniker)
         {
             DefinitionItem = definitionItem;
-            LanguageMoniker = languageMoniker;
         }
 
         public static TargetMenuItemViewModel Create(InheritanceTargetItem target, string displayContent)
-        {
-            var languageGlyph = target.LanguageName switch
-            {
-                LanguageNames.CSharp => Glyph.CSharpFile,
-                LanguageNames.VisualBasic => Glyph.BasicFile,
-                _ => throw ExceptionUtilities.UnexpectedValue(target.LanguageName),
-            };
-
-            return new(
+            => new(
                 displayContent,
                 target.Glyph.GetImageMoniker(),
-                target.DefinitionItem,
-                languageGlyph.GetImageMoniker());
-        }
+                target.DefinitionItem);
     }
 }

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1940,4 +1940,8 @@ Additional information: {1}</value>
   <data name="Prefer_top_level_statements" xml:space="preserve">
     <value>Prefer top-level statements</value>
   </data>
+  <data name="_0_1" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</comment>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1942,6 +1942,6 @@ Additional information: {1}</value>
   </data>
   <data name="_0_1" xml:space="preserve">
     <value>{0} ({1})</value>
-    <comment>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</comment>
+    <comment>Used to show a symbol name, followed by the project name it came from</comment>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">Není platnou hodnotou.</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">{0} se dědí.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">Kein gültiger Wert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">"{0}" wird geerbt.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">No es un valor válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">"{0}" is heredado</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">Valeur non valide</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">« {0} » est hérité</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">Valore non valido</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}' è ereditato</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">有効な値ではありません</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}' が継承済み</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">값이 잘못되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}'이(가) 상속되었습니다.</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">Nieprawidłowa wartość</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">Dziedziczone: „{0}”</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">O valor não é válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}' é herdado</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">Недопустимое значение</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">"{0}" наследуется</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">Geçerli bir değer değil</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">'{0}' devralındı</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">值无效</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">已继承“{0}”</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1662,6 +1662,11 @@
         <target state="translated">值無效</target>
         <note />
       </trans-unit>
+      <trans-unit id="_0_1">
+        <source>{0} ({1})</source>
+        <target state="new">{0} ({1})</target>
+        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+      </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>
         <target state="translated">已繼承 '{0}'</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1665,7 +1665,7 @@
       <trans-unit id="_0_1">
         <source>{0} ({1})</source>
         <target state="new">{0} ({1})</target>
-        <note>Used to show a symbol name, followed by either a language name (like 'C#') or the project name it came from</note>
+        <note>Used to show a symbol name, followed by the project name it came from</note>
       </trans-unit>
       <trans-unit id="_0_is_inherited">
         <source>'{0}' is inherited</source>

--- a/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
@@ -13,6 +13,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.InheritanceMargin
 Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.Core.Imaging
 Imports Microsoft.VisualStudio.Imaging
 Imports Microsoft.VisualStudio.Imaging.Interop
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin
@@ -26,9 +27,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.InheritanceMargin
     <UseExportProvider>
     Public Class InheritanceMarginViewModelTests
 
-        Private Shared s_defaultMargin As Thickness = New Thickness(4, 1, 4, 1)
+        Private Shared ReadOnly s_defaultMargin As Thickness = New Thickness(4, 1, 4, 1)
 
-        Private Shared s_indentMargin As Thickness = New Thickness(22, 1, 4, 1)
+        Private Shared ReadOnly s_indentMargin As Thickness = New Thickness(22, 1, 4, 1)
+
+        Private Shared ReadOnly s_csharpImageId As ImageId = Microsoft.CodeAnalysis.Editor.Shared.Extensions.GlyphExtensions.GetImageCatalogImageId(KnownImageIds.CSFileNode)
+        Private Shared ReadOnly s_csharpImageMoniker As ImageMoniker = New ImageMoniker With {.Guid = s_csharpImageId.Guid, .Id = s_csharpImageId.Id}
 
         Private Structure GlyphViewModelData
             Public ReadOnly Property ImageMoniker As ImageMoniker
@@ -273,20 +277,20 @@ public class Bar3 : Bar2 {}"
 
             Dim tooltipTextForBar1 = String.Format(ServicesVSResources._0_is_inherited, "class Bar1")
             Dim targetForBar1 = ImmutableArray.Create(Of MenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden)).
-                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing)).Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing))
+                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker)).Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker))
 
             Dim tooltipTextForBar2 = String.Format(ServicesVSResources._0_is_inherited, "class Bar2")
 
             Dim targetForBar2 = ImmutableArray.Create(Of MenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding)).
-                    Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing)).
+                    Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker)).
                         Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden)).
-                    Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing))
+                    Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker))
 
             Dim tooltipTextForBar3 = String.Format(ServicesVSResources._0_is_inherited, "class Bar3")
             Dim targetForBar3 = ImmutableArray.Create(Of MenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding)).
-                Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing)).
-                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing))
+                Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker)).
+                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker))
 
             Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, GlyphViewModelData) From {
                 {2, New GlyphViewModelData(

--- a/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
@@ -272,21 +272,21 @@ public class Bar2 : Bar1 {}
 public class Bar3 : Bar2 {}"
 
             Dim tooltipTextForBar1 = String.Format(ServicesVSResources._0_is_inherited, "class Bar1")
-            Dim targetForBar1 = ImmutableArray.Create(Of MenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
-                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, "Bar2", Nothing)).Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, "Bar3", Nothing))
+            Dim targetForBar1 = ImmutableArray.Create(Of MenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden)).
+                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing)).Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing))
 
             Dim tooltipTextForBar2 = String.Format(ServicesVSResources._0_is_inherited, "class Bar2")
 
             Dim targetForBar2 = ImmutableArray.Create(Of MenuItemViewModel)(
-                New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
-                    Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, "Bar1", Nothing)).
-                        Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden, ServicesVSResources.Derived_types)).
-                    Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, "Bar3", Nothing))
+                New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding)).
+                    Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing)).
+                        Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden)).
+                    Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing))
 
             Dim tooltipTextForBar3 = String.Format(ServicesVSResources._0_is_inherited, "class Bar3")
-            Dim targetForBar3 = ImmutableArray.Create(Of MenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding, ServicesVSResources.Base_Types)).
-                Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, "Bar1", Nothing)).
-                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, "Bar2", Nothing))
+            Dim targetForBar3 = ImmutableArray.Create(Of MenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding)).
+                Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing)).
+                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing))
 
             Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, GlyphViewModelData) From {
                 {2, New GlyphViewModelData(

--- a/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
@@ -277,20 +277,20 @@ public class Bar3 : Bar2 {}"
 
             Dim tooltipTextForBar1 = String.Format(ServicesVSResources._0_is_inherited, "class Bar1")
             Dim targetForBar1 = ImmutableArray.Create(Of MenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden)).
-                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker)).Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker))
+                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing)).Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing))
 
             Dim tooltipTextForBar2 = String.Format(ServicesVSResources._0_is_inherited, "class Bar2")
 
             Dim targetForBar2 = ImmutableArray.Create(Of MenuItemViewModel)(
                 New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding)).
-                    Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker)).
+                    Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing)).
                         Add(New HeaderMenuItemViewModel(ServicesVSResources.Derived_types, KnownMonikers.Overridden)).
-                    Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker))
+                    Add(New TargetMenuItemViewModel("Bar3", KnownMonikers.ClassPublic, Nothing))
 
             Dim tooltipTextForBar3 = String.Format(ServicesVSResources._0_is_inherited, "class Bar3")
             Dim targetForBar3 = ImmutableArray.Create(Of MenuItemViewModel)(New HeaderMenuItemViewModel(ServicesVSResources.Base_Types, KnownMonikers.Overriding)).
-                Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker)).
-                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing, s_csharpImageMoniker))
+                Add(New TargetMenuItemViewModel("Bar1", KnownMonikers.ClassPublic, Nothing)).
+                Add(New TargetMenuItemViewModel("Bar2", KnownMonikers.ClassPublic, Nothing))
 
             Return VerifyAsync(markup, LanguageNames.CSharp, New Dictionary(Of Integer, GlyphViewModelData) From {
                 {2, New GlyphViewModelData(

--- a/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
@@ -31,9 +31,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.InheritanceMargin
 
         Private Shared ReadOnly s_indentMargin As Thickness = New Thickness(22, 1, 4, 1)
 
-        Private Shared ReadOnly s_csharpImageId As ImageId = Microsoft.CodeAnalysis.Editor.Shared.Extensions.GlyphExtensions.GetImageCatalogImageId(KnownImageIds.CSFileNode)
-        Private Shared ReadOnly s_csharpImageMoniker As ImageMoniker = New ImageMoniker With {.Guid = s_csharpImageId.Guid, .Id = s_csharpImageId.Id}
-
         Private Structure GlyphViewModelData
             Public ReadOnly Property ImageMoniker As ImageMoniker
             Public ReadOnly Property ToolTipText As String


### PR DESCRIPTION
Looks like this:

First, if the items are from different languages, we include the language name to make it clearer which one they come from:

![image](https://user-images.githubusercontent.com/4564579/165602326-b87a128e-2d17-4fd1-92cc-d8237322aa3b.png)

Then, if all the items are from the same language, we use project name to distinguish instead:

![image](https://user-images.githubusercontent.com/4564579/165604291-9a0b3d29-3414-4814-979b-dd8667b578c7.png)
