### PR TITLE
RazorLineFormattingOptions

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/Razor/Api/Extensions.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Razor/Api/Extensions.cs
@@ -8,17 +8,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Api
 {
     internal static class Extensions
     {
-        private const string RazorCSharp = "RazorCSharp";
-
         public static bool IsRazorDocument(this Document document)
-        {
-            var documentPropertiesService = document.Services.GetService<DocumentPropertiesService>();
-            if (documentPropertiesService != null && documentPropertiesService.DiagnosticsLspClientName == RazorCSharp)
-            {
-                return true;
-            }
-
-            return false;
-        }
+            => Host.Extensions.IsRazorDocument(document);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 var isActiveDocument = _documentTrackingService.TryGetActiveDocument() == document.Id;
                 var isOpenDocument = document.IsOpen();
-                var isGeneratedRazorDocument = document.Services.GetService<DocumentPropertiesService>()?.DiagnosticsLspClientName != null;
+                var isGeneratedRazorDocument = document.IsRazorDocument();
 
                 // Only analyze open/active documents, unless it is a generated Razor document.
                 if (!isActiveDocument && !isOpenDocument && !isGeneratedRazorDocument)

--- a/src/Features/LanguageServer/Protocol/Features/Options/RazorLineFormattingOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/RazorLineFormattingOptionsStorage.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Formatting;
+
+/// <summary>
+/// Formatting options for Razor design-time documents.
+/// </summary>
+internal class RazorLineFormattingOptionsStorage
+{
+    internal static readonly Option2<bool> UseTabs = new(
+        "RazorDesignTimeDocumentFormattingOptions", "UseTabs", LineFormattingOptions.Default.UseTabs);
+
+    internal static readonly Option2<int> TabSize = new(
+        "RazorDesignTimeDocumentFormattingOptions", "TabSize", LineFormattingOptions.Default.TabSize);
+}

--- a/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
@@ -75,5 +75,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             public void SetOptions(OptionSet optionSet) => throw new NotImplementedException();
             public bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey) => throw new NotImplementedException();
             public void UnregisterWorkspace(Workspace workspace) => throw new NotImplementedException();
+        }
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorGlobalOptions.cs
@@ -29,6 +29,18 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         public RazorAutoFormattingOptions GetAutoFormattingOptions()
             => new(_globalOptions.GetAutoFormattingOptions(LanguageNames.CSharp));
 
+        public bool UseTabs
+        {
+            get => _globalOptions.GetOption(RazorLineFormattingOptionsStorage.UseTabs);
+            set => _globalOptions.SetGlobalOption(new OptionKey(RazorLineFormattingOptionsStorage.UseTabs), value);
+        }
+
+        public int TabSize
+        {
+            get => _globalOptions.GetOption(RazorLineFormattingOptionsStorage.TabSize);
+            set => _globalOptions.SetGlobalOption(new OptionKey(RazorLineFormattingOptionsStorage.TabSize), value);
+        }
+
 #pragma warning disable IDE0060 // Remove unused parameter
         /// <summary>
         /// For testing purposes only. Razor does not use MEF composition for host services so we need to return a mock.
@@ -63,6 +75,5 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             public void SetOptions(OptionSet optionSet) => throw new NotImplementedException();
             public bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey) => throw new NotImplementedException();
             public void UnregisterWorkspace(Workspace workspace) => throw new NotImplementedException();
-        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/Extensions.cs
@@ -8,6 +8,8 @@ namespace Microsoft.CodeAnalysis.Host
 {
     internal static class Extensions
     {
+        private const string RazorCSharp = "RazorCSharp";
+
         public static bool CanApplyChange([NotNullWhen(returnValue: true)] this TextDocument? document)
             => document?.State.CanApplyChange() ?? false;
 
@@ -19,5 +21,8 @@ namespace Microsoft.CodeAnalysis.Host
 
         public static bool SupportsDiagnostics([NotNullWhen(returnValue: true)] this TextDocumentState? document)
             => document?.Services.GetService<IDocumentOperationService>()?.SupportDiagnostics ?? false;
+
+        public static bool IsRazorDocument(this TextDocument document)
+            => document.Services.GetService<DocumentPropertiesService>()?.DiagnosticsLspClientName == RazorCSharp;
     }
 }


### PR DESCRIPTION
Add global formatting options (use tabs, tab size) to apply to Razor design-time documents.

This will replace `IDocumentOptionsProviderFactory` in future.

Razor follow up: https://github.com/dotnet/razor-tooling/pull/6338