### PR TITLE
[LSP] Reuse workspace solutions for requests when LSP contents match

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -335,6 +336,9 @@ namespace Roslyn.Test.Utilities
                     continue;
 
                 solution = solution.WithDocumentFilePath(document.Id, GetDocumentFilePathFromName(document.Name));
+
+                var documentText = await solution.GetRequiredDocument(document.Id).GetTextAsync(CancellationToken.None);
+                solution = solution.WithDocumentText(document.Id, SourceText.From(documentText.ToString(), System.Text.Encoding.UTF8));
             }
 
             workspace.ChangeSolution(solution);
@@ -516,10 +520,6 @@ namespace Roslyn.Test.Utilities
 
                 var workspaceWaiter = GetWorkspaceWaiter(TestWorkspace);
                 Assert.False(workspaceWaiter.HasPendingWork);
-
-                // Clear any LSP solutions that were created when the workspace was initialized.
-                // This ensures that the workspace manager starts with a clean slate.
-                GetManagerAccessor().ResetLspSolutions();
             }
 
             private static JsonMessageFormatter CreateJsonMessageFormatter()

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -60,7 +60,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
         public readonly IGlobalOptionService GlobalOptions;
 
-        public readonly LspWorkspaceManager LspWorkspaceManager;
         public readonly ILanguageServerNotificationManager NotificationManager;
         public readonly CancellationToken QueueCancellationToken;
 
@@ -79,7 +78,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             ImmutableDictionary<Uri, SourceText> trackedDocuments,
             ImmutableArray<string> supportedLanguages,
             IGlobalOptionService globalOptions,
-            LspWorkspaceManager lspWorkspaceManager,
             ILanguageServerNotificationManager notificationManager,
             CancellationToken queueCancellationToken)
         {
@@ -92,7 +90,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             _documentChangeTracker = documentChangeTracker;
             _logger = logger;
             _trackedDocuments = trackedDocuments;
-            LspWorkspaceManager = lspWorkspaceManager;
             NotificationManager = notificationManager;
             QueueCancellationToken = queueCancellationToken;
         }
@@ -121,9 +118,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             if (!requiresLSPSolution)
             {
                 return new RequestContext(
-                    solution: null, logger, clientCapabilities, serverKind, document: null,
-                    documentChangeTracker, trackedDocuments, supportedLanguages, globalOptions,
-                    lspWorkspaceManager, notificationManager, queueCancellationToken);
+                    solution: null, logger: logger, clientCapabilities: clientCapabilities, serverKind: serverKind, document: null,
+                    documentChangeTracker: documentChangeTracker, trackedDocuments: trackedDocuments, supportedLanguages: supportedLanguages, globalOptions: globalOptions,
+                    notificationManager: notificationManager, queueCancellationToken: queueCancellationToken);
             }
 
             // Go through each registered workspace, find the solution that contains the document that
@@ -157,7 +154,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 trackedDocuments,
                 supportedLanguages,
                 globalOptions,
-                lspWorkspaceManager,
                 notificationManager,
                 queueCancellationToken);
             return context;

--- a/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestExecutionQueue.RequestTelemetryLogger.cs
@@ -44,6 +44,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
             private readonly LogAggregator _findDocumentResults;
 
+            private readonly LogAggregator _usedForkedSolutionCounter;
+
             private int _disposed;
 
             public RequestTelemetryLogger(string serverTypeName)
@@ -51,6 +53,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 _serverTypeName = serverTypeName;
                 _requestCounters = new();
                 _findDocumentResults = new();
+                _usedForkedSolutionCounter = new();
 
                 // Buckets queued duration into 10ms buckets with the last bucket starting at 1000ms.
                 // Queue times are relatively short and fall under 50ms, so tracking past 1000ms is not useful.
@@ -69,6 +72,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 {
                     _findDocumentResults.IncreaseCount(workspaceKindTelemetryProperty);
                 }
