### PR TITLE
Share SyntaxContext among all internal CompletionProviders

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionContext.cs
+++ b/src/Features/Core/Portable/Completion/CompletionContext.cs
@@ -7,8 +7,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Completion
 {
@@ -33,6 +36,12 @@ namespace Microsoft.CodeAnalysis.Completion
         /// The caret position when completion was triggered.
         /// </summary>
         public int Position { get; }
+
+        /// <summary>
+        /// By providing this object, we have an opportunity to share requested SyntaxContext among all CompletionProviders
+        /// during a completion session to reduce repeat computation.
+        /// </summary>
+        private SharedSyntaxContextsWithSpeculativeModel? SharedSyntaxContextsWithSpeculativeModel { get; }
 
         /// <summary>
         /// The span of the syntax element at the caret position.
@@ -111,6 +120,7 @@ namespace Microsoft.CodeAnalysis.Completion
             : this(provider ?? throw new ArgumentNullException(nameof(provider)),
                    document ?? throw new ArgumentNullException(nameof(document)),
                    position,
+                   sharedSyntaxContextsWithSpeculativeModel: null,
                    defaultSpan,
                    trigger,
                    // Publicly available options do not affect this API.
@@ -129,6 +139,7 @@ namespace Microsoft.CodeAnalysis.Completion
             CompletionProvider provider,
             Document document,
             int position,
+            SharedSyntaxContextsWithSpeculativeModel? sharedSyntaxContextsWithSpeculativeModel,
             TextSpan defaultSpan,
             CompletionTrigger trigger,
             in CompletionOptions options,
@@ -142,6 +153,8 @@ namespace Microsoft.CodeAnalysis.Completion
             CompletionOptions = options;
             CancellationToken = cancellationToken;
             _items = new List<CompletionItem>();
+
+            SharedSyntaxContextsWithSpeculativeModel = sharedSyntaxContextsWithSpeculativeModel;
 
 #pragma warning disable RS0030 // Do not used banned APIs
             Options = OptionValueSet.Empty;
@@ -200,6 +213,14 @@ namespace Microsoft.CodeAnalysis.Completion
 
                 _suggestionModeItem = value;
             }
+        }
+
+        internal Task<SyntaxContext?> GetSyntaxContextWithExistingSpeculativeModelAsync(Document document, CancellationToken cancellationToken)
+        {
+            if (SharedSyntaxContextsWithSpeculativeModel is null)
+                return CompletionHelper.CreateSyntaxContextWithExistingSpeculativeModelAsync(document, Position, cancellationToken);
+
+            return SharedSyntaxContextsWithSpeculativeModel.GetSyntaxContextAsync(document, cancellationToken);
         }
 
         private CompletionItem FixItem(CompletionItem item)

--- a/src/Features/Core/Portable/Completion/CompletionContext.cs
+++ b/src/Features/Core/Portable/Completion/CompletionContext.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Completion
             }
         }
 
-        internal Task<SyntaxContext?> GetSyntaxContextWithExistingSpeculativeModelAsync(Document document, CancellationToken cancellationToken)
+        internal Task<SyntaxContext> GetSyntaxContextWithExistingSpeculativeModelAsync(Document document, CancellationToken cancellationToken)
         {
             if (SharedSyntaxContextsWithSpeculativeModel is null)
                 return CompletionHelper.CreateSyntaxContextWithExistingSpeculativeModelAsync(document, Position, cancellationToken);

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -482,11 +482,9 @@ namespace Microsoft.CodeAnalysis.Completion
             }
         }
 
-        public static async Task<SyntaxContext?> CreateSyntaxContextWithExistingSpeculativeModelAsync(Document document, int position, CancellationToken cancellationToken)
+        public static async Task<SyntaxContext> CreateSyntaxContextWithExistingSpeculativeModelAsync(Document document, int position, CancellationToken cancellationToken)
         {
-            if (!document.SupportsSemanticModel)
-                return null;
-
+            Contract.ThrowIfFalse(document.SupportsSemanticModel, "Should only be called from C#/VB providers.");
             var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
 
             var service = document.GetRequiredLanguageService<ISyntaxContextService>();

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -7,7 +7,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PatternMatching;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -476,6 +480,17 @@ namespace Microsoft.CodeAnalysis.Completion
                     initialTriggerKind == CompletionTriggerKind.Invoke ||
                     initialTriggerKind == CompletionTriggerKind.Deletion;
             }
