### PR TITLE
Revert to pass isBlocking as a parameter

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -467,7 +467,7 @@ class Class
                     var diagnostics = await diagnosticService.GetDiagnosticsForSpanAsync(document, span);
                     Assert.Equal(2, diagnostics.Where(d => d.Id == "CS0219").Count());
 
-                    var allFixes = (await fixService.GetFixesAsync(document, span, CodeActionOptions.DefaultProvider, CancellationToken.None))
+                    var allFixes = (await fixService.GetFixesAsync(document, span, CodeActionOptions.DefaultProvider, isBlocking: false, CancellationToken.None))
                         .SelectMany(fixCollection => fixCollection.Fixes);
 
                     var cs0219Fixes = allFixes.Where(fix => fix.PrimaryDiagnostic.Id == "CS0219").ToArray();

--- a/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/AsyncSuggestedActionsSource.cs
@@ -166,10 +166,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 var fixesTask = GetCodeFixesAsync(
                     state, supportsFeatureService, requestedActionCategories, workspace, document, range,
-                    addOperationScope, priority, options, cancellationToken);
+                    addOperationScope, priority, options, isBlocking: false, cancellationToken);
                 var refactoringsTask = GetRefactoringsAsync(
                     state, supportsFeatureService, requestedActionCategories, GlobalOptions, workspace, document, selection,
-                    addOperationScope, priority, options, cancellationToken);
+                    addOperationScope, priority, options, isBlocking: false, cancellationToken);
 
                 await Task.WhenAll(fixesTask, refactoringsTask).ConfigureAwait(false);
 

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -177,18 +177,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     Func<string, IDisposable?> addOperationScope =
                         description => operationContext?.AddScope(allowCancellation: true, string.Format(EditorFeaturesResources.Gathering_Suggestions_0, description));
 
-                    var options = GlobalOptions.GetBlockingCodeActionOptionsProvider();
+                    var options = GlobalOptions.GetCodeActionOptionsProvider();
 
                     // We convert the code fixes and refactorings to UnifiedSuggestedActionSets instead of
                     // SuggestedActionSets so that we can share logic between local Roslyn and LSP.
                     var fixesTask = GetCodeFixesAsync(
                         state, supportsFeatureService, requestedActionCategories, workspace, document, range,
                         addOperationScope, CodeActionRequestPriority.None,
-                        options, cancellationToken);
+                        options, isBlocking: true, cancellationToken);
 
                     var refactoringsTask = GetRefactoringsAsync(
                         state, supportsFeatureService, requestedActionCategories, GlobalOptions, workspace, document, selection,
-                        addOperationScope, CodeActionRequestPriority.None, options, cancellationToken);
+                        addOperationScope, CodeActionRequestPriority.None, options, isBlocking: true, cancellationToken);
 
                     Task.WhenAll(fixesTask, refactoringsTask).WaitAndGetResult(cancellationToken);
 
@@ -271,6 +271,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 Func<string, IDisposable?> addOperationScope,
                 CodeActionRequestPriority priority,
                 CodeActionOptionsProvider options,
+                bool isBlocking,
                 CancellationToken cancellationToken)
             {
                 if (state.Target.Owner._codeFixService == null ||
@@ -282,7 +283,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
                     workspace, state.Target.Owner._codeFixService, document, range.Span.ToTextSpan(),
-                    priority, options, addOperationScope, cancellationToken).AsTask();
+                    priority, options, isBlocking, addOperationScope, cancellationToken).AsTask();
             }
 
             private static string GetFixCategory(DiagnosticSeverity severity)
@@ -311,6 +312,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 Func<string, IDisposable?> addOperationScope,
                 CodeActionRequestPriority priority,
                 CodeActionOptionsProvider options,
+                bool isBlocking,
                 CancellationToken cancellationToken)
             {
                 if (!selection.HasValue)
@@ -339,7 +341,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 var filterOutsideSelection = !requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring);
 
                 return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(
-                    workspace, state.Target.Owner._codeRefactoringService, document, selection.Value, priority, options,
+                    workspace, state.Target.Owner._codeRefactoringService, document, selection.Value, priority, options, isBlocking,
                     addOperationScope, filterOutsideSelection, cancellationToken);
             }
 