+            }
+
+            public void UpdateUsedForkedSolutionCounter(bool usedForkedSolution)
+            {
+                _usedForkedSolutionCounter.IncreaseCount(usedForkedSolution);
             }
 
             public void UpdateTelemetryData(
@@ -148,6 +156,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 {
                     m["server"] = _serverTypeName;
                     foreach (var kvp in _findDocumentResults)
+                    {
+                        var info = kvp.Key.ToString()!;
+                        m[info] = kvp.Value.GetCount();
+                    }
+                }));
+
+                Logger.Log(FunctionId.LSP_UsedForkedSolution, KeyValueLogMessage.Create(LogType.Trace, m =>
+                {
+                    m["server"] = _serverTypeName;
+                    foreach (var kvp in _usedForkedSolutionCounter)
                     {
                         var info = kvp.Key.ToString()!;
                         m[info] = kvp.Value.GetCount();

--- a/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
+++ b/src/Features/LanguageServer/Protocol/LanguageServerTarget.cs
@@ -248,7 +248,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             _queue.Shutdown();
 
             _requestTelemetryLogger.Dispose();
-            _lspWorkspaceManager.Dispose();
         }
 
         private void RequestExecutionQueue_Errored(object? sender, RequestShutdownEventArgs e)

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -8,7 +8,9 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -23,46 +25,32 @@ namespace Microsoft.CodeAnalysis.LanguageServer;
 /// This type is tied to a particular server.
 /// </summary>
 /// <remarks>
-/// This is built to store incremental solutions that we update based on LSP text changes. This solution is <b>eventually consistent</b> with the workspace:
+/// This type provides an LSP view of the registered workspace solutions so that all LSP requests operate
+/// on the state of the world that matches the LSP requests we've recieved.  
+/// 
+/// This is done by storing the LSP text as provided by client didOpen/didClose/didChange requests.  When asked for a document we provide either
 /// <list type="bullet">
-///   <item> When LSP text changes come in, we only fork the relevant document. </item>
-///   <item> We listen to workspace events. When we receive an event that is not for an LSP open document,
-///          we delete our incremental LSP solution so that we can fork the workspace with all open LSP documents. </item>
+///     <item> The exact workspace solution instance if all the LSP text matches what is currently in the workspace.</item>
+///     <item> A fork from the workspace current solution with the LSP text applied if the LSP text does not match.  This can happen since
+///     LSP text sync is asynchronous and not guaranteed to match the text in the workspace (though the majority of the time in VS it does).</item>
 /// </list>
-///
-/// Doing incremental forking like this is more complex, but has a few nice properties:
+/// 
+/// Doing the forking like this has a few nice properties.
 /// <list type="bullet">
-///   <item>LSP didChange events only cause us to update the document that changed, not all open documents.</item>
-///   <item>Since we incrementally update our LSP documents, we only have to re-parse the document that changed.</item>
-///   <item>Since we incrementally update our LSP documents, project versions for other open documents remain unchanged.</item>
-///   <item>We are not reliant on the workspace being updated frequently (which it is not in VSCode) to do checksum diffing between LSP and the workspace.</item>
+///   <item>99% of the time the VS workspace matches the LSP text.  In those cases we do 0 re-parsing, share compilations, versions, checksum calcs, etc.</item>
+///   <item>In the 1% of the time that we do not match, we can simply and easily compute a fork.</item>
+///   <item>The code is relatively straightforward</item>
 /// </list>
 /// </remarks>
 internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
 {
     /// <summary>
-    /// Indicates whether the LSP solution has changed in a non-tracked document context.
+    /// A cache from workspace to the last solution we returned for LSP.
+    /// When this solution comes from a fork operation we store the workspace version it was forked from.
     /// 
-    /// <b>IMPORTANT:</b> Implementations of this event handler should do as little synchronous work as possible since this will block.
+    /// Access to this is gauranteed to be serial by the <see cref="RequestExecutionQueue"/>
     /// </summary>
-    public EventHandler<WorkspaceChangeEventArgs>? LspSolutionChanged;
-
-    /// <summary>
-    /// Lock to gate access to the <see cref="_workspaceToLspSolution"/> and <see cref="_trackedDocuments"/>
-    /// Access from the LSP server is serial as the LSP queue is processed serially until
-    /// after we give the solution to the request handlers.  However workspace events can interleave
-    /// so we must protect against concurrent access here.
-    /// </summary>
-    private readonly object _gate = new();
-
-    /// <summary>
-    /// A map from the registered workspace to the running lsp solution with incremental changes from LSP
-    /// text sync applied to it.
-    /// All workspaces registered by the <see cref="LspWorkspaceRegistrationService"/> are added as keys to this dictionary
-    /// with a null value (solution) initially.  As LSP text changes come in, we create the incremental solution from the workspace and update it with changes.
-    /// When we detect a change that requires us to re-fork the LSP solution from the workspace we null out the solution for the key.
-    /// </summary>
-    private readonly Dictionary<Workspace, Solution?> _workspaceToLspSolution = new();
+    private readonly Dictionary<Workspace, (int? ForkedFromVersion, Solution Solution)> _cachedLspSolutions = new();
 
     /// <summary>
     /// Stores the current source text for each URI that is being tracked by LSP.
@@ -71,6 +59,8 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
     /// 
     /// Note that the text here is tracked regardless of whether or not we found a matching roslyn document
     /// for the URI.
+    /// 
+    /// Access to this is gauranteed to be serial by the <see cref="RequestExecutionQueue"/>
     /// </summary>
     private ImmutableDictionary<Uri, SourceText> _trackedDocuments = ImmutableDictionary<Uri, SourceText>.Empty;
 
@@ -93,95 +83,12 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
         _requestTelemetryLogger = requestTelemetryLogger;
 
         _lspWorkspaceRegistrationService = lspWorkspaceRegistrationService;
-        // This server may have been started after workspaces were registered, we need to ensure we know about them.
-        foreach (var workspace in lspWorkspaceRegistrationService.GetAllRegistrations())
-        {
-            OnWorkspaceRegistered(this, new LspWorkspaceRegisteredEventArgs(workspace));
-        }
-
-        lspWorkspaceRegistrationService.WorkspaceRegistered += OnWorkspaceRegistered;
     }
 
     public void Dispose()
     {
-        // Workspace events can come in while we're disposing of an LSP server (e.g. restart).
-        lock (_gate)
-        {
-            _lspWorkspaceRegistrationService.WorkspaceRegistered -= OnWorkspaceRegistered;
-            foreach (var registeredWorkspace in _workspaceToLspSolution.Keys)
-            {
-                registeredWorkspace.WorkspaceChanged -= OnWorkspaceChanged;
-            }
-
-            _workspaceToLspSolution.Clear();
-        }
+        _cachedLspSolutions.Clear();
     }
-
-    #region Workspace Updates
-
-    /// <summary>
-    /// Handles cases where a new workspace is registered after an LSP server is already started.
-    /// For example, in VS the metadata as source workspace is not created until a metadata files is opened.
-    /// </summary>
-    private void OnWorkspaceRegistered(object? sender, LspWorkspaceRegisteredEventArgs e)
-    {
-        lock (_gate)
-        {
-            // Set the LSP solution for the workspace to null so that when asked we fork from the workspace.
-            _workspaceToLspSolution.Add(e.Workspace, null);
-            e.Workspace.WorkspaceChanged += OnWorkspaceChanged;
-
-            _logger.TraceInformation($"Registered workspace {e.Workspace.Kind}");
-        }
-    }
-
-    /// <summary>
-    /// Subscribed to the <see cref="Workspace.WorkspaceChanged"/> event for registered workspaces.
-    /// If the workspace change is a change to an open LSP document, we ignore the change event as LSP will update us.
-    /// If the workspace change is a change to a non-open document / project change, we trigger a fork from the workspace.
-    /// </summary>
-    private void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
-    {
-        var workspace = e.NewSolution.Workspace;
-        if (e.Kind is WorkspaceChangeKind.DocumentChanged)
-        {
-            Contract.ThrowIfNull(e.DocumentId, $"DocumentId missing for document change event {e.Kind}");
-
-            // Retrieve the current state of documents owned by LSP.  It is not necessarily
-            // consistent with the workspace, but if the documents owned by LSP change we fork from the workspace
-            // and will eventually become consistent.
-            ImmutableDictionary<Uri, SourceText> trackedDocuments;
-            lock (_gate)
-            {
-                trackedDocuments = _trackedDocuments;
-            }
-
-            if (IsDocumentTrackedByLsp(e.DocumentId, e.NewSolution, trackedDocuments))
-            {
-                // We're tracking the document already, no need to fork the workspace to get the changes, LSP will have sent them to us.
-                return;
-            }
-        }
-
-        lock (_gate)
-        {
-            // Documents added/removed, changes to additional docs, closed document changes, any changes to the project, or any changes to the solution
-            // mean we need to re-fork from the workspace to ensure that the lsp solution contains these updates.
-            _workspaceToLspSolution[workspace] = null;
-        }
-
-        // Send a solution changed notification to anyone subscribed. For example, this is important for semantic tokens refresh.
-        LspSolutionChanged?.Invoke(sender, e);
-
-        static bool IsDocumentTrackedByLsp(DocumentId changedDocumentId, Solution newWorkspaceSolution, ImmutableDictionary<Uri, SourceText> trackedDocuments)
-        {
-            var changedDocument = newWorkspaceSolution.GetRequiredDocument(changedDocumentId);
-            var documentUri = changedDocument.TryGetURI();
-            return documentUri != null && trackedDocuments.ContainsKey(documentUri);
-        }
-    }
-
-    #endregion
 
     #region Implementation of IDocumentChangeTracker
 
@@ -190,27 +97,12 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
     /// </summary>
     public void StartTracking(Uri uri, SourceText documentText)
     {
-        lock (_gate)
-        {
-            // First, store the LSP view of the text as the uri is now owned by the LSP client.
-            Contract.ThrowIfTrue(_trackedDocuments.ContainsKey(uri), $"didOpen received for {uri} which is already open.");
-            _trackedDocuments = _trackedDocuments.Add(uri, documentText);
+        // First, store the LSP view of the text as the uri is now owned by the LSP client.
+        Contract.ThrowIfTrue(_trackedDocuments.ContainsKey(uri), $"didOpen received for {uri} which is already open.");
+        _trackedDocuments = _trackedDocuments.Add(uri, documentText);
 
-            // Make sure we reset/update our LSP incremental solutions now that we potentially have a new document.
-            ResetIncrementalLspSolutions_CalledUnderLock();
-            var updatedSolutions = ComputeIncrementalLspSolutions_CalledUnderLock();
-            if (updatedSolutions.Any(solution => solution.GetDocuments(uri).Any()))
-            {
-                return;
-            }
-
-            // If we can't find the document in any of the registered workspaces, add it to our loose files workspace.
-            var miscDocument = _lspMiscellaneousFilesWorkspace?.AddMiscellaneousDocument(uri, documentText);
-            if (miscDocument != null)
-            {
-                _workspaceToLspSolution[miscDocument.Project.Solution.Workspace] = miscDocument.Project.Solution;
-            }
-        }
+        // If LSP changed, we need to compare against the workspace again to get the updated solution.
+        _cachedLspSolutions.Clear();
     }
 
     /// <summary>
@@ -218,20 +110,15 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
     /// </summary>
     public void StopTracking(Uri uri)
     {
-        lock (_gate)
-        {
-            // First, stop tracking this URI and source text as it is no longer owned by LSP.
-            Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(uri), $"didClose received for {uri} which is not open.");
-            _trackedDocuments = _trackedDocuments.Remove(uri);
+        // First, stop tracking this URI and source text as it is no longer owned by LSP.
+        Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(uri), $"didClose received for {uri} which is not open.");
+        _trackedDocuments = _trackedDocuments.Remove(uri);
 
-            // Trigger a fork of all workspaces, the LSP document text may not match the workspace and this document
-            // may have been removed / moved to a different workspace.
-            ResetIncrementalLspSolutions_CalledUnderLock();
+        // If LSP changed, we need to compare against the workspace again to get the updated solution.
+        _cachedLspSolutions.Clear();
 
-            // If the file was added to the LSP misc files workspace, it needs to be removed as we no longer care about it once closed.
-            // If the misc document ended up being added to an actual workspace, we may have already removed it from LSP misc in UpdateLspDocument.
-            _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri);
-        }
+        // Also remove it from our loose files workspace if it is still there.
+        _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri);
     }
 
     /// <summary>