+        }
+
+        public static async Task<SyntaxContext?> CreateSyntaxContextWithExistingSpeculativeModelAsync(Document document, int position, CancellationToken cancellationToken)
+        {
+            if (!document.SupportsSemanticModel)
+                return null;
+
+            var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
+
+            var service = document.GetRequiredLanguageService<ISyntaxContextService>();
+            return service.CreateContext(document, semanticModel, position, cancellationToken);
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -16,6 +17,7 @@ using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -146,10 +148,14 @@ namespace Microsoft.CodeAnalysis.Completion
             var additionalAugmentingProviders = await GetAugmentingProviders(document, triggeredProviders, caretPosition, trigger, options, cancellationToken).ConfigureAwait(false);
             triggeredProviders = triggeredProviders.Except(additionalAugmentingProviders).ToImmutableArray();
 
+            // PERF: Many CompletionProviders compute identical contexts. This actually shows up on the 2-core typing test.
+            // so we try to share a single SyntaxContext based on document/caretPosition among all providers to reduce repeat computation.
+            var sharedContext = new SharedSyntaxContextsWithSpeculativeModel(document, caretPosition);
+
             // Now, ask all the triggered providers, in parallel, to populate a completion context.
             // Note: we keep any context with items *or* with a suggested item.  
             var triggeredContexts = await ComputeNonEmptyCompletionContextsAsync(
-                document, caretPosition, trigger, options, defaultItemSpan, triggeredProviders, cancellationToken).ConfigureAwait(false);
+                document, caretPosition, trigger, options, defaultItemSpan, triggeredProviders, sharedContext, cancellationToken).ConfigureAwait(false);
 
             // Nothing to do if we didn't even get any regular items back (i.e. 0 items or suggestion item only.)
             if (!triggeredContexts.Any(cc => cc.Items.Count > 0))
@@ -168,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Completion
             var augmentingProviders = providers.Except(triggeredProviders).ToImmutableArray();
 
             var augmentingContexts = await ComputeNonEmptyCompletionContextsAsync(
-                document, caretPosition, trigger, options, defaultItemSpan, augmentingProviders, cancellationToken).ConfigureAwait(false);
+                document, caretPosition, trigger, options, defaultItemSpan, augmentingProviders, sharedContext, cancellationToken).ConfigureAwait(false);
 
             GC.KeepAlive(semanticModel);
 
@@ -303,6 +309,7 @@ namespace Microsoft.CodeAnalysis.Completion
             Document document, int caretPosition, CompletionTrigger trigger,
             CompletionOptions options, TextSpan defaultItemSpan,
             ImmutableArray<CompletionProvider> providers,
+            SharedSyntaxContextsWithSpeculativeModel sharedContext,
             CancellationToken cancellationToken)
         {
             var completionContextTasks = new List<Task<CompletionContext>>();
@@ -310,7 +317,7 @@ namespace Microsoft.CodeAnalysis.Completion
             {
                 completionContextTasks.Add(GetContextAsync(
                     provider, document, caretPosition, trigger,
-                    options, defaultItemSpan, cancellationToken));
+                    options, defaultItemSpan, sharedContext, cancellationToken));
             }
 
             var completionContexts = await Task.WhenAll(completionContextTasks).ConfigureAwait(false);
@@ -399,9 +406,10 @@ namespace Microsoft.CodeAnalysis.Completion
             CompletionTrigger triggerInfo,
             CompletionOptions options,
             TextSpan defaultSpan,
+            SharedSyntaxContextsWithSpeculativeModel? sharedContext,
             CancellationToken cancellationToken)
         {
-            var context = new CompletionContext(provider, document, position, defaultSpan, triggerInfo, options, cancellationToken);
+            var context = new CompletionContext(provider, document, position, sharedContext, defaultSpan, triggerInfo, options, cancellationToken);
             await provider.ProvideCompletionsAsync(context).ConfigureAwait(false);
             return context;
         }
@@ -562,6 +570,7 @@ namespace Microsoft.CodeAnalysis.Completion
                     triggerInfo,
                     options,
                     defaultItemSpan,
