### PR TITLE
Treat some nint/nuint conversions as standard conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1919,48 +1919,39 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        private static bool HasImplicitNumericConversion(TypeSymbol source, TypeSymbol destination)
+
+        private static ConversionKind? GetNumericConversion(TypeSymbol source, TypeSymbol destination)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)destination != null);
 
             if (!IsNumericType(source) || !IsNumericType(destination))
             {
-                return false;
+                return null;
             }
 
             if (source.SpecialType == destination.SpecialType)
             {
                 // Notice that there is no implicit numeric conversion from a type to itself. That's an
                 // identity conversion.
-                return false;
+                return null;
             }
 
             var conversionKind = ConversionEasyOut.ClassifyConversion(source, destination);
             Debug.Assert(conversionKind is ConversionKind.ImplicitNumeric or ConversionKind.ExplicitNumeric);
-            return conversionKind == ConversionKind.ImplicitNumeric;
+            return conversionKind;
+        }
+
+        private static bool HasImplicitNumericConversion(TypeSymbol source, TypeSymbol destination)
+        {
+            return GetNumericConversion(source, destination) == ConversionKind.ImplicitNumeric;
         }
 
         private static bool HasExplicitNumericConversion(TypeSymbol source, TypeSymbol destination)
         {
             // SPEC: The explicit numeric conversions are the conversions from a numeric-type to another 
             // SPEC: numeric-type for which an implicit numeric conversion does not already exist.
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)destination != null);
-
-            if (!IsNumericType(source) || !IsNumericType(destination))
-            {
-                return false;
-            }
-
-            if (source.SpecialType == destination.SpecialType)
-            {
-                return false;
-            }
-
-            var conversionKind = ConversionEasyOut.ClassifyConversion(source, destination);
-            Debug.Assert(conversionKind is ConversionKind.ImplicitNumeric or ConversionKind.ExplicitNumeric);
-            return conversionKind == ConversionKind.ExplicitNumeric;
+            return GetNumericConversion(source, destination) == ConversionKind.ExplicitNumeric;
         }
 
         private static bool IsConstantNumericZero(ConstantValue value)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1925,67 +1925,75 @@ namespace Microsoft.CodeAnalysis.CSharp
         // identity conversion.
         private static readonly bool[,] s_implicitNumericConversions =
         {
-            // to     sb  b  s  us i ui  l ul  c  f  d  m
+            // to     sb  b  s  us i ui  l ul  c  f  d  m n nu
             // from
             /* sb */
-         { F, F, T, F, T, F, T, F, F, T, T, T },
+         { F, F, T, F, T, F, T, F, F, T, T, T, T, F },
             /*  b */
-         { F, F, T, T, T, T, T, T, F, T, T, T },
+         { F, F, T, T, T, T, T, T, F, T, T, T, T, T },
             /*  s */
-         { F, F, F, F, T, F, T, F, F, T, T, T },
+         { F, F, F, F, T, F, T, F, F, T, T, T, T, F },
             /* us */
-         { F, F, F, F, T, T, T, T, F, T, T, T },
+         { F, F, F, F, T, T, T, T, F, T, T, T, T, T },
             /*  i */
-         { F, F, F, F, F, F, T, F, F, T, T, T },
+         { F, F, F, F, F, F, T, F, F, T, T, T, T, F },
             /* ui */
-         { F, F, F, F, F, F, T, T, F, T, T, T },
+         { F, F, F, F, F, F, T, T, F, T, T, T, F, T },
             /*  l */
-         { F, F, F, F, F, F, F, F, F, T, T, T },
+         { F, F, F, F, F, F, F, F, F, T, T, T, F, F },
             /* ul */
-         { F, F, F, F, F, F, F, F, F, T, T, T },
+         { F, F, F, F, F, F, F, F, F, T, T, T, F, F },
             /*  c */
-         { F, F, F, T, T, T, T, T, F, T, T, T },
+         { F, F, F, T, T, T, T, T, F, T, T, T, T, T },
             /*  f */
-         { F, F, F, F, F, F, F, F, F, F, T, F },
+         { F, F, F, F, F, F, F, F, F, F, T, F, F, F },
             /*  d */
-         { F, F, F, F, F, F, F, F, F, F, F, F },
+         { F, F, F, F, F, F, F, F, F, F, F, F, F, F },
             /*  m */
-         { F, F, F, F, F, F, F, F, F, F, F, F }
+         { F, F, F, F, F, F, F, F, F, F, F, F, F, F },
+            /*  n */
+         { F, F, F, F, F, F, T, F, F, T, T, T, F, F },
+            /*  nu */
+         { F, F, F, F, F, F, F, T, F, T, T, T, F, F }
         };
 
         private static readonly bool[,] s_explicitNumericConversions =
         {
-            // to     sb  b  s us  i ui  l ul  c  f  d  m
+            // to     sb  b  s us  i ui  l ul  c  f  d  m n nu
             // from
             /* sb */
-         { F, T, F, T, F, T, F, T, T, F, F, F },
+         { F, T, F, T, F, T, F, T, T, F, F, F, F, T },
             /*  b */
-         { T, F, F, F, F, F, F, F, T, F, F, F },
+         { T, F, F, F, F, F, F, F, T, F, F, F, F, F },
             /*  s */
-         { T, T, F, T, F, T, F, T, T, F, F, F },
+         { T, T, F, T, F, T, F, T, T, F, F, F, F, T },
             /* us */
-         { T, T, T, F, F, F, F, F, T, F, F, F },
+         { T, T, T, F, F, F, F, F, T, F, F, F, F, F },
             /*  i */
-         { T, T, T, T, F, T, F, T, T, F, F, F },
+         { T, T, T, T, F, T, F, T, T, F, F, F, F, T },
             /* ui */
-         { T, T, T, T, T, F, F, F, T, F, F, F },
+         { T, T, T, T, T, F, F, F, T, F, F, F, T, F },
             /*  l */
-         { T, T, T, T, T, T, F, T, T, F, F, F },
+         { T, T, T, T, T, T, F, T, T, F, F, F, T, T },
             /* ul */
-         { T, T, T, T, T, T, T, F, T, F, F, F },
+         { T, T, T, T, T, T, T, F, T, F, F, F, T, T },
             /*  c */
-         { T, T, T, F, F, F, F, F, F, F, F, F },
+         { T, T, T, F, F, F, F, F, F, F, F, F, F, F },
             /*  f */
-         { T, T, T, T, T, T, T, T, T, F, F, T },
+         { T, T, T, T, T, T, T, T, T, F, F, T, T, T },
             /*  d */
-         { T, T, T, T, T, T, T, T, T, T, F, T },
+         { T, T, T, T, T, T, T, T, T, T, F, T, T, T },
             /*  m */
-         { T, T, T, T, T, T, T, T, T, T, T, F }
+         { T, T, T, T, T, T, T, T, T, T, T, F, T, T },
+            /*  n */
+         { T, T, T, T, T, T, F, T, T, F, F, F, F, T },
+            /*  nu */
+         { T, T, T, T, T, T, T, F, T, F, F, F, T, F },
         };
 
