### PR TITLE
Synthesize a method that throws when a method is deleted in EnC

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -641,6 +641,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            // Emit throwing methods for methods that have been deleted in an edit and continue session
+            if (_moduleBeingBuiltOpt != null && _moduleBeingBuiltOpt.IsEncDelta)
+            {
+                CompileDeletedMethods(containingType, compilationState);
+            }
+
             // Emit synthesized methods produced during lowering if any
             if (_moduleBeingBuiltOpt != null)
             {
@@ -803,6 +809,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (object)associatedPropertyOrEvent != null &&
                 associatedPropertyOrEvent.Kind == SymbolKind.Event &&
                 ((EventSymbol)associatedPropertyOrEvent).HasAssociatedField;
+        }
+
+        private void CompileDeletedMethods(NamedTypeSymbol containingType, TypeCompilationState compilationState)
+        {
+            Debug.Assert(_moduleBeingBuiltOpt != null);
+            Debug.Assert(_moduleBeingBuiltOpt.EncSymbolChanges != null);
+
+            var methodsToDelete = _moduleBeingBuiltOpt.EncSymbolChanges.GetDeletedMethods(containingType.GetCciAdapter());
+            foreach (var deletedMethod in methodsToDelete)
+            {
+                var methodSymbol = deletedMethod.GetISymbol().GetSymbol<MethodSymbol>();
+                var method = new SynthesizedDeletedMethod(methodSymbol, containingType);
+
+                method.GenerateMethodBody(compilationState, _diagnostics);
+
+                _moduleBeingBuiltOpt.AddSynthesizedDefinition(containingType, method.GetCciAdapter());
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDeletedMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDeletedMethod.cs
@@ -1,0 +1,192 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// Represents a method that has been deleted in an Edit and Continue session, and whose body
+    /// throws a System.MissingMethodException.
+    /// </summary>
+    internal sealed class SynthesizedDeletedMethod : MethodSymbol, ISynthesizedDeletedMethod
+    {
+        private readonly MethodSymbol _methodSymbol;
+        private readonly NamedTypeSymbol _containingTypeSymbol;
+
+        internal SynthesizedDeletedMethod(MethodSymbol methodSymbol, NamedTypeSymbol containingTypeSymbol)
+            : base()
+        {
+            _methodSymbol = methodSymbol;
+            _containingTypeSymbol = containingTypeSymbol;
+        }
+
+        // MethodSymbol properties that delegate through _containingTypeSymbol
+
+        internal override ModuleSymbol ContainingModule => _containingTypeSymbol.ContainingModule;
+
+        public override Symbol ContainingSymbol => _containingTypeSymbol;
+
+        public override AssemblySymbol ContainingAssembly => _containingTypeSymbol.ContainingAssembly;
+
+        public override NamespaceSymbol ContainingNamespace => _containingTypeSymbol.ContainingNamespace;
+
+        public override bool IsImplicitlyDeclared => true;
+
+        internal override bool SynthesizesLoweredBoundBody => true;
+
+        // MethodSymbol properties that delegate through _methodSymbol
+
+        public override string Name => _methodSymbol.Name;
+
+        public override MethodKind MethodKind => _methodSymbol.MethodKind;
+
+        public override int Arity => _methodSymbol.Arity;
+
+        public override bool IsExtensionMethod => _methodSymbol.IsExtensionMethod;
+
+        public override bool HidesBaseMethodsByName => _methodSymbol.HidesBaseMethodsByName;
+
+        public override bool IsVararg => _methodSymbol.IsVararg;
+
+        public override bool ReturnsVoid => _methodSymbol.ReturnsVoid;
+
+        public override bool IsAsync => _methodSymbol.IsAsync;
+
+        public override RefKind RefKind => _methodSymbol.RefKind;
+
+        public override TypeWithAnnotations ReturnTypeWithAnnotations => _methodSymbol.ReturnTypeWithAnnotations;
+
+        public override FlowAnalysisAnnotations ReturnTypeFlowAnalysisAnnotations => _methodSymbol.ReturnTypeFlowAnalysisAnnotations;
+
+        public override ImmutableHashSet<string> ReturnNotNullIfParameterNotNull => _methodSymbol.ReturnNotNullIfParameterNotNull;
+
+        public override FlowAnalysisAnnotations FlowAnalysisAnnotations => _methodSymbol.FlowAnalysisAnnotations;
+
+        public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations => _methodSymbol.TypeArgumentsWithAnnotations;
+
+        public override ImmutableArray<TypeParameterSymbol> TypeParameters => _methodSymbol.TypeParameters;
+
+        public override ImmutableArray<ParameterSymbol> Parameters => _methodSymbol.Parameters;
+
+        public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations => _methodSymbol.ExplicitInterfaceImplementations;
+
+        public override ImmutableArray<CustomModifier> RefCustomModifiers => _methodSymbol.RefCustomModifiers;
+
+        public override Symbol AssociatedSymbol => _methodSymbol.AssociatedSymbol;
+
+        public override bool AreLocalsZeroed => _methodSymbol.AreLocalsZeroed;
+
+        public override ImmutableArray<Location> Locations => _methodSymbol.Locations;
+
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _methodSymbol.DeclaringSyntaxReferences;
+
+        public override Accessibility DeclaredAccessibility => _methodSymbol.DeclaredAccessibility;
+
+        public override bool IsStatic => _methodSymbol.IsStatic;
+
+        public override bool IsVirtual => _methodSymbol.IsVirtual;
+
+        public override bool IsOverride => _methodSymbol.IsOverride;
+
+        public override bool IsAbstract => _methodSymbol.IsAbstract;
+
+        public override bool IsSealed => _methodSymbol.IsSealed;
+
+        public override bool IsExtern => _methodSymbol.IsExtern;
+
+        internal override bool HasSpecialName => _methodSymbol.HasSpecialName;
+
+        internal override MethodImplAttributes ImplementationAttributes => _methodSymbol.ImplementationAttributes;
+
+        internal override bool HasDeclarativeSecurity => _methodSymbol.HasDeclarativeSecurity;
+
+        internal override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation => _methodSymbol.ReturnValueMarshallingInformation;
+
+        internal override bool RequiresSecurityObject => _methodSymbol.RequiresSecurityObject;
+
+        internal override bool IsDeclaredReadOnly => _methodSymbol.IsDeclaredReadOnly;
+
+        internal override bool IsInitOnly => _methodSymbol.IsInitOnly;
+
+        internal override CallingConvention CallingConvention => _methodSymbol.CallingConvention;
+
+        internal override bool GenerateDebugInfo => _methodSymbol.GenerateDebugInfo;
+
+        internal override ObsoleteAttributeData ObsoleteAttributeData => _methodSymbol.ObsoleteAttributeData;
+
+        // Interesting MethodSymbol methods
+
+        internal override void GenerateMethodBody(TypeCompilationState compilationState, BindingDiagnosticBag diagnostics)
+        {
+            SyntheticBoundNodeFactory F = new SyntheticBoundNodeFactory(this, this.GetNonNullSyntaxNode(), compilationState, diagnostics);
+            F.CurrentFunction = this;
+
+            try
+            {
+                var className = _methodSymbol.ContainingType.Name;
+                var methodName = _methodSymbol.Name;
+
+                //throw new MissingMethodException(className, methodName);
+
+                //TODO: var body = F.Throw(F.New(F.WellKnownMethod(WellKnownMember.System_MissingMethodException__ctorStringString), ImmutableArray.Create<BoundExpression>(F.Parameter(className), F.Parameter(methodName))));
+
+                // NOTE: we created this block in its most-lowered form, so analysis is unnecessary
+                F.CloseMethod(F.ThrowNull());
+            }
+            catch (SyntheticBoundNodeFactory.MissingPredefinedMember ex)
+            {
+                diagnostics.Add(ex.Diagnostic);
+                F.CloseMethod(F.ThrowNull());
+            }
+        }
+
+        // MethodSymbol methods that delegate to _methodSymbol
+
+        public override DllImportData? GetDllImportData()
+        {
+            return _methodSymbol.GetDllImportData();
+        }
+
+        internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
+        {
+            return _methodSymbol.CalculateLocalSyntaxOffset(localPosition, localTree);
+        }
+
+        internal override ImmutableArray<string> GetAppliedConditionalSymbols()
+        {
+            return _methodSymbol.GetAppliedConditionalSymbols();
+        }
+
+        internal override IEnumerable<SecurityAttribute> GetSecurityInformation()
+        {
+            return _methodSymbol.GetSecurityInformation();
+        }
+
+        internal override UnmanagedCallersOnlyAttributeData? GetUnmanagedCallersOnlyAttributeData(bool forceComplete)
+        {
+            return _methodSymbol.GetUnmanagedCallersOnlyAttributeData(forceComplete);
+        }
+
+        internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
+        {
+            return _methodSymbol.IsMetadataNewSlot(ignoreInterfaceImplementationChanges);
+        }
+
+        internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false)
+        {
+            return _methodSymbol.IsMetadataVirtual(ignoreInterfaceImplementationChanges);
+        }
+
+        internal override bool IsNullableAnalysisEnabled()
+        {
+            return _methodSymbol.IsNullableAnalysisEnabled();
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.GenerationInfo.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.GenerationInfo.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
@@ -16,13 +17,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             public readonly MetadataReader MetadataReader;
             public readonly EmitBaseline Baseline;
             public readonly Action<GenerationVerifier> Verifier;
+            public readonly CompilationDifference? CompilationDifference;
 
-            public GenerationInfo(CSharpCompilation compilation, MetadataReader reader, EmitBaseline baseline, Action<GenerationVerifier> verifier)
+            public GenerationInfo(CSharpCompilation compilation, MetadataReader reader, CompilationDifference? diff, EmitBaseline baseline, Action<GenerationVerifier> verifier)
             {
                 Compilation = compilation;
                 MetadataReader = reader;
                 Baseline = baseline;
                 Verifier = verifier;
+                CompilationDifference = diff;
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.GenerationVerifier.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.GenerationVerifier.cs
@@ -18,12 +18,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             private readonly int _ordinal;
             private readonly MetadataReader _metadataReader;
             private readonly IEnumerable<MetadataReader> _readers;
+            private readonly GenerationInfo _generationInfo;
 
-            public GenerationVerifier(int ordinal, MetadataReader metadataReader, IEnumerable<MetadataReader> readers)
+            public GenerationVerifier(int ordinal, GenerationInfo generationInfo, IEnumerable<MetadataReader> readers)
             {
                 _ordinal = ordinal;
-                _metadataReader = metadataReader;
+                _metadataReader = generationInfo.MetadataReader;
                 _readers = readers;
+                _generationInfo = generationInfo;
             }
 
             private string GetAssertMessage(string message)
@@ -90,6 +92,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             internal void VerifyCustomAttributes(IEnumerable<CustomAttributeRow> expected)
             {
                 AssertEx.Equal(expected, _metadataReader.GetCustomAttributeRows(), itemInspector: AttributeRowToString);
+            }
+
+            internal void VerifyIL(string qualifiedMethodName, string expectedIL)
+            {
+                _generationInfo.CompilationDifference.VerifyIL(qualifiedMethodName, expectedIL);
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 
             var baseline = EmitBaseline.CreateInitialBaseline(md, EditAndContinueTestBase.EmptyLocalsProvider);
 
-            _generations.Add(new GenerationInfo(compilation, md.MetadataReader, baseline, validator));
+            _generations.Add(new GenerationInfo(compilation, md.MetadataReader, diff: null, baseline, validator));
 
             return this;
         }
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             var md = diff.GetMetadata();
             _disposables.Add(md);
 
-            _generations.Add(new GenerationInfo(compilation, md.Reader, diff.NextGeneration, validator));
+            _generations.Add(new GenerationInfo(compilation, md.Reader, diff, diff.NextGeneration, validator));
 
             return this;
         }
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
                 }
 
                 readers.Add(generation.MetadataReader);
-                var verifier = new GenerationVerifier(index, generation.MetadataReader, readers);
+                var verifier = new GenerationVerifier(index, generation, readers);
                 generation.Verifier(verifier);
 
                 index++;
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 
         private ImmutableArray<SemanticEdit> GetSemanticEdits(SemanticEditDescription[] edits, Compilation oldCompilation, Compilation newCompilation)
         {
-            return ImmutableArray.CreateRange(edits.Select(e => new SemanticEdit(e.Kind, e.SymbolProvider(oldCompilation), e.SymbolProvider(newCompilation))));
+            return ImmutableArray.CreateRange(edits.Select(e => new SemanticEdit(e.Kind, e.SymbolProvider(oldCompilation), e.SymbolProvider(newCompilation), newContainingType: e.ContainingTypeProvider?.Invoke(newCompilation))));
         }
 
         public void Dispose()

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
@@ -129,8 +129,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             return null;
         }
 
-        internal static SemanticEditDescription Edit(SemanticEditKind kind, Func<Compilation, ISymbol> symbolProvider)
-            => new(kind, symbolProvider);
+        internal static SemanticEditDescription Edit(SemanticEditKind kind, Func<Compilation, ISymbol> symbolProvider, Func<Compilation, ISymbol>? containingTypeProvider = null)
+            => new(kind, symbolProvider, containingTypeProvider);
 
         internal static EditAndContinueLogEntry Row(int rowNumber, TableIndex table, EditAndContinueOperation operation)
         {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -13121,12 +13121,19 @@ class C
         source: @"
 class C
 {
-    void F() { }
+    void M1() { }
+    void M2(string s) { }
+    void M3(C c) { }
+    void M4(N n) { }
+}
+
+class N
+{
 }",
         validator: g =>
         {
-            g.VerifyTypeDefNames("<Module>", "C");
-            g.VerifyMethodDefNames("F", ".ctor");
+            g.VerifyTypeDefNames("<Module>", "C", "N");
+            g.VerifyMethodDefNames("M1", "M2", "M3", "M4", ".ctor", ".ctor");
             g.VerifyMemberRefNames(/*CompilationRelaxationsAttribute.*/".ctor", /*RuntimeCompatibilityAttribute.*/".ctor", /*Object.*/".ctor", /*DebuggableAttribute*/".ctor");
         })
 
@@ -13134,34 +13141,56 @@ class C
         source: @"
 class C
 {
+}
+
+class N
+{
 }",
-        edits: new[] { Edit(SemanticEditKind.Delete, symbolProvider: c => c.GetMember("C.F"), containingTypeProvider: c => c.GetMember("C")) },
+        edits: new[] {
+            Edit(SemanticEditKind.Delete, symbolProvider: c => c.GetMember("C.M1"), containingTypeProvider: c => c.GetMember("C")),
+            Edit(SemanticEditKind.Delete, symbolProvider: c => c.GetMember("C.M2"), containingTypeProvider: c => c.GetMember("C")),
+            Edit(SemanticEditKind.Delete, symbolProvider: c => c.GetMember("C.M3"), containingTypeProvider: c => c.GetMember("C")),
+            Edit(SemanticEditKind.Delete, symbolProvider: c => c.GetMember("C.M4"), containingTypeProvider: c => c.GetMember("C")),
+        },
         validator: g =>
         {
             g.VerifyTypeDefNames();
-            g.VerifyMethodDefNames("F"); // Deleting F is an update to F
-            g.VerifyEncLog(new[]
+            g.VerifyMethodDefNames("M1", "M2", "M3", "M4");
+            g.VerifyEncLogDefinitions(new[]
             {
-                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(6, TableIndex.TypeRef, EditAndContinueOperation.Default),
                 Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(2, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(3, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(1, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(2, TableIndex.Param, EditAndContinueOperation.Default),
+                Row(3, TableIndex.Param, EditAndContinueOperation.Default)
             });
-            g.VerifyEncMap(new[]
+            g.VerifyEncMapDefinitions(new[]
             {
-                Handle(6, TableIndex.TypeRef),
                 Handle(1, TableIndex.MethodDef),
-                Handle(2, TableIndex.AssemblyRef)
+                Handle(2, TableIndex.MethodDef),
+                Handle(3, TableIndex.MethodDef),
+                Handle(4, TableIndex.MethodDef),
+                Handle(1, TableIndex.Param),
+                Handle(2, TableIndex.Param),
+                Handle(3, TableIndex.Param),
             });
 
-            // TODO: This should be throwing MissingMethodException
-            g.VerifyIL("C.F", @"
+            var expectedIL = @"
 {
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldnull
   IL_0001:  throw
 }
-");
+";
+
+            // TODO: This should be throwing MissingMethodException
+            g.VerifyIL("C.M1", expectedIL);
+            g.VerifyIL("C.M2(string)", expectedIL);
+            g.VerifyIL("C.M3(C)", expectedIL);
+            g.VerifyIL("C.M4(N)", expectedIL);
         })
                 .Verify();
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -13112,5 +13112,58 @@ class C
     IL_0002:  ret
 }");
         }
+
+        [Fact]
+        public void Delete_Method()
+        {
+            using var _ = new EditAndContinueTest(options: TestOptions.DebugDll, targetFramework: TargetFramework.NetStandard20)
+                .AddGeneration(
+        source: @"
+class C
+{
+    void F() { }
+}",
+        validator: g =>
+        {
+            g.VerifyTypeDefNames("<Module>", "C");
+            g.VerifyMethodDefNames("F", ".ctor");
+            g.VerifyMemberRefNames(/*CompilationRelaxationsAttribute.*/".ctor", /*RuntimeCompatibilityAttribute.*/".ctor", /*Object.*/".ctor", /*DebuggableAttribute*/".ctor");
+        })
+
+                .AddGeneration(
+        source: @"
+class C
+{
+}",
+        edits: new[] { Edit(SemanticEditKind.Delete, symbolProvider: c => c.GetMember("C.F"), containingTypeProvider: c => c.GetMember("C")) },
+        validator: g =>
+        {
+            g.VerifyTypeDefNames();
+            g.VerifyMethodDefNames("F"); // Deleting F is an update to F
+            g.VerifyEncLog(new[]
+            {
+                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
+                Row(6, TableIndex.TypeRef, EditAndContinueOperation.Default),
+                Row(1, TableIndex.MethodDef, EditAndContinueOperation.Default),
+            });
+            g.VerifyEncMap(new[]
+            {
+                Handle(6, TableIndex.TypeRef),
+                Handle(1, TableIndex.MethodDef),
+                Handle(2, TableIndex.AssemblyRef)
+            });
+
+            // TODO: This should be throwing MissingMethodException
+            g.VerifyIL("C.F", @"
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  IL_0000:  ldnull
+  IL_0001:  throw
+}
+");
+        })
+                .Verify();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SemanticEditDescription.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SemanticEditDescription.cs
@@ -11,13 +11,16 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
     {
         public readonly SemanticEditKind Kind;
         public readonly Func<Compilation, ISymbol> SymbolProvider;
+        public readonly Func<Compilation, ISymbol>? ContainingTypeProvider;
 
         public SemanticEditDescription(
             SemanticEditKind kind,
-            Func<Compilation, ISymbol> symbolProvider)
+            Func<Compilation, ISymbol> symbolProvider,
+            Func<Compilation, ISymbol>? containingTypeProvider = null)
         {
             Kind = kind;
             SymbolProvider = symbolProvider;
+            ContainingTypeProvider = containingTypeProvider;
         }
     }
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -333,8 +333,11 @@ namespace Microsoft.CodeAnalysis.Emit
                             // If a type has a single change that is a deletion, then nothing will be emitted
                             // for it, so we need to make sure we track the containing type of the delection
                             // from the new compilation, as containing changes.
-                            changesBuilder.Add(edit.NewContainingSymbol, SymbolChange.ContainsChanges);
-                            AddContainingTypesAndNamespaces(changesBuilder, edit.NewContainingSymbol);
+                            if (!changesBuilder.ContainsKey(edit.NewContainingSymbol))
+                            {
+                                changesBuilder.Add(edit.NewContainingSymbol, SymbolChange.ContainsChanges);
+                                AddContainingTypesAndNamespaces(changesBuilder, edit.NewContainingSymbol);
+                            }
                         }
                         continue;
 

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Cci;
-using Roslyn.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System;
+using Microsoft.Cci;
 using Microsoft.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
@@ -30,16 +30,44 @@ namespace Microsoft.CodeAnalysis.Emit
         /// </summary>
         private readonly ISet<ISymbol> _replacedSymbols;
 
+        /// <summary>
+        /// A set of symbols that have been deleted.
+        /// Populated based on semantic edits with <see cref="SemanticEditKind.Replace"/>.
+        /// </summary>
+        private readonly IReadOnlyDictionary<ISymbol, ISet<ISymbol>> _deletedSymbols;
+
         private readonly Func<ISymbol, bool> _isAddedSymbol;
 
         protected SymbolChanges(DefinitionMap definitionMap, IEnumerable<SemanticEdit> edits, Func<ISymbol, bool> isAddedSymbol)
         {
             _definitionMap = definitionMap;
             _isAddedSymbol = isAddedSymbol;
-            CalculateChanges(edits, out _changes, out _replacedSymbols);
+            CalculateChanges(edits, out _changes, out _replacedSymbols, out _deletedSymbols);
         }
 
         public DefinitionMap DefinitionMap => _definitionMap;
+
+        public IEnumerable<IMethodSymbolInternal> GetDeletedMethods(IDefinition containingType)
+        {
+            var containingSymbol = containingType.GetInternalSymbol()?.GetISymbol();
+            if (containingSymbol is null)
+            {
+                yield break;
+            }
+
+            if (!_deletedSymbols.TryGetValue(containingSymbol, out var deleted))
+            {
+                yield break;
+            }
+
+            foreach (var symbol in deleted)
+            {
+                if (GetISymbolInternalOrNull(symbol) is IMethodSymbolInternal method)
+                {
+                    yield return method;
+                }
+            }
+        }
 
         public bool IsReplaced(IDefinition definition)
         {
@@ -94,7 +122,13 @@ namespace Microsoft.CodeAnalysis.Emit
         public SymbolChange GetChange(IDefinition def)
         {
             var symbol = def.GetInternalSymbol();
-            if (symbol is ISynthesizedMethodBodyImplementationSymbol synthesizedSymbol)
+
+            if (symbol is ISynthesizedDeletedMethod)
+            {
+                // Deleting a method is always an update
+                return SymbolChange.Updated;
+            }
+            else if (symbol is ISynthesizedMethodBodyImplementationSymbol synthesizedSymbol)
             {
                 RoslynDebug.Assert(synthesizedSymbol.Method != null);
 
@@ -258,10 +292,11 @@ namespace Microsoft.CodeAnalysis.Emit
         /// Note that these changes only include user-defined source symbols, not synthesized symbols since those will be 
         /// generated during lowering of the changed user-defined symbols.
         /// </summary>
-        private static void CalculateChanges(IEnumerable<SemanticEdit> edits, out IReadOnlyDictionary<ISymbol, SymbolChange> changes, out ISet<ISymbol> replaceSymbols)
+        private static void CalculateChanges(IEnumerable<SemanticEdit> edits, out IReadOnlyDictionary<ISymbol, SymbolChange> changes, out ISet<ISymbol> replaceSymbols, out IReadOnlyDictionary<ISymbol, ISet<ISymbol>> deletedSymbols)
         {
             var changesBuilder = new Dictionary<ISymbol, SymbolChange>();
             HashSet<ISymbol>? lazyReplaceSymbolsBuilder = null;
+            Dictionary<ISymbol, ISet<ISymbol>>? lazyDeletedSymbolsBuilder = null;
 
             foreach (var edit in edits)
             {
@@ -284,7 +319,23 @@ namespace Microsoft.CodeAnalysis.Emit
                         break;
 
                     case SemanticEditKind.Delete:
-                        // No work to do.
+                        // We allow method deletions only at the moment
+                        if (edit.OldSymbol is IMethodSymbol && edit.NewContainingSymbol is not null)
+                        {
+                            Debug.Assert(edit.OldSymbol != null);
+                            lazyDeletedSymbolsBuilder ??= new();
+                            if (!lazyDeletedSymbolsBuilder.TryGetValue(edit.NewContainingSymbol, out var set))
+                            {
+                                set = new HashSet<ISymbol>();
+                                lazyDeletedSymbolsBuilder.Add(edit.NewContainingSymbol, set);
+                            }
+                            set.Add(edit.OldSymbol);
+                            // If a type has a single change that is a deletion, then nothing will be emitted
+                            // for it, so we need to make sure we track the containing type of the delection
+                            // from the new compilation, as containing changes.
+                            changesBuilder.Add(edit.NewContainingSymbol, SymbolChange.ContainsChanges);
+                            AddContainingTypesAndNamespaces(changesBuilder, edit.NewContainingSymbol);
+                        }
                         continue;
 
                     default:
@@ -317,6 +368,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
             changes = changesBuilder;
             replaceSymbols = lazyReplaceSymbolsBuilder ?? SpecializedCollections.EmptySet<ISymbol>();
+            deletedSymbols = lazyDeletedSymbolsBuilder ?? SpecializedCollections.EmptyReadOnlyDictionary<ISymbol, ISet<ISymbol>>();
         }
 
         private static void AddContainingTypesAndNamespaces(Dictionary<ISymbol, SymbolChange> changes, ISymbol symbol)

--- a/src/Compilers/Core/Portable/Emit/SemanticEdit.cs
+++ b/src/Compilers/Core/Portable/Emit/SemanticEdit.cs
@@ -32,6 +32,12 @@ namespace Microsoft.CodeAnalysis.Emit
         public ISymbol? NewSymbol { get; }
 
         /// <summary>
+        /// The symbol that matches the containing symbol of OldSymbol, but from
+        /// the later compilation. Used to turn deletes into updates.
+        /// </summary>
+        public ISymbol? NewContainingSymbol { get; }
+
+        /// <summary>
         /// A map from syntax node in the later compilation to syntax node in the previous compilation, 
         /// or null if <see cref="PreserveLocalVariables"/> is false and the map is not needed or 
         /// the source of the current method is the same as the source of the previous method.
@@ -72,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Emit
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="kind"/> is not a valid kind.
         /// </exception>
-        public SemanticEdit(SemanticEditKind kind, ISymbol? oldSymbol, ISymbol? newSymbol, Func<SyntaxNode, SyntaxNode?>? syntaxMap = null, bool preserveLocalVariables = false)
+        public SemanticEdit(SemanticEditKind kind, ISymbol? oldSymbol, ISymbol? newSymbol, Func<SyntaxNode, SyntaxNode?>? syntaxMap = null, bool preserveLocalVariables = false, ISymbol? newContainingType = null)
         {
             if (oldSymbol == null && kind is not (SemanticEditKind.Insert or SemanticEditKind.Replace))
             {
@@ -92,6 +98,7 @@ namespace Microsoft.CodeAnalysis.Emit
             Kind = kind;
             OldSymbol = oldSymbol;
             NewSymbol = newSymbol;
+            NewContainingSymbol = newContainingType;
             PreserveLocalVariables = preserveLocalVariables;
             SyntaxMap = syntaxMap;
         }

--- a/src/Compilers/Core/Portable/Symbols/ISynthesizedDeletedMethod.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISynthesizedDeletedMethod.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Symbols
+{
+    internal interface ISynthesizedDeletedMethod
+    {
+    }
+}


### PR DESCRIPTION
@cston and/or @RikkiGibson and/or @tmat if you could have a look at this I would most appreciate it. It's is just a start, and won't be merged, but I'm fairly outside my comfort zone in terms of the compiler stuff so thought I'd put it up for a sanity check to see if I'm heading in a reasonable direction.

The basic theory is that when a method is deleted during an Edit and Continue session, the compiler emits a method in its place that throws MissingMethodException. This will eventually be extended to more than just methods, and will allow renaming methods (ie, a rename can just be an add and a delete) etc. In future the method emitted might be smarter, perhaps trampolining to the new method for a rename, or if parameters are removed, etc.

Things still to do are many:
* Handle re-adding a method with the same name (needs to be an update, not an add)
* Actually emit the right exception
* Actually update the edit and continue analyzer to produce the right edits

There is enough here to review though, particularly because dealing with the symbols is a bit of a pain. Since we only get the `OldSymbol` for a delete, we can't match that up with anything from the new compilation, so I'm having to track an extra symbol in the edit, for the containing type, and when it comes to the metadata, I have to check for the explicit generated symbol for the deleted method. It doesn't seem to me to be horrible, but you might think differently.

I even added a test that passes!