### PR TITLE
Enable semantic token LSP integration tests + re-enable quick info tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpClassification.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpClassification.cs
@@ -23,7 +23,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
         public void VerifyColorOfSomeTokens()
         {
             VisualStudio.Editor.SetText(@"using System;
@@ -71,7 +71,7 @@ namespace ConsoleApplication1
             VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "identifier");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
         public void SemanticClassification()
         {
             VisualStudio.Editor.SetText(@"
@@ -106,7 +106,7 @@ class Program : Attribute
             VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "class name");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
         public void VerifyProjectConfigChange()
         {
             VisualStudio.Editor.SetText(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpQuickInfo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpQuickInfo.cs
@@ -40,7 +40,7 @@ class Program
                 VisualStudio.Editor.GetQuickInfo());
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/53979"), Trait(Traits.Feature, Traits.Features.QuickInfo), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
         public void QuickInfo_Documentation()
         {
             SetUpEditor(@"
@@ -55,7 +55,7 @@ class Program$$
             Assert.Equal("class Program\r\nHello!", VisualStudio.Editor.GetQuickInfo());
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/53979"), Trait(Traits.Feature, Traits.Features.QuickInfo), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
         public void International()
         {
             SetUpEditor(@"
@@ -74,7 +74,7 @@ class العربية123
 This is an XML doc comment defined in code.", VisualStudio.Editor.GetQuickInfo());
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/53979"), Trait(Traits.Feature, Traits.Features.QuickInfo), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.QuickInfo), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
         public void SectionOrdering()
         {
             SetUpEditor(@"


### PR DESCRIPTION
Enables semantic token integration tests to be run in the LSP editor alongside the regular editor. Tests successfully pass locally on my machine.
PR also unskips quick info integration tests since the underlying issue is resolved.

Fixes https://github.com/dotnet/roslyn/issues/53979