-        private static int GetNumericTypeIndex(SpecialType specialType)
+        private static int GetNumericTypeIndex(TypeSymbol type)
         {
-            switch (specialType)
+            switch (type.SpecialType)
             {
                 case SpecialType.System_SByte: return 0;
                 case SpecialType.System_Byte: return 1;
@@ -1999,7 +2007,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SpecialType.System_Single: return 9;
                 case SpecialType.System_Double: return 10;
                 case SpecialType.System_Decimal: return 11;
-                default: return -1;
+                case SpecialType.System_IntPtr when type.IsNativeIntegerType: return 12;
+                case SpecialType.System_UIntPtr when type.IsNativeIntegerType: return 13;
+                default:
+                    Debug.Assert(!IsNumericType(type));
+                    return -1;
             }
         }
 
@@ -2009,21 +2021,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)source != null);
             Debug.Assert((object)destination != null);
 
-            int sourceIndex = GetNumericTypeIndex(source.SpecialType);
+            int sourceIndex = GetNumericTypeIndex(source);
             if (sourceIndex < 0)
             {
                 return false;
             }
 
-            int destinationIndex = GetNumericTypeIndex(destination.SpecialType);
+            int destinationIndex = GetNumericTypeIndex(destination);
             if (destinationIndex < 0)
             {
                 return false;
             }
 
