### PR TITLE
Take trivia from old method references when replacing them with generated property references

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2618,5 +2618,55 @@ class C
     }
 }");
         }
+
+        [WorkItem(40758, "https://github.com/dotnet/roslyn/issues/40758")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestReferenceTrivia3()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    static bool [||]Value() => default;
+
+    static void Main()
+    {
+        var valueAsDelegate = /*test*/Value;
+    }
+}",
+@"class Class
+{
+    static bool Value => default;
+
+    static void Main()
+    {
+        var valueAsDelegate = /*test*/{|Conflict:Value|};
+    }
+}");
+        }
+
+        [WorkItem(40758, "https://github.com/dotnet/roslyn/issues/40758")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestReferenceTrivia4()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    static bool [||]Value() => default;
+
+    static void Main()
+    {
+        var valueAsDelegate = Value/*test*/;
+    }
+}",
+@"class Class
+{
+    static bool Value => default;
+
+    static void Main()
+    {
+        var valueAsDelegate = {|Conflict:Value|}/*test*/;
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2560,5 +2560,63 @@ class C
     public Task<string> SomeTask { get => this.someTask; set => this.someTask = value; }
 }", index: 1);
         }
+
+        [WorkItem(40758, "https://github.com/dotnet/roslyn/issues/40758")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestReferenceTrivia1()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    static bool [||]Value() => default;
+
+    static void Main()
+    {
+        if (/*test*/Value())
+        {
+        }
+    }
+}",
+@"class Class
+{
+    static bool Value => default;
+
+    static void Main()
+    {
+        if (/*test*/Value)
+        {
+        }
+    }
+}");
+        }
+
+        [WorkItem(40758, "https://github.com/dotnet/roslyn/issues/40758")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestReferenceTrivia2()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Class
+{
+    static bool [||]Value() => default;
+
+    static void Main()
+    {
+        if (Value()/*test*/)
+        {
+        }
+    }
+}",
+@"class Class
+{
+    static bool Value => default;
+
+    static void Main()
+    {
+        if (Value/*test*/)
+        {
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
             }
 
             // It was invoked.  Remove the invocation, and also change the name if necessary.
-            replace(editor, invocation, nameNode, newName);
+            replace(editor, invocation, nameNode, newName.WithTriviaFrom(invocation));
         }
 
         private static bool IsInvocationName(IdentifierNameSyntax nameNode, ExpressionSyntax invocationExpression)

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -373,18 +373,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
             var newName = nameNode;
             if (nameChanged)
             {
-                if (invocation == null)
-                {
-                    newName = SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(propertyName)
-                        .WithTriviaFrom(nameToken));
-                }
-                else
-                {
-                    newName = SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(propertyName)
-                        .WithLeadingTrivia(nameToken.LeadingTrivia)
-                        .WithTrailingTrivia(invocation.ArgumentList.CloseParenToken.TrailingTrivia));
-                }
+                newName = SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(propertyName));
             }
+
+            newName = newName.WithTriviaFrom(invocation is null ? nameToken.Parent : invocation);
 
             var invocationExpression = invocation?.Expression;
             if (!IsInvocationName(nameNode, invocationExpression))
@@ -396,7 +388,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
             }
 
             // It was invoked.  Remove the invocation, and also change the name if necessary.
-            replace(editor, invocation, nameNode, newName.WithTriviaFrom(invocation));
+            replace(editor, invocation, nameNode, newName);
         }
 
         private static bool IsInvocationName(IdentifierNameSyntax nameNode, ExpressionSyntax invocationExpression)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/40758

This fixes only the main issue. I'll extract issue in the comment when this PR gets merged