### PR TITLE
Prevent EnC error when changing partial methods with lambdas

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Emit
         private SymbolChange GetChange(ISymbol symbol)
         {
             // In CalculateChanges we always store definitions for partial methods, so we have to
-            // make sure we do the same thing here when we try to retreive a change, as the compiler
+            // make sure we do the same thing here when we try to retrieve a change, as the compiler
             // associates synthesized methods with the implementation of the method that caused it
             // to be generated.
             if (symbol is IMethodSymbol method)

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -191,6 +191,15 @@ namespace Microsoft.CodeAnalysis.Emit
 
         private SymbolChange GetChange(ISymbol symbol)
         {
+            // In CalculateChanges we always store definitions for partial methods, so we have to
+            // make sure we do the same thing here when we try to retreive a change, as the compiler
+            // associates synthesized methods with the implementation of the method that caused it
+            // to be generated.
+            if (symbol is IMethodSymbol method)
+            {
+                symbol = method.PartialDefinitionPart ?? symbol;
+            }
+
             if (_changes.TryGetValue(symbol, out var change))
             {
                 return change;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/60804