+                    sharedContext: null,
                     cancellationToken).ConfigureAwait(false);
             }
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -178,7 +178,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             foreach (var relatedId in relatedDocumentIds)
             {
                 var relatedDocument = document.Project.Solution.GetRequiredDocument(relatedId);
-                var context = await CreateContextAsync(relatedDocument, position, cancellationToken).ConfigureAwait(false);
+                var context = await CompletionHelper.CreateSyntaxContextWithExistingSpeculativeModelAsync(relatedDocument, position, cancellationToken).ConfigureAwait(false) as TSyntaxContext;
+                Contract.ThrowIfNull(context);
                 var symbols = await TryGetSymbolsForContextAsync(completionContext: null, context, options, cancellationToken).ConfigureAwait(false);
 
                 if (!symbols.IsDefault)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -27,11 +27,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
     internal abstract partial class AbstractSymbolCompletionProvider<TSyntaxContext> : LSPCompletionProvider
         where TSyntaxContext : SyntaxContext
     {
-        // PERF: Many CompletionProviders derive AbstractSymbolCompletionProvider and therefore
-        // compute identical contexts. This actually shows up on the 2-core typing test.
-        // Cache the most recent document/position/computed SyntaxContext to reduce repeat computation.
-        private static readonly ConditionalWeakTable<Document, Tuple<int, AsyncLazy<TSyntaxContext>>> s_cachedDocuments = new();
-
         protected AbstractSymbolCompletionProvider()
         {
         }
@@ -261,9 +256,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 using (Logger.LogBlock(FunctionId.Completion_SymbolCompletionProvider_GetItemsWorker, cancellationToken))
                 using (var telemetryCounter = new TelemetryCounter(ShouldCollectTelemetryForTargetTypeCompletion && options.TargetTypedCompletionFilter))
                 {
-                    var syntaxContext = await GetOrCreateContextAsync(document, position, cancellationToken).ConfigureAwait(false);
-                    var regularItems = await GetItemsAsync(completionContext, syntaxContext, document, position, options, telemetryCounter, cancellationToken).ConfigureAwait(false);
+                    var syntaxContext = await completionContext.GetSyntaxContextWithExistingSpeculativeModelAsync(document, cancellationToken).ConfigureAwait(false) as TSyntaxContext;
+                    Contract.ThrowIfNull(syntaxContext);
 
+                    var regularItems = await GetItemsAsync(completionContext, syntaxContext, document, position, options, telemetryCounter, cancellationToken).ConfigureAwait(false);
                     completionContext.AddItems(regularItems);
                 }
             }
@@ -290,7 +286,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 return CreateItems(completionContext, itemsForCurrentDocument, _ => syntaxContext, invalidProjectMap: null, totalProjects: null, telemetryCounter);
             }
 
-            var contextAndSymbolLists = await GetPerContextSymbolsAsync(completionContext, document, position, options, new[] { document.Id }.Concat(relatedDocumentIds), cancellationToken).ConfigureAwait(false);
+            var contextAndSymbolLists = await GetPerContextSymbolsAsync(completionContext, document, options, new[] { document.Id }.Concat(relatedDocumentIds), cancellationToken).ConfigureAwait(false);
             var symbolToContextMap = UnionSymbols(contextAndSymbolLists);
             var missingSymbolsMap = FindSymbolsMissingInLinkedContexts(symbolToContextMap, contextAndSymbolLists);
             var totalProjects = contextAndSymbolLists.Select(t => t.documentId.ProjectId).ToList();
