### PR TITLE
Suggest `fixed` keyword in unsafe local functions

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/FixedKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/FixedKeywordRecommenderTests.cs
@@ -6,6 +6,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
@@ -147,6 +148,40 @@ $$");
             await VerifyAbsenceAsync(
 @"unsafe struct S {
     static $$");
+        }
+
+        [WorkItem(52296, "https://github.com/dotnet/roslyn/issues/52296")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestInUnsafeLocalFunction()
+        {
+            await VerifyKeywordAsync(
+@"public class C
+{
+    public void M()
+    {
+        unsafe void Local()
+        {
+            $$
+        }
+    }
+}");
+        }
+
+        [WorkItem(52296, "https://github.com/dotnet/roslyn/issues/52296")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotInOrdinaryLocalFunction()
+        {
+            await VerifyAbsenceAsync(
+@"public class C
+{
+    public void M()
+    {
+        void Local()
+        {
+            $$
+        }
+    }
+}");
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -504,7 +504,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         {
             return
                 targetToken.GetAncestors<StatementSyntax>().Any(s => s.IsKind(SyntaxKind.UnsafeStatement)) ||
-                targetToken.GetAncestors<MemberDeclarationSyntax>().Any(m => m.GetModifiers().Any(SyntaxKind.UnsafeKeyword));
+                targetToken.GetAncestors<MemberDeclarationSyntax>().Any(m => m.GetModifiers().Any(SyntaxKind.UnsafeKeyword) ||
+                targetToken.GetAncestors<LocalFunctionStatementSyntax>().Any(f => f.GetModifiers().Any(SyntaxKind.UnsafeKeyword)));
         }
 
         public static bool IsAfterYieldKeyword(this SyntaxToken targetToken)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/52296