### PR TITLE
Use correct directory for loghub logs

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -471,7 +471,7 @@ function TestUsingRunTests() {
       }
 
       if ($lspEditor) {
-        $lspLogs = Join-Path $TempDir "VisualStudio\LSP"
+        $lspLogs = Join-Path $TempDir "VSLogs"
         $telemetryLog = Join-Path $TempDir "VSTelemetryLog"
         if (Test-Path $lspLogs) {
           Write-Host "Copying LSP logs to $LogDir"


### PR DESCRIPTION
LSP logs moved to loghub so integration tests need to look at the correct location