@@ -439,7 +441,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         state.Target.SubjectBuffer.SupportsCodeFixes())
                     {
                         var result = await state.Target.Owner._codeFixService.GetMostSevereFixAsync(
-                            document, range.Span.ToTextSpan(), priority, options, cancellationToken).ConfigureAwait(false);
+                            document, range.Span.ToTextSpan(), priority, options, isBlocking: false, cancellationToken).ConfigureAwait(false);
 
                         if (result.HasFix)
                         {

--- a/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/CodeActions/CodeActionHelpers.cs
@@ -254,10 +254,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
             var codeFixes = await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
                 document.Project.Solution.Workspace, codeFixService, document, textSpan,
                 CodeActionRequestPriority.None,
-                options, addOperationScope: _ => null, cancellationToken).ConfigureAwait(false);
+                options, isBlocking: false, addOperationScope: _ => null, cancellationToken).ConfigureAwait(false);
 
             var codeRefactorings = await UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(
-                document.Project.Solution.Workspace, codeRefactoringService, document, textSpan, CodeActionRequestPriority.None, options,
+                document.Project.Solution.Workspace, codeRefactoringService, document, textSpan, CodeActionRequestPriority.None, options, isBlocking: false,
                 addOperationScope: _ => null, filterOutsideSelection: false, cancellationToken).ConfigureAwait(false);
 
             var actionSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 CodeActionOptionsStorage.GetCodeActionOptionsProvider(workspace.GlobalOptions) :
                 CodeActionOptions.DefaultProvider;
 
