### PR TITLE
Temporarily disable editorconfig tests on linux

### DIFF
--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 });
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/61017")]
         public void TestDiscoverEditorConfigFiles()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -428,7 +428,7 @@ some_prop = some_val");
                 }));
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/61017")]
         public void TestDiscoverEditorConfigFilesCanBeDisabled()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -456,7 +456,7 @@ some_prop = some_val");
                 expectedResults: AppendExtraEditorConfigs(new[] { "" }, findEditorConfigs: false));
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/61017")]
         public void TestDiscoverGlobalConfigFiles()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -490,7 +490,7 @@ some_prop = some_val");
                 }));
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/61017")]
         public void TestDiscoverGlobalConfigFilesCanBeDisabled()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -523,7 +523,7 @@ some_prop = some_val");
                 }, findGlobalConfigs: false));
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/61017")]
         public void TestDiscoverGlobalConfigFilesWhenEditorConfigDisabled()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -617,7 +617,7 @@ some_prop = some_val");
                  expectedResults: new[] { "" });
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/61017")]
         public void TestGlobalConfigsCanBeManuallyAdded()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
                 });
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
         public void TestDiscoverEditorConfigFiles()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -428,7 +428,7 @@ some_prop = some_val");
                 }));
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
         public void TestDiscoverEditorConfigFilesCanBeDisabled()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -456,7 +456,7 @@ some_prop = some_val");
                 expectedResults: AppendExtraEditorConfigs(new[] { "" }, findEditorConfigs: false));
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
         public void TestDiscoverGlobalConfigFiles()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -490,7 +490,7 @@ some_prop = some_val");
                 }));
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
         public void TestDiscoverGlobalConfigFilesCanBeDisabled()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -523,7 +523,7 @@ some_prop = some_val");
                 }, findGlobalConfigs: false));
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
         public void TestDiscoverGlobalConfigFilesWhenEditorConfigDisabled()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");
@@ -617,7 +617,7 @@ some_prop = some_val");
                  expectedResults: new[] { "" });
         }
 
-        [ConditionalFact(typeof(DotNetSdkAvailable))]
+        [ConditionalFact(typeof(DotNetSdkAvailable), typeof(WindowsOnly))]
         public void TestGlobalConfigsCanBeManuallyAdded()
         {
             var srcFile = ProjectDir.CreateFile("lib1.cs").WriteAllText("class C { }");


### PR DESCRIPTION
Tracking issue to re-enable

https://github.com/dotnet/roslyn/issues/61017


Due to failing runs, e.g.
https://dev.azure.com/dnceng/public/_build/results?buildId=1742521&view=ms.vss-test-web.build-test-results-tab&runId=47095474&resultId=157944&paneView=debug

Error message
```
System.UnauthorizedAccessException : Access to the path '/datadisks' is denied.
---- System.IO.IOException : Permission denied
```

Stack trace
```
   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
   at System.IO.Enumeration.FileSystemEnumerableFactory.FileInfos(String directory, String expression, EnumerationOptions options, Boolean isNormalized)
   at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.DirectoryInfo.GetFiles(String searchPattern, EnumerationOptions enumerationOptions)
   at Microsoft.CodeAnalysis.BuildTasks.UnitTests.DotNetSdkTests.AppendExtraEditorConfigs(String[] expected, Boolean findEditorConfigs, Boolean findGlobalConfigs) in /_/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs:line 570
   at Microsoft.CodeAnalysis.BuildTasks.UnitTests.DotNetSdkTests.TestDiscoverEditorConfigFilesCanBeDisabled() in /_/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs:line 440
----- Inner Stack Trace -----
```