### PR TITLE
Improve performance of SourceText.IsBinary on .NET Core

### DIFF
--- a/src/Compilers/Core/Portable/Text/LargeText.cs
+++ b/src/Compilers/Core/Portable/Text/LargeText.cs
@@ -132,34 +132,6 @@ namespace Microsoft.CodeAnalysis.Text
             return chunks.ToImmutableAndFree();
         }
 
-        /// <summary>
-        /// Check for occurrence of two consecutive NUL (U+0000) characters.
-        /// This is unlikely to appear in genuine text, so it's a good heuristic
-        /// to detect binary files.
-        /// </summary>
-        private static bool IsBinary(char[] chunk)
-        {
-            // PERF: We can advance two chars at a time unless we find a NUL.
-            for (int i = 1; i < chunk.Length;)
-            {
-                if (chunk[i] == '\0')
-                {
-                    if (chunk[i - 1] == '\0')
-                    {
-                        return true;
-                    }
-
-                    i += 1;
-                }
-                else
-                {
-                    i += 2;
-                }
-            }
-
-            return false;
-        }
-
         private int GetIndexFromPosition(int position)
         {
             // Binary search to find the chunk that contains the given position.


### PR DESCRIPTION
The code is self explanatory 🙃

Tiny benchmark testing just the IsBinary method on a string from a 74 kB source file on .NET 6, where `IsBinary` is the old implementation and `IsBinary2` is the new one:
```
|    Method |      Mean |     Error |    StdDev |    Median |
|---------- |----------:|----------:|----------:|----------:|
|  IsBinary | 45.144 us | 0.8997 us | 2.4780 us | 44.511 us |
| IsBinary2 |  4.814 us | 0.2391 us | 0.7049 us |  4.492 us |
```

Benchmark testing `SourceText.From(fileStream, throwIfBinaryDetected: true)` for BoundNodes.xml.Generated.cs,
before the change:
```
|         Method |                  Job |              Runtime |     Mean |     Error |    StdDev |
|--------------- |--------------------- |--------------------- |---------:|----------:|----------:|
| SourceTextFrom |             .NET 6.0 |             .NET 6.0 | 5.295 ms | 0.1426 ms | 0.4068 ms |
| SourceTextFrom |        .NET Core 3.1 |        .NET Core 3.1 | 5.412 ms | 0.1082 ms | 0.2962 ms |
| SourceTextFrom | .NET Framework 4.7.2 | .NET Framework 4.7.2 | 5.712 ms | 0.1141 ms | 0.2480 ms |
```
after the change:
```
|         Method |                  Job |              Runtime |     Mean |     Error |    StdDev |
|--------------- |--------------------- |--------------------- |---------:|----------:|----------:|
| SourceTextFrom |             .NET 6.0 |             .NET 6.0 | 3.975 ms | 0.1002 ms | 0.2906 ms |
| SourceTextFrom |        .NET Core 3.1 |        .NET Core 3.1 | 4.046 ms | 0.0827 ms | 0.2424 ms |
| SourceTextFrom | .NET Framework 4.7.2 | .NET Framework 4.7.2 | 5.481 ms | 0.1149 ms | 0.3389 ms |
```
EDIT: It seems the difference is exaggerated in the SourceTextFrom benchmarks, I guess because it's completely different runs. The actual difference shouldn't be more than 500ms because that seems to be the difference between using `throwIfBinaryDetected` true vs false with the original code.