-            var context = new CodeRefactoringContext(document, selectedOrAnnotatedSpan, (a, t) => actions.Add((a, t)), codeActionOptionsProvider, CancellationToken.None);
+            var context = new CodeRefactoringContext(document, selectedOrAnnotatedSpan, (a, t) => actions.Add((a, t)), codeActionOptionsProvider, isBlocking: false, CancellationToken.None);
             await provider.ComputeRefactoringsAsync(context);
             var result = actions.Count > 0 ? new CodeRefactoring(provider, actions.ToImmutable(), FixAllProviderInfo.Create(provider)) : null;
             actions.Free();

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeFixVerifier`2+Test.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 => new WorkspaceAnalyzerOptions(base.GetAnalyzerOptions(project), project.Solution, _sharedState.GetIdeAnalyzerOptions(project));
 
             protected override CodeFixContext CreateCodeFixContext(Document document, TextSpan span, ImmutableArray<Diagnostic> diagnostics, Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix, CancellationToken cancellationToken)
-                => new(document, span, diagnostics, registerCodeFix, new DelegatingCodeActionOptionsProvider(_ => _sharedState.CodeActionOptions), cancellationToken);
+                => new(document, span, diagnostics, registerCodeFix, new DelegatingCodeActionOptionsProvider(_ => _sharedState.CodeActionOptions), isBlocking: false, cancellationToken);
 
             protected override FixAllContext CreateFixAllContext(
                 Document? document,

--- a/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -154,6 +154,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                     ImmutableArray.Create(diagnostic),
                     (a, d) => fixes.Add(new CodeFix(document.Project, a, d)),
                     testDriver.FallbackOptions,
+                    isBlocking: false,
                     CancellationToken.None);
 
                 await fixer.RegisterCodeFixesAsync(context);

--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
             var document = project.Documents.Single();
             var unused = await fixService.GetMostSevereFixAsync(
-                document, TextSpan.FromBounds(0, 0), CodeActionRequestPriority.None, CodeActionOptions.DefaultProvider, CancellationToken.None);
+                document, TextSpan.FromBounds(0, 0), CodeActionRequestPriority.None, CodeActionOptions.DefaultProvider, isBlocking: false, CancellationToken.None);
 
             var fixer1 = (MockFixer)fixers.Single().Value;
             var fixer2 = (MockFixer)reference.Fixer!;
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager, analyzerReference);
 
             // Verify that we do not crash when computing fixes.
-            _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, CancellationToken.None);
+            _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, isBlocking: false, CancellationToken.None);
 
             // Verify that code fix is invoked with both the diagnostics in the context,
             // i.e. duplicate diagnostics are not silently discarded by the CodeFixService.
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager, analyzerReference);
 
             // Verify registered configuration code actions do not have duplicates.
-            var fixCollections = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, CancellationToken.None);
+            var fixCollections = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, isBlocking: false, CancellationToken.None);
             var codeActions = fixCollections.SelectMany(c => c.Fixes.Select(f => f.Action)).ToImmutableArray();
             Assert.Equal(7, codeActions.Length);
             var uniqueTitles = new HashSet<string>();
@@ -147,14 +147,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
             // Verify only analyzerWithFix is executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Normal'.
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                priority: CodeActionRequestPriority.Normal, CodeActionOptions.DefaultProvider,
+                priority: CodeActionRequestPriority.Normal, CodeActionOptions.DefaultProvider, isBlocking: false,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(analyzerWithFix.ReceivedCallback);
             Assert.False(analyzerWithoutFix.ReceivedCallback);
 
             // Verify both analyzerWithFix and analyzerWithoutFix are executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Lowest'.
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                priority: CodeActionRequestPriority.Lowest, CodeActionOptions.DefaultProvider,
+                priority: CodeActionRequestPriority.Lowest, CodeActionOptions.DefaultProvider, isBlocking: false,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(analyzerWithFix.ReceivedCallback);
             Assert.True(analyzerWithoutFix.ReceivedCallback);
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
             // Verify both analyzers are executed when GetFixesAsync is invoked with 'CodeActionRequestPriority.Normal'.
             _ = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0),
-                priority: CodeActionRequestPriority.Normal, CodeActionOptions.DefaultProvider,
+                priority: CodeActionRequestPriority.Normal, CodeActionOptions.DefaultProvider, isBlocking: false,
                 addOperationScope: _ => null, cancellationToken: CancellationToken.None);
             Assert.True(documentDiagnosticAnalyzer.ReceivedCallback);
         }
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
             var reference = new MockAnalyzerReference(codefix, ImmutableArray.Create(diagnosticAnalyzer));
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
             document = project.Documents.Single();
-            var fixes = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, CancellationToken.None);
+            var fixes = await tuple.codeFixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, isBlocking: false, CancellationToken.None);
 
             if (exception)
             {
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
             GetDocumentAndExtensionManager(tuple.analyzerService, workspace, out var document, out var extensionManager);
             var unused = await tuple.codeFixService.GetMostSevereFixAsync(
-                document, TextSpan.FromBounds(0, 0), CodeActionRequestPriority.None, CodeActionOptions.DefaultProvider, CancellationToken.None);
+                document, TextSpan.FromBounds(0, 0), CodeActionRequestPriority.None, CodeActionOptions.DefaultProvider, isBlocking: false, CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(codefix));
             Assert.False(extensionManager.IsIgnored(codefix));
             Assert.True(errorReported);
@@ -683,7 +683,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
             var document = project.Documents.Single();
 
-            return await fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, CancellationToken.None);
+            return await fixService.GetFixesAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, isBlocking: false, CancellationToken.None);
         }
 
         private sealed class NuGetCodeFixProvider : AbstractNuGetOrVsixCodeFixProvider

--- a/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
+++ b/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
@@ -4,7 +4,9 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
+using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,8 +16,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Extensions;
+using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.UnitTests;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
@@ -44,10 +49,52 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
             var reference = new StubAnalyzerReference();
             var project = workspace.CurrentSolution.Projects.Single().AddAnalyzerReference(reference);
             var document = project.Documents.Single();
-            var refactorings = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, CancellationToken.None);
+            var refactorings = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, isBlocking: false, CancellationToken.None);
 
             var stubRefactoringAction = refactorings.Single(refactoring => refactoring.CodeActions.FirstOrDefault().action?.Title == nameof(StubRefactoring));
             Assert.True(stubRefactoringAction is object);
+        }
+
+        [ExportCodeRefactoringProvider(InternalLanguageNames.TypeScript, Name = "TypeScript CodeRefactoring Provider"), Shared, PartNotDiscoverable]
+        internal sealed class TypeScriptCodeRefactoringProvider : CodeRefactoringProvider
+        {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public TypeScriptCodeRefactoringProvider()
+            {
+            }
+
+            public override Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+            {
+#pragma warning disable CS0612 // Type or member is obsolete
+                var isBlocking = ((ITypeScriptCodeRefactoringContext)context).IsBlocking;
+#pragma warning restore
+
+                context.RegisterRefactoring(CodeAction.Create($"Blocking={isBlocking}", _ => Task.FromResult<Document>(null)));
+
+                return Task.CompletedTask;
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task TestTypeScriptRefactorings(bool isBlocking)
+        {
+            var composition = FeaturesTestCompositions.Features.AddParts(typeof(TypeScriptCodeRefactoringProvider));
+
+            using var workspace = TestWorkspace.Create(@"
+<Workspace>
+    <Project Language=""TypeScript"">
+        <Document FilePath=""Test"">abc</Document>
+    </Project>
+</Workspace>", composition: composition);
+
+            var refactoringService = workspace.GetService<ICodeRefactoringService>();
+
+            var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
+            var optionsProvider = workspace.GlobalOptions.GetCodeActionOptionsProvider();
+            var refactorings = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), optionsProvider, isBlocking, CancellationToken.None);
+            Assert.Equal($"Blocking={isBlocking}", refactorings.Single().CodeActions.Single().action.Title);
         }
 
         private static async Task VerifyRefactoringDisabledAsync<T>()
@@ -67,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
             var project = workspace.CurrentSolution.Projects.Single();
             var document = project.Documents.Single();
             var extensionManager = (EditorLayerExtensionManager.ExtensionManager)document.Project.Solution.Workspace.Services.GetRequiredService<IExtensionManager>();
-            var result = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, CancellationToken.None);
+            var result = await refactoringService.GetRefactoringsAsync(document, TextSpan.FromBounds(0, 0), CodeActionOptions.DefaultProvider, isBlocking: false, CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(codeRefactoring));
             Assert.False(extensionManager.IsIgnored(codeRefactoring));
 

--- a/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
+++ b/src/EditorFeatures/Test2/CodeFixes/CodeFixServiceTests.vb
@@ -77,6 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
                     CodeActionOptions.DefaultProvider,
+                    isBlocking:=False,
                     CancellationToken.None)
 
                 Assert.Equal(0, fixes.Count())
@@ -93,6 +94,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
                     CodeActionOptions.DefaultProvider,
+                    isBlocking:=False,
                     CancellationToken.None)
                 Assert.Equal(1, fixes.Count())
 
@@ -103,6 +105,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
                     CodeActionOptions.DefaultProvider,
+                    isBlocking:=False,
                     CancellationToken.None)
 
                 Assert.Equal(0, fixes.Count())
@@ -153,6 +156,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
                     CodeActionOptions.DefaultProvider,
+                    isBlocking:=False,
                     CancellationToken.None)
 
                 Assert.Equal(0, fixes.Count())
@@ -169,6 +173,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeFixes.UnitTests
                     document,
                     (Await document.GetSyntaxRootAsync()).FullSpan,
                     CodeActionOptions.DefaultProvider,
+                    isBlocking:=False,
                     CancellationToken.None)
 
                 Assert.Equal(0, fixes.Count())

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                 RefactoringToMetadataMap.TryGetValue(provider, out var providerMetadata);
 
                 var refactoring = await GetRefactoringFromProviderAsync(
-                    document, state, provider, providerMetadata, extensionManager, options, cancellationToken).ConfigureAwait(false);
+                    document, state, provider, providerMetadata, extensionManager, options, isBlocking: false, cancellationToken).ConfigureAwait(false);
 
                 if (refactoring != null)
                 {
@@ -109,6 +109,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             TextSpan state,
             CodeActionRequestPriority priority,
             CodeActionOptionsProvider options,
+            bool isBlocking,
             Func<string, IDisposable?> addOperationScope,
             CancellationToken cancellationToken)
         {
@@ -131,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                             using (RoslynEventSource.LogInformationalBlock(FunctionId.Refactoring_CodeRefactoringService_GetRefactoringsAsync, providerName, cancellationToken))
                             {
                                 return GetRefactoringFromProviderAsync(document, state, provider, providerMetadata,
-                                    extensionManager, options, cancellationToken);
+                                    extensionManager, options, isBlocking, cancellationToken);
                             }
                         },
                         cancellationToken));
@@ -149,6 +150,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             CodeChangeProviderMetadata? providerMetadata,
             IExtensionManager extensionManager,
             CodeActionOptionsProvider options,
+            bool isBlocking,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -177,6 +179,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                         }
                     },
                     options,
+                    isBlocking,
                     cancellationToken);
 
                 var task = provider.ComputeRefactoringsAsync(context) ?? Task.CompletedTask;

--- a/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
@@ -15,12 +15,12 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
     {
         Task<bool> HasRefactoringsAsync(Document document, TextSpan textSpan, CodeActionOptionsProvider options, CancellationToken cancellationToken);
 
-        Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
+        Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider options, bool isBlocking, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
     }
 
     internal static class ICodeRefactoringServiceExtensions
     {
-        public static Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(this ICodeRefactoringService service, Document document, TextSpan state, CodeActionOptionsProvider options, CancellationToken cancellationToken)
-            => service.GetRefactoringsAsync(document, state, CodeActionRequestPriority.None, options, addOperationScope: _ => null, cancellationToken);
+        public static Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(this ICodeRefactoringService service, Document document, TextSpan state, CodeActionOptionsProvider options, bool isBlocking, CancellationToken cancellationToken)
+            => service.GetRefactoringsAsync(document, state, CodeActionRequestPriority.None, options, isBlocking, addOperationScope: _ => null, cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/SyncNamespaces/AbstractSyncNamespacesSevice.cs
+++ b/src/Features/Core/Portable/SyncNamespaces/AbstractSyncNamespacesSevice.cs
@@ -112,6 +112,7 @@ namespace Microsoft.CodeAnalysis.SyncNamespaces
                 ImmutableArray.Create(firstDiagnostic),
                 (a, _) => action ??= a,
                 options,
+                isBlocking: false,
                 cancellationToken);
             await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
 

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/ICodeFixService.cs
@@ -16,14 +16,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 {
     internal interface ICodeFixService
     {
-        IAsyncEnumerable<CodeFixCollection> StreamFixesAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
+        IAsyncEnumerable<CodeFixCollection> StreamFixesAsync(Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider options, bool isBlocking, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken);
 
         /// <summary>
         /// Similar to <see cref="StreamFixesAsync"/> except that instead of streaming all results, this ends with the
         /// first.  This will also attempt to return a fix for an error first, but will fall back to any fix if that
         /// does not succeed.
         /// </summary>
-        Task<FirstFixResult> GetMostSevereFixAsync(Document document, TextSpan range, CodeActionRequestPriority priority, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
+        Task<FirstFixResult> GetMostSevereFixAsync(Document document, TextSpan range, CodeActionRequestPriority priority, CodeActionOptionsProvider fallbackOptions, bool isBlocking, CancellationToken cancellationToken);
 
         Task<CodeFixCollection?> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken);
         CodeFixProvider? GetSuppressionFixer(string language, IEnumerable<string> diagnosticIds);
@@ -31,13 +31,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
     internal static class ICodeFixServiceExtensions
     {
-        public static IAsyncEnumerable<CodeFixCollection> StreamFixesAsync(this ICodeFixService service, Document document, TextSpan range, CodeActionOptionsProvider options, CancellationToken cancellationToken)
-            => service.StreamFixesAsync(document, range, CodeActionRequestPriority.None, options, addOperationScope: _ => null, cancellationToken);
+        public static IAsyncEnumerable<CodeFixCollection> StreamFixesAsync(this ICodeFixService service, Document document, TextSpan range, CodeActionOptionsProvider options, bool isBlocking, CancellationToken cancellationToken)
+            => service.StreamFixesAsync(document, range, CodeActionRequestPriority.None, options, isBlocking, addOperationScope: _ => null, cancellationToken);
 
-        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, CodeActionOptionsProvider options, CancellationToken cancellationToken)
-            => service.StreamFixesAsync(document, range, options, cancellationToken).ToImmutableArrayAsync(cancellationToken);
+        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan range, CodeActionOptionsProvider options, bool isBlocking, CancellationToken cancellationToken)
+            => service.StreamFixesAsync(document, range, options, isBlocking, cancellationToken).ToImmutableArrayAsync(cancellationToken);
 
-        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider options, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken)
-            => service.StreamFixesAsync(document, textSpan, priority, options, addOperationScope, cancellationToken).ToImmutableArrayAsync(cancellationToken);
+        public static Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(this ICodeFixService service, Document document, TextSpan textSpan, CodeActionRequestPriority priority, CodeActionOptionsProvider options, bool isBlocking, Func<string, IDisposable?> addOperationScope, CancellationToken cancellationToken)
+            => service.StreamFixesAsync(document, textSpan, priority, options, isBlocking, addOperationScope, cancellationToken).ToImmutableArrayAsync(cancellationToken);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/Options/CodeActionOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CodeActionOptionsStorage.cs
@@ -21,13 +21,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
         public static readonly PerLanguageOption2<int> WrappingColumn =
             new("FormattingOptions", "WrappingColumn", CodeActionOptions.DefaultWrappingColumn);
 
-        internal static CodeActionOptions GetCodeActionOptions(this IGlobalOptionService globalOptions, HostLanguageServices languageServices)
-            => GetCodeActionOptions(globalOptions, languageServices, isBlocking: false);
-
-        internal static CodeActionOptions GetBlockingCodeActionOptions(this IGlobalOptionService globalOptions, HostLanguageServices languageServices)
-            => GetCodeActionOptions(globalOptions, languageServices, isBlocking: true);
-
-        private static CodeActionOptions GetCodeActionOptions(this IGlobalOptionService globalOptions, HostLanguageServices languageServices, bool isBlocking)
+        public static CodeActionOptions GetCodeActionOptions(this IGlobalOptionService globalOptions, HostLanguageServices languageServices)
             => new(
                 SearchOptions: globalOptions.GetSymbolSearchOptions(languageServices.Language),
                 ImplementTypeOptions: globalOptions.GetImplementTypeOptions(languageServices.Language),
@@ -35,30 +29,23 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 CleanupOptions: globalOptions.GetCodeCleanupOptions(languageServices),
                 CodeGenerationOptions: globalOptions.GetCodeGenerationOptions(languageServices),
                 HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsStorage.HideAdvancedMembers, languageServices.Language),
-                IsBlocking: isBlocking,
                 WrappingColumn: globalOptions.GetOption(WrappingColumn, languageServices.Language));
 
         internal static CodeActionOptionsProvider GetCodeActionOptionsProvider(this IGlobalOptionService globalOptions)
-            => new CachingCodeActionsOptionsProvider(globalOptions, isBlocking: false);
-
-        internal static CodeActionOptionsProvider GetBlockingCodeActionOptionsProvider(this IGlobalOptionService globalOptions)
-            => new CachingCodeActionsOptionsProvider(globalOptions, isBlocking: true);
+            => new CachingCodeActionsOptionsProvider(globalOptions);
 
         private sealed class CachingCodeActionsOptionsProvider : AbstractCodeActionOptionsProvider
         {
             private readonly IGlobalOptionService _globalOptions;
-            private readonly bool _isBlocking;
-
             private ImmutableDictionary<string, CodeActionOptions> _cache = ImmutableDictionary<string, CodeActionOptions>.Empty;
 
-            public CachingCodeActionsOptionsProvider(IGlobalOptionService globalOptions, bool isBlocking)
+            public CachingCodeActionsOptionsProvider(IGlobalOptionService globalOptions)
             {
                 _globalOptions = globalOptions;
-                _isBlocking = isBlocking;
             }
 
             public override CodeActionOptions GetOptions(HostLanguageServices languageService)
-                => ImmutableInterlocked.GetOrAdd(ref _cache, languageService.Language, (language, options) => GetCodeActionOptions(options, languageService, _isBlocking), _globalOptions);
+                => ImmutableInterlocked.GetOrAdd(ref _cache, languageService.Language, (language, options) => GetCodeActionOptions(options, languageService), _globalOptions);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             TextSpan selection,
             CodeActionRequestPriority priority,
             CodeActionOptionsProvider options,
+            bool isBlocking,
             Func<string, IDisposable?> addOperationScope,
             CancellationToken cancellationToken)
         {
@@ -48,6 +49,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 selection,
                 priority,
                 options,
+                isBlocking,
                 addOperationScope,
                 cancellationToken), cancellationToken).ConfigureAwait(false);
 
@@ -413,6 +415,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             TextSpan selection,
             CodeActionRequestPriority priority,
             CodeActionOptionsProvider options,
+            bool isBlocking,
             Func<string, IDisposable?> addOperationScope,
             bool filterOutsideSelection,
             CancellationToken cancellationToken)
@@ -423,7 +426,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             // the UI thread.
             var refactorings = await Task.Run(
                 () => codeRefactoringService.GetRefactoringsAsync(
-                    document, selection, priority, options, addOperationScope,
+                    document, selection, priority, options, isBlocking, addOperationScope,
                     cancellationToken), cancellationToken).ConfigureAwait(false);
 
             var filteredRefactorings = FilterOnAnyThread(refactorings, selection, filterOutsideSelection);

--- a/src/Tools/ExternalAccess/OmniSharp/CodeActions/OmniSharpCodeFixContextFactory.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/CodeActions/OmniSharpCodeFixContextFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CodeActions
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
             OmniSharpCodeActionOptions options,
             CancellationToken cancellationToken)
-            => new(document, span, diagnostics, registerCodeFix, new DelegatingCodeActionOptionsProvider(_ => options.GetCodeActionOptions()), cancellationToken);
+            => new(document, span, diagnostics, registerCodeFix, new DelegatingCodeActionOptionsProvider(_ => options.GetCodeActionOptions()), isBlocking: false, cancellationToken);
 
         public static CodeAnalysis.CodeRefactorings.CodeRefactoringContext CreateCodeRefactoringContext(
             Document document,
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CodeActions
             Action<CodeAction, TextSpan?> registerRefactoring,
             OmniSharpCodeActionOptions options,
             CancellationToken cancellationToken)
-            => new(document, span, registerRefactoring, new DelegatingCodeActionOptionsProvider(_ => options.GetCodeActionOptions()), cancellationToken);
+            => new(document, span, registerRefactoring, new DelegatingCodeActionOptionsProvider(_ => options.GetCodeActionOptions()), isBlocking: false, cancellationToken);
 
         public static FixAllContext CreateFixAllContext(
             Document? document,

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         internal readonly CodeActionOptionsProvider Options;
 
         /// <summary>
-        /// TypeScript specific.
+        /// TypeScript specific. https://github.com/dotnet/roslyn/issues/61122
         /// </summary>
         private readonly bool _isBlocking;
 

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -56,9 +56,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// </remarks>
         internal readonly CodeActionOptionsProvider Options;
 
+        /// <summary>
+        /// TypeScript specific.
+        /// </summary>
+        private readonly bool _isBlocking;
+
         [Obsolete]
         bool ITypeScriptCodeFixContext.IsBlocking
-            => Options.GetOptions(Document.Project.LanguageServices).IsBlocking;
+            => _isBlocking;
 
         /// <summary>
         /// Creates a code fix context to be passed into <see cref="CodeFixProvider.RegisterCodeFixesAsync(CodeFixContext)"/> method.
@@ -88,6 +93,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                    VerifyDiagnosticsArgument(diagnostics, span),
                    registerCodeFix ?? throw new ArgumentNullException(nameof(registerCodeFix)),
                    CodeActionOptions.DefaultProvider,
+                   isBlocking: false,
                    cancellationToken)
         {
         }
@@ -113,6 +119,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                    ImmutableArray.Create(diagnostic),
                    registerCodeFix ?? throw new ArgumentNullException(nameof(registerCodeFix)),
                    CodeActionOptions.DefaultProvider,
+                   isBlocking: false,
                    cancellationToken)
         {
         }
@@ -123,6 +130,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             ImmutableArray<Diagnostic> diagnostics,
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
             CodeActionOptionsProvider options,
+            bool isBlocking,
             CancellationToken cancellationToken)
         {
             Debug.Assert(diagnostics.Any(d => d.Location.SourceSpan == span));
@@ -132,6 +140,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             _diagnostics = diagnostics;
             _registerCodeFix = registerCodeFix;
             Options = options;
+            _isBlocking = isBlocking;
             _cancellationToken = cancellationToken;
         }
 

--- a/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
@@ -34,9 +34,14 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 
         internal readonly CodeActionOptionsProvider Options;
 
+        /// <summary>
+        /// TypeScript specific.
+        /// </summary>
+        private readonly bool _isBlocking;
+
         [Obsolete]
         bool ITypeScriptCodeRefactoringContext.IsBlocking
-            => Options.GetOptions(Document.Project.LanguageServices).IsBlocking;
+            => _isBlocking;
 
         private readonly Action<CodeAction, TextSpan?> _registerRefactoring;
 
@@ -48,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             TextSpan span,
             Action<CodeAction> registerRefactoring,
             CancellationToken cancellationToken)
-            : this(document, span, (action, textSpan) => registerRefactoring(action), CodeActionOptions.DefaultProvider, cancellationToken)
+            : this(document, span, (action, textSpan) => registerRefactoring(action), CodeActionOptions.DefaultProvider, isBlocking: false, cancellationToken)
         { }
 
         /// <summary>
@@ -59,6 +64,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             TextSpan span,
             Action<CodeAction, TextSpan?> registerRefactoring,
             CodeActionOptionsProvider options,
+            bool isBlocking,
             CancellationToken cancellationToken)
         {
             // NOTE/TODO: Don't make this overload public & obsolete the `Action<CodeAction> registerRefactoring`
@@ -67,6 +73,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             Span = span;
             _registerRefactoring = registerRefactoring ?? throw new ArgumentNullException(nameof(registerRefactoring));
             Options = options;
+            _isBlocking = isBlocking;
             CancellationToken = cancellationToken;
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CodeActionOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CodeActionOptions.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.CodeActions
         [DataMember(Order = 3)] public CodeCleanupOptions? CleanupOptions { get; init; }
         [DataMember(Order = 4)] public CodeGenerationOptions? CodeGenerationOptions { get; init; }
         [DataMember(Order = 5)] public bool HideAdvancedMembers { get; init; }
-        [DataMember(Order = 6)] public bool IsBlocking { get; init; }
         [DataMember(Order = 7)] public int WrappingColumn { get; init; }
 
         /// <summary>
@@ -60,7 +59,6 @@ namespace Microsoft.CodeAnalysis.CodeActions
             CodeCleanupOptions? CleanupOptions = null,
             CodeGenerationOptions? CodeGenerationOptions = null,
             bool HideAdvancedMembers = false,
-            bool IsBlocking = false,
             int WrappingColumn = DefaultWrappingColumn)
         {
             this.SearchOptions = SearchOptions ?? SymbolSearchOptions.Default;
@@ -69,7 +67,6 @@ namespace Microsoft.CodeAnalysis.CodeActions
             this.CleanupOptions = CleanupOptions;
             this.CodeGenerationOptions = CodeGenerationOptions;
             this.HideAdvancedMembers = HideAdvancedMembers;
-            this.IsBlocking = IsBlocking;
             this.WrappingColumn = WrappingColumn;
         }
 


### PR DESCRIPTION
Removes `IsBlocking` property from `CodeActionOptions` as it is used only for TypeScript and the rest of the options can't be created for TypeScript documents as they include C#/VB specific options. Recent option changes broke TypeScript and this PR fixes that break.

Since `IsBlocking` is only used by TypeScript refactorings we should remove it once TypeScript migrates away from using Roslyn code action infrastructure.

Adds a test.