### PR TITLE
Move 'Identifiers' out of metadata about an embedded lang classifier

### DIFF
--- a/src/Features/CSharp/Portable/EmbeddedLanguages/CSharpJsonEmbeddedLanguageClassifier.cs
+++ b/src/Features/CSharp/Portable/EmbeddedLanguages/CSharpJsonEmbeddedLanguageClassifier.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 namespace Microsoft.CodeAnalysis.CSharp.Features.EmbeddedLanguages
 {
     [ExportEmbeddedLanguageClassifierInternal(
-        PredefinedEmbeddedLanguageClassifierNames.Json, LanguageNames.CSharp, supportsUnannotatedAPIs: true, "Json"), Shared]
+        PredefinedEmbeddedLanguageClassifierNames.Json, LanguageNames.CSharp, supportsUnannotatedAPIs: true), Shared]
     internal class CSharpJsonEmbeddedLanguageClassifier : AbstractJsonEmbeddedLanguageClassifier
     {
         [ImportingConstructor]

--- a/src/Features/CSharp/Portable/EmbeddedLanguages/CSharpRegexEmbeddedLanguageClassifier.cs
+++ b/src/Features/CSharp/Portable/EmbeddedLanguages/CSharpRegexEmbeddedLanguageClassifier.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Features.EmbeddedLanguages
     // want that to happen for APIs that are certain to be another language like Regex.
     [ExtensionOrder(Before = PredefinedEmbeddedLanguageClassifierNames.Json)]
     [ExportEmbeddedLanguageClassifierInternal(
-        PredefinedEmbeddedLanguageClassifierNames.Regex, LanguageNames.CSharp, supportsUnannotatedAPIs: true, "Regex", "Regexp"), Shared]
+        PredefinedEmbeddedLanguageClassifierNames.Regex, LanguageNames.CSharp, supportsUnannotatedAPIs: true), Shared]
     internal class CSharpRegexEmbeddedLanguageClassifier : AbstractRegexEmbeddedLanguageClassifier
     {
         [ImportingConstructor]

--- a/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonEmbeddedLanguageClassifier.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Json/LanguageServices/AbstractJsonEmbeddedLanguageClassifier.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.EmbeddedLanguages;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.Common;
@@ -21,6 +22,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.Json.LanguageService
     {
         private static readonly ObjectPool<Visitor> s_visitorPool = new(() => new Visitor());
         private readonly EmbeddedLanguageInfo _info;
+
+        public ImmutableArray<string> Identifiers { get; } = ImmutableArray.Create("Json");
 
         public AbstractJsonEmbeddedLanguageClassifier(EmbeddedLanguageInfo info)
         {

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexEmbeddedLanguageClassifier.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/AbstractRegexEmbeddedLanguageClassifier.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.EmbeddedLanguages;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.Common;
@@ -23,6 +24,8 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
         private static readonly ObjectPool<Visitor> s_visitorPool = SharedPools.Default<Visitor>();
 
         private readonly EmbeddedLanguageInfo _info;
+
+        public ImmutableArray<string> Identifiers { get; } = ImmutableArray.Create("Regex", "Regexp");
 
         protected AbstractRegexEmbeddedLanguageClassifier(EmbeddedLanguageInfo info)
         {

--- a/src/Features/VisualBasic/Portable/EmbeddedLanguages/VisualBasicJsonEmbeddedLanguageClassifier.vb
+++ b/src/Features/VisualBasic/Portable/EmbeddedLanguages/VisualBasicJsonEmbeddedLanguageClassifier.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.EmbeddedLanguages.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Features.EmbeddedLanguages
     <ExportEmbeddedLanguageClassifierInternal(
-        PredefinedEmbeddedLanguageClassifierNames.Json, LanguageNames.VisualBasic, True, "Json"), [Shared]>
+        PredefinedEmbeddedLanguageClassifierNames.Json, LanguageNames.VisualBasic, True), [Shared]>
     Friend Class VisualBasicJsonEmbeddedLanguageClassifier
         Inherits AbstractJsonEmbeddedLanguageClassifier
 

--- a/src/Features/VisualBasic/Portable/EmbeddedLanguages/VisualBasicRegexEmbeddedLanguageClassifier.vb
+++ b/src/Features/VisualBasic/Portable/EmbeddedLanguages/VisualBasicRegexEmbeddedLanguageClassifier.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Features.EmbeddedLanguages
     ' want that to happen for APIs that are certain to be another language Like Regex.
     <ExtensionOrder(Before:=PredefinedEmbeddedLanguageClassifierNames.Json)>
     <ExportEmbeddedLanguageClassifierInternal(
-        PredefinedEmbeddedLanguageClassifierNames.Regex, LanguageNames.VisualBasic, True, "Regex", "Regexp"), [Shared]>
+        PredefinedEmbeddedLanguageClassifierNames.Regex, LanguageNames.VisualBasic, True), [Shared]>
     Friend Class VisualBasicRegexEmbeddedLanguageClassifier
         Inherits AbstractRegexEmbeddedLanguageClassifier
 

--- a/src/Workspaces/Core/Portable/Classification/EmbeddedLanguages/AbstractFallbackEmbeddedLanguageClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/EmbeddedLanguages/AbstractFallbackEmbeddedLanguageClassifier.cs
@@ -12,6 +12,8 @@ namespace Microsoft.CodeAnalysis.Classification
         private readonly EmbeddedLanguageInfo _info;
         private readonly ImmutableArray<int> _supportedKinds;
 
+        public ImmutableArray<string> Identifiers => ImmutableArray<string>.Empty;
+
         protected AbstractFallbackEmbeddedLanguageClassifier(EmbeddedLanguageInfo info)
         {
             _info = info;

--- a/src/Workspaces/Core/Portable/Classification/EmbeddedLanguages/ExportEmbeddedLanguageClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/EmbeddedLanguages/ExportEmbeddedLanguageClassifier.cs
@@ -26,23 +26,12 @@ namespace Microsoft.CodeAnalysis.Classification
         /// </summary>
         public string Language { get; }
 
-        /// <summary>
-        /// Identifiers in code (or StringSyntaxAttribute) used to identify an embedded language string. For example
-        /// <c>Regex</c> or <c>Json</c>.
-        /// </summary>
-        /// <remarks>This can be used to find usages of an embedded language using a comment marker like <c>//
-        /// lang=regex</c> or passed to a symbol annotated with <c>[StringSyntaxAttribyte("Regex")]</c>.  The identifier
-        /// is case sensitive for the StringSyntaxAttribute, and case insensitive for the comment.
-        /// </remarks>
-        public string[] Identifiers { get; }
-
         public ExportEmbeddedLanguageClassifierAttribute(
-            string name, string language, params string[] identifiers)
+            string name, string language)
             : base(typeof(IEmbeddedLanguageClassifier))
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Language = language ?? throw new ArgumentNullException(nameof(language));
-            Identifiers = identifiers ?? throw new ArgumentNullException(nameof(identifiers));
         }
     }
 
