### PR TITLE
Remove extra new line character from end of file

### DIFF
--- a/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
+++ b/src/Dependencies/Collections/RoslynImmutableInterlocked.cs
@@ -486,4 +486,3 @@ namespace Microsoft.CodeAnalysis.Collections
         }
     }
 }
-


### PR DESCRIPTION
This PR removes a single new line character to help with an analyzer change in msbuild.
Relates to https://github.com/dotnet/msbuild/pull/7571

Associated analyzer that someone might want to implement in roslyn:
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md