### PR TITLE
Adjust timeout on helix runs to 15 minutes to ensure dumps are captur…

### DIFF
--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -155,7 +155,7 @@ namespace RunTests
                 // figure out solutions for issues such as creating file paths in the correct format for the target machine.
                 var isUnix = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-                var commandLineArguments = _testExecutor.GetCommandLineArguments(assemblyInfo, useSingleQuotes: isUnix);
+                var commandLineArguments = _testExecutor.GetCommandLineArguments(assemblyInfo, useSingleQuotes: isUnix, isHelix: true);
                 commandLineArguments = SecurityElement.Escape(commandLineArguments);
                 var setEnvironmentVariable = isUnix ? "export" : "set";
 


### PR DESCRIPTION
…ed within the 30minute timeout of a helix run

See - https://github.com/dotnet/roslyn/pull/57549#discussion_r745197736

Was changed in https://github.com/dotnet/roslyn/pull/59783 to fix integration tests, but we should keep the old timeout for helix jobs.