+            Debug.Assert(sourceIndex == destinationIndex ||
+                s_implicitNumericConversions[sourceIndex, destinationIndex] != s_explicitNumericConversions[sourceIndex, destinationIndex]);
+
             return s_implicitNumericConversions[sourceIndex, destinationIndex];
         }
 
+        // TODO2 I'm not sure how to observe the change here...
         private static bool HasExplicitNumericConversion(TypeSymbol source, TypeSymbol destination)
         {
             // SPEC: The explicit numeric conversions are the conversions from a numeric-type to another 
@@ -2031,18 +2047,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)source != null);
             Debug.Assert((object)destination != null);
 
-            int sourceIndex = GetNumericTypeIndex(source.SpecialType);
+            int sourceIndex = GetNumericTypeIndex(source);
             if (sourceIndex < 0)
             {
                 return false;
             }
 
-            int destinationIndex = GetNumericTypeIndex(destination.SpecialType);
+            int destinationIndex = GetNumericTypeIndex(destination);
             if (destinationIndex < 0)
             {
                 return false;
             }
 
+            Debug.Assert(sourceIndex == destinationIndex ||
+                s_implicitNumericConversions[sourceIndex, destinationIndex] != s_explicitNumericConversions[sourceIndex, destinationIndex]);
+
+            // TODO2 consider removing this redundant table
             return s_explicitNumericConversions[sourceIndex, destinationIndex];
         }
 
@@ -2442,6 +2462,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new Conversion(ConversionKind.ExplicitNullable, Conversion.ImplicitNumericUnderlying);
             }
 
+            // TODO2 test this
             if (HasExplicitNumericConversion(unwrappedSource, unwrappedDestination))
             {
                 return new Conversion(ConversionKind.ExplicitNullable, Conversion.ExplicitNumericUnderlying);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1948,7 +1948,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)source != null);
             Debug.Assert((object)destination != null);
 
-
             if (!IsNumericType(source) || !IsNumericType(destination))
             {
                 return false;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1920,21 +1920,21 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #nullable enable
 
-        private static ConversionKind? GetNumericConversion(TypeSymbol source, TypeSymbol destination)
+        private static ConversionKind GetNumericConversion(TypeSymbol source, TypeSymbol destination)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)destination != null);
 
             if (!IsNumericType(source) || !IsNumericType(destination))
             {
-                return null;
+                return ConversionKind.UnsetConversionKind;
             }
 
             if (source.SpecialType == destination.SpecialType)
             {
                 // Notice that there is no implicit numeric conversion from a type to itself. That's an
                 // identity conversion.
-                return null;
+                return ConversionKind.UnsetConversionKind;
             }
 
             var conversionKind = ConversionEasyOut.ClassifyConversion(source, destination);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -10050,7 +10050,7 @@ $@"class MyInt
     public static implicit operator MyInt({type} i) => throw null;
 }}";
                 string sourceB =