@@ -59,8 +48,8 @@ namespace Microsoft.CodeAnalysis.Classification
         public bool SupportsUnannotatedAPIs { get; }
 
         public ExportEmbeddedLanguageClassifierInternalAttribute(
-            string name, string language, bool supportsUnannotatedAPIs, params string[] identifiers)
-            : base(name, language, identifiers)
+            string name, string language, bool supportsUnannotatedAPIs)
+            : base(name, language)
         {
             SupportsUnannotatedAPIs = supportsUnannotatedAPIs;
         }

--- a/src/Workspaces/Core/Portable/Classification/EmbeddedLanguages/IEmbeddedLanguageClassifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/EmbeddedLanguages/IEmbeddedLanguageClassifier.cs
@@ -3,12 +3,23 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 
 namespace Microsoft.CodeAnalysis.Classification
 {
     internal interface IEmbeddedLanguageClassifier
     {
+        /// <summary>
+        /// Identifiers in code (or StringSyntaxAttribute) used to identify an embedded language string. For example
+        /// <c>Regex</c> or <c>Json</c>.
+        /// </summary>
+        /// <remarks>This can be used to find usages of an embedded language using a comment marker like <c>//
+        /// lang=regex</c> or passed to a symbol annotated with <c>[StringSyntaxAttribyte("Regex")]</c>.  The identifier
+        /// is case sensitive for the StringSyntaxAttribute, and case insensitive for the comment.
+        /// </remarks>
+        ImmutableArray<string> Identifiers { get; }
+
         /// <summary>
         /// This method will be called for all string and character tokens in a file to determine if there are special
         /// embedded language strings to classify.

--- a/src/Workspaces/Core/Portable/EmbeddedLanguages/EmbeddedLanguageMetadata.cs
+++ b/src/Workspaces/Core/Portable/EmbeddedLanguages/EmbeddedLanguageMetadata.cs
@@ -11,11 +11,6 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages
     internal class EmbeddedLanguageMetadata : OrderableLanguageMetadata
     {
         /// <summary>
-        /// The particular language-IDs this language supports (for example 'regex/regexp/etc.').
-        /// </summary>
-        public IEnumerable<string> Identifiers { get; }
-
-        /// <summary>
         /// If this language supports strings being passed to APIs that do not have a <c>// lang=...</c> comment or a
         /// <c>[StringSyntax]</c> attribute on them.  This is not exposed publicly as all modern language plugins should
         /// use those mechanisms.  This is for Regex/Json to support lighting up on older platform APIs that shipped
@@ -26,15 +21,13 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages
         public EmbeddedLanguageMetadata(IDictionary<string, object> data)
             : base(data)
         {
-            this.Identifiers = ((IReadOnlyDictionary<string, object>)data).GetEnumerableMetadata<string>(nameof(Identifiers)).WhereNotNull();
             this.SupportsUnannotatedAPIs = data.GetValueOrDefault(nameof(SupportsUnannotatedAPIs)) is bool b ? b : false;
         }
 
         public EmbeddedLanguageMetadata(
-            string name, string language, IEnumerable<string> after, IEnumerable<string> before, IEnumerable<string> identifiers, bool supportsUnannotatedAPIs)
+            string name, string language, IEnumerable<string> after, IEnumerable<string> before, bool supportsUnannotatedAPIs)
             : base(name, language, after, before)
         {
-            this.Identifiers = identifiers;
             SupportsUnannotatedAPIs = supportsUnannotatedAPIs;
         }
     }


### PR DESCRIPTION
This was originally added as metadata to make it easy to use exports+mef to try to figure out waht identifiers an embedded language applied to.  The original belief was that this would make it easier for the work to add support for ASP.Net 'Route' syntax.  However, with all the work being done to move that out of proc and use the EA pattern for discovery, this actually just makes this more difficult.  So i'm removing this to just make this something we determine just by making a runtime clal to the extension.