@@ -327,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         private async Task<ImmutableArray<(DocumentId documentId, TSyntaxContext syntaxContext, ImmutableArray<(ISymbol symbol, bool preselect)> symbols)>> GetPerContextSymbolsAsync(
-            CompletionContext completionContext, Document document, int position, CompletionOptions options, IEnumerable<DocumentId> relatedDocuments, CancellationToken cancellationToken)
+            CompletionContext completionContext, Document document, CompletionOptions options, IEnumerable<DocumentId> relatedDocuments, CancellationToken cancellationToken)
         {
             var solution = document.Project.Solution;
 
@@ -339,7 +335,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 tasks.Add(Task.Run(async () =>
                 {
                     var relatedDocument = solution.GetRequiredDocument(relatedDocumentId);
-                    var syntaxContext = await GetOrCreateContextAsync(relatedDocument, position, cancellationToken).ConfigureAwait(false);
+                    var syntaxContext = await completionContext.GetSyntaxContextWithExistingSpeculativeModelAsync(relatedDocument, cancellationToken).ConfigureAwait(false) as TSyntaxContext;
+
+                    Contract.ThrowIfNull(syntaxContext);
                     var symbols = await TryGetSymbolsForContextAsync(completionContext, syntaxContext, options, cancellationToken).ConfigureAwait(false);
 
                     return (relatedDocument.Id, syntaxContext, symbols);
@@ -368,33 +366,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return syntaxFacts.IsInInactiveRegion(syntaxContext.SyntaxTree, syntaxContext.Position, cancellationToken)
                 ? default
                 : await GetSymbolsAsync(completionContext, syntaxContext, syntaxContext.Position, options, cancellationToken).ConfigureAwait(false);
-        }
-
-        protected static async Task<TSyntaxContext> CreateContextAsync(Document document, int position, CancellationToken cancellationToken)
-        {
-            var semanticModel = await document.ReuseExistingSpeculativeModelAsync(position, cancellationToken).ConfigureAwait(false);
-
-            var service = document.GetRequiredLanguageService<ISyntaxContextService>();
-            return (TSyntaxContext)service.CreateContext(document, semanticModel, position, cancellationToken);
-        }
-
-        private static Task<TSyntaxContext> GetOrCreateContextAsync(Document document, int position, CancellationToken cancellationToken)
-        {
-            lock (s_cachedDocuments)
-            {
-                var (cachedPosition, cachedLazyContext) = s_cachedDocuments.GetValue(
-                    document, d => Tuple.Create(position, new AsyncLazy<TSyntaxContext>(ct => CreateContextAsync(d, position, ct), cacheResult: true)));
-
-                if (cachedPosition == position)
-                {
-                    return cachedLazyContext.GetValueAsync(cancellationToken);
-                }
-
-                var lazyContext = new AsyncLazy<TSyntaxContext>(ct => CreateContextAsync(document, position, ct), cacheResult: true);
-                s_cachedDocuments.Remove(document);
-                s_cachedDocuments.Add(document, Tuple.Create(position, lazyContext));
-                return lazyContext.GetValueAsync(cancellationToken);
-            }
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Completion/SharedSyntaxContextsWithSpeculativeModel.cs
+++ b/src/Features/Core/Portable/Completion/SharedSyntaxContextsWithSpeculativeModel.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Completion
+{
+    internal sealed class SharedSyntaxContextsWithSpeculativeModel
+    {
+        public Document Document { get; }
+        public int Position { get; }
+
+        private readonly ConcurrentDictionary<Document, AsyncLazy<SyntaxContext?>> _cache;
+        private readonly Lazy<ImmutableArray<DocumentId>> _lazyRelatedDocumentIds;
+
+        public SharedSyntaxContextsWithSpeculativeModel(Document document, int position)
+        {
+            Document = document;
+            Position = position;
+            _cache = new();
+            _lazyRelatedDocumentIds = new(Document.GetLinkedDocumentIds, isThreadSafe: true);
+        }
+
+        public Task<SyntaxContext?> GetSyntaxContextAsync(Document document, CancellationToken cancellationToken)
+        {
+            if (!_cache.TryGetValue(document, out var lazyContext))
+            {
+                if (Document.Id != document.Id || !_lazyRelatedDocumentIds.Value.Contains(document.Id))
+                    throw new ArgumentException("Don't support getting SyntaxContext for document unrelated to the original document");
+
+                lazyContext = GetLazySyntaxContextWithSpeculativeModel(document, Position);
+            }
+
+            return lazyContext.GetValueAsync(cancellationToken);
+        }
+
+        private AsyncLazy<SyntaxContext?> GetLazySyntaxContextWithSpeculativeModel(Document document, int position)
+        {
+            return _cache.GetOrAdd(document, d => AsyncLazy.Create(cancellationToken
+                => CompletionHelper.CreateSyntaxContextWithExistingSpeculativeModelAsync(document, position, cancellationToken), cacheResult: true));
+        }
+    }
+}


### PR DESCRIPTION
via CompletionContext during a completion session to reduce repeat computation.

Fixes [AB#1460014](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1460014)