@@ -239,56 +126,15 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
     /// </summary>
     public void UpdateTrackedDocument(Uri uri, SourceText newSourceText)
     {
-        lock (_gate)
-        {
-            // Store the updated LSP view of the source text.
-            Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(uri), $"didChange received for {uri} which is not open.");
-            _trackedDocuments = _trackedDocuments.SetItem(uri, newSourceText);
+        // Store the updated LSP view of the source text.
+        Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(uri), $"didChange received for {uri} which is not open.");
+        _trackedDocuments = _trackedDocuments.SetItem(uri, newSourceText);
 
-            // Get our current solutions and re-fork from the workspace as needed.
-            var updatedSolutions = ComputeIncrementalLspSolutions_CalledUnderLock();
-
-            var findDocumentResult = FindDocuments(uri, updatedSolutions, _requestTelemetryLogger, _logger);
-            if (findDocumentResult.IsEmpty)
-            {
-                // We didn't find this document in a registered workspace or in the misc workspace.
-                // This can happen when workspace event processing is behind LSP and a new document was added that has not been reflected in the incremental LSP solution yet.
-                //
-                // This means that the LSP solution will be stale until the event is processed and will not be able to answer requests on this URI.
-                // When the workspace event is processed, we will fork from the workspace and apply all missed incremental LSP text (stored in IDocumentChangeTracker)
-                // to bring the incremental LSP solution up to date.
-                //
-                // TODO - Once we always create the misc files workspace we should never hit this path (when workspace events are behind the doc will go into misc).
-                // Remove as part of https://github.com/dotnet/roslyn/issues/57243
-                return;
-            }
-
-            // Update all the documents that have a matching uri with the new source text and store as our new incremental solution.
-            // We can have multiple documents with the same URI (e.g. linked documents).
-            var solution = GetSolutionWithReplacedDocuments(findDocumentResult.First().Project.Solution, ImmutableArray.Create((uri, newSourceText)));
-            _workspaceToLspSolution[solution.Workspace] = solution;
-
-            if (solution.Workspace is not LspMiscellaneousFilesWorkspace && _lspMiscellaneousFilesWorkspace != null)
-            {
-                // If we found the uri in a workspace that isn't LSP misc files, we can remove it from the lsp misc files if it is there.
-                //
-                // Example: In VSCode, the server is started and file opened before the user has chosen which project/sln in the folder they want to open,
-                // and therefore on didOpen the file gets put into LSP misc files.
-                //
-                // Once the workspace is updated with the document however, we proactively cleanup the lsp misc files workspace here
-                // so that we don't keep lingering references around.
-                _lspMiscellaneousFilesWorkspace.TryRemoveMiscellaneousDocument(uri);
-            }
-        }
+        // If LSP changed, we need to compare against the workspace again to get the updated solution.
+        _cachedLspSolutions.Clear();
     }
 