-    @"class Program
+@"class Program
 {
     static void F(MyInt x, MyInt y)
     {
@@ -14427,7 +14427,6 @@ class C5 : I<(System.IntPtr A, System.UIntPtr[]? B)> { }
             verify(sourceType: "System.UIntPtr", destType: "nint", noConversion: true);
 
             // nint to type
-            //verify(sourceType: "nint", destType: "object", isExplicit: true); // user-defined conversions to or from a base type are not allowed
             verify(sourceType: "nint", destType: "string", noConversion: true);
             verify(sourceType: "nint", destType: "void*", noConversion: true);
             verify(sourceType: "nint", destType: "delegate*<void>", noConversion: true);
@@ -14475,7 +14474,6 @@ class C5 : I<(System.IntPtr A, System.UIntPtr[]? B)> { }
             verify(sourceType: "System.UIntPtr", destType: "nuint");
 
             // nuint to type
-            //verify(sourceType: "nuint", destType: "object", isExplicit: true); // user-defined conversions to or from a base type are not allowed
             verify(sourceType: "nuint", destType: "string", noConversion: true);
             verify(sourceType: "nuint", destType: "void*", noConversion: true);
             verify(sourceType: "nuint", destType: "delegate*<void>", noConversion: true);
@@ -14497,6 +14495,101 @@ class C5 : I<(System.IntPtr A, System.UIntPtr[]? B)> { }
             verify(sourceType: "nuint", destType: "nuint");
             verify(sourceType: "nuint", destType: "System.IntPtr", noConversion: true);
             verify(sourceType: "nuint", destType: "System.UIntPtr");
+
+
+            // type to System.IntPtr
+            verify(sourceType: "object", destType: "System.IntPtr", isExplicit: true);
+            verify(sourceType: "string", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "void*", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "delegate*<void>", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "E", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "bool", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "sbyte", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "byte", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "short", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "ushort", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "int", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "uint", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "long", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "ulong", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "char", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "float", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "double", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "decimal", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "nint", destType: "System.IntPtr");
+            verify(sourceType: "nuint", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "System.IntPtr");
+            verify(sourceType: "System.UIntPtr", destType: "System.IntPtr", noConversion: true);
+
+            // System.IntPtr to type
+            verify(sourceType: "System.IntPtr", destType: "string", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "void*", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "delegate*<void>", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "E", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "bool", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "sbyte", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "byte", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "short", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "ushort", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "int", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "uint", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "long", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "ulong", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "char", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "float", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "double", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "decimal", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "nint");
+            verify(sourceType: "System.IntPtr", destType: "nuint", noConversion: true);
+            verify(sourceType: "System.IntPtr", destType: "System.IntPtr");
+            verify(sourceType: "System.IntPtr", destType: "System.UIntPtr", noConversion: true);
+
+            // type to System.UIntPtr
+            verify(sourceType: "object", destType: "System.UIntPtr", isExplicit: true);
+            verify(sourceType: "string", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "void*", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "delegate*<void>", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "E", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "bool", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "sbyte", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "byte", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "short", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "ushort", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "int", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "uint", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "long", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "ulong", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "char", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "float", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "double", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "decimal", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "nint", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "nuint", destType: "System.UIntPtr");
+            verify(sourceType: "System.IntPtr", destType: "System.UIntPtr", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "System.UIntPtr");
+
+            // System.UIntPtr to type
+            verify(sourceType: "System.UIntPtr", destType: "string", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "void*", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "delegate*<void>", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "E", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "bool", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "sbyte", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "byte", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "short", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "ushort", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "int", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "uint", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "long", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "ulong", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "char", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "float", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "double", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "decimal", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "nint", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "nuint");
+            verify(sourceType: "System.UIntPtr", destType: "System.IntPtr", noConversion: true);
+            verify(sourceType: "System.UIntPtr", destType: "System.UIntPtr");
 
             void verify(string sourceType, string destType, bool noConversion = false, bool isExplicit = false)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;


### PR DESCRIPTION
See https://github.com/dotnet/csharpstandard/blob/draft-v7/standard/conversions.md#1042-standard-implicit-conversions

For reference: https://github.com/dotnet/csharplang/blob/main/proposals/csharp-9.0/native-integers.md#conversions