### PR TITLE
[LSP] Null check semantic tokens workspace capability

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             {
                 if (_supportsRefresh == null)
                 {
-                    _supportsRefresh = context.ClientCapabilities.Workspace?.SemanticTokens.RefreshSupport is true;
+                    _supportsRefresh = context.ClientCapabilities.Workspace?.SemanticTokens?.RefreshSupport is true;
 
                     if (_supportsRefresh.Value)
                     {


### PR DESCRIPTION
The client didn't implement this capability until 17.3 so the `SemanticTokens` workspace capability returns null in 17.2 and prior. This breaks F5'ing in Roslyn for external contributors.

I think this simple fix should do the trick, currently installing latest preview to confirm.