-    public ImmutableDictionary<Uri, SourceText> GetTrackedLspText()
-    {
-        lock (_gate)
-        {
-            return _trackedDocuments;
-        }
-    }
+    public ImmutableDictionary<Uri, SourceText> GetTrackedLspText() => _trackedDocuments;
 
     #endregion
 
@@ -300,14 +146,13 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
     /// </summary>
     public Solution? TryGetHostLspSolution()
     {
-        lock (_gate)
-        {
-            // Ensure we have the latest lsp solutions
-            var updatedSolutions = ComputeIncrementalLspSolutions_CalledUnderLock();
+        // Ensure we have the latest lsp solutions
+        var updatedSolutions = GetLspSolutions();
 
-            var hostWorkspaceSolution = updatedSolutions.FirstOrDefault(s => s.Workspace.Kind == _hostWorkspaceKind);
-            return hostWorkspaceSolution;
-        }
+        var (hostWorkspaceSolution, isForked) = updatedSolutions.FirstOrDefault(lspSolution => lspSolution.Solution.Workspace.Kind == _hostWorkspaceKind);
+        _requestTelemetryLogger.UpdateUsedForkedSolutionCounter(isForked);
+
+        return hostWorkspaceSolution;
     }
 
     /// <summary>
@@ -315,146 +160,158 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
     /// </summary>
     public Document? GetLspDocument(TextDocumentIdentifier textDocumentIdentifier)
     {
-        lock (_gate)
-        {
-            // Ensure we have the latest lsp solutions
-            var currentLspSolutions = ComputeIncrementalLspSolutions_CalledUnderLock();
+        var uri = textDocumentIdentifier.Uri;
 
-            // Search through the latest lsp solutions to find the document with matching uri and client name.
-            var findDocumentResult = FindDocuments(textDocumentIdentifier.Uri, currentLspSolutions, _requestTelemetryLogger, _logger);
-            if (findDocumentResult.IsEmpty)
+        // Get the LSP view of all the workspace solutions.
+        var lspSolutions = GetLspSolutions();
+
+        // Find the matching document from the LSP solutions.
+        foreach (var (lspSolution, isForked) in lspSolutions)
+        {
+            var documents = lspSolution.GetDocuments(uri);
+            if (documents.Any())
             {
-                return null;
+                var document = documents.FindDocumentInProjectContext(textDocumentIdentifier);
+
+                // Record metadata on how we got this document.
+                var workspaceKind = document.Project.Solution.Workspace.Kind;
+                _requestTelemetryLogger.UpdateFindDocumentTelemetryData(success: true, workspaceKind);
+                _requestTelemetryLogger.UpdateUsedForkedSolutionCounter(isForked);
+                _logger.TraceInformation($"{document.FilePath} found in workspace {workspaceKind}");
+
+                return document;
+            }
+        }
+
+        // We didn't find the document in any workspace, record a telemetry notification that we did not find it.
+        var searchedWorkspaceKinds = string.Join(";", lspSolutions.SelectAsArray(lspSolution => lspSolution.Solution.Workspace.Kind));
+        _logger.TraceError($"Could not find '{uri}'.  Searched {searchedWorkspaceKinds}");
+        _requestTelemetryLogger.UpdateFindDocumentTelemetryData(success: false, workspaceKind: null);
+
+        // Add the document to our loose files workspace if its open.
+        var miscDocument = _trackedDocuments.ContainsKey(uri) ? _lspMiscellaneousFilesWorkspace?.AddMiscellaneousDocument(uri, _trackedDocuments[uri]) : null;
+        return miscDocument;
+    }
+
+    /// <summary>
+    /// Gets the LSP view of all the registered workspaces' current solutions.
+    /// </summary>
+    private ImmutableArray<(Solution Solution, bool IsForked)> GetLspSolutions()
+    {
+        // Ensure that the loose files workspace is searched last.
+        var registeredWorkspaces = _lspWorkspaceRegistrationService.GetAllRegistrations();
+        registeredWorkspaces = registeredWorkspaces
+            .Where(workspace => workspace is not LspMiscellaneousFilesWorkspace)
+            .Concat(registeredWorkspaces.Where(workspace => workspace is LspMiscellaneousFilesWorkspace)).ToImmutableArray();
+
+        using var _ = ArrayBuilder<(Solution, bool)>.GetInstance(out var solutions);
+        foreach (var workspace in registeredWorkspaces)
+        {
+            var workspaceCurrentSolution = workspace.CurrentSolution;
+            var lspSolution = GetLspSolutionForWorkspace(workspaceCurrentSolution);
+            solutions.Add(lspSolution);
+        }
+
+        return solutions.ToImmutable();
+
+        (Solution Solution, bool IsForked) GetLspSolutionForWorkspace(Solution workspaceCurrentSolution)
+        {
+            // At a high level these are the steps we take to compute what the desired LSP solution should be.
+            //
+            //   1.  First we want to check if our workspace current solution is the same as the last workspace current solution that we verified matches the LSP text.
+            //       If so, we can skip comparing the LSP text against the workspace text and just return the cached one since absolutely nothing has changed.
+            //       Importantly, we do not return a cached forked solution - we do not want to re-use a forked solution if the LSP text has changed and now matches the workspace.
+            //
+            //   2.  If the cached solution isn't a match, we compare the LSP text to the workspace's text and return the workspace text if all LSP text matches.
+            //       This check is performant as checksums will be computed for these documents in order to make requests OOP.  So these are already computed or will be later in this request.
+            //
+            //   3.  Third, we check to see if we have cached a forked LSP solution for the current set of LSP texts against the current workspace version.
+            //       If so, we can just reuse that instead of re-forking and blowing away the trees / source generated docs / etc. that we created for the fork.
+            //       
+            //   4.  We have nothing cached for this combination of LSP texts and workspace version.  We have exhausted our options and must create an LSP fork
+            //       from the current workspace solution with the current LSP text.
+            //
+            //   We propogate the IsForked value back up so that we only report telemetry on forking if the forked solution is actually requested.
+
+            // Step 1: Check if nothing has changed and we already verified that the workspace text matches our LSP text.
+            if (_cachedLspSolutions.TryGetValue(workspaceCurrentSolution.Workspace, out var cachedSolution) && cachedSolution.Solution == workspaceCurrentSolution)
+            {
+                return (workspaceCurrentSolution, IsForked: false);
             }
 
-            // Filter the matching documents by project context.
-            var documentInProjectContext = findDocumentResult.FindDocumentInProjectContext(textDocumentIdentifier);
-            return documentInProjectContext;
+            // Step 2: Check to see if the LSP text matches the workspace text.
+            var documentsInWorkspace = GetDocumentsForUris(_trackedDocuments.Keys.ToImmutableArray(), workspaceCurrentSolution);
+            if (DoesAllTextMatchWorkspaceSolution(documentsInWorkspace))
+            {
+                // Remember that the current LSP text matches the text in this workspace solution.
+                _cachedLspSolutions[workspaceCurrentSolution.Workspace] = (ForkedFromVersion: null, workspaceCurrentSolution);
+                return (workspaceCurrentSolution, IsForked: false);
+            }
+
+            // Step 3: See if we can reuse a previously forked solution.
+            if (cachedSolution != default && cachedSolution.ForkedFromVersion == workspaceCurrentSolution.WorkspaceVersion)
+            {
+                return (cachedSolution.Solution, IsForked: true);
+            }
+
+            // Step 4: Fork a new solution from the workspace with the LSP text applied.
+            var lspSolution = workspaceCurrentSolution;
+            foreach (var (uri, workspaceDocuments) in documentsInWorkspace)
+            {
+                lspSolution = lspSolution.WithDocumentText(workspaceDocuments.Select(d => d.Id), _trackedDocuments[uri]);
+            }
+
+            // Remember this forked solution and the workspace version it was forked from.
+            _cachedLspSolutions[workspaceCurrentSolution.Workspace] = (workspaceCurrentSolution.WorkspaceVersion, lspSolution);
+            return (lspSolution, IsForked: true);
         }
+    }
+
+    /// <summary>
+    /// Given a set of documents from the workspace current solution, verify that the LSP text is the same as the document contents.
+    /// </summary>
+    private bool DoesAllTextMatchWorkspaceSolution(ImmutableDictionary<Uri, ImmutableArray<Document>> documentsInWorkspace)
+    {
+        foreach (var (uriInWorkspace, documentsForUri) in documentsInWorkspace)
+        {
+            var isTextEquivalent = AreChecksumsEqual(documentsForUri.First(), _trackedDocuments[uriInWorkspace]);
+
+            if (!isTextEquivalent)
+            {
+                _logger.TraceWarning($"Text for {uriInWorkspace} did not match text in workspace's current solution");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool AreChecksumsEqual(Document document, SourceText lspText)
+    {
+        var documentText = document.GetTextSynchronously(CancellationToken.None);
+        var documentTextChecksum = documentText.GetChecksum();
+        var lspTextChecksum = lspText.GetChecksum();
+        return lspTextChecksum.SequenceEqual(documentTextChecksum);
     }
 
     #endregion
 
     /// <summary>
-    /// Helper to clear out the LSP incremental solution for all registered workspaces.
-    /// Should be called under <see cref="_gate"/>
+    /// Using the workspace's current solutions, find the matching documents in for each URI.
     /// </summary>
-    private void ResetIncrementalLspSolutions_CalledUnderLock()
+    private static ImmutableDictionary<Uri, ImmutableArray<Document>> GetDocumentsForUris(ImmutableArray<Uri> trackedDocuments, Solution workspaceCurrentSolution)
     {
-        Contract.ThrowIfFalse(Monitor.IsEntered(_gate));
-
-        var workspaces = _workspaceToLspSolution.Keys.ToImmutableArray();
-        foreach (var workspace in workspaces)
+        using var _ = PooledDictionary<Uri, ImmutableArray<Document>>.GetInstance(out var documentsInSolution);
+        foreach (var trackedDoc in trackedDocuments)
         {
-            _workspaceToLspSolution[workspace] = null;
-        }
-    }
-
-    /// <summary>
-    /// Helper to get LSP solutions for all the registered workspaces.
-    /// If the incremental lsp solution is missing, this will re-fork from the workspace.
-    /// Should be called under <see cref="_gate"/>
-    /// </summary>
-    private ImmutableArray<Solution> ComputeIncrementalLspSolutions_CalledUnderLock()
-    {
-        Contract.ThrowIfFalse(Monitor.IsEntered(_gate));
-
-        var workspacePairs = _workspaceToLspSolution.ToImmutableArray();
-        using var updatedSolutions = TemporaryArray<Solution>.Empty;
-        foreach (var (workspace, incrementalSolution) in workspacePairs)
-        {
-            if (incrementalSolution == null)
+            var documents = workspaceCurrentSolution.GetDocuments(trackedDoc);
+            if (documents.Any())
             {
-                // We have no incremental lsp solution, create a new one forked from the workspace with LSP tracked documents.
-                var newIncrementalSolution = GetSolutionWithReplacedDocuments(workspace.CurrentSolution, _trackedDocuments.Select(k => (k.Key, k.Value)).ToImmutableArray());
-                _workspaceToLspSolution[workspace] = newIncrementalSolution;
-                updatedSolutions.Add(newIncrementalSolution);
-            }
-            else
-            {
-                updatedSolutions.Add(incrementalSolution);
+                documentsInSolution[trackedDoc] = documents;
             }
         }
 
-        return updatedSolutions.ToImmutableAndClear();
-    }
-
-    /// <summary>
-    /// Looks for document(s - e.g. linked docs) from a single solution matching the input URI in the set of passed in solutions.
-    /// 
-    /// Client name is used in razor cases to filter out non-razor documents.  However once we switch fully over to pull
-    /// diagnostics, the client should only ever ask the razor server about razor documents, so we may be able to remove it here.
-    /// </summary>
-    private static ImmutableArray<Document> FindDocuments(
-        Uri uri,
-        ImmutableArray<Solution> registeredSolutions,
-        RequestTelemetryLogger telemetryLogger,
-        ILspLogger logger)
-    {
-        logger.TraceInformation($"Finding document corresponding to {uri}");
-
-        // Ensure we search the lsp misc files solution last if it is present.
-        registeredSolutions = registeredSolutions
-            .Where(solution => solution.Workspace is not LspMiscellaneousFilesWorkspace)
-            .Concat(registeredSolutions.Where(solution => solution.Workspace is LspMiscellaneousFilesWorkspace)).ToImmutableArray();
-
-        // First search the registered workspaces for documents with a matching URI.
-        if (TryGetDocumentsForUri(uri, registeredSolutions, out var documents, out var solution))
-        {
-            telemetryLogger.UpdateFindDocumentTelemetryData(success: true, solution.Workspace.Kind);
-            logger.TraceInformation($"{documents.Value.First().FilePath} found in workspace {solution.Workspace.Kind}");
-
-            return documents.Value;
-        }
-
-        // We didn't find the document in any workspace, record a telemetry notification that we did not find it.
-        var searchedWorkspaceKinds = string.Join(";", registeredSolutions.SelectAsArray(s => s.Workspace.Kind));
-        logger.TraceError($"Could not find '{uri}'.  Searched {searchedWorkspaceKinds}");
-        telemetryLogger.UpdateFindDocumentTelemetryData(success: false, workspaceKind: null);
-        return ImmutableArray<Document>.Empty;
-
-        static bool TryGetDocumentsForUri(
-            Uri uri,
-            ImmutableArray<Solution> registeredSolutions,
-            [NotNullWhen(true)] out ImmutableArray<Document>? documents,
-            [NotNullWhen(true)] out Solution? solution)
-        {
-            foreach (var registeredSolution in registeredSolutions)
-            {
-                var matchingDocuments = registeredSolution.GetDocuments(uri);
-                if (matchingDocuments.Any())
-                {
-                    documents = matchingDocuments;
-                    solution = registeredSolution;
-                    return true;
-                }
-            }
-
-            documents = null;
-            solution = null;
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Gets a solution that represents the workspace view of the world (as passed in via the solution parameter)
-    /// but with document text for any open documents updated to match the LSP view of the world. This makes
-    /// the LSP server the source of truth for all document text, but all other changes come from the workspace
-    /// </summary>
-    private static Solution GetSolutionWithReplacedDocuments(Solution solution, ImmutableArray<(Uri DocumentUri, SourceText Text)> documentsToReplace)
-    {
-        foreach (var (uri, text) in documentsToReplace)
-        {
-            var documentIds = solution.GetDocumentIds(uri);
-
-            // The tracked document might not be a part of this solution.
-            if (documentIds.Any())
-            {
-                solution = solution.WithDocumentText(documentIds, text);
-            }
-        }
-
-        return solution;
+        return documentsInSolution.ToImmutableDictionary();
     }
 
     internal TestAccessor GetTestAccessor()
@@ -470,24 +327,9 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
         public LspMiscellaneousFilesWorkspace? GetLspMiscellaneousFilesWorkspace()
             => _manager._lspMiscellaneousFilesWorkspace;
 
-        public ImmutableDictionary<Workspace, Solution?> GetWorkspaceState()
+        public bool IsWorkspaceRegistered(Workspace workspace)
         {
-            lock (_manager._gate)
-            {
-                return _manager._workspaceToLspSolution.ToImmutableDictionary();
-            }
-        }
-
-        /// <summary>
-        /// Used to ensure that tests start with a consistent state in the LSP manager
-        /// no matter what workspace events were triggered during creation.
-        /// </summary>
-        public void ResetLspSolutions()
-        {
-            lock (_manager._gate)
-            {
-                _manager.ResetIncrementalLspSolutions_CalledUnderLock();
-            }
+            return _manager._lspWorkspaceRegistrationService.GetAllRegistrations().Contains(workspace);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -275,11 +275,13 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, IDisposable
     {
         foreach (var (uriInWorkspace, documentsForUri) in documentsInWorkspace)
         {
-            var isTextEquivalent = await AreChecksumsEqualAsync(documentsForUri.First(), _trackedDocuments[uriInWorkspace], cancellationToken).ConfigureAwait(false);
+            // We're comparing text, so we can take any of the linked documents.
+            var firstDocument = documentsForUri.First();
+            var isTextEquivalent = await AreChecksumsEqualAsync(firstDocument, _trackedDocuments[uriInWorkspace], cancellationToken).ConfigureAwait(false);
 
             if (!isTextEquivalent)
             {
-                _logger.TraceWarning($"Text for {uriInWorkspace} did not match text in workspace's current solution");
+                _logger.TraceWarning($"Text for {uriInWorkspace} did not match document text {firstDocument.Id} in workspace's {firstDocument.Project.Solution.Workspace.Kind} current solution");
                 return false;
             }
         }

--- a/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.LinkedDocuments.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.LinkedDocuments.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.DocumentChanges
             var trackedDocuments = testLspServer.GetQueueAccessor().GetTrackedTexts();
             Assert.Equal(1, trackedDocuments.Length);
 
-            var solution = GetLSPSolution(testLspServer, caretLocation.Uri);
+            var solution = await GetLSPSolutionAsync(testLspServer, caretLocation.Uri).ConfigureAwait(false);
 
             foreach (var document in solution.Projects.First().Documents)
             {
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.DocumentChanges
 
             await DidChange(testLspServer, caretLocation.Uri, (4, 8, "// hi there"));
 
-            var solution = GetLSPSolution(testLspServer, caretLocation.Uri);
+            var solution = await GetLSPSolutionAsync(testLspServer, caretLocation.Uri).ConfigureAwait(false);
 
             foreach (var document in solution.Projects.First().Documents)
             {
@@ -99,9 +99,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.DocumentChanges
             Assert.Empty(testLspServer.GetQueueAccessor().GetTrackedTexts());
         }
 
-        private static Solution GetLSPSolution(TestLspServer testLspServer, Uri uri)
+        private static async Task<Solution> GetLSPSolutionAsync(TestLspServer testLspServer, Uri uri)
         {
-            var lspDocument = testLspServer.GetManager().GetLspDocument(new TextDocumentIdentifier { Uri = uri });
+            var lspDocument = await testLspServer.GetManager().GetLspDocumentAsync(new TextDocumentIdentifier { Uri = uri }, CancellationToken.None).ConfigureAwait(false);
             Contract.ThrowIfNull(lspDocument);
             return lspDocument.Project.Solution;
         }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
@@ -32,19 +32,12 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         using var testLspServer = await CreateTestLspServerAsync(string.Empty);
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
-        // Open a loose file and verify it gets added to the misc workspace.
+        // Open an empty loose file and make a request to verify it gets added to the misc workspace.
         var looseFileUri = new Uri(@"C:\SomeFile.cs");
         await testLspServer.OpenDocumentAsync(looseFileUri, source).ConfigureAwait(false);
-        Assert.Equal(looseFileUri.AbsolutePath, GetMiscellaneousDocument(testLspServer)!.FilePath);
 
-        // Verify requests succeed against the loose file.
-        var caret = new LSP.Location
-        {
-            Range = new LSP.Range { Start = new LSP.Position { Character = 6, Line = 0 }, End = new LSP.Position { Character = 7, Line = 0 } },
-            Uri = looseFileUri,
-        };
-        var hover = await RunGetHoverAsync(testLspServer, caret).ConfigureAwait(false);
-        Assert.Contains("class A", hover.Contents.Third.Value);
+        // Verify file is added to the misc file workspace.
+        AssertFileInMiscWorkspace(testLspServer, looseFileUri);
     }
 
     [Fact]
@@ -63,20 +56,16 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
 
         var looseFileUri = new Uri(@"C:\SomeFile.cs");
 
-        // Open an empty loose file and verify it gets added to the misc workspace.
+        // Open an empty loose file and make a request to verify it gets added to the misc workspace.
         await testLspServer.OpenDocumentAsync(looseFileUri, string.Empty).ConfigureAwait(false);
-        var docText = await GetMiscellaneousDocument(testLspServer)!.GetTextAsync(CancellationToken.None).ConfigureAwait(false);
-        Assert.Equal(string.Empty, docText.ToString());
+        AssertFileInMiscWorkspace(testLspServer, looseFileUri);
 
         // Make a text change to the loose file and verify requests appropriately reflect the changes.
         await testLspServer.InsertTextAsync(looseFileUri, (0, 0, source)).ConfigureAwait(false);
-        var caret = new LSP.Location
-        {
-            Range = new LSP.Range { Start = new LSP.Position { Character = 6, Line = 0 }, End = new LSP.Position { Character = 7, Line = 0 } },
-            Uri = looseFileUri,
-        };
+        var caret = new LSP.Location { Range = new() { Start = new(0, 6), End = new(0, 7) }, Uri = looseFileUri };
         var hover = await RunGetHoverAsync(testLspServer, caret).ConfigureAwait(false);
         Assert.Contains("class A", hover.Contents.Third.Value);
+        AssertFileInMiscWorkspace(testLspServer, looseFileUri);
     }
 
     [Fact]
@@ -94,10 +83,10 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         using var testLspServer = await CreateTestLspServerAsync(string.Empty);
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
-        // Open a loose file and verify it gets added to the misc workspace.
+        // Open an empty loose file and make a request to verify it gets added to the misc workspace.
         var looseFileUri = new Uri(@"C:\SomeFile.cs");
         await testLspServer.OpenDocumentAsync(looseFileUri, source).ConfigureAwait(false);
-        Assert.Equal(looseFileUri.AbsolutePath, GetMiscellaneousDocument(testLspServer)!.FilePath);
+        AssertFileInMiscWorkspace(testLspServer, looseFileUri);
 
         // Verify the loose file is removed from the misc workspace on close.
         await testLspServer.CloseDocumentAsync(looseFileUri).ConfigureAwait(false);
@@ -140,19 +129,13 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
         using var testLspServer = await CreateTestLspServerAsync(string.Empty);
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
-        // Open a loose file and verify it gets added to the misc workspace.
+        // Open an empty loose file and make a request to verify it gets added to the misc workspace.
         var looseFileUri = new Uri(@"C:\SomeFile.cs");
+        var looseFileTextDocumentIdentifier = new LSP.TextDocumentIdentifier { Uri = looseFileUri };
         await testLspServer.OpenDocumentAsync(looseFileUri, source).ConfigureAwait(false);
-        Assert.Equal(looseFileUri.AbsolutePath, GetMiscellaneousDocument(testLspServer)!.FilePath);
 
-        // Verify requests succeed against the loose file.
-        var caret = new LSP.Location
-        {
-            Range = new LSP.Range { Start = new LSP.Position { Character = 6, Line = 0 }, End = new LSP.Position { Character = 7, Line = 0 } },
-            Uri = looseFileUri,
-        };
-        var hover = await RunGetHoverAsync(testLspServer, caret).ConfigureAwait(false);
-        Assert.Contains("class A", hover.Contents.Third.Value);
+        // Verify that the file returned by the manager is in the lsp misc files workspace.
+        AssertFileInMiscWorkspace(testLspServer, looseFileUri);
 
         // Update the workspace to contain the loose file.
         var project = testLspServer.GetCurrentSolution().Projects.Single();
@@ -167,18 +150,20 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
 
         Assert.Contains(looseFileUri.AbsolutePath, testLspServer.GetCurrentSolution().Projects.Single().Documents.Select(d => d.FilePath));
 
-        // Make a change and verify that the file is no longer present in the misc workspace.
-        await testLspServer.InsertTextAsync(looseFileUri, (0, 6, "B")).ConfigureAwait(false);
-        Assert.Null(GetMiscellaneousDocument(testLspServer));
+        // Verify that the manager returns the file that has been added to the main workspace.
+        AssertFileInMainWorkspace(testLspServer, looseFileUri);
+    }
 
-        // Verify the change is reflected in subsequent requests.
-        caret = new LSP.Location
-        {
-            Range = new LSP.Range { Start = new LSP.Position { Character = 6, Line = 0 }, End = new LSP.Position { Character = 8, Line = 0 } },
-            Uri = looseFileUri,
-        };
-        hover = await RunGetHoverAsync(testLspServer, caret).ConfigureAwait(false);
-        Assert.Contains("class BA", hover.Contents.Third.Value);
+    private static void AssertFileInMiscWorkspace(TestLspServer testLspServer, Uri fileUri)
+    {
+        Assert.Equal(testLspServer.GetManagerAccessor().GetLspMiscellaneousFilesWorkspace(),
+            testLspServer.GetManager().GetLspDocument(new LSP.TextDocumentIdentifier { Uri = fileUri })!.Project.Solution.Workspace);
+    }
+
+    private static void AssertFileInMainWorkspace(TestLspServer testLspServer, Uri fileUri)
+    {
+        Assert.Equal(testLspServer.TestWorkspace, testLspServer.GetManager().GetLspDocument(new LSP.TextDocumentIdentifier { Uri = fileUri })!.Project.Solution.Workspace);
+
     }
 
     private static Document? GetMiscellaneousDocument(TestLspServer testLspServer)

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.RequestOrdering
             Contract.ThrowIfNull(response);
             if (response.ContextHasSolution)
             {
-                var solution = testLspServer.GetManager().TryGetHostLspSolution();
+                var solution = await testLspServer.GetManager().TryGetHostLspSolutionAsync(CancellationToken.None).ConfigureAwait(false);
                 Contract.ThrowIfNull(solution);
                 return solution;
             }

--- a/src/Features/LanguageServer/ProtocolUnitTests/SpellCheck/SpellCheckTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SpellCheck/SpellCheckTests.cs
@@ -168,7 +168,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.SpellCheck
 
             await InsertTextAsync(testLspServer, document, buffer.CurrentSnapshot.Length, "// comment");
 
-            document = testLspServer.GetManager().TryGetHostLspSolution()!.Projects.Single().Documents.Single();
+            var lspSolution = await testLspServer.GetManager().TryGetHostLspSolutionAsync(CancellationToken.None).ConfigureAwait(false);
+            document = lspSolution!.Projects.Single().Documents.Single();
             results = await RunGetDocumentSpellCheckSpansAsync(testLspServer, document.GetURI(), results.Single().ResultId);
 
             MarkupTestFile.GetSpans(
@@ -463,7 +464,8 @@ class {|Identifier:A|}
             var results2 = await RunGetWorkspaceSpellCheckSpansAsync(testLspServer, previousResults: CreateParamsFromPreviousReports(results));
 
             Assert.Equal(2, results2.Length);
-            document = testLspServer.GetManager().TryGetHostLspSolution()!.Projects.Single().Documents.First();
+            var lspSolution = await testLspServer.GetManager().TryGetHostLspSolutionAsync(CancellationToken.None).ConfigureAwait(false);
+            document = lspSolution!.Projects.Single().Documents.First();
             sourceText = await document.GetTextAsync();
 
             MarkupTestFile.GetSpans(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -546,5 +546,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Refactoring_FixAllOccurrencesContext = 561,
         Refactoring_FixAllOccurrencesComputation = 562,
         Refactoring_FixAllOccurrencesPreviewChanges = 563,
+
+        LSP_UsedForkedSolution = 571,
     }
 }


### PR DESCRIPTION
### I recomend reviewing one commit at a time
The first commit is the majority of the work
The second commit makes stuff async
The third is some small cleanup

Numbers from testing locally about 4% of requests had to use a forked solution.  The rest were able to re-use the workspace solution.

e.g.
```
vs.ide.vbcs.lsp.usedforkedsolution.false	3276
vs.ide.vbcs.lsp.usedforkedsolution.server	AlwaysActivateInProcLanguageClient
vs.ide.vbcs.lsp.usedforkedsolution.true	116
```


It's consistently even better in Razor, around 0.2% (perhaps due to the fact that the generated doc in the C# workspace is updated as part of the overall LSP change for the razor file).

e.g.
```
vs.ide.vbcs.lsp.usedforkedsolution.false	1724
vs.ide.vbcs.lsp.usedforkedsolution.server	RazorInProcLanguageClient
vs.ide.vbcs.lsp.usedforkedsolution.true	4
```
 