### PR TITLE
Switch smart-copy-paste tests to use raw-string-literals.

### DIFF
--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
@@ -894,9 +894,9 @@ var dest =
 """");
         }
 
-#endregion
+        #endregion
 
-#region Known Source tests 'PasteUnknownSourceIntoSingleLineInterpolatedRawStringTests'
+        #region Known Source tests 'PasteUnknownSourceIntoSingleLineInterpolatedRawStringTests'
 
         // Tests where we place things directly on the clipboard (avoiding the need to do the actual copy).
         // This allows a port of the tests in PasteUnknownSourceIntoSingleLineInterpolatedRawStringTests.cs
@@ -3085,6 +3085,6 @@ var x = $""""""[||]"""
 """"""");
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
@@ -163,25 +163,25 @@ var dest =
 """");
         }
 
-#if false
-
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
 @"var v = ""{|Copy:\n|}"";",
-@"var dest =
-    $""""""
+""""
+var dest =
+    $"""
     [||]
-    """""";",
+    """;
+"""",
 "var dest =\r\n    $\"\"\"\r\n    \n    [||]\r\n    \"\"\";",
-@"var dest =
-    $""""""
+""""
+var dest =
+    $"""
     \n[||]
-    """""";");
+    """;
+"""");
         }
-
-#endif
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent()
@@ -1001,22 +1001,20 @@ var dest =
 """");
         }
 
-#if false
-
         [WpfFact]
         public void TestNewLineIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
                 pasteText: "\n",
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""",
+    """
+"""",
 "var x = $\"\"\"\r\n    \n    [||]\r\n    \"\"\"",
                 afterUndo:
 "var x = $\"\"\"\r\n    \n[||]\r\n    \"\"\"");
         }
-
-#endif
 
         [WpfFact]
         public void TestNewLineIntoSingleLineRawString2_A()
@@ -2068,23 +2066,22 @@ var x = $"""
 
         #endregion
 
-#region Known Source tests 'PasteUnknownSourceIntoMultiLineInterpolatedRawStringTests'
+        #region Known Source tests 'PasteUnknownSourceIntoMultiLineInterpolatedRawStringTests'
 
-#if false
         [WpfFact]
         public void TestNewLineIntoMultiLineRawString1()
         {
             TestPasteKnownSource(
                 pasteText: "\n",
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""",
+    """
+"""",
 "var x = $\"\"\"\r\n    \n    [||]\r\n    \"\"\"",
                 afterUndo:
 "var x = $\"\"\"\r\n    \n[||]\r\n    \"\"\"");
         }
-
-#endif
 
         [WpfFact]
         public void TestNewLineIntoMultiLineRawString2()

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
@@ -92,58 +92,78 @@ var dest =
         public void TestPasteLooksLikeInterpolationNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""
+"""var v = "{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $$""""""
+    """;
+"""",
+""""
+var dest =
+    $$"""
     {0}[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"var dest =
-    $""""""
+"""var v = "g{|Copy:o|}o";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     o[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"var dest =
-    $""""""
+"""var v = "\{|Copy:n|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     n[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
+
+#if false
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent()
@@ -161,543 +181,722 @@ var dest =
     """""";");
         }
 
+#endif
+
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"var dest =
-    $""""""
+"""var v = "\{|Copy:"|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
-    ""[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
+    "[||]
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"var dest =
-    $""""""
+"""var v = "{|Copy:\"|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
-    ""[||]
-    """""";",
-@"var dest =
-    $""""""
-    \""[||]
-    """""";");
+    """;
+"""",
+""""
+var dest =
+    $"""
+    "[||]
+    """;
+"""",
+""""
+var dest =
+    $"""
+    \"[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"var dest =
-    $""""""
+"""var v = @"{|Copy:goo|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     goo[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"var dest =
-    $""""""
+"""var v = @"g{|Copy:o|}o";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     o[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"var dest =
-    $""""""
+"""
+var v = @"{|Copy:
+|}";
+""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     
 [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"var dest =
-    $""""""
+"""var v = @"{|Copy:""|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
+    "[||]
+    """;
+"""",
+""""
+var dest =
+    $"""
     ""[||]
-    """""";",
-@"var dest =
-    $""""""
-    """"[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"var dest =
-    $""""""
+""""var v = """{|Copy:goo|}""";"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     goo[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"var dest =
-    $""""""
+""""var v = """{|Copy: "" |}""";"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
-     """" [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
+     "" [||]
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     goo[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     goo
     bar[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     goo
     bar[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
         goo
     bar[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"var dest =
-    $""""""
+"""var v = $"{|Copy:{0:X}|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0:X}[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"var dest =
-    $""""""
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
-    {0:""X""}[||]
-    """""";",
-@"var dest =
-    $""""""
-    {0:\""X\""}[||]
-    """""";");
+    """;
+"""",
+""""
+var dest =
+    $"""
+    {0:"X"}[||]
+    """;
+"""",
+""""
+var dest =
+    $"""
+    {0:\"X\"}[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"var dest =
-    $""""""
+"""var v = $@"{|Copy:{0:X}|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0:X}[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"var dest =
-    $""""""
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
+    {0:"X"}[||]
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0:""X""}[||]
-    """""";",
-@"var dest =
-    $""""""
-    {0:""""X""""}[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""[||]{|Selection:|}
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""[||]{|Selection:|}
 
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}[||]
 
-    """""";",
-@"var dest =
-    $""""""{0}[||]
+    """;
+"""",
+""""
+var dest =
+    $"""{0}[||]
 
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""[||]{|Selection:
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""[||]{|Selection:
 |}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}[||]
-    """""";",
-@"var dest =
-    $""""""{0}[||]
-    """""";");
+    """;
+"""",
+""""
+var dest =
+    $"""{0}[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection3()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""[||]{|Selection:
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""[||]{|Selection:
   |}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}[||]
-    """""";",
-@"var dest =
-    $""""""{0}[||]
-    """""";");
+    """;
+"""",
+""""
+var dest =
+    $"""{0}[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection4()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""[||]{|Selection:
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""[||]{|Selection:
     |}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}[||]
-    """""";",
-@"var dest =
-    $""""""{0}[||]
-    """""";");
+    """;
+"""",
+""""
+var dest =
+    $"""{0}[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection5()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""[||]{|Selection:
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""[||]{|Selection:
 
-|}    """""";",
-@"var dest =
-    $""""""
+|}    """;
+"""",
+""""
+var dest =
+    $"""
     {0}
-[||]    """""";",
-@"var dest =
-    $""""""{0}[||]    """""";");
+[||]    """;
+"""",
+""""
+var dest =
+    $"""{0}[||]    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection6()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""[||]{|Selection:
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""[||]{|Selection:
 
-  |}  """""";",
-@"var dest =
-    $""""""
+  |}  """;
+"""",
+""""
+var dest =
+    $"""
     {0}
-  [||]  """""";",
-@"var dest =
-    $""""""{0}[||]  """""";");
+  [||]  """;
+"""",
+""""
+var dest =
+    $"""{0}[||]  """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection7()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""[||]{|Selection:
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""[||]{|Selection:
 
-    |}"""""";",
-@"var dest =
-    $""""""
+    |}""";
+"""",
+""""
+var dest =
+    $"""
     {0}
-    [||]"""""";",
-@"var dest =
-    $""""""{0}[||]"""""";");
+    [||]""";
+"""",
+""""
+var dest =
+    $"""{0}[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection8()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""
 [||]{|Selection:|}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
 {0}[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection9()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""
 [||]{|Selection:  |}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
 {0}[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection10()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""
 [||]{|Selection:    |}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
 {0}[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection11()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""
 [||]{|Selection:
-|}    """""";",
-@"var dest =
-    $""""""
+|}    """;
+"""",
+""""
+var dest =
+    $"""
     {0}
-[||]    """""";",
-@"var dest =
-    $""""""
-{0}[||]    """""";");
+[||]    """;
+"""",
+""""
+var dest =
+    $"""
+{0}[||]    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection12()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""
 [||]{|Selection:
-  |}  """""";",
-@"var dest =
-    $""""""
+  |}  """;
+"""",
+""""
+var dest =
+    $"""
     {0}
-  [||]  """""";",
-@"var dest =
-    $""""""
-{0}[||]  """""";");
+  [||]  """;
+"""",
+""""
+var dest =
+    $"""
+{0}[||]  """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationIntoSelection13()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"var dest =
-    $""""""
+"""var v = $@"{|Copy:{0}|}";""",
+""""
+var dest =
+    $"""
 [||]{|Selection:
-    |}"""""";",
-@"var dest =
-    $""""""
+    |}""";
+"""",
+""""
+var dest =
+    $"""
     {0}
-    [||]"""""";",
-@"var dest =
-    $""""""
-{0}[||]"""""";");
+    [||]""";
+"""",
+""""
+var dest =
+    $"""
+{0}[||]""";
+"""");
         }
 
-        #endregion
+#endregion
 
-        #region Known Source tests 'PasteUnknownSourceIntoSingleLineInterpolatedRawStringTests'
+#region Known Source tests 'PasteUnknownSourceIntoSingleLineInterpolatedRawStringTests'
 
         // Tests where we place things directly on the clipboard (avoiding the need to do the actual copy).
         // This allows a port of the tests in PasteUnknownSourceIntoSingleLineInterpolatedRawStringTests.cs
@@ -706,77 +905,103 @@ var dest =
         public void TestPasteBracesWithExistingInterpolation1()
         {
             TestPasteKnownSource(
-pasteText: @"{{{",
-@"var dest =
-    $""""""
+pasteText: """{{{""",
+""""
+var dest =
+    $"""
     [||]{0}
-    """""";",
-@"var dest =
-    $$$$""""""
+    """;
+"""",
+""""
+var dest =
+    $$$$"""
     {{{[||]{{{{0}}}}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {{{[||]{0}
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteBracesWithExistingInterpolation2()
         {
             TestPasteKnownSource(
-pasteText: @"{{{",
-@"var dest =
-    $""""""
+pasteText: """{{{""",
+""""
+var dest =
+    $"""
     {0}[||]
-    """""";",
-@"var dest =
-    $$$$""""""
+    """;
+"""",
+""""
+var dest =
+    $$$$"""
     {{{{0}}}}{{{[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}{{{[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteBracesWithExistingInterpolation3()
         {
             TestPasteKnownSource(
-pasteText: @"{{{",
-@"var dest =
-    $""""""
+pasteText: """{{{""",
+""""
+var dest =
+    $"""
     {0}[||]{1}
-    """""";",
-@"var dest =
-    $$$$""""""
+    """;
+"""",
+""""
+var dest =
+    $$$$"""
     {{{{0}}}}{{{[||]{{{{1}}}}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}{{{[||]{1}
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteBracesWithExistingInterpolation4()
         {
             TestPasteKnownSource(
-pasteText: @"{{{",
-@"var dest =
-    $""""""
+pasteText: """{{{""",
+""""
+var dest =
+    $"""
     {0}[||]{|Selection:{1}|}{2}
-    """""";",
-@"var dest =
-    $$$$""""""
+    """;
+"""",
+""""
+var dest =
+    $$$$"""
     {{{{0}}}}{{{[||]{{{{2}}}}
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {0}{{{[||]{2}
-    """""";");
+    """;
+"""");
         }
+
+#if false
 
         [WpfFact]
         public void TestNewLineIntoSingleLineRawString1_A()
@@ -791,735 +1016,1061 @@ pasteText: @"{{{",
 "var x = $\"\"\"\r\n    \n[||]\r\n    \"\"\"");
         }
 
+#endif
+
         [WpfFact]
         public void TestNewLineIntoSingleLineRawString2_A()
         {
             TestPasteKnownSource(
-                pasteText: "\r\n",
-@"var x = $""""""
+                pasteText: """
+
+
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-"var x = $\"\"\"\r\n    \r\n    [||]\r\n    \"\"\"",
+    """
+"""",
+""""
+var x = $"""
+    
+    [||]
+    """
+"""",
                 afterUndo:
-"var x = $\"\"\"\r\n    \r\n[||]\r\n    \"\"\"");
+""""
+var x = $"""
+    
+[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "    ",
-@"var x = $""""""
+                pasteText: """    """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
         [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "    \r\n",
-@"var x = $""""""
+                pasteText: """
+                    
+
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
         
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
         
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "'",
-@"var x = $""""""
+                pasteText: """'""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     '[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
-    ""[||] 
-    """"""",
+                pasteText: """
+                "
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
+    "[||] 
+    """
+"""",
                 afterUndo:
-@"var x = $""""""""[||] """"""");
+"""""
+var x = $""""[||] """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""""
-    """"""[||] 
-    """"""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""[||] """
+"""",
+"""""
+var x = $""""
+    """[||] 
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""""""""[||] """"""");
+"""""""
+var x = $""""""[||] """
+""""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""
-    ""[||]
-    """"""",
-@"var x = $""""""""""
-    """"""""[||]
-    """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""
+    "[||]
+    """
+"""",
+""""""
+var x = $"""""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = $""""""
-    """"""""[||]
-    """"""");
+"""""
+var x = $"""
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""
-    ""[||]""
-    """"""",
-@"var x = $""""""""""""
-    """"""""[||]""
-    """"""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""
+    "[||]"
+    """
+"""",
+"""""""
+var x = $""""""
+    """"[||]"
+    """"""
+""""""",
                 afterUndo:
-@"var x = $""""""
-    """"""""[||]""
-    """"""");
+"""""
+var x = $"""
+    """"[||]"
+    """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""
-    [||]""
-    """"""",
-@"var x = $""""""""""
-    """"""[||]""
-    """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""
+    [||]"
+    """
+"""",
+""""""
+var x = $"""""
+    """[||]"
+    """""
+"""""",
                 afterUndo:
-@"var x = $""""""
-    """"""[||]""
-    """"""");
+""""
+var x = $"""
+    """[||]"
+    """
+"""");
         }
 
         [WpfFact]
         public void TestQuadrupleQuoteIntoSingleLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"\"",
-@"var x = $""""""
+                pasteText: """""
+                """"
+                """"",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""""""
-    """"""""[||]
-    """"""""""",
+    """
+"""",
+""""""
+var x = $"""""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = $""""""
-    """"""""[||]
-    """"""");
+"""""
+var x = $"""
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "{",
-@"var x = $""""""
+                pasteText: """{""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$""""""
+    """
+"""",
+""""
+var x = $$"""
     {[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenQuoteAndTripleOpenBraceIntoSingleLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "\"{{{",
-@"var x = $""""""
+                pasteText: """
+                "{{{
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$$""""""
-    ""{{{[||]
-    """"""",
+    """
+"""",
+""""
+var x = $$$$"""
+    "{{{[||]
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
-    ""{{{[||]
-    """"""");
+""""
+var x = $"""
+    "{{{[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenQuoteAndTripleOpenBraceIntoSingleLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"{{{",
-@"var x = $""""""
+                pasteText: """"
+                """{{{
+                """",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$$""""""""
-    """"""{{{[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = $$$$""""
+    """{{{[||]
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""
-    """"""{{{[||]
-    """"""");
+""""
+var x = $"""
+    """{{{[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenQuoteAndTripleOpenBraceIntoSingleLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: " \"\"\"{{{",
-@"var x = $""""""
+                pasteText: """" """{{{"""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$$""""""""
-     """"""{{{[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = $$$$""""
+     """{{{[||]
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""
-     """"""{{{[||]
-    """"""");
+""""
+var x = $"""
+     """{{{[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $""""""
+                pasteText: """{{{""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$$""""""
+    """
+"""",
+""""
+var x = $$$$"""
     {{{[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {{{[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $""""""
-    ""[||]
-    """"""",
-@"var x = $$$$""""""
-    ""{{{[||]
-    """"""",
+                pasteText: """{{{""",
+""""
+var x = $"""
+    "[||]
+    """
+"""",
+""""
+var x = $$$$"""
+    "{{{[||]
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
-    ""{{{[||]
-    """"""");
+""""
+var x = $"""
+    "{{{[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $""""""
-    ""[||]""
-    """"""",
-@"var x = $$$$""""""
-    ""{{{[||]""
-    """"""",
+                pasteText: """{{{""",
+""""
+var x = $"""
+    "[||]"
+    """
+"""",
+""""
+var x = $$$$"""
+    "{{{[||]"
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
-    ""{{{[||]""
-    """"""");
+""""
+var x = $"""
+    "{{{[||]"
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $""""""
-    [||]""
-    """"""",
-@"var x = $$$$""""""
-    {{{[||]""
-    """"""",
+                pasteText: """{{{""",
+""""
+var x = $"""
+    [||]"
+    """
+"""",
+""""
+var x = $$$$"""
+    {{{[||]"
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
-    {{{[||]""
-    """"""");
+""""
+var x = $"""
+    {{{[||]"
+    """
+"""");
         }
 
         [WpfFact]
         public void TestInterpolationIntoSingleLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "{0}",
-@"var x = $""""""
+                pasteText: """{0}""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$""""""
+    """
+"""",
+""""
+var x = $$"""
     {0}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {0}[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "{}",
-@"var x = $""""""
+                pasteText: """{}""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$""""""
+    """
+"""",
+""""
+var x = $$"""
     {}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {}[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "{}",
-@"var x = $$""""""
+                pasteText: """{}""",
+""""
+var x = $$"""
     [||]
-    """"""",
-@"var x = $$""""""
+    """
+"""",
+""""
+var x = $$"""
     {}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $$""""""
+""""
+var x = $$"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "{{}",
-@"var x = $$""""""
+                pasteText: """{{}""",
+""""
+var x = $$"""
     [||]
-    """"""",
-@"var x = $$$""""""
+    """
+"""",
+""""
+var x = $$$"""
     {{}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $$""""""
+""""
+var x = $$"""
     {{}[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "{}}",
-@"var x = $$""""""
+                pasteText: """{}}""",
+""""
+var x = $$"""
     [||]
-    """"""",
-@"var x = $$$""""""
+    """
+"""",
+""""
+var x = $$$"""
     {}}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $$""""""
+""""
+var x = $$"""
     {}}[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "{{}}",
-@"var x = $$""""""
+                pasteText: """{{}}""",
+""""
+var x = $$"""
     [||]
-    """"""",
-@"var x = $$$""""""
+    """
+"""",
+""""
+var x = $$$"""
     {{}}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $$""""""
+""""
+var x = $$"""
     {{}}[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestComplexStringIntoSingleLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "  \"\"  ",
-@"var x = $""""""
+                pasteText: """  ""  """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
-      """"  [||]
-    """"""",
+    """
+"""",
+""""
+var x = $"""
+      ""  [||]
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc",
-@"var x = $""""""
+                pasteText: """abc""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine4()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     goo[||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     gooabc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     gooabc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine5()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     goo[||]bar
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     gooabc
     def[||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     gooabc
 def[||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine6()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""
     goo[||]bar
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     gooabc
     def
     [||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     gooabc
 def
 [||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
         def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
     def
 ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = $"""
           [||]
-          """"""",
-@"var x = $""""""
+          """
+"""",
+""""
+var x = $"""
           abc
               def
           ghi[||]
-          """"""",
+          """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
           abc
     def
 ghi[||]
-          """"""");
+          """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
         def
         ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_A()
         {
             TestPasteKnownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = $""""""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
         abc
         def
         ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
         abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_A()
         {
             TestPasteKnownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = $""""""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
             abc
         def
         ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
             abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     [||]{|Selection:    |}
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""
     [||]{|Selection:    |}
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
 def
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     [||]{|Selection:    |}  
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
 def[||]  
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"bar",
-@"var x = $""""""
+                pasteText: """
+                "bar
+                """,
+""""
+var x = $"""
     [||]goo
-    """"""",
-@"var x = $""""""
-    ""bar[||]goo
-    """"""",
+    """
+"""",
+""""
+var x = $"""
+    "bar[||]goo
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]goo
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader1()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"",
-@"var x = $""""""
+                pasteText: """
+                ""
+                """,
+""""
+var x = $"""
     [||]{|Selection:    |}
-    """"""",
-@"var x = $""""""
-    """"[||]
-    """"""",
+    """
+"""",
+""""
+var x = $"""
+    ""[||]
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
         [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader2()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""
     [||]{|Selection:    |}
-    """"""",
-@"var x = $""""""""
-    """"""[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = $""""
+    """[||]
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""
-    """"""[||]
-    """"""");
+""""
+var x = $"""
+    """[||]
+    """
+"""");
         }
 
         #endregion
 
-        #region Known Source tests 'PasteUnknownSourceIntoMultiLineInterpolatedRawStringTests'
+#region Known Source tests 'PasteUnknownSourceIntoMultiLineInterpolatedRawStringTests'
 
+#if false
         [WpfFact]
         public void TestNewLineIntoMultiLineRawString1()
         {
@@ -1533,697 +2084,1010 @@ def[||]
 "var x = $\"\"\"\r\n    \n[||]\r\n    \"\"\"");
         }
 
+#endif
+
         [WpfFact]
         public void TestNewLineIntoMultiLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "\r\n",
-@"var x = $""""""
+                pasteText: """
+
+
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-"var x = $\"\"\"\r\n    \r\n    [||]\r\n    \"\"\"",
+    """
+"""",
+""""
+var x = $"""
+    
+    [||]
+    """
+"""",
                 afterUndo:
-"var x = $\"\"\"\r\n    \r\n[||]\r\n    \"\"\"");
+""""
+var x = $"""
+    
+[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoMultiLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "    ",
-@"var x = $""""""
+                pasteText: """    """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
         [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoMultiLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "    \r\n",
-@"var x = $""""""
+                pasteText: """
+                    
+
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
         
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
         
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoMultiLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "'",
-@"var x = $""""""
+                pasteText: """'""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     '[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoMultiLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "\"",
-@"var x = $""""""
+                pasteText: """
+                "
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
-    ""[||]
-    """"""",
+    """
+"""",
+""""
+var x = $"""
+    "[||]
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""""
-    """"""[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = $""""
+    """[||]
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""
-    """"""[||]
-    """"""");
+""""
+var x = $"""
+    """[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""  
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""  
     [||]
-    """"""  ",
-@"var x = $""""""""  
-    """"""[||]
-    """"""""  ",
+    """  
+"""",
+"""""
+var x = $""""  
+    """[||]
+    """"  
+""""",
                 afterUndo:
-@"var x = $""""""  
-    """"""[||]
-    """"""  ");
+""""
+var x = $"""  
+    """[||]
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""  
-    ""[||]
-    """"""  ",
-@"var x = $""""""""""  
-    """"""""[||]
-    """"""""""  ",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""  
+    "[||]
+    """  
+"""",
+""""""
+var x = $"""""  
+    """"[||]
+    """""  
+"""""",
                 afterUndo:
-@"var x = $""""""  
-    """"""""[||]
-    """"""  ");
+"""""
+var x = $"""  
+    """"[||]
+    """  
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""  
-    ""[||]""  
-    """"""  ",
-@"var x = $""""""""""""  
-    """"""""[||]""  
-    """"""""""""  ",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""  
+    "[||]"  
+    """  
+"""",
+"""""""
+var x = $""""""  
+    """"[||]"  
+    """"""  
+""""""",
                 afterUndo:
-@"var x = $""""""  
-    """"""""[||]""  
-    """"""  ");
+"""""
+var x = $"""  
+    """"[||]"  
+    """  
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""  
-    [||]""
-    """"""  ",
-@"var x = $""""""""""  
-    """"""[||]""
-    """"""""""  ",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""  
+    [||]"
+    """  
+"""",
+""""""
+var x = $"""""  
+    """[||]"
+    """""  
+"""""",
                 afterUndo:
-@"var x = $""""""  
-    """"""[||]""
-    """"""  ");
+""""
+var x = $"""  
+    """[||]"
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestQuadrupleQuoteIntoMultiLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"\"",
-@"var x = $""""""
+                pasteText: """""
+                """"
+                """"",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""""""
-    """"""""[||]
-    """"""""""",
+    """
+"""",
+""""""
+var x = $"""""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = $""""""
-    """"""""[||]
-    """"""");
+"""""
+var x = $"""
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestOpenBraceIntoMultiLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "{",
-@"var x = $""""""
+                pasteText: """{""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$""""""
+    """
+"""",
+""""
+var x = $$"""
     {[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoMultiLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $""""""
+                pasteText: """{{{""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$$""""""
+    """
+"""",
+""""
+var x = $$$$"""
     {{{[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {{{[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoMultiLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $$""""""
+                pasteText: """{{{""",
+""""
+var x = $$"""
     [||]
-    """"""",
-@"var x = $$$$""""""
+    """
+"""",
+""""
+var x = $$$$"""
     {{{[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $$""""""
+""""
+var x = $$"""
     {{{[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenBraceIntoMultiLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "{",
-@"var x = $$$""""""  
+                pasteText: """{""",
+""""
+var x = $$$"""  
     {[||]{
-    """"""  ",
-@"var x = $$$$""""""  
+    """  
+"""",
+""""
+var x = $$$$"""  
     {{[||]{
-    """"""  ",
+    """  
+"""",
                 afterUndo:
-@"var x = $$$""""""  
+""""
+var x = $$$"""  
     {{[||]{
-    """"""  ");
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestInterpolationIntoMultiLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "{0}",
-@"var x = $""""""  
+                pasteText: """{0}""",
+""""
+var x = $"""  
     [||]
-    """"""  ",
-@"var x = $$""""""  
+    """  
+"""",
+""""
+var x = $$"""  
     {0}[||]
-    """"""  ",
+    """  
+"""",
                 afterUndo:
-@"var x = $""""""  
+""""
+var x = $"""  
     {0}[||]
-    """"""  ");
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseIntoMultiLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "{}",
-@"var x = $""""""  
+                pasteText: """{}""",
+""""
+var x = $"""  
     [||]  
-    """"""  ",
-@"var x = $$""""""  
+    """  
+"""",
+""""
+var x = $$"""  
     {}[||]  
-    """"""  ",
+    """  
+"""",
                 afterUndo:
-@"var x = $""""""  
+""""
+var x = $"""  
     {}[||]  
-    """"""  ");
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoMultiLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "{{}",
-@"var x = $$""""""  
+                pasteText: """{{}""",
+""""
+var x = $$"""  
     [||]
-    """"""  ",
-@"var x = $$$""""""  
+    """  
+"""",
+""""
+var x = $$$"""  
     {{}[||]
-    """"""  ",
+    """  
+"""",
                 afterUndo:
-@"var x = $$""""""  
+""""
+var x = $$"""  
     {{}[||]
-    """"""  ");
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoMultiLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "{}}",
-@"var x = $""""""
+                pasteText: """{}}""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$""""""
+    """
+"""",
+""""
+var x = $$$"""
     {}}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {}}[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoMultiLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "{{}}",
-@"var x = $""""""
+                pasteText: """{{}}""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$""""""
+    """
+"""",
+""""
+var x = $$$"""
     {{}}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {{}}[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteTripleOpenBraceIntoMultiLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"{{{",
-@"var x = $""""""
+                pasteText: """"
+                """{{{
+                """",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$$""""""""
-    """"""{{{[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = $$$$""""
+    """{{{[||]
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""
-    """"""{{{[||]
-    """"""");
+""""
+var x = $"""
+    """{{{[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestComplexStringIntoMultiLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "  \"\"  ",
-@"var x = $""""""
+                pasteText: """  ""  """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
-      """"  [||]
-    """"""",
+    """
+"""",
+""""
+var x = $"""
+      ""  [||]
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "abc",
-@"var x = $""""""
+                pasteText: """abc""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine1()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine2()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
 [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
 abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine3()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]
 
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def[||]
 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
 def[||]
 
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine4()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     goo[||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     gooabc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     gooabc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine5()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     goo[||]bar
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     gooabc
     def[||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     gooabc
 def[||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine6()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""
     goo[||]bar
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     gooabc
     def
     [||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     gooabc
 def
 [||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine7()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
         def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
     def
 ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine8()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
         def
         ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine9()
         {
             TestPasteKnownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = $""""""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
         abc
         def
         ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
         abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine10()
         {
             TestPasteKnownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = $""""""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
             abc
         def
         ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
             abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine11()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]{|Selection:
 
-    |}""""""",
-@"var x = $""""""
+    |}"""
+"""",
+""""
+var x = $"""
     abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||]""""""");
+""""
+var x = $"""abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine12()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """
+                abc
+                def
 
-    |}""""""",
-@"var x = $""""""
+                """,
+""""
+var x = $"""[||]{|Selection:
+
+    |}"""
+"""",
+""""
+var x = $"""
     abc
     def
     
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
 def
-[||]""""""");
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine13()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]{|Selection:
 
- |}   """"""",
-@"var x = $""""""
+ |}   """
+"""",
+""""
+var x = $"""
     abc
     def
- [||]   """"""",
+ [||]   """
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||]   """"""");
+""""
+var x = $"""abc
+def[||]   """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringHeader1()
         {
             TestPasteKnownSource(
-                pasteText: "bar",
-@"var x = $""""""[||]
+                pasteText: """bar""",
+""""
+var x = $"""[||]
     goo
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     bar[||]
     goo
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""bar[||]
+""""
+var x = $"""bar[||]
     goo
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader1_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """
+                ""
+                """,
+""""
+var x = $"""[||]{|Selection:
 
-    |}""""""",
-@"var x = $""""""
-    """"
-    [||]""""""",
+    |}"""
+"""",
+""""
+var x = $"""
+    ""
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""""""[||]""""""");
+""""""
+var x = $"""""[||]"""
+"""""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader2_B()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""[||]{|Selection:
 
-    |}""""""",
-@"var x = $""""""""
-    """"""
-    [||]""""""""",
+    |}"""
+"""",
+"""""
+var x = $""""
+    """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = $""""""""""""[||]""""""");
+"""""""
+var x = $""""""[||]"""
+""""""");
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
@@ -17,19 +17,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestPasteSimpleNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+""""
 var dest =
-    $""""""
+    $"""
     [||]
-    """""";",
-@"
-var dest =
+    """;
+"""",
+@"var dest =
     $""""""
     goo[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -40,18 +39,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = ""{|Copy:{|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $$""""""
     {[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {[||]
     """""";");
@@ -62,18 +58,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = ""{|Copy:{}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $$""""""
     {}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {}[||]
     """""";");
@@ -84,18 +77,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = ""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $$""""""
     {0}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]
     """""";");
@@ -106,18 +96,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = ""g{|Copy:o|}o"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     o[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -128,18 +115,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = ""\{|Copy:n|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     n[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -150,14 +134,12 @@ var dest =
         {
             TestCopyPaste(
 @"var v = ""{|Copy:\n|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-"\r\nvar dest =\r\n    $\"\"\"\r\n    \n    [||]\r\n    \"\"\";",
-@"
-var dest =
+"var dest =\r\n    $\"\"\"\r\n    \n    [||]\r\n    \"\"\";",
+@"var dest =
     $""""""
     \n[||]
     """""";");
@@ -168,18 +150,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = ""\{|Copy:""|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     ""[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -190,18 +169,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = ""{|Copy:\""|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     ""[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     \""[||]
     """""";");
@@ -212,18 +188,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = @""{|Copy:goo|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     goo[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -234,18 +207,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = @""g{|Copy:o|}o"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     o[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -256,19 +226,16 @@ var dest =
         {
             TestCopyPaste(
 "var v = @\"{|Copy:\r\n|}\";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     
 [||]
@@ -280,18 +247,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = @""{|Copy:""""|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     ""[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     """"[||]
     """""";");
@@ -302,18 +266,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = """"""{|Copy:goo|}"""""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     goo[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -324,18 +285,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = """"""{|Copy: """" |}"""""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
      """" [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -348,18 +306,15 @@ var dest =
 @"var v = """"""
     {|Copy:goo|}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     goo[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -373,19 +328,16 @@ var dest =
     {|Copy:goo
     bar|}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     goo
     bar[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -399,19 +351,16 @@ var dest =
 {|Copy:    goo
     bar|}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     goo
     bar[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
         goo
     bar[||]
@@ -423,18 +372,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $""{|Copy:{0:X}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0:X}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -445,18 +391,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0:""X""}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0:\""X\""}[||]
     """""";");
@@ -467,18 +410,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0:X}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0:X}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";");
@@ -489,18 +429,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0:""X""}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0:""""X""""}[||]
     """""";");
@@ -511,19 +448,16 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""[||]{|Selection:|}
 
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]
 
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""{0}[||]
 
     """""";");
@@ -534,18 +468,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""[||]{|Selection:
 |}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""{0}[||]
     """""";");
         }
@@ -555,18 +486,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""[||]{|Selection:
   |}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""{0}[||]
     """""";");
         }
@@ -576,18 +504,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""[||]{|Selection:
     |}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""{0}[||]
     """""";");
         }
@@ -597,18 +522,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""[||]{|Selection:
 
 |}    """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}
 [||]    """""";",
-@"
-var dest =
+@"var dest =
     $""""""{0}[||]    """""";");
         }
 
@@ -617,18 +539,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""[||]{|Selection:
 
   |}  """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}
   [||]  """""";",
-@"
-var dest =
+@"var dest =
     $""""""{0}[||]  """""";");
         }
 
@@ -637,18 +556,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""[||]{|Selection:
 
     |}"""""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}
     [||]"""""";",
-@"
-var dest =
+@"var dest =
     $""""""{0}[||]"""""";");
         }
 
@@ -657,18 +573,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
 [||]{|Selection:|}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
 {0}[||]
     """""";");
@@ -679,18 +592,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
 [||]{|Selection:  |}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
 {0}[||]
     """""";");
@@ -701,18 +611,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
 [||]{|Selection:    |}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
 {0}[||]
     """""";");
@@ -723,18 +630,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
 [||]{|Selection:
 |}    """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}
 [||]    """""";",
-@"
-var dest =
+@"var dest =
     $""""""
 {0}[||]    """""";");
         }
@@ -744,18 +648,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
 [||]{|Selection:
   |}  """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}
   [||]  """""";",
-@"
-var dest =
+@"var dest =
     $""""""
 {0}[||]  """""";");
         }
@@ -765,18 +666,15 @@ var dest =
         {
             TestCopyPaste(
 @"var v = $@""{|Copy:{0}|}"";",
-@"
-var dest =
+@"var dest =
     $""""""
 [||]{|Selection:
     |}"""""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}
     [||]"""""";",
-@"
-var dest =
+@"var dest =
     $""""""
 {0}[||]"""""";");
         }
@@ -793,18 +691,15 @@ var dest =
         {
             TestPasteKnownSource(
 pasteText: @"{{{",
-@"
-var dest =
+@"var dest =
     $""""""
     [||]{0}
     """""";",
-@"
-var dest =
+@"var dest =
     $$$$""""""
     {{{[||]{{{{0}}}}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {{{[||]{0}
     """""";");
@@ -815,18 +710,15 @@ var dest =
         {
             TestPasteKnownSource(
 pasteText: @"{{{",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $$$$""""""
     {{{{0}}}}{{{[||]
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}{{{[||]
     """""";");
@@ -837,18 +729,15 @@ var dest =
         {
             TestPasteKnownSource(
 pasteText: @"{{{",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]{1}
     """""";",
-@"
-var dest =
+@"var dest =
     $$$$""""""
     {{{{0}}}}{{{[||]{{{{1}}}}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}{{{[||]{1}
     """""";");
@@ -859,18 +748,15 @@ var dest =
         {
             TestPasteKnownSource(
 pasteText: @"{{{",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}[||]{|Selection:{1}|}{2}
     """""";",
-@"
-var dest =
+@"var dest =
     $$$$""""""
     {{{{0}}}}{{{[||]{{{{2}}}}
     """""";",
-@"
-var dest =
+@"var dest =
     $""""""
     {0}{{{[||]{2}
     """""";");

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawInterpolatedStringTests.cs
@@ -24,52 +24,68 @@ var dest =
     [||]
     """;
 """",
-@"var dest =
-    $""""""
+""""
+var dest =
+    $"""
     goo[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteOpenBraceNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{|}"";",
-@"var dest =
-    $""""""
+"""var v = "{|Copy:{|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $$""""""
+    """;
+"""",
+""""
+var dest =
+    $$"""
     {[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteOpenCloseBraceNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{}|}"";",
-@"var dest =
-    $""""""
+"""var v = "{|Copy:{}|}";""",
+""""
+var dest =
+    $"""
     [||]
-    """""";",
-@"var dest =
-    $$""""""
+    """;
+"""",
+""""
+var dest =
+    $$"""
     {}[||]
-    """""";",
-@"var dest =
-    $""""""
+    """;
+"""",
+""""
+var dest =
+    $"""
     {}[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawStringTests.cs
@@ -1532,6 +1532,6 @@ var x = """
 """");
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoMultiLineRawStringTests.cs
@@ -17,638 +17,742 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestPasteSimpleNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     goo[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"
+"""var v = "g{|Copy:o|}o";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     o[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"
+"""var v = "\{|Copy:n|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     n[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\n|}"";",
-@"
+"""var v = "{|Copy:\n|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-"\r\nvar dest =\r\n    \"\"\"\r\n    \n    [||]\r\n    \"\"\";",
-"\r\nvar dest =\r\n    \"\"\"\r\n    \\n[||]\r\n    \"\"\";");
+    """;
+"""",
+"var dest =\r\n    \"\"\"\r\n    \n    [||]\r\n    \"\"\";",
+""""
+var dest =
+    """
+    \n[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"
+"""var v = "\{|Copy:"|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    ""[||]
-    """""";",
-@"
+    """
+    "[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"
+"""var v = "{|Copy:\"|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    ""[||]
-    """""";",
-@"
+    """
+    "[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
-    \""[||]
-    """""";");
+    """
+    \"[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"
+"""var v = @"{|Copy:goo|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     goo[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"
+"""var v = @"g{|Copy:o|}o";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     o[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"
+"""
+var v = @"{|Copy:
+|}";
+""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     
     [||]
-    """""";",
-"\r\nvar dest =\r\n    \"\"\"\r\n    \r\n[||]\r\n    \"\"\";");
+    """;
+"""",
+""""
+var dest =
+    """
+    
+[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"
+"""var v = @"{|Copy:""|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
+    "[||]
+    """;
+"""",
+""""
+var dest =
+    """
     ""[||]
-    """""";",
-@"
-var dest =
-    """"""
-    """"[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"
+""""var v = """{|Copy:goo|}""";"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     goo[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"
+""""var v = """{|Copy: "" |}""";"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-     """" [||]
-    """""";",
-@"
+    """
+     "" [||]
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     goo[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     goo
     bar[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     goo
     bar[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
         goo
     bar[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromInterpolatedStringLiteralContent()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0}|}"";",
-@"
+"""var v = $"{|Copy:{0}|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     {0}[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"
+"""var v = $"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     {0:X}[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    {0:""X""}[||]
-    """""";",
-@"
+    """
+    {0:"X"}[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
-    {0:\""X\""}[||]
-    """""";");
+    """
+    {0:\"X\"}[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $"{|Copy:{"goo"}|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    {""goo""}[||]
-    """""";",
-@"
+    """
+    {"goo"}[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $"{|Copy:X{"goo"}Y|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    X{""goo""}Y[||]
-    """""";",
-@"
+    """
+    X{"goo"}Y[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent3()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{"goo"}Y\"|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    ""X{""goo""}Y""[||]
-    """""";",
-@"
+    """
+    "X{"goo"}Y"[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
-    \""X{""goo""}Y\""[||]
-    """""";");
+    """
+    \"X{"goo"}Y\"[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent4()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{@""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{@"goo"}Y\"|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    ""X{@""goo""}Y""[||]
-    """""";",
-@"
+    """
+    "X{@"goo"}Y"[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
-    \""X{@""goo""}Y\""[||]
-    """""";");
+    """
+    \"X{@"goo"}Y\"[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromVerbatimInterpolatedStringLiteralContent()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"
+"""var v = $@"{|Copy:{0}|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     {0}[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"
+"""var v = $@"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     {0:X}[||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
+    {0:"X"}[||]
+    """;
+"""",
+""""
+var dest =
+    """
     {0:""X""}[||]
-    """""";",
-@"
-var dest =
-    """"""
-    {0:""""X""""}[||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $@"{|Copy:{"goo"}|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    {""goo""}[||]
-    """""";",
-@"
+    """
+    {"goo"}[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $@"{|Copy:X{"goo"}Y|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    X{""goo""}Y[||]
-    """""";",
-@"
+    """
+    X{"goo"}Y[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";");
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent3()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{"goo"}Y""|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    ""X{""goo""}Y""[||]
-    """""";",
-@"
+    """
+    "X{"goo"}Y"[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
-    """"X{""goo""}Y""""[||]
-    """""";");
+    """
+    ""X{"goo"}Y""[||]
+    """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent4()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{@""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{@"goo"}Y""|}";""",
+""""
 var dest =
-    """"""
+    """
     [||]
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""
-    ""X{@""goo""}Y""[||]
-    """""";",
-@"
+    """
+    "X{@"goo"}Y"[||]
+    """;
+"""",
+""""
 var dest =
-    """"""
-    """"X{@""goo""}Y""""[||]
-    """""";");
+    """
+    ""X{@"goo"}Y""[||]
+    """;
+"""");
         }
 
         #endregion
@@ -663,9 +767,11 @@ var dest =
         {
             TestPasteKnownSource(
                 pasteText: "\n",
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""",
+    """
+"""",
 "var x = \"\"\"\r\n    \n    [||]\r\n    \"\"\"",
                 afterUndo:
 "var x = \"\"\"\r\n    \n[||]\r\n    \"\"\"");
@@ -675,514 +781,757 @@ var dest =
         public void TestNewLineIntoSingleLineRawString2_A()
         {
             TestPasteKnownSource(
-                pasteText: "\r\n",
-@"var x = """"""
+                pasteText: """
+
+
+                """,
+""""
+var x = """
     [||]
-    """"""",
-"var x = \"\"\"\r\n    \r\n    [||]\r\n    \"\"\"",
+    """
+"""",
+""""
+var x = """
+    
+    [||]
+    """
+"""",
                 afterUndo:
-"var x = \"\"\"\r\n    \r\n[||]\r\n    \"\"\"");
+""""
+var x = """
+    
+[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "    ",
-@"var x = """"""
+                pasteText: """    """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
         [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "    \r\n",
-@"var x = """"""
+                pasteText: """
+                    
+
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
         
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
         
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "'",
-@"var x = """"""
+                pasteText: """'""",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     '[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"",
-@"var x = """"""
+                pasteText: """
+                "
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
-    ""[||]
-    """"""",
+    """
+"""",
+""""
+var x = """
+    "[||]
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""
+                pasteText: """"
+                """
+                """",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""""
-    """"""[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = """"
+    """[||]
+    """"
+""""",
                 afterUndo:
-@"var x = """"""
-    """"""[||]
-    """"""");
+""""
+var x = """
+    """[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTwoQuotesIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"",
-@"var x = """"""
-    ""[||]
-    """"""",
-@"var x = """"""""
-    """"""[||]
-    """"""""",
+                pasteText: """
+                ""
+                """,
+""""
+var x = """
+    "[||]
+    """
+"""",
+"""""
+var x = """"
+    """[||]
+    """"
+""""",
                 afterUndo:
-@"var x = """"""
-    """"""[||]
-    """"""");
+""""
+var x = """
+    """[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""
-    ""[||]
-    """"""",
-@"var x = """"""""""
-    """"""""[||]
-    """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """
+    "[||]
+    """
+"""",
+""""""
+var x = """""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = """"""
-    """"""""[||]
-    """"""");
+"""""
+var x = """
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""
-    ""[||]""
-    """"""",
-@"var x = """"""""""""
-    """"""""[||]""
-    """"""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """
+    "[||]"
+    """
+"""",
+"""""""
+var x = """"""
+    """"[||]"
+    """"""
+""""""",
                 afterUndo:
-@"var x = """"""
-    """"""""[||]""
-    """"""");
+"""""
+var x = """
+    """"[||]"
+    """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""
-    [||]""
-    """"""",
-@"var x = """"""""""
-    """"""[||]""
-    """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """
+    [||]"
+    """
+"""",
+""""""
+var x = """""
+    """[||]"
+    """""
+"""""",
                 afterUndo:
-@"var x = """"""
-    """"""[||]""
-    """"""");
+""""
+var x = """
+    """[||]"
+    """
+"""");
         }
 
         [WpfFact]
         public void TestQuadrupleQuoteIntoSingleLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"\"",
-@"var x = """"""
+                pasteText: """""
+                """"
+                """"",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""""""
-    """"""""[||]
-    """"""""""",
+    """
+"""",
+""""""
+var x = """""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = """"""
-    """"""""[||]
-    """"""");
+"""""
+var x = """
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestComplexStringIntoSingleLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "  \"\"  ",
-@"var x = """"""
+                pasteText: """  ""  """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
-      """"  [||]
-    """"""",
+    """
+"""",
+""""
+var x = """
+      ""  [||]
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc",
-@"var x = """"""
+                pasteText: """abc""",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine4()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """
     goo[||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     gooabc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     gooabc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine5()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """
     goo[||]bar
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     gooabc
     def[||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     gooabc
 def[||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine6()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = """
     goo[||]bar
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     gooabc
     def
     [||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     gooabc
 def
 [||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
         def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     abc
     def
 ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = """
           [||]
-          """"""",
-@"var x = """"""
+          """
+"""",
+""""
+var x = """
           abc
               def
           ghi[||]
-          """"""",
+          """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
           abc
     def
 ghi[||]
-          """"""");
+          """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
         def
         ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_A()
         {
             TestPasteKnownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = """"""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
         abc
         def
         ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
         abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_A()
         {
             TestPasteKnownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = """"""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
             abc
         def
         ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
             abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """
     [||]{|Selection:    |}
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = """
     [||]{|Selection:    |}
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
     def
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     abc
 def
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """
     [||]{|Selection:    |}  
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     abc
 def[||]  
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"bar",
-@"var x = """"""
+                pasteText: """
+                "bar
+                """,
+""""
+var x = """
     [||]goo
-    """"""",
-@"var x = """"""
-    ""bar[||]goo
-    """"""",
+    """
+"""",
+""""
+var x = """
+    "bar[||]goo
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]goo
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader1()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"",
-@"var x = """"""
+                pasteText: """
+                ""
+                """,
+""""
+var x = """
     [||]{|Selection:    |}
-    """"""",
-@"var x = """"""
-    """"[||]
-    """"""",
+    """
+"""",
+""""
+var x = """
+    ""[||]
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
         [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader2()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""
+                pasteText: """"
+                """
+                """",
+""""
+var x = """
     [||]{|Selection:    |}
-    """"""",
-@"var x = """"""""
-    """"""[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = """"
+    """[||]
+    """"
+""""",
                 afterUndo:
-@"var x = """"""
-    """"""[||]
-    """"""");
+""""
+var x = """
+    """[||]
+    """
+"""");
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoNormalInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoNormalInterpolatedStringTests.cs
@@ -13,362 +13,437 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestPasteSimpleNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""goo[||]"";",
-@"
+    $"goo[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteOpenBraceNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{|}"";",
-@"
+"""var v = "{|Copy:{|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""{{[||]"";",
-@"
+    $"{{[||]";
+""",
+"""
 var dest =
-    $""{[||]"";");
+    $"{[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteOpenCloseBraceNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{}|}"";",
-@"
+"""var v = "{|Copy:{}|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""{{}}[||]"";",
-@"
+    $"{{}}[||]";
+""",
+"""
 var dest =
-    $""{}[||]"";");
+    $"{}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteLooksLikeInterpolationNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{0}|}"";",
-@"
+"""var v = "{|Copy:{0}|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""{{0}}[||]"";",
-@"
+    $"{{0}}[||]";
+""",
+"""
 var dest =
-    $""{0}[||]"";");
+    $"{0}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"
+"""var v = "g{|Copy:o|}o";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""o[||]"";",
-@"
+    $"o[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"
+"""var v = "\{|Copy:n|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""n[||]"";",
-@"
+    $"n[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\n|}"";",
-@"
+"""var v = "{|Copy:\n|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""\n[||]"";",
-@"
+    $"\n[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"
+"""var v = "\{|Copy:"|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""\""[||]"";",
-@"
+    $"\"[||]";
+""",
+"""
 var dest =
-    $""""[||]"";");
+    $""[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"
+"""var v = "{|Copy:\"|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""\""[||]"";",
-@"
+    $"\"[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"
+"""var v = @"{|Copy:goo|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""goo[||]"";",
-@"
+    $"goo[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"
+"""var v = @"g{|Copy:o|}o";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""o[||]"";",
-@"
+    $"o[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"
+"""
+var v = @"{|Copy:
+|}";
+""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""\r\n[||]"";",
-@"
+    $"\r\n[||]";
+""",
+"""
 var dest =
-    $""
-[||]"";");
+    $"
+[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"
+"""var v = @"{|Copy:""|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""\""[||]"";",
-@"
+    $"\"[||]";
+""",
+""""
 var dest =
-    $""""""[||]"";");
+    $"""[||]";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"
+""""var v = """{|Copy:goo|}""";"""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""goo[||]"";",
-@"
+    $"goo[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"
+""""var v = """{|Copy: "" |}""";"""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $"" \""\"" [||]"";",
-@"
+    $" \"\" [||]";
+""",
+"""
 var dest =
-    $"" """" [||]"";");
+    $" "" [||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""goo[||]"";",
-@"
+    $"goo[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""goo\r\nbar[||]"";",
-@"
+    $"goo\r\nbar[||]";
+""",
+"""
 var dest =
-    $""goo
-    bar[||]"";");
+    $"goo
+    bar[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""goo\r\nbar[||]"";",
-@"
+    $"goo\r\nbar[||]";
+""",
+"""
 var dest =
-    $""    goo
-    bar[||]"";");
+    $"    goo
+    bar[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"
+"""var v = $"{|Copy:{0:X}|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""{0:X}[||]"";",
-@"
+    $"{0:X}[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""{0:\""X\""}[||]"";",
-@"
+    $"{0:\"X\"}[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"
+"""var v = $@"{|Copy:{0:X}|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""{0:X}[||]"";",
-@"
+    $"{0:X}[||]";
+""",
+"""
 var dest =
-    $""[||]"";");
+    $"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+"""
 var dest =
-    $""[||]"";",
-@"
+    $"[||]";
+""",
+"""
 var dest =
-    $""{0:\""X\""}[||]"";",
-@"
+    $"{0:\"X\"}[||]";
+""",
+"""
 var dest =
-    $""{0:""""X""""}[||]"";");
+    $"{0:""X""}[||]";
+""");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoNormalStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoNormalStringTests.cs
@@ -13,472 +13,571 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestPasteSimpleNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""goo[||]"";",
-@"
+    "goo[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"
+"""var v = "g{|Copy:o|}o";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""o[||]"";",
-@"
+    "o[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"
+"""var v = "\{|Copy:n|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""n[||]"";",
-@"
+    "n[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\n|}"";",
-@"
+"""var v = "{|Copy:\n|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""\n[||]"";",
-@"
+    "\n[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"
+"""var v = "\{|Copy:"|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""\""[||]"";",
-@"
+    "\"[||]";
+""",
+"""
 var dest =
-    """"[||]"";");
+    ""[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"
+"""var v = "{|Copy:\"|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""\""[||]"";",
-@"
+    "\"[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"
+"""var v = @"{|Copy:goo|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""goo[||]"";",
-@"
+    "goo[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"
+"""var v = @"g{|Copy:o|}o";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""o[||]"";",
-@"
+    "o[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"
+"""
+var v = @"{|Copy:
+|}";
+""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""\r\n[||]"";",
-"\r\nvar dest =\r\n    \"\r\n[||]\";");
+    "\r\n[||]";
+""",
+"""
+var dest =
+    "
+[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"
+"""var v = @"{|Copy:""|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""\""[||]"";",
-@"
+    "\"[||]";
+""",
+""""
 var dest =
-    """"""[||]"";");
+    """[||]";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"
+""""var v = """{|Copy:goo|}""";"""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""goo[||]"";",
-@"
+    "goo[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"
+""""var v = """{|Copy: "" |}""";"""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    "" \""\"" [||]"";",
-@"
+    " \"\" [||]";
+""",
+"""
 var dest =
-    "" """" [||]"";");
+    " "" [||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""goo[||]"";",
-@"
+    "goo[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""goo\r\nbar[||]"";",
-@"
+    "goo\r\nbar[||]";
+""",
+"""
 var dest =
-    ""goo
-    bar[||]"";");
+    "goo
+    bar[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""goo\r\nbar[||]"";",
-@"
+    "goo\r\nbar[||]";
+""",
+"""
 var dest =
-    ""    goo
-    bar[||]"";");
+    "    goo
+    bar[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromInterpolatedStringLiteralContent()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0}|}"";",
-@"
+"""var v = $"{|Copy:{0}|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""{0}[||]"";",
-@"
+    "{0}[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"
+"""var v = $"{|Copy:{0:X}|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""{0:X}[||]"";",
-@"
+    "{0:X}[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""{0:\""X\""}[||]"";",
-@"
+    "{0:\"X\"}[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $"{|Copy:{"goo"}|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""{\""goo\""}[||]"";",
-@"
+    "{\"goo\"}[||]";
+""",
+"""
 var dest =
-    ""{""goo""}[||]"";");
+    "{"goo"}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $"{|Copy:X{"goo"}Y|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""X{\""goo\""}Y[||]"";",
-@"
+    "X{\"goo\"}Y[||]";
+""",
+"""
 var dest =
-    ""X{""goo""}Y[||]"";");
+    "X{"goo"}Y[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent3()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{"goo"}Y\"|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""\""X{\""goo\""}Y\""[||]"";",
-@"
+    "\"X{\"goo\"}Y\"[||]";
+""",
+"""
 var dest =
-    ""\""X{""goo""}Y\""[||]"";");
+    "\"X{"goo"}Y\"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent4()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{@""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{@"goo"}Y\"|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""\""X{@\""goo\""}Y\""[||]"";",
-@"
+    "\"X{@\"goo\"}Y\"[||]";
+""",
+"""
 var dest =
-    ""\""X{@""goo""}Y\""[||]"";");
+    "\"X{@"goo"}Y\"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromVerbatimInterpolatedStringLiteralContent()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"
+"""var v = $@"{|Copy:{0}|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""{0}[||]"";",
-@"
+    "{0}[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"
+"""var v = $@"{|Copy:{0:X}|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""{0:X}[||]"";",
-@"
+    "{0:X}[||]";
+""",
+"""
 var dest =
-    ""[||]"";");
+    "[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""{0:\""X\""}[||]"";",
-@"
+    "{0:\"X\"}[||]";
+""",
+"""
 var dest =
-    ""{0:""""X""""}[||]"";");
+    "{0:""X""}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $@"{|Copy:{"goo"}|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""{\""goo\""}[||]"";",
-@"
+    "{\"goo\"}[||]";
+""",
+"""
 var dest =
-    ""{""goo""}[||]"";");
+    "{"goo"}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $@"{|Copy:X{"goo"}Y|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""X{\""goo\""}Y[||]"";",
-@"
+    "X{\"goo\"}Y[||]";
+""",
+"""
 var dest =
-    ""X{""goo""}Y[||]"";");
+    "X{"goo"}Y[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent3()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{"goo"}Y""|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""\""X{\""goo\""}Y\""[||]"";",
-@"
+    "\"X{\"goo\"}Y\"[||]";
+""",
+""""
 var dest =
-    """"""X{""goo""}Y""""[||]"";");
+    """X{"goo"}Y""[||]";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent4()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{@""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{@"goo"}Y""|}";""",
+"""
 var dest =
-    ""[||]"";",
-@"
+    "[||]";
+""",
+"""
 var dest =
-    ""\""X{@\""goo\""}Y\""[||]"";",
-@"
+    "\"X{@\"goo\"}Y\"[||]";
+""",
+""""
 var dest =
-    """"""X{@""goo""}Y""""[||]"";");
+    """X{@"goo"}Y""[||]";
+"""");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoSingleLineRawInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoSingleLineRawInterpolatedStringTests.cs
@@ -17,752 +17,906 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestPasteSimpleNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""goo[||] """""";",
-@"
+    $"""goo[||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleNormalLiteralContent2()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" goo[||]"""""";",
-@"
+    $""" goo[||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteOpenBraceNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{|}"";",
-@"
+"""var v = "{|Copy:{|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $$""""""{[||] """""";",
-@"
+    $$"""{[||] """;
+"""",
+""""
 var dest =
-    $""""""{[||] """""";");
+    $"""{[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteOpenBraceNormalLiteralContent2()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{|}"";",
-@"
+"""var v = "{|Copy:{|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $$"""""" {[||]"""""";",
-@"
+    $$""" {[||]""";
+"""",
+""""
 var dest =
-    $"""""" {[||]"""""";");
+    $""" {[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteOpenCloseBraceNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{}|}"";",
-@"
+"""var v = "{|Copy:{}|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $$""""""{}[||] """""";",
-@"
+    $$"""{}[||] """;
+"""",
+""""
 var dest =
-    $""""""{}[||] """""";");
+    $"""{}[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteOpenCloseBraceNormalLiteralContent2()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{}|}"";",
-@"
+"""var v = "{|Copy:{}|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $$"""""" {}[||]"""""";",
-@"
+    $$""" {}[||]""";
+"""",
+""""
 var dest =
-    $"""""" {}[||]"""""";");
+    $""" {}[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteLooksLikeInterpolationNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{0}|}"";",
-@"
+"""var v = "{|Copy:{0}|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $$""""""{0}[||] """""";",
-@"
+    $$"""{0}[||] """;
+"""",
+""""
 var dest =
-    $""""""{0}[||] """""";");
+    $"""{0}[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteLooksLikeInterpolationNormalLiteralContent2()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{0}|}"";",
-@"
+"""var v = "{|Copy:{0}|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $$"""""" {0}[||]"""""";",
-@"
+    $$""" {0}[||]""";
+"""",
+""""
 var dest =
-    $"""""" {0}[||]"""""";");
+    $""" {0}[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"
+"""var v = "g{|Copy:o|}o";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""o[||] """""";",
-@"
+    $"""o[||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent2()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"
+"""var v = "g{|Copy:o|}o";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" o[||]"""""";",
-@"
+    $""" o[||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"
+"""var v = "\{|Copy:n|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""n[||] """""";",
-@"
+    $"""n[||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent2()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"
+"""var v = "\{|Copy:n|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" n[||]"""""";",
-@"
+    $""" n[||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\n|}"";",
-@"
+"""var v = "{|Copy:\n|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-"\r\nvar dest =\r\n    $\"\"\"\r\n    \n    [||] \r\n    \"\"\";",
-@"
+    $"""[||] """;
+"""",
+"var dest =\r\n    $\"\"\"\r\n    \n    [||] \r\n    \"\"\";",
+""""
 var dest =
-    $""""""\n[||] """""";");
+    $"""\n[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent2()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\n|}"";",
-@"
+"""var v = "{|Copy:\n|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-"\r\nvar dest =\r\n    $\"\"\"\r\n     \n    \r\n    [||]\"\"\";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" \n[||]"""""";");
+    $"""
+     
+    
+    [||]""";
+"""",
+""""
+var dest =
+    $""" \n[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"
+"""var v = "\{|Copy:"|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""
-    ""[||] 
-    """""";",
-@"
+    $"""
+    "[||] 
+    """;
+"""",
+"""""
 var dest =
-    $""""""""[||] """""";");
+    $""""[||] """;
+""""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent2()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"
+"""var v = "\{|Copy:"|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $""""""
-     ""
-    [||]"""""";",
-@"
+    $"""
+     "
+    [||]""";
+"""",
+""""
 var dest =
-    $"""""" ""[||]"""""";");
+    $""" "[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"
+"""var v = "{|Copy:\"|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""
-    ""[||] 
-    """""";",
-@"
+    $"""
+    "[||] 
+    """;
+"""",
+""""
 var dest =
-    $""""""\""[||] """""";");
+    $"""\"[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent2()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"
+"""var v = "{|Copy:\"|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $""""""
-     ""
-    [||]"""""";",
-@"
+    $"""
+     "
+    [||]""";
+"""",
+""""
 var dest =
-    $"""""" \""[||]"""""";");
+    $""" \"[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"
+"""var v = @"{|Copy:goo|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""goo[||] """""";",
-@"
+    $"""goo[||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent2()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"
+"""var v = @"{|Copy:goo|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" goo[||]"""""";",
-@"
+    $""" goo[||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"
+"""var v = @"g{|Copy:o|}o";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""o[||] """""";",
-@"
+    $"""o[||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent2()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"
+"""var v = @"g{|Copy:o|}o";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" o[||]"""""";",
-@"
+    $""" o[||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"
+"""
+var v = @"{|Copy:
+|}";
+""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""
+    $"""
     
     [||] 
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    $""""""
-[||] """""";");
+    $"""
+[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent2()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"
+"""
+var v = @"{|Copy:
+|}";
+""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $""""""
+    $"""
      
     
-    [||]"""""";",
-@"
+    [||]""";
+"""",
+""""
 var dest =
-    $"""""" 
-[||]"""""";");
+    $""" 
+[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"
+"""var v = @"{|Copy:""|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""
-    ""[||] 
-    """""";",
-@"
+    $"""
+    "[||] 
+    """;
+"""",
+""""""
 var dest =
-    $""""""""""[||] """""";");
+    $"""""[||] """;
+"""""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent2()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"
+"""var v = @"{|Copy:""|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $""""""
-     ""
-    [||]"""""";",
-@"
+    $"""
+     "
+    [||]""";
+"""",
+""""
 var dest =
-    $"""""" """"[||]"""""";");
+    $""" ""[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"
+""""var v = """{|Copy:goo|}""";"""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""goo[||] """""";",
-@"
+    $"""goo[||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"
+""""var v = """{|Copy:goo|}""";"""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" goo[||]"""""";",
-@"
+    $""" goo[||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"
+""""var v = """{|Copy: "" |}""";"""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $"""""" """" [||] """""";",
-@"
+    $""" "" [||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"
+""""var v = """{|Copy: "" |}""";"""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $""""""  """" [||]"""""";",
-@"
+    $"""  "" [||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""goo[||] """""";",
-@"
+    $"""goo[||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1B()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" goo[||]"""""";",
-@"
+    $""" goo[||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""
+    $"""
     goo
     bar[||] 
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    $""""""goo
-    bar[||] """""";");
+    $"""goo
+    bar[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2B()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $""""""
+    $"""
      goo
     bar
-    [||]"""""";",
-@"
+    [||]""";
+"""",
+""""
 var dest =
-    $"""""" goo
-    bar[||]"""""";");
+    $""" goo
+    bar[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""
+    $"""
     goo
     bar[||] 
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    $""""""    goo
-    bar[||] """""";");
+    $"""    goo
+    bar[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3B()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $""""""
+    $"""
      goo
     bar
-    [||]"""""";",
-@"
+    [||]""";
+"""",
+""""
 var dest =
-    $""""""     goo
-    bar[||]"""""";");
+    $"""     goo
+    bar[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"
+"""var v = $"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""{0:X}[||] """""";",
-@"
+    $"""{0:X}[||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1B()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"
+"""var v = $"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" {0:X}[||]"""""";",
-@"
+    $""" {0:X}[||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""{0:""X""}[||] """""";",
-@"
+    $"""{0:"X"}[||] """;
+"""",
+""""
 var dest =
-    $""""""{0:\""X\""}[||] """""";");
+    $"""{0:\"X\"}[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2B()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" {0:""X""}[||]"""""";",
-@"
+    $""" {0:"X"}[||]""";
+"""",
+""""
 var dest =
-    $"""""" {0:\""X\""}[||]"""""";");
+    $""" {0:\"X\"}[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"
+"""var v = $@"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""{0:X}[||] """""";",
-@"
+    $"""{0:X}[||] """;
+"""",
+""""
 var dest =
-    $""""""[||] """""";");
+    $"""[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1B()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"
+"""var v = $@"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" {0:X}[||]"""""";",
-@"
+    $""" {0:X}[||]""";
+"""",
+""""
 var dest =
-    $"""""" [||]"""""";");
+    $""" [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+""""
 var dest =
-    $""""""[||] """""";",
-@"
+    $"""[||] """;
+"""",
+""""
 var dest =
-    $""""""{0:""X""}[||] """""";",
-@"
+    $"""{0:"X"}[||] """;
+"""",
+""""
 var dest =
-    $""""""{0:""""X""""}[||] """""";");
+    $"""{0:""X""}[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2B()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+""""
 var dest =
-    $"""""" [||]"""""";",
-@"
+    $""" [||]""";
+"""",
+""""
 var dest =
-    $"""""" {0:""X""}[||]"""""";",
-@"
+    $""" {0:"X"}[||]""";
+"""",
+""""
 var dest =
-    $"""""" {0:""""X""""}[||]"""""";");
+    $""" {0:""X""}[||]""";
+"""");
         }
 
         #endregion
@@ -777,7 +931,9 @@ var dest =
         {
             TestPasteKnownSource(
                 pasteText: "\n",
-@"var x = $""""""[||] """"""",
+""""
+var x = $"""[||] """
+"""",
 "var x = $\"\"\"\r\n    \n    [||] \r\n    \"\"\"",
                 afterUndo:
 "var x = $\"\"\"\n[||] \"\"\"");
@@ -788,7 +944,9 @@ var dest =
         {
             TestPasteKnownSource(
                 pasteText: "\n",
-@"var x = $"""""" [||]""""""",
+""""
+var x = $""" [||]"""
+"""",
 "var x = $\"\"\"\r\n     \n    \r\n    [||]\"\"\"",
                 afterUndo:
 "var x = $\"\"\" \n[||]\"\"\"");
@@ -798,761 +956,1216 @@ var dest =
         public void TestNewLineIntoSingleLineRawString2_A()
         {
             TestPasteKnownSource(
-                pasteText: "\r\n",
-@"var x = $""""""[||] """"""",
-"var x = $\"\"\"\r\n    \r\n    [||] \r\n    \"\"\"",
+                pasteText: """
+
+
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
+    
+    [||] 
+    """
+"""",
                 afterUndo:
-"var x = $\"\"\"\r\n[||] \"\"\"");
+""""
+var x = $"""
+[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNewLineIntoSingleLineRawString2_B()
         {
             TestPasteKnownSource(
-                pasteText: "\r\n",
-@"var x = $"""""" [||]""""""",
-"var x = $\"\"\"\r\n     \r\n    \r\n    [||]\"\"\"",
+                pasteText: """
+
+
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
+     
+    
+    [||]"""
+"""",
                 afterUndo:
-"var x = $\"\"\" \r\n[||]\"\"\"");
+""""
+var x = $""" 
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "    ",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""    [||] """"""",
+                pasteText: """    """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""    [||] """
+"""",
                 afterUndo:
-@"var x = $""""""[||] """"""");
+""""
+var x = $"""[||] """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_B()
         {
             TestPasteKnownSource(
-                pasteText: "    ",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""     [||]""""""",
+                pasteText: """    """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""     [||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" [||]""""""");
+""""
+var x = $""" [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "    \r\n",
-@"var x = $""""""
+                pasteText: """
+                    
+
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
         
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
         
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "'",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""'[||] """"""",
+                pasteText: """'""",
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""'[||] """
+"""",
                 afterUndo:
-@"var x = $""""""[||] """"""");
+""""
+var x = $"""[||] """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_B()
         {
             TestPasteKnownSource(
-                pasteText: "'",
-@"var x = $"""""" [||]""""""",
-@"var x = $"""""" '[||]""""""",
+                pasteText: """'""",
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $""" '[||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" [||]""""""");
+""""
+var x = $""" [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
-    ""[||] 
-    """"""",
+                pasteText: """
+                "
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
+    "[||] 
+    """
+"""",
                 afterUndo:
-@"var x = $""""""""[||] """"""");
+"""""
+var x = $""""[||] """
+""""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_B()
         {
             TestPasteKnownSource(
-                pasteText: "\"",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
-     ""
-    [||]""""""",
+                pasteText: """
+                "
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
+     "
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" ""[||]""""""");
+""""
+var x = $""" "[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""""
-    """"""[||] 
-    """"""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""[||] """
+"""",
+"""""
+var x = $""""
+    """[||] 
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""""""""[||] """"""");
+"""""""
+var x = $""""""[||] """
+""""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_B()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""""
-     """"""
-    [||]""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $""" [||]"""
+"""",
+"""""
+var x = $""""
+     """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = $"""""" """"""[||]""""""");
+""""
+var x = $""" """[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $"""""" ""[||] """"""",
-@"var x = $"""""""""" """"""""[||] """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $""" "[||] """
+"""",
+""""""
+var x = $""""" """"[||] """""
+"""""",
                 afterUndo:
-@"var x = $"""""" """"""""[||] """"""");
+"""""
+var x = $""" """"[||] """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $"""""" ""[||]"" """"""",
-@"var x = $"""""""""""" """"""""[||]"" """"""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $""" "[||]" """
+"""",
+"""""""
+var x = $"""""" """"[||]" """"""
+""""""",
                 afterUndo:
-@"var x = $"""""" """"""""[||]"" """"""");
+"""""
+var x = $""" """"[||]" """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $"""""" [||]"" """"""",
-@"var x = $"""""""""" """"""[||]"" """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $""" [||]" """
+"""",
+""""""
+var x = $""""" """[||]" """""
+"""""",
                 afterUndo:
-@"var x = $"""""" """"""[||]"" """"""");
+""""
+var x = $""" """[||]" """
+"""");
         }
 
         [WpfFact]
         public void TestQuadrupleQuoteIntoSingleLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"\"",
-@"var x = $""""""
+                pasteText: """""
+                """"
+                """"",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""""""
-    """"""""[||]
-    """"""""""",
+    """
+"""",
+""""""
+var x = $"""""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = $""""""
-    """"""""[||]
-    """"""");
+"""""
+var x = $"""
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "{",
-@"var x = $""""""[||] """"""",
-@"var x = $$""""""{[||] """"""",
+                pasteText: """{""",
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $$"""{[||] """
+"""",
                 afterUndo:
-@"var x = $""""""{[||] """"""");
+""""
+var x = $"""{[||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoSingleLineRawString_B()
         {
             TestPasteKnownSource(
-                pasteText: "{",
-@"var x = $"""""" [||]""""""",
-@"var x = $$"""""" {[||]""""""",
+                pasteText: """{""",
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $$""" {[||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" {[||]""""""");
+""""
+var x = $""" {[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestOpenQuoteAndTripleOpenBraceIntoSingleLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "\"{{{",
-@"var x = $""""""[||] """"""",
-@"var x = $$$$""""""
-    ""{{{[||] 
-    """"""",
+                pasteText: """
+                "{{{
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $$$$"""
+    "{{{[||] 
+    """
+"""",
                 afterUndo:
-@"var x = $""""""""{{{[||] """"""");
+"""""
+var x = $""""{{{[||] """
+""""");
         }
 
         [WpfFact]
         public void TestTripleOpenQuoteAndTripleOpenBraceIntoSingleLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"{{{",
-@"var x = $""""""[||] """"""",
-@"var x = $$$$""""""""
-    """"""{{{[||] 
-    """"""""",
+                pasteText: """"
+                """{{{
+                """",
+""""
+var x = $"""[||] """
+"""",
+"""""
+var x = $$$$""""
+    """{{{[||] 
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""""""""{{{[||] """"""");
+"""""""
+var x = $""""""{{{[||] """
+""""""");
         }
 
         [WpfFact]
         public void TestTripleOpenQuoteAndTripleOpenBraceIntoSingleLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: " \"\"\"{{{",
-@"var x = $""""""[||] """"""",
-@"var x = $$$$"""""""" """"""{{{[||] """"""""",
+                pasteText: """" """{{{"""",
+""""
+var x = $"""[||] """
+"""",
+"""""
+var x = $$$$"""" """{{{[||] """"
+""""",
                 afterUndo:
-@"var x = $"""""" """"""{{{[||] """"""");
+""""
+var x = $""" """{{{[||] """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $""""""[||] """"""",
-@"var x = $$$$""""""{{{[||] """"""",
+                pasteText: """{{{""",
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $$$$"""{{{[||] """
+"""",
                 afterUndo:
-@"var x = $""""""{{{[||] """"""");
+""""
+var x = $"""{{{[||] """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString1_B()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $"""""" [||]""""""",
-@"var x = $$$$"""""" {{{[||]""""""",
+                pasteText: """{{{""",
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $$$$""" {{{[||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" {{{[||]""""""");
+""""
+var x = $""" {{{[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $"""""" ""[||] """"""",
-@"var x = $$$$"""""" ""{{{[||] """"""",
+                pasteText: """{{{""",
+""""
+var x = $""" "[||] """
+"""",
+""""
+var x = $$$$""" "{{{[||] """
+"""",
                 afterUndo:
-@"var x = $"""""" ""{{{[||] """"""");
+""""
+var x = $""" "{{{[||] """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $"""""" ""[||]"" """"""",
-@"var x = $$$$"""""" ""{{{[||]"" """"""",
+                pasteText: """{{{""",
+""""
+var x = $""" "[||]" """
+"""",
+""""
+var x = $$$$""" "{{{[||]" """
+"""",
                 afterUndo:
-@"var x = $"""""" ""{{{[||]"" """"""");
+""""
+var x = $""" "{{{[||]" """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "{{{",
-@"var x = $"""""" [||]"" """"""",
-@"var x = $$$$"""""" {{{[||]"" """"""",
+                pasteText: """{{{""",
+""""
+var x = $""" [||]" """
+"""",
+""""
+var x = $$$$""" {{{[||]" """
+"""",
                 afterUndo:
-@"var x = $"""""" {{{[||]"" """"""");
+""""
+var x = $""" {{{[||]" """
+"""");
         }
 
         [WpfFact]
         public void TestInterpolationIntoSingleLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "{0}",
-@"var x = $"""""" [||] """"""",
-@"var x = $$"""""" {0}[||] """"""",
+                pasteText: """{0}""",
+""""
+var x = $""" [||] """
+"""",
+""""
+var x = $$""" {0}[||] """
+"""",
                 afterUndo:
-@"var x = $"""""" {0}[||] """"""");
+""""
+var x = $""" {0}[||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString1()
         {
             TestPasteKnownSource(
-                pasteText: "{}",
-@"var x = $"""""" [||] """"""",
-@"var x = $$"""""" {}[||] """"""",
+                pasteText: """{}""",
+""""
+var x = $""" [||] """
+"""",
+""""
+var x = $$""" {}[||] """
+"""",
                 afterUndo:
-@"var x = $"""""" {}[||] """"""");
+""""
+var x = $""" {}[||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "{}",
-@"var x = $$"""""" [||] """"""",
-@"var x = $$"""""" {}[||] """"""",
+                pasteText: """{}""",
+""""
+var x = $$""" [||] """
+"""",
+""""
+var x = $$""" {}[||] """
+"""",
                 afterUndo:
-@"var x = $$"""""" [||] """"""");
+""""
+var x = $$""" [||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "{{}",
-@"var x = $$"""""" [||] """"""",
-@"var x = $$$"""""" {{}[||] """"""",
+                pasteText: """{{}""",
+""""
+var x = $$""" [||] """
+"""",
+""""
+var x = $$$""" {{}[||] """
+"""",
                 afterUndo:
-@"var x = $$"""""" {{}[||] """"""");
+""""
+var x = $$""" {{}[||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "{}}",
-@"var x = $$"""""" [||] """"""",
-@"var x = $$$"""""" {}}[||] """"""",
+                pasteText: """{}}""",
+""""
+var x = $$""" [||] """
+"""",
+""""
+var x = $$$""" {}}[||] """
+"""",
                 afterUndo:
-@"var x = $$"""""" {}}[||] """"""");
+""""
+var x = $$""" {}}[||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "{{}}",
-@"var x = $$"""""" [||] """"""",
-@"var x = $$$"""""" {{}}[||] """"""",
+                pasteText: """{{}}""",
+""""
+var x = $$""" [||] """
+"""",
+""""
+var x = $$$""" {{}}[||] """
+"""",
                 afterUndo:
-@"var x = $$"""""" {{}}[||] """"""");
+""""
+var x = $$""" {{}}[||] """
+"""");
         }
 
         [WpfFact]
         public void TestComplexStringIntoSingleLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "  \"\"  ",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""  """"  [||] """"""",
+                pasteText: """  ""  """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""  ""  [||] """
+"""",
                 afterUndo:
-@"var x = $""""""[||] """"""");
+""""
+var x = $"""[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""abc[||] """"""",
+                pasteText: """abc""",
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""abc[||] """
+"""",
                 afterUndo:
-@"var x = $""""""[||] """"""");
+""""
+var x = $"""[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc",
-@"var x = $"""""" [||]""""""",
-@"var x = $"""""" abc[||]""""""",
+                pasteText: """abc""",
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $""" abc[||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" [||]""""""");
+""""
+var x = $""" [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
     abc
     def[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||] """"""");
+""""
+var x = $"""abc
+def[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
      abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" abc
-def[||]""""""");
+""""
+var x = $""" abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine4()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""goo[||]""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""goo[||]"""
+"""",
+""""
+var x = $"""
     gooabc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""gooabc
-def[||]""""""");
+""""
+var x = $"""gooabc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine5()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""goo[||]bar""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""goo[||]bar"""
+"""",
+""""
+var x = $"""
     gooabc
     def[||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""gooabc
-def[||]bar""""""");
+""""
+var x = $"""gooabc
+def[||]bar"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine6()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""goo[||]bar""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""goo[||]bar"""
+"""",
+""""
+var x = $"""
     gooabc
     def
     [||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""gooabc
+""""
+var x = $"""gooabc
 def
-[||]bar""""""");
+[||]bar"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
     abc
         def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
     def
-ghi[||] """"""");
+ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
      abc
         def
     ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" abc
+""""
+var x = $""" abc
     def
-ghi[||]""""""");
+ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
     abc
         def
         ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
     abc
         def
         ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_A()
         {
             TestPasteKnownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
         abc
         def
         ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""    abc
+""""
+var x = $"""    abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_B()
         {
             TestPasteKnownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
          abc
         def
         ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""     abc
+""""
+var x = $"""     abc
     def
-    ghi[||]""""""");
+    ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_A()
         {
             TestPasteKnownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
             abc
         def
         ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""        abc
+""""
+var x = $"""        abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_B()
         {
             TestPasteKnownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
              abc
         def
         ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""         abc
+""""
+var x = $"""         abc
     def
-    ghi[||]""""""");
+    ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]{|Selection:    |}""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]{|Selection:    |}"""
+"""",
+""""
+var x = $"""
     abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||]""""""");
+""""
+var x = $"""abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""  [||]{|Selection:    |}  """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""  [||]{|Selection:    |}  """
+"""",
+""""
+var x = $"""
       abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""  abc
-def[||]  """"""");
+""""
+var x = $"""  abc
+def[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""[||]{|Selection:    |}""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""[||]{|Selection:    |}"""
+"""",
+""""
+var x = $"""
     abc
     def
     
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
 def
-[||]""""""");
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""  [||]{|Selection:    |}  """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""  [||]{|Selection:    |}  """
+"""",
+""""
+var x = $"""
       abc
     def
     [||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""  abc
+""""
+var x = $"""  abc
 def
-[||]  """"""");
+[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]{|Selection:    |}  """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]{|Selection:    |}  """
+"""",
+""""
+var x = $"""
     abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||]  """"""");
+""""
+var x = $"""abc
+def[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""  [||]{|Selection:    |}""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""  [||]{|Selection:    |}"""
+"""",
+""""
+var x = $"""
       abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""  abc
-def[||]""""""");
+""""
+var x = $"""  abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"bar",
-@"var x = $""""""[||]goo""""""",
-@"var x = $""""""
-    ""bar[||]goo
-    """"""",
+                pasteText: """
+                "bar
+                """,
+""""
+var x = $"""[||]goo"""
+"""",
+""""
+var x = $"""
+    "bar[||]goo
+    """
+"""",
                 afterUndo:
-@"var x = $""""""""bar[||]goo""""""");
+"""""
+var x = $""""bar[||]goo"""
+""""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_B()
         {
             TestPasteKnownSource(
-                pasteText: "bar\"",
-@"var x = $""""""goo[||]""""""",
-@"var x = $""""""
-    goobar""
-    [||]""""""",
+                pasteText: """
+                bar"
+                """,
+""""
+var x = $"""goo[||]"""
+"""",
+""""
+var x = $"""
+    goobar"
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""goobar""[||]""""""");
+""""
+var x = $"""goobar"[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader1()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"",
-@"var x = $""""""[||]{|Selection:    |}""""""",
-@"var x = $""""""
-    """"
-    [||]""""""",
+                pasteText: """
+                ""
+                """,
+""""
+var x = $"""[||]{|Selection:    |}"""
+"""",
+""""
+var x = $"""
+    ""
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""""""[||]""""""");
+""""""
+var x = $"""""[||]"""
+"""""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader2()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""[||]{|Selection:    |}""""""",
-@"var x = $""""""""
-    """"""
-    [||]""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""[||]{|Selection:    |}"""
+"""",
+"""""
+var x = $""""
+    """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = $""""""""""""[||]""""""");
+"""""""
+var x = $""""""[||]"""
+""""""");
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoSingleLineRawInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoSingleLineRawInterpolatedStringTests.cs
@@ -2166,6 +2166,6 @@ var x = $""""""[||]"""
 """"""");
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoSingleLineRawStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoSingleLineRawStringTests.cs
@@ -17,982 +17,1176 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestPasteSimpleNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""goo[||] """""";",
-@"
+    """goo[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleNormalLiteralContent_2()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" goo[||]"""""";",
-@"
+    """ goo[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"
+"""var v = "g{|Copy:o|}o";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""o[||] """""";",
-@"
+    """o[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent_2()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"
+"""var v = "g{|Copy:o|}o";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" o[||]"""""";",
-@"
+    """ o[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"
+"""var v = "\{|Copy:n|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""n[||] """""";",
-@"
+    """n[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent_2()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"
+"""var v = "\{|Copy:n|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" n[||]"""""";",
-@"
+    """ n[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\n|}"";",
-@"
+"""var v = "{|Copy:\n|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-"\r\nvar dest =\r\n    \"\"\"\r\n    \n    [||] \r\n    \"\"\";",
-"\r\nvar dest =\r\n    \"\"\"\\n[||] \"\"\";");
+    """[||] """;
+"""",
+"var dest =\r\n    \"\"\"\r\n    \n    [||] \r\n    \"\"\";",
+"var dest =\r\n    \"\"\"\\n[||] \"\"\";");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent_2()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\n|}"";",
-@"
+"""var v = "{|Copy:\n|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-"\r\nvar dest =\r\n    \"\"\"\r\n     \n    \r\n    [||]\"\"\";",
-"\r\nvar dest =\r\n    \"\"\" \\n[||]\"\"\";");
+    """ [||]""";
+"""",
+"var dest =\r\n    \"\"\"\r\n     \n    \r\n    [||]\"\"\";",
+"var dest =\r\n    \"\"\" \\n[||]\"\"\";");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"
+"""var v = "\{|Copy:"|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
-    ""[||] 
-    """""";",
-@"
+    """
+    "[||] 
+    """;
+"""",
+"""""
 var dest =
-    """"""""[||] """""";");
+    """"[||] """;
+""""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent_2()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"
+"""var v = "\{|Copy:"|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
-     ""
-    [||]"""""";",
-@"
+    """
+     "
+    [||]""";
+"""",
+""""
 var dest =
-    """""" ""[||]"""""";");
+    """ "[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"
+"""var v = "{|Copy:\"|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
-    ""[||] 
-    """""";",
-@"
+    """
+    "[||] 
+    """;
+"""",
+""""
 var dest =
-    """"""\""[||] """""";");
+    """\"[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent_2()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"
+"""var v = "{|Copy:\"|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
-     ""
-    [||]"""""";",
-@"
+    """
+     "
+    [||]""";
+"""",
+""""
 var dest =
-    """""" \""[||]"""""";");
+    """ \"[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"
+"""var v = @"{|Copy:goo|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""goo[||] """""";",
-@"
+    """goo[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent_2()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"
+"""var v = @"{|Copy:goo|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" goo[||]"""""";",
-@"
+    """ goo[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"
+"""var v = @"g{|Copy:o|}o";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""o[||] """""";",
-@"
+    """o[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent2()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"
+"""var v = @"g{|Copy:o|}o";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" o[||]"""""";",
-@"
+    """ o[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"
+"""
+var v = @"{|Copy:
+|}";
+""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
+    """
     
     [||] 
-    """""";",
-"\r\nvar dest =\r\n    \"\"\"\r\n[||] \"\"\";");
+    """;
+"""",
+""""
+var dest =
+    """
+[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent2()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"
+"""
+var v = @"{|Copy:
+|}";
+""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
+    """
      
     
-    [||]"""""";",
-"\r\nvar dest =\r\n    \"\"\" \r\n[||]\"\"\";");
+    [||]""";
+"""",
+""""
+var dest =
+    """ 
+[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"
+"""var v = @"{|Copy:""|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
-    ""[||] 
-    """""";",
-@"
+    """
+    "[||] 
+    """;
+"""",
+""""""
 var dest =
-    """"""""""[||] """""";");
+    """""[||] """;
+"""""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent2()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"
+"""var v = @"{|Copy:""|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
-     ""
-    [||]"""""";",
-@"
+    """
+     "
+    [||]""";
+"""",
+""""
 var dest =
-    """""" """"[||]"""""";");
+    """ ""[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"
+""""var v = """{|Copy:goo|}""";"""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""goo[||] """""";",
-@"
+    """goo[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"
+""""var v = """{|Copy:goo|}""";"""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" goo[||]"""""";",
-@"
+    """ goo[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"
+""""var v = """{|Copy: "" |}""";"""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """""" """" [||] """""";",
-@"
+    """ "" [||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"
+""""var v = """{|Copy: "" |}""";"""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""  """" [||]"""""";",
-@"
+    """  "" [||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""goo[||] """""";",
-@"
+    """goo[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1b()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" goo[||]"""""";",
-@"
+    """ goo[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
+    """
     goo
     bar[||] 
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""goo
-    bar[||] """""";");
+    """goo
+    bar[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2b()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
+    """
      goo
     bar
-    [||]"""""";",
-@"
+    [||]""";
+"""",
+""""
 var dest =
-    """""" goo
-    bar[||]"""""";");
+    """ goo
+    bar[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
+    """
     goo
     bar[||] 
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """"""    goo
-    bar[||] """""";");
+    """    goo
+    bar[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3b()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
+    """
      goo
     bar
-    [||]"""""";",
-@"
+    [||]""";
+"""",
+""""
 var dest =
-    """"""     goo
-    bar[||]"""""";");
+    """     goo
+    bar[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromInterpolatedStringLiteralContent()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0}|}"";",
-@"
+"""var v = $"{|Copy:{0}|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""{0}[||] """""";",
-@"
+    """{0}[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromInterpolatedStringLiteralContentb()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0}|}"";",
-@"
+"""var v = $"{|Copy:{0}|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" {0}[||]"""""";",
-@"
+    """ {0}[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"
+"""var v = $"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""{0:X}[||] """""";",
-@"
+    """{0:X}[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1b()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"
+"""var v = $"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" {0:X}[||]"""""";",
-@"
+    """ {0:X}[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""{0:""X""}[||] """""";",
-@"
+    """{0:"X"}[||] """;
+"""",
+""""
 var dest =
-    """"""{0:\""X\""}[||] """""";");
+    """{0:\"X\"}[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2b()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" {0:""X""}[||]"""""";",
-@"
+    """ {0:"X"}[||]""";
+"""",
+""""
 var dest =
-    """""" {0:\""X\""}[||]"""""";");
+    """ {0:\"X\"}[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $"{|Copy:{"goo"}|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""{""goo""}[||] """""";",
-@"
+    """{"goo"}[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent1b()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $"{|Copy:{"goo"}|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" {""goo""}[||]"""""";",
-@"
+    """ {"goo"}[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $"{|Copy:X{"goo"}Y|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""X{""goo""}Y[||] """""";",
-@"
+    """X{"goo"}Y[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent2b()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $"{|Copy:X{"goo"}Y|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" X{""goo""}Y[||]"""""";",
-@"
+    """ X{"goo"}Y[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent3()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{"goo"}Y\"|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
-    ""X{""goo""}Y""[||] 
-    """""";",
-@"
+    """
+    "X{"goo"}Y"[||] 
+    """;
+"""",
+""""
 var dest =
-    """"""\""X{""goo""}Y\""[||] """""";");
+    """\"X{"goo"}Y\"[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent3b()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{"goo"}Y\"|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
-     ""X{""goo""}Y""
-    [||]"""""";",
-@"
+    """
+     "X{"goo"}Y"
+    [||]""";
+"""",
+""""
 var dest =
-    """""" \""X{""goo""}Y\""[||]"""""";");
+    """ \"X{"goo"}Y\"[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent4()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{@""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{@"goo"}Y\"|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
-    ""X{@""goo""}Y""[||] 
-    """""";",
-@"
+    """
+    "X{@"goo"}Y"[||] 
+    """;
+"""",
+""""
 var dest =
-    """"""\""X{@""goo""}Y\""[||] """""";");
+    """\"X{@"goo"}Y\"[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent4b()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{@""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{@"goo"}Y\"|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
-     ""X{@""goo""}Y""
-    [||]"""""";",
-@"
+    """
+     "X{@"goo"}Y"
+    [||]""";
+"""",
+""""
 var dest =
-    """""" \""X{@""goo""}Y\""[||]"""""";");
+    """ \"X{@"goo"}Y\"[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromVerbatimInterpolatedStringLiteralContent()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"
+"""var v = $@"{|Copy:{0}|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""{0}[||] """""";",
-@"
+    """{0}[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromVerbatimInterpolatedStringLiteralContentb()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"
+"""var v = $@"{|Copy:{0}|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" {0}[||]"""""";",
-@"
+    """ {0}[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"
+"""var v = $@"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""{0:X}[||] """""";",
-@"
+    """{0:X}[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1b()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"
+"""var v = $@"{|Copy:{0:X}|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" {0:X}[||]"""""";",
-@"
+    """ {0:X}[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""{0:""X""}[||] """""";",
-@"
+    """{0:"X"}[||] """;
+"""",
+""""
 var dest =
-    """"""{0:""""X""""}[||] """""";");
+    """{0:""X""}[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2b()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" {0:""X""}[||]"""""";",
-@"
+    """ {0:"X"}[||]""";
+"""",
+""""
 var dest =
-    """""" {0:""""X""""}[||]"""""";");
+    """ {0:""X""}[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $@"{|Copy:{"goo"}|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""{""goo""}[||] """""";",
-@"
+    """{"goo"}[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent1b()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $@"{|Copy:{"goo"}|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" {""goo""}[||]"""""";",
-@"
+    """ {"goo"}[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $@"{|Copy:X{"goo"}Y|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""X{""goo""}Y[||] """""";",
-@"
+    """X{"goo"}Y[||] """;
+"""",
+""""
 var dest =
-    """"""[||] """""";");
+    """[||] """;
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent2b()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $@"{|Copy:X{"goo"}Y|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """""" X{""goo""}Y[||]"""""";",
-@"
+    """ X{"goo"}Y[||]""";
+"""",
+""""
 var dest =
-    """""" [||]"""""";");
+    """ [||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent3()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{"goo"}Y""|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
-    ""X{""goo""}Y""[||] 
-    """""";",
-@"
+    """
+    "X{"goo"}Y"[||] 
+    """;
+"""",
+""""""
 var dest =
-    """"""""""X{""goo""}Y""""[||] """""";");
+    """""X{"goo"}Y""[||] """;
+"""""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent3b()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{"goo"}Y""|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
-     ""X{""goo""}Y""
-    [||]"""""";",
-@"
+    """
+     "X{"goo"}Y"
+    [||]""";
+"""",
+""""
 var dest =
-    """""" """"X{""goo""}Y""""[||]"""""";");
+    """ ""X{"goo"}Y""[||]""";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent4()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{@""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{@"goo"}Y""|}";""",
+""""
 var dest =
-    """"""[||] """""";",
-@"
+    """[||] """;
+"""",
+""""
 var dest =
-    """"""
-    ""X{@""goo""}Y""[||] 
-    """""";",
-@"
+    """
+    "X{@"goo"}Y"[||] 
+    """;
+"""",
+""""""
 var dest =
-    """"""""""X{@""goo""}Y""""[||] """""";");
+    """""X{@"goo"}Y""[||] """;
+"""""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent4b()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{@""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{@"goo"}Y""|}";""",
+""""
 var dest =
-    """""" [||]"""""";",
-@"
+    """ [||]""";
+"""",
+""""
 var dest =
-    """"""
-     ""X{@""goo""}Y""
-    [||]"""""";",
-@"
+    """
+     "X{@"goo"}Y"
+    [||]""";
+"""",
+""""
 var dest =
-    """""" """"X{@""goo""}Y""""[||]"""""";");
+    """ ""X{@"goo"}Y""[||]""";
+"""");
         }
 
         #endregion
@@ -1007,7 +1201,9 @@ var dest =
         {
             TestPasteKnownSource(
                 pasteText: "\n",
-@"var x = """"""[||] """"""",
+""""
+var x = """[||] """
+"""",
 "var x = \"\"\"\r\n    \n    [||] \r\n    \"\"\"",
                 afterUndo:
 "var x = \"\"\"\n[||] \"\"\"");
@@ -1018,7 +1214,9 @@ var dest =
         {
             TestPasteKnownSource(
                 pasteText: "\n",
-@"var x = """""" [||]""""""",
+""""
+var x = """ [||]"""
+"""",
 "var x = \"\"\"\r\n     \n    \r\n    [||]\"\"\"",
                 afterUndo:
 "var x = \"\"\" \n[||]\"\"\"");
@@ -1028,592 +1226,955 @@ var dest =
         public void TestNewLineIntoSingleLineRawString2_A()
         {
             TestPasteKnownSource(
-                pasteText: "\r\n",
-@"var x = """"""[||] """"""",
-"var x = \"\"\"\r\n    \r\n    [||] \r\n    \"\"\"",
+                pasteText: """
+
+
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
+    
+    [||] 
+    """
+"""",
                 afterUndo:
-"var x = \"\"\"\r\n[||] \"\"\"");
+""""
+var x = """
+[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNewLineIntoSingleLineRawString2_B()
         {
             TestPasteKnownSource(
-                pasteText: "\r\n",
-@"var x = """""" [||]""""""",
-"var x = \"\"\"\r\n     \r\n    \r\n    [||]\"\"\"",
+                pasteText: """
+
+
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
+     
+    
+    [||]"""
+"""",
                 afterUndo:
-"var x = \"\"\" \r\n[||]\"\"\"");
+""""
+var x = """ 
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "    ",
-@"var x = """"""[||] """"""",
-@"var x = """"""    [||] """"""",
+                pasteText: """    """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """    [||] """
+"""",
                 afterUndo:
-@"var x = """"""[||] """"""");
+""""
+var x = """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_B()
         {
             TestPasteKnownSource(
-                pasteText: "    ",
-@"var x = """""" [||]""""""",
-@"var x = """"""     [||]""""""",
+                pasteText: """    """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """     [||]"""
+"""",
                 afterUndo:
-@"var x = """""" [||]""""""");
+""""
+var x = """ [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString2()
         {
             TestPasteKnownSource(
-                pasteText: "    \r\n",
-@"var x = """"""
+                pasteText: """
+                    
+
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
         
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
         
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "'",
-@"var x = """"""[||] """"""",
-@"var x = """"""'[||] """"""",
+                pasteText: """'""",
+""""
+var x = """[||] """
+"""",
+""""
+var x = """'[||] """
+"""",
                 afterUndo:
-@"var x = """"""[||] """"""");
+""""
+var x = """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_B()
         {
             TestPasteKnownSource(
-                pasteText: "'",
-@"var x = """""" [||]""""""",
-@"var x = """""" '[||]""""""",
+                pasteText: """'""",
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """ '[||]"""
+"""",
                 afterUndo:
-@"var x = """""" [||]""""""");
+""""
+var x = """ [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"",
-@"var x = """"""[||] """"""",
-@"var x = """"""
-    ""[||] 
-    """"""",
+                pasteText: """
+                "
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
+    "[||] 
+    """
+"""",
                 afterUndo:
-@"var x = """"""""[||] """"""");
+"""""
+var x = """"[||] """
+""""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_B()
         {
             TestPasteKnownSource(
-                pasteText: "\"",
-@"var x = """""" [||]""""""",
-@"var x = """"""
-     ""
-    [||]""""""",
+                pasteText: """
+                "
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
+     "
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """""" ""[||]""""""");
+""""
+var x = """ "[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""[||] """"""",
-@"var x = """"""""
-    """"""[||] 
-    """"""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """[||] """
+"""",
+"""""
+var x = """"
+    """[||] 
+    """"
+""""",
                 afterUndo:
-@"var x = """"""""""""[||] """"""");
+"""""""
+var x = """"""[||] """
+""""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_B()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """""" [||]""""""",
-@"var x = """"""""
-     """"""
-    [||]""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """ [||]"""
+"""",
+"""""
+var x = """"
+     """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = """""" """"""[||]""""""");
+""""
+var x = """ """[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTwoQuotesIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"",
-@"var x = """""" ""[||] """"""",
-@"var x = """""""" """"""[||] """"""""",
+                pasteText: """
+                ""
+                """,
+""""
+var x = """ "[||] """
+"""",
+"""""
+var x = """" """[||] """"
+""""",
                 afterUndo:
-@"var x = """""" """"""[||] """"""");
+""""
+var x = """ """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString3()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """""" ""[||] """"""",
-@"var x = """""""""" """"""""[||] """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """ "[||] """
+"""",
+""""""
+var x = """"" """"[||] """""
+"""""",
                 afterUndo:
-@"var x = """""" """"""""[||] """"""");
+"""""
+var x = """ """"[||] """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString4()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """""" ""[||]"" """"""",
-@"var x = """""""""""" """"""""[||]"" """"""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """ "[||]" """
+"""",
+"""""""
+var x = """""" """"[||]" """"""
+""""""",
                 afterUndo:
-@"var x = """""" """"""""[||]"" """"""");
+"""""
+var x = """ """"[||]" """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString5()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """""" [||]"" """"""",
-@"var x = """""""""" """"""[||]"" """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """ [||]" """
+"""",
+""""""
+var x = """"" """[||]" """""
+"""""",
                 afterUndo:
-@"var x = """""" """"""[||]"" """"""");
+""""
+var x = """ """[||]" """
+"""");
         }
 
         [WpfFact]
         public void TestQuadrupleQuoteIntoSingleLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"\"",
-@"var x = """"""
+                pasteText: """""
+                """"
+                """"",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""""""
-    """"""""[||]
-    """"""""""",
+    """
+"""",
+""""""
+var x = """""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = """"""
-    """"""""[||]
-    """"""");
+"""""
+var x = """
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestComplexStringIntoSingleLineRawString()
         {
             TestPasteKnownSource(
-                pasteText: "  \"\"  ",
-@"var x = """"""[||] """"""",
-@"var x = """"""  """"  [||] """"""",
+                pasteText: """  ""  """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """  ""  [||] """
+"""",
                 afterUndo:
-@"var x = """"""[||] """"""");
+""""
+var x = """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc",
-@"var x = """"""[||] """"""",
-@"var x = """"""abc[||] """"""",
+                pasteText: """abc""",
+""""
+var x = """[||] """
+"""",
+""""
+var x = """abc[||] """
+"""",
                 afterUndo:
-@"var x = """"""[||] """"""");
+""""
+var x = """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc",
-@"var x = """""" [||]""""""",
-@"var x = """""" abc[||]""""""",
+                pasteText: """abc""",
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """ abc[||]"""
+"""",
                 afterUndo:
-@"var x = """""" [||]""""""");
+""""
+var x = """ [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
     abc
     def[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
-def[||] """"""");
+""""
+var x = """abc
+def[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """""" [||]""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
      abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """""" abc
-def[||]""""""");
+""""
+var x = """ abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine4()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""goo[||]""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """goo[||]"""
+"""",
+""""
+var x = """
     gooabc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""gooabc
-def[||]""""""");
+""""
+var x = """gooabc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine5()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""goo[||]bar""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """goo[||]bar"""
+"""",
+""""
+var x = """
     gooabc
     def[||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""gooabc
-def[||]bar""""""");
+""""
+var x = """gooabc
+def[||]bar"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine6()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""goo[||]bar""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = """goo[||]bar"""
+"""",
+""""
+var x = """
     gooabc
     def
     [||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""gooabc
+""""
+var x = """gooabc
 def
-[||]bar""""""");
+[||]bar"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
     abc
         def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
     def
-ghi[||] """"""");
+ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = """""" [||]""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
      abc
         def
     ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """""" abc
+""""
+var x = """ abc
     def
-ghi[||]""""""");
+ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
     abc
         def
         ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
     abc
         def
         ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_A()
         {
             TestPasteKnownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
         abc
         def
         ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""    abc
+""""
+var x = """    abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_B()
         {
             TestPasteKnownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = """""" [||]""""""",
-@"var x = """"""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
          abc
         def
         ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""     abc
+""""
+var x = """     abc
     def
-    ghi[||]""""""");
+    ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_A()
         {
             TestPasteKnownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
             abc
         def
         ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""        abc
+""""
+var x = """        abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_B()
         {
             TestPasteKnownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = """""" [||]""""""",
-@"var x = """"""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
              abc
         def
         ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""         abc
+""""
+var x = """         abc
     def
-    ghi[||]""""""");
+    ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""[||]{|Selection:    |}""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """[||]{|Selection:    |}"""
+"""",
+""""
+var x = """
     abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""abc
-def[||]""""""");
+""""
+var x = """abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""  [||]{|Selection:    |}  """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """  [||]{|Selection:    |}  """
+"""",
+""""
+var x = """
       abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""  abc
-def[||]  """"""");
+""""
+var x = """  abc
+def[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""[||]{|Selection:    |}""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = """[||]{|Selection:    |}"""
+"""",
+""""
+var x = """
     abc
     def
     
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
 def
-[||]""""""");
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""  [||]{|Selection:    |}  """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = """  [||]{|Selection:    |}  """
+"""",
+""""
+var x = """
       abc
     def
     [||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""  abc
+""""
+var x = """  abc
 def
-[||]  """"""");
+[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_A()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""[||]{|Selection:    |}  """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """[||]{|Selection:    |}  """
+"""",
+""""
+var x = """
     abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
-def[||]  """"""");
+""""
+var x = """abc
+def[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_B()
         {
             TestPasteKnownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""  [||]{|Selection:    |}""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """  [||]{|Selection:    |}"""
+"""",
+""""
+var x = """
       abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""  abc
-def[||]""""""");
+""""
+var x = """  abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_A()
         {
             TestPasteKnownSource(
-                pasteText: "\"bar",
-@"var x = """"""[||]goo""""""",
-@"var x = """"""
-    ""bar[||]goo
-    """"""",
+                pasteText: """
+                "bar
+                """,
+""""
+var x = """[||]goo"""
+"""",
+""""
+var x = """
+    "bar[||]goo
+    """
+"""",
                 afterUndo:
-@"var x = """"""""bar[||]goo""""""");
+"""""
+var x = """"bar[||]goo"""
+""""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_B()
         {
             TestPasteKnownSource(
-                pasteText: "bar\"",
-@"var x = """"""goo[||]""""""",
-@"var x = """"""
-    goobar""
-    [||]""""""",
+                pasteText: """
+                bar"
+                """,
+""""
+var x = """goo[||]"""
+"""",
+""""
+var x = """
+    goobar"
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""goobar""[||]""""""");
+""""
+var x = """goobar"[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader1()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"",
-@"var x = """"""[||]{|Selection:    |}""""""",
-@"var x = """"""
-    """"
-    [||]""""""",
+                pasteText: """
+                ""
+                """,
+""""
+var x = """[||]{|Selection:    |}"""
+"""",
+""""
+var x = """
+    ""
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""""""[||]""""""");
+""""""
+var x = """""[||]"""
+"""""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader2()
         {
             TestPasteKnownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""[||]{|Selection:    |}""""""",
-@"var x = """"""""
-    """"""
-    [||]""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """[||]{|Selection:    |}"""
+"""",
+"""""
+var x = """"
+    """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = """"""""""""[||]""""""");
+"""""""
+var x = """"""[||]"""
+""""""");
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoSingleLineRawStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoSingleLineRawStringTests.cs
@@ -2175,6 +2175,6 @@ var x = """"""[||]"""
 """"""");
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoVerbatimInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoVerbatimInterpolatedStringTests.cs
@@ -13,366 +13,441 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestPasteSimpleNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""goo[||]"";",
-@"
+    $@"goo[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteOpenBraceNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{|}"";",
-@"
+"""var v = "{|Copy:{|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""{{[||]"";",
-@"
+    $@"{{[||]";
+""",
+"""
 var dest =
-    $@""{[||]"";");
+    $@"{[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteOpenCloseBraceNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{}|}"";",
-@"
+"""var v = "{|Copy:{}|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""{{}}[||]"";",
-@"
+    $@"{{}}[||]";
+""",
+"""
 var dest =
-    $@""{}[||]"";");
+    $@"{}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteLooksLikeInterpolationNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:{0}|}"";",
-@"
+"""var v = "{|Copy:{0}|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""{{0}}[||]"";",
-@"
+    $@"{{0}}[||]";
+""",
+"""
 var dest =
-    $@""{0}[||]"";");
+    $@"{0}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"
+"""var v = "g{|Copy:o|}o";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""o[||]"";",
-@"
+    $@"o[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"
+"""var v = "\{|Copy:n|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""n[||]"";",
-@"
+    $@"n[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\r\n|}"";",
-@"
+"""var v = "{|Copy:\r\n|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""
-[||]"";",
-@"
+    $@"
+[||]";
+""",
+"""
 var dest =
-    $@""\r\n[||]"";");
+    $@"\r\n[||]";
+""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"
+"""var v = "\{|Copy:"|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+""""
 var dest =
-    $@""""""[||]"";",
-@"
+    $@"""[||]";
+"""",
+"""
 var dest =
-    $@""""[||]"";");
+    $@""[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"
+"""var v = "{|Copy:\"|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+""""
 var dest =
-    $@""""""[||]"";",
-@"
+    $@"""[||]";
+"""",
+"""
 var dest =
-    $@""\""[||]"";");
+    $@"\"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"
+"""var v = @"{|Copy:goo|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""goo[||]"";",
-@"
+    $@"goo[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"
+"""var v = @"g{|Copy:o|}o";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""o[||]"";",
-@"
+    $@"o[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"
+"""
+var v = @"{|Copy:
+|}";
+""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""
-[||]"";",
-@"
+    $@"
+[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"
+"""var v = @"{|Copy:""|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+""""
 var dest =
-    $@""""""[||]"";",
-@"
+    $@"""[||]";
+"""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"
+""""var v = """{|Copy:goo|}""";"""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""goo[||]"";",
-@"
+    $@"goo[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"
+""""var v = """{|Copy: "" |}""";"""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""""
 var dest =
-    $@"" """""""" [||]"";",
-@"
+    $@" """" [||]";
+""""",
+"""
 var dest =
-    $@"" """" [||]"";");
+    $@" "" [||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""goo[||]"";",
-@"
+    $@"goo[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""goo
-bar[||]"";",
-@"
+    $@"goo
+bar[||]";
+""",
+"""
 var dest =
-    $@""goo
-    bar[||]"";");
+    $@"goo
+    bar[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""goo
-bar[||]"";",
-@"
+    $@"goo
+bar[||]";
+""",
+"""
 var dest =
-    $@""    goo
-    bar[||]"";");
+    $@"    goo
+    bar[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"
+"""var v = $"{|Copy:{0:X}|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""{0:X}[||]"";",
-@"
+    $@"{0:X}[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""{0:""""X""""}[||]"";",
-@"
+    $@"{0:""X""}[||]";
+""",
+"""
 var dest =
-    $@""{0:\""X\""}[||]"";");
+    $@"{0:\"X\"}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"
+"""var v = $@"{|Copy:{0:X}|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""{0:X}[||]"";",
-@"
+    $@"{0:X}[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+"""
 var dest =
-    $@""[||]"";",
-@"
+    $@"[||]";
+""",
+"""
 var dest =
-    $@""{0:""""X""""}[||]"";",
-@"
+    $@"{0:""X""}[||]";
+""",
+"""
 var dest =
-    $@""[||]"";");
+    $@"[||]";
+""");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoVerbatimStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteKnownSourceIntoVerbatimStringTests.cs
@@ -13,477 +13,573 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestPasteSimpleNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:goo|}"";",
-@"
+"""var v = "{|Copy:goo|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""goo[||]"";",
-@"
+    @"goo[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""g{|Copy:o|}o"";",
-@"
+"""var v = "g{|Copy:o|}o";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""o[||]"";",
-@"
+    @"o[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:n|}"";",
-@"
+"""var v = "\{|Copy:n|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""n[||]"";",
-@"
+    @"n[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\r\n|}"";",
-@"
+"""var v = "{|Copy:\r\n|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""
-[||]"";",
-@"
+    @"
+[||]";
+""",
+"""
 var dest =
-    @""\r\n[||]"";");
+    @"\r\n[||]";
+""");
         }
 
         [WpfFact]
         public void TestPastePartiallySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""\{|Copy:""|}"";",
-@"
+"""var v = "\{|Copy:"|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+""""
 var dest =
-    @""""""[||]"";",
-@"
+    @"""[||]";
+"""",
+"""
 var dest =
-    @""""[||]"";");
+    @""[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedQuoteNormalLiteralContent()
         {
             TestCopyPaste(
-@"var v = ""{|Copy:\""|}"";",
-@"
+"""var v = "{|Copy:\"|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+""""
 var dest =
-    @""""""[||]"";",
-@"
+    @"""[||]";
+"""",
+"""
 var dest =
-    @""\""[||]"";");
+    @"\"[||]";
+""");
         }
         [WpfFact]
         public void TestPasteSimpleVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:goo|}"";",
-@"
+"""var v = @"{|Copy:goo|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""goo[||]"";",
-@"
+    @"goo[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleSubstringVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""g{|Copy:o|}o"";",
-@"
+"""var v = @"g{|Copy:o|}o";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""o[||]"";",
-@"
+    @"o[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSelectedVerbatimNewLineLiteralContent()
         {
             TestCopyPaste(
-"var v = @\"{|Copy:\r\n|}\";",
-@"
+"""
+var v = @"{|Copy:
+|}";
+""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""
-[||]"";",
-@"
+    @"
+[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteFullySelectedEscapeVerbatimLiteralContent()
         {
             TestCopyPaste(
-@"var v = @""{|Copy:""""|}"";",
-@"
+"""var v = @"{|Copy:""|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+""""
 var dest =
-    @""""""[||]"";",
-@"
+    @"""[||]";
+"""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy:goo|}"""""";",
-@"
+""""var v = """{|Copy:goo|}""";"""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""goo[||]"";",
-@"
+    @"goo[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteQuotesRawSingleLineLiteralContent()
         {
             TestCopyPaste(
-@"var v = """"""{|Copy: """" |}"""""";",
-@"
+""""var v = """{|Copy: "" |}""";"""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""""
 var dest =
-    @"" """""""" [||]"";",
-@"
+    @" """" [||]";
+""""",
+"""
 var dest =
-    @"" """" [||]"";");
+    @" "" [||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent1()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""goo[||]"";",
-@"
+    @"goo[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent2()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
     {|Copy:goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""goo
-bar[||]"";",
-@"
+    @"goo
+bar[||]";
+""",
+"""
 var dest =
-    @""goo
-    bar[||]"";");
+    @"goo
+    bar[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteSimpleRawMultiLineLiteralContent3()
         {
             TestCopyPaste(
-@"var v = """"""
+""""
+var v = """
 {|Copy:    goo
     bar|}
-    """""";",
-@"
+    """;
+"""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""goo
-bar[||]"";",
-@"
+    @"goo
+bar[||]";
+""",
+"""
 var dest =
-    @""    goo
-    bar[||]"";");
+    @"    goo
+    bar[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromInterpolatedStringLiteralContent()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0}|}"";",
-@"
+"""var v = $"{|Copy:{0}|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""{0}[||]"";",
-@"
+    @"{0}[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:X}|}"";",
-@"
+"""var v = $"{|Copy:{0:X}|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""{0:X}[||]"";",
-@"
+    @"{0:X}[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{0:\""X\""}|}"";",
-@"
+"""var v = $"{|Copy:{0:\"X\"}|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""{0:""""X""""}[||]"";",
-@"
+    @"{0:""X""}[||]";
+""",
+"""
 var dest =
-    @""{0:\""X\""}[||]"";");
+    @"{0:\"X\"}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $"{|Copy:{"goo"}|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""{""""goo""""}[||]"";",
-@"
+    @"{""goo""}[||]";
+""",
+"""
 var dest =
-    @""{""goo""}[||]"";");
+    @"{"goo"}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $"{|Copy:X{"goo"}Y|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""X{""""goo""""}Y[||]"";",
-@"
+    @"X{""goo""}Y[||]";
+""",
+"""
 var dest =
-    @""X{""goo""}Y[||]"";");
+    @"X{"goo"}Y[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent3()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{"goo"}Y\"|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+""""
 var dest =
-    @""""""X{""""goo""""}Y""""[||]"";",
-@"
+    @"""X{""goo""}Y""[||]";
+"""",
+"""
 var dest =
-    @""\""X{""goo""}Y\""[||]"";");
+    @"\"X{"goo"}Y\"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromInterpolatedStringLiteralContent4()
         {
             TestCopyPaste(
-@"var v = $""{|Copy:\""X{@""goo""}Y\""|}"";",
-@"
+"""var v = $"{|Copy:\"X{@"goo"}Y\"|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+""""
 var dest =
-    @""""""X{@""""goo""""}Y""""[||]"";",
-@"
+    @"""X{@""goo""}Y""[||]";
+"""",
+"""
 var dest =
-    @""\""X{@""goo""}Y\""[||]"";");
+    @"\"X{@"goo"}Y\"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationFromVerbatimInterpolatedStringLiteralContent()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0}|}"";",
-@"
+"""var v = $@"{|Copy:{0}|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""{0}[||]"";",
-@"
+    @"{0}[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:X}|}"";",
-@"
+"""var v = $@"{|Copy:{0:X}|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""{0:X}[||]"";",
-@"
+    @"{0:X}[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithFormatClauseFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{0:""""X""""}|}"";",
-@"
+"""var v = $@"{|Copy:{0:""X""}|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""{0:""""X""""}[||]"";",
-@"
+    @"{0:""X""}[||]";
+""",
+"""
 var dest =
-    @""[||]"";");
+    @"[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent1()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:{""goo""}|}"";",
-@"
+"""var v = $@"{|Copy:{"goo"}|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""{""""goo""""}[||]"";",
-@"
+    @"{""goo""}[||]";
+""",
+"""
 var dest =
-    @""{""goo""}[||]"";");
+    @"{"goo"}[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent2()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:X{""goo""}Y|}"";",
-@"
+"""var v = $@"{|Copy:X{"goo"}Y|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+"""
 var dest =
-    @""X{""""goo""""}Y[||]"";",
-@"
+    @"X{""goo""}Y[||]";
+""",
+"""
 var dest =
-    @""X{""goo""}Y[||]"";");
+    @"X{"goo"}Y[||]";
+""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent3()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{"goo"}Y""|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+""""
 var dest =
-    @""""""X{""""goo""""}Y""""[||]"";",
-@"
+    @"""X{""goo""}Y""[||]";
+"""",
+""""
 var dest =
-    @""""""X{""goo""}Y""""[||]"";");
+    @"""X{"goo"}Y""[||]";
+"""");
         }
 
         [WpfFact]
         public void TestPasteInterpolationWithStringFromVerbatimInterpolatedStringLiteralContent4()
         {
             TestCopyPaste(
-@"var v = $@""{|Copy:""""X{@""goo""}Y""""|}"";",
-@"
+"""var v = $@"{|Copy:""X{@"goo"}Y""|}";""",
+"""
 var dest =
-    @""[||]"";",
-@"
+    @"[||]";
+""",
+""""
 var dest =
-    @""""""X{@""""goo""""}Y""""[||]"";",
-@"
+    @"""X{@""goo""}Y""[||]";
+"""",
+""""
 var dest =
-    @""""""X{@""goo""}Y""""[||]"";");
+    @"""X{@"goo"}Y""[||]";
+"""");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoMultiLineInterpolatedRawStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoMultiLineInterpolatedRawStringTests.cs
@@ -15,9 +15,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""",
+    """
+"""",
 "var x = $\"\"\"\r\n    \n    [||]\r\n    \"\"\"",
                 afterUndo:
 "var x = $\"\"\"\r\n    \n[||]\r\n    \"\"\"");
@@ -27,710 +29,1031 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNewLineIntoMultiLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-@"var x = $""""""
+                pasteText: """
+
+
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-"var x = $\"\"\"\r\n    \r\n    [||]\r\n    \"\"\"",
+    """
+"""",
+""""
+var x = $"""
+    
+    [||]
+    """
+"""",
                 afterUndo:
-"var x = $\"\"\"\r\n    \r\n[||]\r\n    \"\"\"");
+""""
+var x = $"""
+    
+[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoMultiLineRawString1()
         {
             TestPasteUnknownSource(
-                pasteText: "    ",
-@"var x = $""""""
+                pasteText: """    """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
         [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoMultiLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "    \r\n",
-@"var x = $""""""
+                pasteText: """
+                    
+
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
         
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-@"var x = $""""""
+                pasteText: """'""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     '[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-@"var x = $""""""
+                pasteText: """
+                "
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
-    ""[||]
-    """"""",
+    """
+"""",
+""""
+var x = $"""
+    "[||]
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString1()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""""
-    """"""[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = $""""
+    """[||]
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""
-    """"""[||]
-    """"""");
+""""
+var x = $"""
+    """[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""  
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""  
     [||]
-    """"""  ",
-@"var x = $""""""""  
-    """"""[||]
-    """"""""  ",
+    """  
+"""",
+"""""
+var x = $""""  
+    """[||]
+    """"  
+""""",
                 afterUndo:
-@"var x = $""""""  
-    """"""[||]
-    """"""  ");
+""""
+var x = $"""  
+    """[||]
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString3()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""  
-    ""[||]
-    """"""  ",
-@"var x = $""""""""""  
-    """"""""[||]
-    """"""""""  ",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""  
+    "[||]
+    """  
+"""",
+""""""
+var x = $"""""  
+    """"[||]
+    """""  
+"""""",
                 afterUndo:
-@"var x = $""""""  
-    """"""""[||]
-    """"""  ");
+"""""
+var x = $"""  
+    """"[||]
+    """  
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString4()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""  
-    ""[||]""  
-    """"""  ",
-@"var x = $""""""""""""  
-    """"""""[||]""  
-    """"""""""""  ",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""  
+    "[||]"  
+    """  
+"""",
+"""""""
+var x = $""""""  
+    """"[||]"  
+    """"""  
+""""""",
                 afterUndo:
-@"var x = $""""""  
-    """"""""[||]""  
-    """"""  ");
+"""""
+var x = $"""  
+    """"[||]"  
+    """  
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString5()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""  
-    [||]""
-    """"""  ",
-@"var x = $""""""""""  
-    """"""[||]""
-    """"""""""  ",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""  
+    [||]"
+    """  
+"""",
+""""""
+var x = $"""""  
+    """[||]"
+    """""  
+"""""",
                 afterUndo:
-@"var x = $""""""  
-    """"""[||]""
-    """"""  ");
+""""
+var x = $"""  
+    """[||]"
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestQuadrupleQuoteIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"\"",
-@"var x = $""""""
+                pasteText: """""
+                """"
+                """"",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""""""
-    """"""""[||]
-    """"""""""",
+    """
+"""",
+""""""
+var x = $"""""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = $""""""
-    """"""""[||]
-    """"""");
+"""""
+var x = $"""
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestOpenBraceIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-@"var x = $""""""
+                pasteText: """{""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$""""""
+    """
+"""",
+""""
+var x = $$"""
     {[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "{{{",
-@"var x = $""""""
+                pasteText: """{{{""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$$""""""
+    """
+"""",
+""""
+var x = $$$$"""
     {{{[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {{{[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoMultiLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "{{{",
-@"var x = $$""""""
+                pasteText: """{{{""",
+""""
+var x = $$"""
     [||]
-    """"""",
-@"var x = $$$$""""""
+    """
+"""",
+""""
+var x = $$$$"""
     {{{[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $$""""""
+""""
+var x = $$"""
     {{{[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenBraceIntoMultiLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-@"var x = $$$""""""  
+                pasteText: """{""",
+""""
+var x = $$$"""  
     {[||]{
-    """"""  ",
-@"var x = $$$$""""""  
+    """  
+"""",
+""""
+var x = $$$$"""  
     {{[||]{
-    """"""  ",
+    """  
+"""",
                 afterUndo:
-@"var x = $$$""""""  
+""""
+var x = $$$"""  
     {{[||]{
-    """"""  ");
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestInterpolationIntoMultiLineRawString3()
         {
             TestPasteUnknownSource(
-                pasteText: "{0}",
-@"var x = $""""""  
+                pasteText: """{0}""",
+""""
+var x = $"""  
     [||]
-    """"""  ",
-@"var x = $""""""  
+    """  
+"""",
+""""
+var x = $"""  
     {0}[||]
-    """"""  ",
+    """  
+"""",
                 afterUndo:
-@"var x = $""""""  
+""""
+var x = $"""  
     [||]
-    """"""  ");
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseIntoMultiLineRawString4()
         {
             TestPasteUnknownSource(
-                pasteText: "{}",
-@"var x = $""""""  
+                pasteText: """{}""",
+""""
+var x = $"""  
     [||]  
-    """"""  ",
-@"var x = $$""""""  
+    """  
+"""",
+""""
+var x = $$"""  
     {}[||]  
-    """"""  ",
+    """  
+"""",
                 afterUndo:
-@"var x = $""""""  
+""""
+var x = $"""  
     {}[||]  
-    """"""  ");
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoMultiLineRawString5()
         {
             TestPasteUnknownSource(
-                pasteText: "{{}",
-@"var x = $$""""""  
+                pasteText: """{{}""",
+""""
+var x = $$"""  
     [||]
-    """"""  ",
-@"var x = $$$""""""  
+    """  
+"""",
+""""
+var x = $$$"""  
     {{}[||]
-    """"""  ",
+    """  
+"""",
                 afterUndo:
-@"var x = $$""""""  
+""""
+var x = $$"""  
     {{}[||]
-    """"""  ");
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "{}}",
-@"var x = $""""""
+                pasteText: """{}}""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$""""""
+    """
+"""",
+""""
+var x = $$$"""
     {}}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {}}[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoMultiLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "{{}}",
-@"var x = $""""""
+                pasteText: """{{}}""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$""""""
+    """
+"""",
+""""
+var x = $$$"""
     {{}}[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     {{}}[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteTripleOpenBraceIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"{{{",
-@"var x = $""""""
+                pasteText: """"
+                """{{{
+                """",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $$$$""""""""
-    """"""{{{[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = $$$$""""
+    """{{{[||]
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""
-    """"""{{{[||]
-    """"""");
+""""
+var x = $"""
+    """{{{[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestComplexStringIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "  \"\"  ",
-@"var x = $""""""
+                pasteText: """  ""  """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
-    """"  [||]
-    """"""",
+    """
+"""",
+""""
+var x = $"""
+    ""  [||]
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
-      """"  [||]
-    """"""");
+""""
+var x = $"""
+      ""  [||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-@"var x = $""""""
+                pasteText: """abc""",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine1()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine2()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
 [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
 abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine3()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]
 
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def[||]
 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
 def[||]
 
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine4()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     goo[||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     gooabc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     gooabc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine5()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""
     goo[||]bar
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     gooabc
     def[||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     gooabc
 def[||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine6()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""
     goo[||]bar
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     gooabc
     def
     [||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     gooabc
 def
 [||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine7()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
         def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     abc
     def
 ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine7_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = $"""
           [||]
-          """"""",
-@"var x = $""""""
+          """
+"""",
+""""
+var x = $"""
           abc
               def
           ghi[||]
-          """"""",
+          """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
           abc
     def
 ghi[||]
-          """"""");
+          """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine8()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine9()
         {
             TestPasteUnknownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = $""""""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     abc
     def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
         abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine10()
         {
             TestPasteUnknownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = $""""""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
         abc
     def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
             abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine11()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]{|Selection:
 
-    |}""""""",
-@"var x = $""""""
+    |}"""
+"""",
+""""
+var x = $"""
     abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||]""""""");
+""""
+var x = $"""abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine12()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """
+                abc
+                def
 
-    |}""""""",
-@"var x = $""""""
+                """,
+""""
+var x = $"""[||]{|Selection:
+
+    |}"""
+"""",
+""""
+var x = $"""
     abc
     def
     
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
 def
-[||]""""""");
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine13()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]{|Selection:
 
- |}   """"""",
-@"var x = $""""""
+ |}   """
+"""",
+""""
+var x = $"""
     abc
     def
- [||]   """"""",
+ [||]   """
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||]   """"""");
+""""
+var x = $"""abc
+def[||]   """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringHeader1()
         {
             TestPasteUnknownSource(
-                pasteText: "bar",
-@"var x = $""""""[||]
+                pasteText: """bar""",
+""""
+var x = $"""[||]
     goo
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     bar[||]
     goo
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""bar[||]
+""""
+var x = $"""bar[||]
     goo
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader1()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """
+                ""
+                """,
+""""
+var x = $"""[||]{|Selection:
 
-    |}""""""",
-@"var x = $""""""
-    """"
-    [||]""""""",
+    |}"""
+"""",
+""""
+var x = $"""
+    ""
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""""""[||]""""""");
+""""""
+var x = $"""""[||]"""
+"""""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader2()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""[||]{|Selection:
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""[||]{|Selection:
 
-    |}""""""",
-@"var x = $""""""""
-    """"""
-    [||]""""""""",
+    |}"""
+"""",
+"""""
+var x = $""""
+    """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = $""""""""""""[||]""""""");
+"""""""
+var x = $""""""[||]"""
+""""""");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoMultiLineRawStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoMultiLineRawStringTests.cs
@@ -15,9 +15,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""",
+    """
+"""",
 "var x = \"\"\"\r\n    \n    [||]\r\n    \"\"\"",
                 afterUndo:
 "var x = \"\"\"\r\n    \n[||]\r\n    \"\"\"");
@@ -27,540 +29,799 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNewLineIntoMultiLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-@"var x = """"""
+                pasteText: """
+
+
+                """,
+""""
+var x = """
     [||]
-    """"""",
-"var x = \"\"\"\r\n    \r\n    [||]\r\n    \"\"\"",
+    """
+"""",
+""""
+var x = """
+    
+    [||]
+    """
+"""",
                 afterUndo:
-"var x = \"\"\"\r\n    \r\n[||]\r\n    \"\"\"");
+""""
+var x = """
+    
+[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoMultiLineRawString1()
         {
             TestPasteUnknownSource(
-                pasteText: "    ",
-@"var x = """"""
+                pasteText: """    """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
         [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoMultiLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "    \r\n",
-@"var x = """"""
+                pasteText: """
+                    
+
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
         
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-@"var x = """"""
+                pasteText: """'""",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     '[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-@"var x = """"""
+                pasteText: """
+                "
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
-    ""[||]
-    """"""",
+    """
+"""",
+""""
+var x = """
+    "[||]
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString1()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""
+                pasteText: """"
+                """
+                """",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""""
-    """"""[||]
-    """"""""",
+    """
+"""",
+"""""
+var x = """"
+    """[||]
+    """"
+""""",
                 afterUndo:
-@"var x = """"""
-    """"""[||]
-    """"""");
+""""
+var x = """
+    """[||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""  
+                pasteText: """"
+                """
+                """",
+""""
+var x = """  
     [||]
-    """"""  ",
-@"var x = """"""""  
-    """"""[||]
-    """"""""  ",
+    """  
+"""",
+"""""
+var x = """"  
+    """[||]
+    """"  
+""""",
                 afterUndo:
-@"var x = """"""  
-    """"""[||]
-    """"""  ");
+""""
+var x = """  
+    """[||]
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString3()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""  
-    ""[||]
-    """"""  ",
-@"var x = """"""""""  
-    """"""""[||]
-    """"""""""  ",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """  
+    "[||]
+    """  
+"""",
+""""""
+var x = """""  
+    """"[||]
+    """""  
+"""""",
                 afterUndo:
-@"var x = """"""  
-    """"""""[||]
-    """"""  ");
+"""""
+var x = """  
+    """"[||]
+    """  
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString4()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""  
-    ""[||]""  
-    """"""  ",
-@"var x = """"""""""""  
-    """"""""[||]""  
-    """"""""""""  ",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """  
+    "[||]"  
+    """  
+"""",
+"""""""
+var x = """"""  
+    """"[||]"  
+    """"""  
+""""""",
                 afterUndo:
-@"var x = """"""  
-    """"""""[||]""  
-    """"""  ");
+"""""
+var x = """  
+    """"[||]"  
+    """  
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoMultiLineRawString5()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""  
-    [||]""
-    """"""  ",
-@"var x = """"""""""  
-    """"""[||]""
-    """"""""""  ",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """  
+    [||]"
+    """  
+"""",
+""""""
+var x = """""  
+    """[||]"
+    """""  
+"""""",
                 afterUndo:
-@"var x = """"""  
-    """"""[||]""
-    """"""  ");
+""""
+var x = """  
+    """[||]"
+    """  
+"""");
         }
 
         [WpfFact]
         public void TestQuadrupleQuoteIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"\"",
-@"var x = """"""
+                pasteText: """""
+                """"
+                """"",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""""""
-    """"""""[||]
-    """"""""""",
+    """
+"""",
+""""""
+var x = """""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = """"""
-    """"""""[||]
-    """"""");
+"""""
+var x = """
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestComplexStringIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "  \"\"  ",
-@"var x = """"""
+                pasteText: """  ""  """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
-    """"  [||]
-    """"""",
+    """
+"""",
+""""
+var x = """
+    ""  [||]
+    """
+"""",
                 afterUndo:
-@"var x = """"""
-      """"  [||]
-    """"""");
+""""
+var x = """
+      ""  [||]
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-@"var x = """"""
+                pasteText: """abc""",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine1()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine2()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """
 [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
 abc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine3()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""[||]
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """[||]
 
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
     def[||]
 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
 def[||]
 
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine4()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """
     goo[||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     gooabc
     def[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     gooabc
 def[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine5()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """
     goo[||]bar
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     gooabc
     def[||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     gooabc
 def[||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine6()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = """
     goo[||]bar
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     gooabc
     def
     [||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     gooabc
 def
 [||]bar
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine7()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
         def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     abc
     def
 ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine7_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = """
           [||]
-          """"""",
-@"var x = """"""
+          """
+"""",
+""""
+var x = """
           abc
               def
           ghi[||]
-          """"""",
+          """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
           abc
     def
 ghi[||]
-          """"""");
+          """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine8()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
     def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
     [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine9()
         {
             TestPasteUnknownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = """"""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     abc
     def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
         abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine10()
         {
             TestPasteUnknownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = """"""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
         abc
     def
     ghi[||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
             abc
     def
     ghi[||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine11()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""[||]{|Selection:
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """[||]{|Selection:
 
-    |}""""""",
-@"var x = """"""
+    |}"""
+"""",
+""""
+var x = """
     abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""abc
-def[||]""""""");
+""""
+var x = """abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine12()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""[||]{|Selection:
+                pasteText: """
+                abc
+                def
 
-    |}""""""",
-@"var x = """"""
+                """,
+""""
+var x = """[||]{|Selection:
+
+    |}"""
+"""",
+""""
+var x = """
     abc
     def
     
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
 def
-[||]""""""");
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringMultiLine13()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""[||]{|Selection:
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """[||]{|Selection:
 
- |}   """"""",
-@"var x = """"""
+ |}   """
+"""",
+""""
+var x = """
     abc
     def
- [||]   """"""",
+ [||]   """
+"""",
                 afterUndo:
-@"var x = """"""abc
-def[||]   """"""");
+""""
+var x = """abc
+def[||]   """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoMultiLineRawStringHeader1()
         {
             TestPasteUnknownSource(
-                pasteText: "bar",
-@"var x = """"""[||]
+                pasteText: """bar""",
+""""
+var x = """[||]
     goo
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     bar[||]
     goo
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""bar[||]
+""""
+var x = """bar[||]
     goo
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader1()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"",
-@"var x = """"""[||]{|Selection:
+                pasteText: """
+                ""
+                """,
+""""
+var x = """[||]{|Selection:
 
-    |}""""""",
-@"var x = """"""
-    """"
-    [||]""""""",
+    |}"""
+"""",
+""""
+var x = """
+    ""
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""""""[||]""""""");
+""""""
+var x = """""[||]"""
+"""""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader2()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""[||]{|Selection:
+                pasteText: """"
+                """
+                """",
+""""
+var x = """[||]{|Selection:
 
-    |}""""""",
-@"var x = """"""""
-    """"""
-    [||]""""""""",
+    |}"""
+"""",
+"""""
+var x = """"
+    """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = """"""""""""[||]""""""");
+"""""""
+var x = """"""[||]"""
+""""""");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoNormalInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoNormalInterpolatedStringTests.cs
@@ -496,9 +496,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
                 """);
         }
 
-#endregion
+        #endregion
 
-#region Paste from external source into normal interpolated string after hole
+        #region Paste from external source into normal interpolated string after hole
 
         [WpfFact]
         public void TestNewLineIntoNormalInterpolatedStringAfterHole1()
@@ -740,6 +740,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
                 """);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoNormalInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoNormalInterpolatedStringTests.cs
@@ -17,8 +17,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-                @"var x = $""[||]""",
-                @"var x = $""\n[||]""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"\n[||]"
+                """,
                 afterUndo: "var x = $\"\n[||]\"");
         }
 
@@ -26,10 +30,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNewLineIntoNormalInterpolatedString2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-                @"var x = $""[||]""",
-                @"var x = $""\r\n[||]""",
-                afterUndo: "var x = $\"\r\n[||]\"");
+                pasteText: """
+
+
+                """,
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"\r\n[||]"
+                """,
+                afterUndo: """
+                var x = $"
+                [||]"
+                """);
         }
 
         [WpfFact]
@@ -37,8 +51,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t",
-                @"var x = $""[||]""",
-                @"var x = $""\t[||]""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"\t[||]"
+                """,
                 afterUndo: "var x = $\"\t[||]\"");
         }
 
@@ -46,20 +64,34 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestSingleQuoteIntoNormalInterpolatedString()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-                @"var x = $""[||]""",
-                @"var x = $""'[||]""",
-                afterUndo: "var x = $\"[||]\"");
+                pasteText: """'""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"'[||]"
+                """,
+                afterUndo: """
+                var x = $"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoNormalInterpolatedString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-                @"var x = $""[||]""",
-                @"var x = $""\""[||]""",
-                afterUndo: "var x = $\"\"[||]\"");
+                pasteText: """
+                "
+                """,
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"\"[||]"
+                """,
+                afterUndo: """
+                var x = $""[||]"
+                """);
         }
 
         [WpfFact]
@@ -67,8 +99,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t\"\"\t",
-                @"var x = $""[||]""",
-                @"var x = $""\t\""\""\t[||]""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"\t\"\"\t[||]"
+                """,
                 afterUndo: "var x = $\"\t\"\"\t[||]\"");
         }
 
@@ -76,90 +112,144 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNormalTextIntoNormalInterpolatedString()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-                @"var x = $""[||]""",
-                @"var x = $""abc[||]""",
-                afterUndo: @"var x = $""[||]""");
+                pasteText: """abc""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"abc[||]"
+                """,
+                afterUndo: """
+                var x = $"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoNormalInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-                @"var x = $""[||]""",
-                @"var x = $""{{[||]""",
-                afterUndo: "var x = $\"{[||]\"");
+                pasteText: """{""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"{{[||]"
+                """,
+                afterUndo: """
+                var x = $"{[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesIntoNormalInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{",
-                @"var x = $""[||]""",
-                @"var x = $""{{[||]""",
-                afterUndo: "var x = $\"[||]\"");
+                pasteText: """{{""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"{{[||]"
+                """,
+                afterUndo: """
+                var x = $"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesAndContentIntoNormalInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{0",
-                @"var x = $""[||]""",
-                @"var x = $""{{0[||]""",
-                afterUndo: "var x = $\"[||]\"");
+                pasteText: """{{0""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"{{0[||]"
+                """,
+                afterUndo: """
+                var x = $"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCloseCurlyIntoNormalInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "}",
-                @"var x = $""[||]""",
-                @"var x = $""}}[||]""",
-                afterUndo: "var x = $\"}[||]\"");
+                pasteText: """}""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"}}[||]"
+                """,
+                afterUndo: """
+                var x = $"}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesIntoNormalInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}",
-                @"var x = $""[||]""",
-                @"var x = $""}}[||]""",
-                afterUndo: "var x = $\"[||]\"");
+                pasteText: """}}""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"}}[||]"
+                """,
+                afterUndo: """
+                var x = $"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesAndContentIntoNormalInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}0",
-                @"var x = $""[||]""",
-                @"var x = $""}}0[||]""",
-                afterUndo: "var x = $\"[||]\"");
+                pasteText: """}}0""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"}}0[||]"
+                """,
+                afterUndo: """
+                var x = $"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCurlyWithContentIntoNormalInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{0}y",
-                @"var x = $""[||]""",
-                @"var x = $""x{0}y[||]""",
-                afterUndo: "var x = $\"[||]\"");
+                pasteText: """x{0}y""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"x{0}y[||]"
+                """,
+                afterUndo: """
+                var x = $"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCurliesWithContentIntoNormalInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{{0}}y",
-                @"var x = $""[||]""",
-                @"var x = $""x{{0}}y[||]""",
-                afterUndo: "var x = $\"[||]\"");
+                pasteText: """x{{0}}y""",
+                """
+                var x = $"[||]"
+                """,
+                """
+                var x = $"x{{0}}y[||]"
+                """,
+                afterUndo: """
+                var x = $"[||]"
+                """);
         }
 
         #endregion
@@ -171,8 +261,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-                @"var x = $""[||]{0}""",
-                @"var x = $""\n[||]{0}""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"\n[||]{0}"
+                """,
                 afterUndo: "var x = $\"\n[||]{0}\"");
         }
 
@@ -180,10 +274,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNewLineIntoNormalInterpolatedStringBeforeHole2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-                @"var x = $""[||]{0}""",
-                @"var x = $""\r\n[||]{0}""",
-                afterUndo: "var x = $\"\r\n[||]{0}\"");
+                pasteText: """
+
+
+                """,
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"\r\n[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"
+                [||]{0}"
+                """);
         }
 
         [WpfFact]
@@ -191,8 +295,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t",
-                @"var x = $""[||]{0}""",
-                @"var x = $""\t[||]{0}""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"\t[||]{0}"
+                """,
                 afterUndo: "var x = $\"\t[||]{0}\"");
         }
 
@@ -200,20 +308,34 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestSingleQuoteIntoNormalInterpolatedStringBeforeHole()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-                @"var x = $""[||]{0}""",
-                @"var x = $""'[||]{0}""",
-                afterUndo: "var x = $\"[||]{0}\"");
+                pasteText: """'""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"'[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoNormalInterpolatedStringBeforeHole()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-                @"var x = $""[||]{0}""",
-                @"var x = $""\""[||]{0}""",
-                afterUndo: "var x = $\"\"[||]{0}\"");
+                pasteText: """
+                "
+                """,
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"\"[||]{0}"
+                """,
+                afterUndo: """
+                var x = $""[||]{0}"
+                """);
         }
 
         [WpfFact]
@@ -221,8 +343,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t\"\"\t",
-                @"var x = $""[||]{0}""",
-                @"var x = $""\t\""\""\t[||]{0}""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"\t\"\"\t[||]{0}"
+                """,
                 afterUndo: "var x = $\"\t\"\"\t[||]{0}\"");
         }
 
@@ -230,103 +356,161 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNormalTextIntoNormalInterpolatedStringBeforeHole()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-                @"var x = $""[||]{0}""",
-                @"var x = $""abc[||]{0}""",
-                afterUndo: @"var x = $""[||]{0}""");
+                pasteText: """abc""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"abc[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoNormalInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-                @"var x = $""[||]{0}""",
-                @"var x = $""{{[||]{0}""",
-                afterUndo: "var x = $\"{[||]{0}\"");
+                pasteText: """{""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"{{[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"{[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesIntoNormalInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{",
-                @"var x = $""[||]{0}""",
-                @"var x = $""{{[||]{0}""",
-                afterUndo: "var x = $\"[||]{0}\"");
+                pasteText: """{{""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"{{[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesAndContentIntoNormalInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{0",
-                @"var x = $""[||]{0}""",
-                @"var x = $""{{0[||]{0}""",
-                afterUndo: "var x = $\"[||]{0}\"");
+                pasteText: """{{0""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"{{0[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestCloseCurlyIntoNormalInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}",
-                @"var x = $""[||]{0}""",
-                @"var x = $""}}[||]{0}""",
-                afterUndo: "var x = $\"}[||]{0}\"");
+                pasteText: """}""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"}}[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"}[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesIntoNormalInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}",
-                @"var x = $""[||]{0}""",
-                @"var x = $""}}[||]{0}""",
-                afterUndo: "var x = $\"[||]{0}\"");
+                pasteText: """}}""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"}}[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesAndContentIntoNormalInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}0",
-                @"var x = $""[||]{0}""",
-                @"var x = $""}}0[||]{0}""",
-                afterUndo: "var x = $\"[||]{0}\"");
+                pasteText: """}}0""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"}}0[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestCurlyWithContentIntoNormalInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{0}y",
-                @"var x = $""[||]{0}""",
-                @"var x = $""x{0}y[||]{0}""",
-                afterUndo: "var x = $\"[||]{0}\"");
+                pasteText: """x{0}y""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"x{0}y[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestCurliesWithContentIntoNormalInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{{0}}y",
-                @"var x = $""[||]{0}""",
-                @"var x = $""x{{0}}y[||]{0}""",
-                afterUndo: "var x = $\"[||]{0}\"");
+                pasteText: """x{{0}}y""",
+                """
+                var x = $"[||]{0}"
+                """,
+                """
+                var x = $"x{{0}}y[||]{0}"
+                """,
+                afterUndo: """
+                var x = $"[||]{0}"
+                """);
         }
 
-        #endregion
+#endregion
 
-        #region Paste from external source into normal interpolated string after hole
+#region Paste from external source into normal interpolated string after hole
 
         [WpfFact]
         public void TestNewLineIntoNormalInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}\n[||]""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}\n[||]"
+                """,
                 afterUndo: "var x = $\"{0}\n[||]\"");
         }
 
@@ -334,10 +518,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNewLineIntoNormalInterpolatedStringAfterHole2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}\r\n[||]""",
-                afterUndo: "var x = $\"{0}\r\n[||]\"");
+                pasteText: """
+
+
+                """,
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}\r\n[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}
+                [||]"
+                """);
         }
 
         [WpfFact]
@@ -345,8 +539,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}\t[||]""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}\t[||]"
+                """,
                 afterUndo: "var x = $\"{0}\t[||]\"");
         }
 
@@ -354,20 +552,34 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestSingleQuoteIntoNormalInterpolatedStringAfterHole()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}'[||]""",
-                afterUndo: "var x = $\"{0}[||]\"");
+                pasteText: """'""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}'[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoNormalInterpolatedStringAfterHole()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}\""[||]""",
-                afterUndo: "var x = $\"{0}\"[||]\"");
+                pasteText: """
+                "
+                """,
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}\"[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}"[||]"
+                """);
         }
 
         [WpfFact]
@@ -375,8 +587,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t\"\"\t",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}\t\""\""\t[||]""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}\t\"\"\t[||]"
+                """,
                 afterUndo: "var x = $\"{0}\t\"\"\t[||]\"");
         }
 
@@ -384,92 +600,146 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNormalTextIntoNormalInterpolatedStringAfterHole()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}abc[||]""",
-                afterUndo: @"var x = $""{0}[||]""");
+                pasteText: """abc""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}abc[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoNormalInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}{{[||]""",
-                afterUndo: "var x = $\"{0}{[||]\"");
+                pasteText: """{""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}{{[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}{[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesIntoNormalInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}{{[||]""",
-                afterUndo: "var x = $\"{0}[||]\"");
+                pasteText: """{{""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}{{[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesAndContentIntoNormalInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{0",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}{{0[||]""",
-                afterUndo: "var x = $\"{0}[||]\"");
+                pasteText: """{{0""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}{{0[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCloseCurlyIntoNormalInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}}}[||]""",
-                afterUndo: "var x = $\"{0}}[||]\"");
+                pasteText: """}""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}}}[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesIntoNormalInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}}}[||]""",
-                afterUndo: "var x = $\"{0}[||]\"");
+                pasteText: """}}""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}}}[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesAndContentIntoNormalInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}0",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}}}0[||]""",
-                afterUndo: "var x = $\"{0}[||]\"");
+                pasteText: """}}0""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}}}0[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCurlyWithContentIntoNormalInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{0}y",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}x{0}y[||]""",
-                afterUndo: "var x = $\"{0}[||]\"");
+                pasteText: """x{0}y""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}x{0}y[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCurliesWithContentIntoNormalInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{{0}}y",
-                @"var x = $""{0}[||]""",
-                @"var x = $""{0}x{{0}}y[||]""",
-                afterUndo: "var x = $\"{0}[||]\"");
+                pasteText: """x{{0}}y""",
+                """
+                var x = $"{0}[||]"
+                """,
+                """
+                var x = $"{0}x{{0}}y[||]"
+                """,
+                afterUndo: """
+                var x = $"{0}[||]"
+                """);
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoNormalStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoNormalStringTests.cs
@@ -15,8 +15,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-                @"var x = ""[||]""",
-                @"var x = ""\n[||]""",
+                """
+                var x = "[||]"
+                """,
+                """
+                var x = "\n[||]"
+                """,
                 afterUndo: "var x = \"\n[||]\"");
         }
 
@@ -24,10 +28,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNewLineIntoNormalString2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-                @"var x = ""[||]""",
-                @"var x = ""\r\n[||]""",
-                afterUndo: "var x = \"\r\n[||]\"");
+                pasteText: """
+
+
+                """,
+                """
+                var x = "[||]"
+                """,
+                """
+                var x = "\r\n[||]"
+                """,
+                afterUndo: """
+                var x = "
+                [||]"
+                """);
         }
 
         [WpfFact]
@@ -35,8 +49,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t",
-                @"var x = ""[||]""",
-                @"var x = ""\t[||]""",
+                """
+                var x = "[||]"
+                """,
+                """
+                var x = "\t[||]"
+                """,
                 afterUndo: "var x = \"\t[||]\"");
         }
 
@@ -44,30 +62,50 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestBackslashTIntoNormalString1()
         {
             TestPasteUnknownSource(
-                pasteText: @"\t",
-                @"var x = ""[||]""",
-                @"var x = ""\t[||]""",
-                afterUndo: @"var x = ""[||]""");
+                pasteText: """\t""",
+                """
+                var x = "[||]"
+                """,
+                """
+                var x = "\t[||]"
+                """,
+                afterUndo: """
+                var x = "[||]"
+                """);
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoNormalString()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-                @"var x = ""[||]""",
-                @"var x = ""'[||]""",
-                afterUndo: "var x = \"[||]\"");
+                pasteText: """'""",
+                """
+                var x = "[||]"
+                """,
+                """
+                var x = "'[||]"
+                """,
+                afterUndo: """
+                var x = "[||]"
+                """);
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoNormalString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-                @"var x = ""[||]""",
-                @"var x = ""\""[||]""",
-                afterUndo: "var x = \"\"[||]\"");
+                pasteText: """
+                "
+                """,
+                """
+                var x = "[||]"
+                """,
+                """
+                var x = "\"[||]"
+                """,
+                afterUndo: """
+                var x = ""[||]"
+                """);
         }
 
         [WpfFact]
@@ -75,8 +113,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t\"\"\t",
-                @"var x = ""[||]""",
-                @"var x = ""\t\""\""\t[||]""",
+                """
+                var x = "[||]"
+                """,
+                """
+                var x = "\t\"\"\t[||]"
+                """,
                 afterUndo: "var x = \"\t\"\"\t[||]\"");
         }
 
@@ -84,10 +126,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNormalTextIntoNormalString()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-                @"var x = ""[||]""",
-                @"var x = ""abc[||]""",
-                afterUndo: @"var x = ""[||]""");
+                pasteText: """abc""",
+                """
+                var x = "[||]"
+                """,
+                """
+                var x = "abc[||]"
+                """,
+                afterUndo: """
+                var x = "[||]"
+                """);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoSingleLineInterpolatedRawStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoSingleLineInterpolatedRawStringTests.cs
@@ -14,7 +14,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-@"var x = $""""""[||] """"""",
+""""
+var x = $"""[||] """
+"""",
 "var x = $\"\"\"\r\n    \n    [||] \r\n    \"\"\"",
                 afterUndo:
 "var x = $\"\"\"\n[||] \"\"\"");
@@ -25,7 +27,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-@"var x = $"""""" [||]""""""",
+""""
+var x = $""" [||]"""
+"""",
 "var x = $\"\"\"\r\n     \n    \r\n    [||]\"\"\"",
                 afterUndo:
 "var x = $\"\"\" \n[||]\"\"\"");
@@ -35,759 +39,1214 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNewLineIntoSingleLineRawString2_A()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-@"var x = $""""""[||] """"""",
-"var x = $\"\"\"\r\n    \r\n    [||] \r\n    \"\"\"",
+                pasteText: """
+
+
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
+    
+    [||] 
+    """
+"""",
                 afterUndo:
-"var x = $\"\"\"\r\n[||] \"\"\"");
+""""
+var x = $"""
+[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNewLineIntoSingleLineRawString2_B()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-@"var x = $"""""" [||]""""""",
-"var x = $\"\"\"\r\n     \r\n    \r\n    [||]\"\"\"",
+                pasteText: """
+
+
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
+     
+    
+    [||]"""
+"""",
                 afterUndo:
-"var x = $\"\"\" \r\n[||]\"\"\"");
+""""
+var x = $""" 
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_A()
         {
             TestPasteUnknownSource(
-                pasteText: "    ",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""    [||] """"""",
+                pasteText: """    """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""    [||] """
+"""",
                 afterUndo:
-@"var x = $""""""[||] """"""");
+""""
+var x = $"""[||] """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_B()
         {
             TestPasteUnknownSource(
-                pasteText: "    ",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""     [||]""""""",
+                pasteText: """    """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""     [||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" [||]""""""");
+""""
+var x = $""" [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "    \r\n",
-@"var x = $""""""
+                pasteText: """
+                    
+
+                """,
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""
+    """
+"""",
+""""
+var x = $"""
     
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""
+""""
+var x = $"""
         
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_A()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""'[||] """"""",
+                pasteText: """'""",
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""'[||] """
+"""",
                 afterUndo:
-@"var x = $""""""[||] """"""");
+""""
+var x = $"""[||] """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_B()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-@"var x = $"""""" [||]""""""",
-@"var x = $"""""" '[||]""""""",
+                pasteText: """'""",
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $""" '[||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" [||]""""""");
+""""
+var x = $""" [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_A()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
-    ""[||] 
-    """"""",
+                pasteText: """
+                "
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
+    "[||] 
+    """
+"""",
                 afterUndo:
-@"var x = $""""""""[||] """"""");
+"""""
+var x = $""""[||] """
+""""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_B()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
-     ""
-    [||]""""""",
+                pasteText: """
+                "
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
+     "
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" ""[||]""""""");
+""""
+var x = $""" "[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_A()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""""
-    """"""[||] 
-    """"""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""[||] """
+"""",
+"""""
+var x = $""""
+    """[||] 
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""""""""[||] """"""");
+"""""""
+var x = $""""""[||] """
+""""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_B()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""""
-     """"""
-    [||]""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $""" [||]"""
+"""",
+"""""
+var x = $""""
+     """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = $"""""" """"""[||]""""""");
+""""
+var x = $""" """[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString3()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $"""""" ""[||] """"""",
-@"var x = $"""""""""" """"""""[||] """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $""" "[||] """
+"""",
+""""""
+var x = $""""" """"[||] """""
+"""""",
                 afterUndo:
-@"var x = $"""""" """"""""[||] """"""");
+"""""
+var x = $""" """"[||] """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString4()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $"""""" ""[||]"" """"""",
-@"var x = $"""""""""""" """"""""[||]"" """"""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $""" "[||]" """
+"""",
+"""""""
+var x = $"""""" """"[||]" """"""
+""""""",
                 afterUndo:
-@"var x = $"""""" """"""""[||]"" """"""");
+"""""
+var x = $""" """"[||]" """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString5()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $"""""" [||]"" """"""",
-@"var x = $"""""""""" """"""[||]"" """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $""" [||]" """
+"""",
+""""""
+var x = $""""" """[||]" """""
+"""""",
                 afterUndo:
-@"var x = $"""""" """"""[||]"" """"""");
+""""
+var x = $""" """[||]" """
+"""");
         }
 
         [WpfFact]
         public void TestQuadrupleQuoteIntoSingleLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"\"",
-@"var x = $""""""
+                pasteText: """""
+                """"
+                """"",
+""""
+var x = $"""
     [||]
-    """"""",
-@"var x = $""""""""""
-    """"""""[||]
-    """"""""""",
+    """
+"""",
+""""""
+var x = $"""""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = $""""""
-    """"""""[||]
-    """"""");
+"""""
+var x = $"""
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoSingleLineRawString_A()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-@"var x = $""""""[||] """"""",
-@"var x = $$""""""{[||] """"""",
+                pasteText: """{""",
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $$"""{[||] """
+"""",
                 afterUndo:
-@"var x = $""""""{[||] """"""");
+""""
+var x = $"""{[||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoSingleLineRawString_B()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-@"var x = $"""""" [||]""""""",
-@"var x = $$"""""" {[||]""""""",
+                pasteText: """{""",
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $$""" {[||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" {[||]""""""");
+""""
+var x = $""" {[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestOpenQuoteAndTripleOpenBraceIntoSingleLineRawString1()
         {
             TestPasteUnknownSource(
-                pasteText: "\"{{{",
-@"var x = $""""""[||] """"""",
-@"var x = $$$$""""""
-    ""{{{[||] 
-    """"""",
+                pasteText: """
+                "{{{
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $$$$"""
+    "{{{[||] 
+    """
+"""",
                 afterUndo:
-@"var x = $""""""""{{{[||] """"""");
+"""""
+var x = $""""{{{[||] """
+""""");
         }
 
         [WpfFact]
         public void TestTripleOpenQuoteAndTripleOpenBraceIntoSingleLineRawString1()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"{{{",
-@"var x = $""""""[||] """"""",
-@"var x = $$$$""""""""
-    """"""{{{[||] 
-    """"""""",
+                pasteText: """"
+                """{{{
+                """",
+""""
+var x = $"""[||] """
+"""",
+"""""
+var x = $$$$""""
+    """{{{[||] 
+    """"
+""""",
                 afterUndo:
-@"var x = $""""""""""""{{{[||] """"""");
+"""""""
+var x = $""""""{{{[||] """
+""""""");
         }
 
         [WpfFact]
         public void TestTripleOpenQuoteAndTripleOpenBraceIntoSingleLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: " \"\"\"{{{",
-@"var x = $""""""[||] """"""",
-@"var x = $$$$"""""""" """"""{{{[||] """"""""",
+                pasteText: """" """{{{"""",
+""""
+var x = $"""[||] """
+"""",
+"""""
+var x = $$$$"""" """{{{[||] """"
+""""",
                 afterUndo:
-@"var x = $"""""" """"""{{{[||] """"""");
+""""
+var x = $""" """{{{[||] """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString1_A()
         {
             TestPasteUnknownSource(
-                pasteText: "{{{",
-@"var x = $""""""[||] """"""",
-@"var x = $$$$""""""{{{[||] """"""",
+                pasteText: """{{{""",
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $$$$"""{{{[||] """
+"""",
                 afterUndo:
-@"var x = $""""""{{{[||] """"""");
+""""
+var x = $"""{{{[||] """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString1_B()
         {
             TestPasteUnknownSource(
-                pasteText: "{{{",
-@"var x = $"""""" [||]""""""",
-@"var x = $$$$"""""" {{{[||]""""""",
+                pasteText: """{{{""",
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $$$$""" {{{[||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" {{{[||]""""""");
+""""
+var x = $""" {{{[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString3()
         {
             TestPasteUnknownSource(
-                pasteText: "{{{",
-@"var x = $"""""" ""[||] """"""",
-@"var x = $$$$"""""" ""{{{[||] """"""",
+                pasteText: """{{{""",
+""""
+var x = $""" "[||] """
+"""",
+""""
+var x = $$$$""" "{{{[||] """
+"""",
                 afterUndo:
-@"var x = $"""""" ""{{{[||] """"""");
+""""
+var x = $""" "{{{[||] """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString4()
         {
             TestPasteUnknownSource(
-                pasteText: "{{{",
-@"var x = $"""""" ""[||]"" """"""",
-@"var x = $$$$"""""" ""{{{[||]"" """"""",
+                pasteText: """{{{""",
+""""
+var x = $""" "[||]" """
+"""",
+""""
+var x = $$$$""" "{{{[||]" """
+"""",
                 afterUndo:
-@"var x = $"""""" ""{{{[||]"" """"""");
+""""
+var x = $""" "{{{[||]" """
+"""");
         }
 
         [WpfFact]
         public void TestTripleOpenBraceIntoSingleLineRawString5()
         {
             TestPasteUnknownSource(
-                pasteText: "{{{",
-@"var x = $"""""" [||]"" """"""",
-@"var x = $$$$"""""" {{{[||]"" """"""",
+                pasteText: """{{{""",
+""""
+var x = $""" [||]" """
+"""",
+""""
+var x = $$$$""" {{{[||]" """
+"""",
                 afterUndo:
-@"var x = $"""""" {{{[||]"" """"""");
+""""
+var x = $""" {{{[||]" """
+"""");
         }
 
         [WpfFact]
         public void TestInterpolationIntoSingleLineRawString1()
         {
             TestPasteUnknownSource(
-                pasteText: "{0}",
-@"var x = $"""""" [||] """"""",
-@"var x = $"""""" {0}[||] """"""",
+                pasteText: """{0}""",
+""""
+var x = $""" [||] """
+"""",
+""""
+var x = $""" {0}[||] """
+"""",
                 afterUndo:
-@"var x = $"""""" [||] """"""");
+""""
+var x = $""" [||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString1()
         {
             TestPasteUnknownSource(
-                pasteText: "{}",
-@"var x = $"""""" [||] """"""",
-@"var x = $$"""""" {}[||] """"""",
+                pasteText: """{}""",
+""""
+var x = $""" [||] """
+"""",
+""""
+var x = $$""" {}[||] """
+"""",
                 afterUndo:
-@"var x = $"""""" {}[||] """"""");
+""""
+var x = $""" {}[||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "{}",
-@"var x = $$"""""" [||] """"""",
-@"var x = $$"""""" {}[||] """"""",
+                pasteText: """{}""",
+""""
+var x = $$""" [||] """
+"""",
+""""
+var x = $$""" {}[||] """
+"""",
                 afterUndo:
-@"var x = $$"""""" [||] """"""");
+""""
+var x = $$""" [||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString3()
         {
             TestPasteUnknownSource(
-                pasteText: "{{}",
-@"var x = $$"""""" [||] """"""",
-@"var x = $$$"""""" {{}[||] """"""",
+                pasteText: """{{}""",
+""""
+var x = $$""" [||] """
+"""",
+""""
+var x = $$$""" {{}[||] """
+"""",
                 afterUndo:
-@"var x = $$"""""" {{}[||] """"""");
+""""
+var x = $$""" {{}[||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString4()
         {
             TestPasteUnknownSource(
-                pasteText: "{}}",
-@"var x = $$"""""" [||] """"""",
-@"var x = $$$"""""" {}}[||] """"""",
+                pasteText: """{}}""",
+""""
+var x = $$""" [||] """
+"""",
+""""
+var x = $$$""" {}}[||] """
+"""",
                 afterUndo:
-@"var x = $$"""""" {}}[||] """"""");
+""""
+var x = $$""" {}}[||] """
+"""");
         }
 
         [WpfFact]
         public void TestOpenCloseBraceIntoSingleLineRawString5()
         {
             TestPasteUnknownSource(
-                pasteText: "{{}}",
-@"var x = $$"""""" [||] """"""",
-@"var x = $$$"""""" {{}}[||] """"""",
+                pasteText: """{{}}""",
+""""
+var x = $$""" [||] """
+"""",
+""""
+var x = $$$""" {{}}[||] """
+"""",
                 afterUndo:
-@"var x = $$"""""" {{}}[||] """"""");
+""""
+var x = $$""" {{}}[||] """
+"""");
         }
 
         [WpfFact]
         public void TestComplexStringIntoSingleLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "  \"\"  ",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""  """"  [||] """"""",
+                pasteText: """  ""  """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""  ""  [||] """
+"""",
                 afterUndo:
-@"var x = $""""""[||] """"""");
+""""
+var x = $"""[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""abc[||] """"""",
+                pasteText: """abc""",
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""abc[||] """
+"""",
                 afterUndo:
-@"var x = $""""""[||] """"""");
+""""
+var x = $"""[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-@"var x = $"""""" [||]""""""",
-@"var x = $"""""" abc[||]""""""",
+                pasteText: """abc""",
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $""" abc[||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" [||]""""""");
+""""
+var x = $""" [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
     abc
     def[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||] """"""");
+""""
+var x = $"""abc
+def[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
      abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" abc
-def[||]""""""");
+""""
+var x = $""" abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine4()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""goo[||]""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""goo[||]"""
+"""",
+""""
+var x = $"""
     gooabc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""gooabc
-def[||]""""""");
+""""
+var x = $"""gooabc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine5()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""goo[||]bar""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""goo[||]bar"""
+"""",
+""""
+var x = $"""
     gooabc
     def[||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""gooabc
-def[||]bar""""""");
+""""
+var x = $"""gooabc
+def[||]bar"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine6()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""goo[||]bar""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""goo[||]bar"""
+"""",
+""""
+var x = $"""
     gooabc
     def
     [||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""gooabc
+""""
+var x = $"""gooabc
 def
-[||]bar""""""");
+[||]bar"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
     abc
         def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
     def
-ghi[||] """"""");
+ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
      abc
         def
     ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $"""""" abc
+""""
+var x = $""" abc
     def
-ghi[||]""""""");
+ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
     abc
     def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
     abc
     def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_A()
         {
             TestPasteUnknownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
     abc
     def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""    abc
+""""
+var x = $"""    abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_B()
         {
             TestPasteUnknownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
      abc
     def
     ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""     abc
+""""
+var x = $"""     abc
     def
-    ghi[||]""""""");
+    ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_A()
         {
             TestPasteUnknownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = $""""""[||] """"""",
-@"var x = $""""""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = $"""[||] """
+"""",
+""""
+var x = $"""
         abc
     def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""        abc
+""""
+var x = $"""        abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_B()
         {
             TestPasteUnknownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = $"""""" [||]""""""",
-@"var x = $""""""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = $""" [||]"""
+"""",
+""""
+var x = $"""
          abc
     def
     ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""         abc
+""""
+var x = $"""         abc
     def
-    ghi[||]""""""");
+    ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]{|Selection:    |}""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]{|Selection:    |}"""
+"""",
+""""
+var x = $"""
     abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||]""""""");
+""""
+var x = $"""abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""  [||]{|Selection:    |}  """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""  [||]{|Selection:    |}  """
+"""",
+""""
+var x = $"""
       abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""  abc
-def[||]  """"""");
+""""
+var x = $"""  abc
+def[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""[||]{|Selection:    |}""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""[||]{|Selection:    |}"""
+"""",
+""""
+var x = $"""
     abc
     def
     
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""abc
+""""
+var x = $"""abc
 def
-[||]""""""");
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = $""""""  [||]{|Selection:    |}  """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = $"""  [||]{|Selection:    |}  """
+"""",
+""""
+var x = $"""
       abc
     def
     [||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""  abc
+""""
+var x = $"""  abc
 def
-[||]  """"""");
+[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""[||]{|Selection:    |}  """"""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""[||]{|Selection:    |}  """
+"""",
+""""
+var x = $"""
     abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = $""""""abc
-def[||]  """"""");
+""""
+var x = $"""abc
+def[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = $""""""  [||]{|Selection:    |}""""""",
-@"var x = $""""""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = $"""  [||]{|Selection:    |}"""
+"""",
+""""
+var x = $"""
       abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""  abc
-def[||]""""""");
+""""
+var x = $"""  abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_A()
         {
             TestPasteUnknownSource(
-                pasteText: "\"bar",
-@"var x = $""""""[||]goo""""""",
-@"var x = $""""""
-    ""bar[||]goo
-    """"""",
+                pasteText: """
+                "bar
+                """,
+""""
+var x = $"""[||]goo"""
+"""",
+""""
+var x = $"""
+    "bar[||]goo
+    """
+"""",
                 afterUndo:
-@"var x = $""""""""bar[||]goo""""""");
+"""""
+var x = $""""bar[||]goo"""
+""""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_B()
         {
             TestPasteUnknownSource(
-                pasteText: "bar\"",
-@"var x = $""""""goo[||]""""""",
-@"var x = $""""""
-    goobar""
-    [||]""""""",
+                pasteText: """
+                bar"
+                """,
+""""
+var x = $"""goo[||]"""
+"""",
+""""
+var x = $"""
+    goobar"
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""goobar""[||]""""""");
+""""
+var x = $"""goobar"[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader1()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"",
-@"var x = $""""""[||]{|Selection:    |}""""""",
-@"var x = $""""""
-    """"
-    [||]""""""",
+                pasteText: """
+                ""
+                """,
+""""
+var x = $"""[||]{|Selection:    |}"""
+"""",
+""""
+var x = $"""
+    ""
+    [||]"""
+"""",
                 afterUndo:
-@"var x = $""""""""""[||]""""""");
+""""""
+var x = $"""""[||]"""
+"""""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader2()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = $""""""[||]{|Selection:    |}""""""",
-@"var x = $""""""""
-    """"""
-    [||]""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = $"""[||]{|Selection:    |}"""
+"""",
+"""""
+var x = $""""
+    """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = $""""""""""""[||]""""""");
+"""""""
+var x = $""""""[||]"""
+""""""");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoSingleLineRawStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoSingleLineRawStringTests.cs
@@ -15,7 +15,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-@"var x = """"""[||] """"""",
+""""
+var x = """[||] """
+"""",
 "var x = \"\"\"\r\n    \n    [||] \r\n    \"\"\"",
                 afterUndo:
 "var x = \"\"\"\n[||] \"\"\"");
@@ -26,7 +28,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-@"var x = """""" [||]""""""",
+""""
+var x = """ [||]"""
+"""",
 "var x = \"\"\"\r\n     \n    \r\n    [||]\"\"\"",
                 afterUndo:
 "var x = \"\"\" \n[||]\"\"\"");
@@ -36,590 +40,953 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         public void TestNewLineIntoSingleLineRawString2_A()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-@"var x = """"""[||] """"""",
-"var x = \"\"\"\r\n    \r\n    [||] \r\n    \"\"\"",
+                pasteText: """
+
+
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
+    
+    [||] 
+    """
+"""",
                 afterUndo:
-"var x = \"\"\"\r\n[||] \"\"\"");
+""""
+var x = """
+[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNewLineIntoSingleLineRawString2_B()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-@"var x = """""" [||]""""""",
-"var x = \"\"\"\r\n     \r\n    \r\n    [||]\"\"\"",
+                pasteText: """
+
+
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
+     
+    
+    [||]"""
+"""",
                 afterUndo:
-"var x = \"\"\" \r\n[||]\"\"\"");
+""""
+var x = """ 
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_A()
         {
             TestPasteUnknownSource(
-                pasteText: "    ",
-@"var x = """"""[||] """"""",
-@"var x = """"""    [||] """"""",
+                pasteText: """    """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """    [||] """
+"""",
                 afterUndo:
-@"var x = """"""[||] """"""");
+""""
+var x = """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString1_B()
         {
             TestPasteUnknownSource(
-                pasteText: "    ",
-@"var x = """""" [||]""""""",
-@"var x = """"""     [||]""""""",
+                pasteText: """    """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """     [||]"""
+"""",
                 afterUndo:
-@"var x = """""" [||]""""""");
+""""
+var x = """ [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestSpacesIntoSingleLineRawString2()
         {
             TestPasteUnknownSource(
-                pasteText: "    \r\n",
-@"var x = """"""
+                pasteText: """
+                    
+
+                """,
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""
+    """
+"""",
+""""
+var x = """
     
     [||]
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""
+""""
+var x = """
         
 [||]
-    """"""");
+    """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_A()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-@"var x = """"""[||] """"""",
-@"var x = """"""'[||] """"""",
+                pasteText: """'""",
+""""
+var x = """[||] """
+"""",
+""""
+var x = """'[||] """
+"""",
                 afterUndo:
-@"var x = """"""[||] """"""");
+""""
+var x = """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoSingleLineRawString_B()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-@"var x = """""" [||]""""""",
-@"var x = """""" '[||]""""""",
+                pasteText: """'""",
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """ '[||]"""
+"""",
                 afterUndo:
-@"var x = """""" [||]""""""");
+""""
+var x = """ [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_A()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-@"var x = """"""[||] """"""",
-@"var x = """"""
-    ""[||] 
-    """"""",
+                pasteText: """
+                "
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
+    "[||] 
+    """
+"""",
                 afterUndo:
-@"var x = """"""""[||] """"""");
+"""""
+var x = """"[||] """
+""""");
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoSingleLineRawString_B()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-@"var x = """""" [||]""""""",
-@"var x = """"""
-     ""
-    [||]""""""",
+                pasteText: """
+                "
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
+     "
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """""" ""[||]""""""");
+""""
+var x = """ "[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_A()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""[||] """"""",
-@"var x = """"""""
-    """"""[||] 
-    """"""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """[||] """
+"""",
+"""""
+var x = """"
+    """[||] 
+    """"
+""""",
                 afterUndo:
-@"var x = """"""""""""[||] """"""");
+"""""""
+var x = """"""[||] """
+""""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString1_B()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """""" [||]""""""",
-@"var x = """"""""
-     """"""
-    [||]""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """ [||]"""
+"""",
+"""""
+var x = """"
+     """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = """""" """"""[||]""""""");
+""""
+var x = """ """[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestTwoQuotesIntoSingleLineRawString3()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"",
-@"var x = """""" ""[||] """"""",
-@"var x = """""""" """"""[||] """"""""",
+                pasteText: """
+                ""
+                """,
+""""
+var x = """ "[||] """
+"""",
+"""""
+var x = """" """[||] """"
+""""",
                 afterUndo:
-@"var x = """""" """"""[||] """"""");
+""""
+var x = """ """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString3()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """""" ""[||] """"""",
-@"var x = """""""""" """"""""[||] """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """ "[||] """
+"""",
+""""""
+var x = """"" """"[||] """""
+"""""",
                 afterUndo:
-@"var x = """""" """"""""[||] """"""");
+"""""
+var x = """ """"[||] """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString4()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """""" ""[||]"" """"""",
-@"var x = """""""""""" """"""""[||]"" """"""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """ "[||]" """
+"""",
+"""""""
+var x = """""" """"[||]" """"""
+""""""",
                 afterUndo:
-@"var x = """""" """"""""[||]"" """"""");
+"""""
+var x = """ """"[||]" """
+""""");
         }
 
         [WpfFact]
         public void TestTripleQuoteIntoSingleLineRawString5()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """""" [||]"" """"""",
-@"var x = """""""""" """"""[||]"" """"""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """ [||]" """
+"""",
+""""""
+var x = """"" """[||]" """""
+"""""",
                 afterUndo:
-@"var x = """""" """"""[||]"" """"""");
+""""
+var x = """ """[||]" """
+"""");
         }
 
         [WpfFact]
         public void TestQuadrupleQuoteIntoSingleLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"\"",
-@"var x = """"""
+                pasteText: """""
+                """"
+                """"",
+""""
+var x = """
     [||]
-    """"""",
-@"var x = """"""""""
-    """"""""[||]
-    """"""""""",
+    """
+"""",
+""""""
+var x = """""
+    """"[||]
+    """""
+"""""",
                 afterUndo:
-@"var x = """"""
-    """"""""[||]
-    """"""");
+"""""
+var x = """
+    """"[||]
+    """
+""""");
         }
 
         [WpfFact]
         public void TestComplexStringIntoSingleLineRawString()
         {
             TestPasteUnknownSource(
-                pasteText: "  \"\"  ",
-@"var x = """"""[||] """"""",
-@"var x = """"""  """"  [||] """"""",
+                pasteText: """  ""  """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """  ""  [||] """
+"""",
                 afterUndo:
-@"var x = """"""[||] """"""");
+""""
+var x = """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-@"var x = """"""[||] """"""",
-@"var x = """"""abc[||] """"""",
+                pasteText: """abc""",
+""""
+var x = """[||] """
+"""",
+""""
+var x = """abc[||] """
+"""",
                 afterUndo:
-@"var x = """"""[||] """"""");
+""""
+var x = """[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawString_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-@"var x = """""" [||]""""""",
-@"var x = """""" abc[||]""""""",
+                pasteText: """abc""",
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """ abc[||]"""
+"""",
                 afterUndo:
-@"var x = """""" [||]""""""");
+""""
+var x = """ [||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
     abc
     def[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
-def[||] """"""");
+""""
+var x = """abc
+def[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine1_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """""" [||]""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
      abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """""" abc
-def[||]""""""");
+""""
+var x = """ abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine4()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""goo[||]""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """goo[||]"""
+"""",
+""""
+var x = """
     gooabc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""gooabc
-def[||]""""""");
+""""
+var x = """gooabc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine5()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""goo[||]bar""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """goo[||]bar"""
+"""",
+""""
+var x = """
     gooabc
     def[||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""gooabc
-def[||]bar""""""");
+""""
+var x = """gooabc
+def[||]bar"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine6()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""goo[||]bar""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = """goo[||]bar"""
+"""",
+""""
+var x = """
     gooabc
     def
     [||]bar
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""gooabc
+""""
+var x = """gooabc
 def
-[||]bar""""""");
+[||]bar"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
     abc
         def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
     def
-ghi[||] """"""");
+ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine7_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\nghi",
-@"var x = """""" [||]""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                ghi
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
      abc
         def
     ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """""" abc
+""""
+var x = """ abc
     def
-ghi[||]""""""");
+ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
     abc
     def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine8_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\n    def\r\n    ghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                    def
+                    ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
     abc
     def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_A()
         {
             TestPasteUnknownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
     abc
     def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""    abc
+""""
+var x = """    abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine9_B()
         {
             TestPasteUnknownSource(
-                pasteText: "    abc\r\n    def\r\n    ghi",
-@"var x = """""" [||]""""""",
-@"var x = """"""
+                pasteText: """
+                    abc
+                    def
+                    ghi
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
      abc
     def
     ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""     abc
+""""
+var x = """     abc
     def
-    ghi[||]""""""");
+    ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_A()
         {
             TestPasteUnknownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = """"""[||] """"""",
-@"var x = """"""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = """[||] """
+"""",
+""""
+var x = """
         abc
     def
     ghi[||] 
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""        abc
+""""
+var x = """        abc
     def
-    ghi[||] """"""");
+    ghi[||] """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine10_B()
         {
             TestPasteUnknownSource(
-                pasteText: "        abc\r\n    def\r\n    ghi",
-@"var x = """""" [||]""""""",
-@"var x = """"""
+                pasteText: """
+                        abc
+                    def
+                    ghi
+                """,
+""""
+var x = """ [||]"""
+"""",
+""""
+var x = """
          abc
     def
     ghi
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""         abc
+""""
+var x = """         abc
     def
-    ghi[||]""""""");
+    ghi[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""[||]{|Selection:    |}""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """[||]{|Selection:    |}"""
+"""",
+""""
+var x = """
     abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""abc
-def[||]""""""");
+""""
+var x = """abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine11_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""  [||]{|Selection:    |}  """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """  [||]{|Selection:    |}  """
+"""",
+""""
+var x = """
       abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""  abc
-def[||]  """"""");
+""""
+var x = """  abc
+def[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""[||]{|Selection:    |}""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = """[||]{|Selection:    |}"""
+"""",
+""""
+var x = """
     abc
     def
     
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""abc
+""""
+var x = """abc
 def
-[||]""""""");
+[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine12_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef\r\n",
-@"var x = """"""  [||]{|Selection:    |}  """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+
+                """,
+""""
+var x = """  [||]{|Selection:    |}  """
+"""",
+""""
+var x = """
       abc
     def
     [||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""  abc
+""""
+var x = """  abc
 def
-[||]  """"""");
+[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_A()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""[||]{|Selection:    |}  """"""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """[||]{|Selection:    |}  """
+"""",
+""""
+var x = """
     abc
     def[||]  
-    """"""",
+    """
+"""",
                 afterUndo:
-@"var x = """"""abc
-def[||]  """"""");
+""""
+var x = """abc
+def[||]  """
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringSingleLine13_B()
         {
             TestPasteUnknownSource(
-                pasteText: "abc\r\ndef",
-@"var x = """"""  [||]{|Selection:    |}""""""",
-@"var x = """"""
+                pasteText: """
+                abc
+                def
+                """,
+""""
+var x = """  [||]{|Selection:    |}"""
+"""",
+""""
+var x = """
       abc
     def
-    [||]""""""",
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""  abc
-def[||]""""""");
+""""
+var x = """  abc
+def[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_A()
         {
             TestPasteUnknownSource(
-                pasteText: "\"bar",
-@"var x = """"""[||]goo""""""",
-@"var x = """"""
-    ""bar[||]goo
-    """"""",
+                pasteText: """
+                "bar
+                """,
+""""
+var x = """[||]goo"""
+"""",
+""""
+var x = """
+    "bar[||]goo
+    """
+"""",
                 afterUndo:
-@"var x = """"""""bar[||]goo""""""");
+"""""
+var x = """"bar[||]goo"""
+""""");
         }
 
         [WpfFact]
         public void TestNormalTextIntoSingleLineRawStringHeader1_B()
         {
             TestPasteUnknownSource(
-                pasteText: "bar\"",
-@"var x = """"""goo[||]""""""",
-@"var x = """"""
-    goobar""
-    [||]""""""",
+                pasteText: """
+                bar"
+                """,
+""""
+var x = """goo[||]"""
+"""",
+""""
+var x = """
+    goobar"
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""goobar""[||]""""""");
+""""
+var x = """goobar"[||]"""
+"""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader1()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"",
-@"var x = """"""[||]{|Selection:    |}""""""",
-@"var x = """"""
-    """"
-    [||]""""""",
+                pasteText: """
+                ""
+                """,
+""""
+var x = """[||]{|Selection:    |}"""
+"""",
+""""
+var x = """
+    ""
+    [||]"""
+"""",
                 afterUndo:
-@"var x = """"""""""[||]""""""");
+""""""
+var x = """""[||]"""
+"""""");
         }
 
         [WpfFact]
         public void TestQuotesIntoHeader2()
         {
             TestPasteUnknownSource(
-                pasteText: "\"\"\"",
-@"var x = """"""[||]{|Selection:    |}""""""",
-@"var x = """"""""
-    """"""
-    [||]""""""""",
+                pasteText: """"
+                """
+                """",
+""""
+var x = """[||]{|Selection:    |}"""
+"""",
+"""""
+var x = """"
+    """
+    [||]""""
+""""",
                 afterUndo:
-@"var x = """"""""""""[||]""""""");
+"""""""
+var x = """"""[||]"""
+""""""");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoVerbatimInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoVerbatimInterpolatedStringTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
 
         #endregion
 
-#region Paste from external source into verbatim interpolated string before hole
+        #region Paste from external source into verbatim interpolated string before hole
 
         [WpfFact]
         public void TestNewLineIntoVerbatimInterpolatedStringBeforeHole1()
@@ -501,7 +501,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
 
         #endregion
 
-#region Paste from external source into verbatim interpolated string after hole
+        #region Paste from external source into verbatim interpolated string after hole
 
         [WpfFact]
         public void TestNewLineIntoVerbatimInterpolatedStringAfterHole1()
@@ -743,6 +743,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
                 """);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoVerbatimInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoVerbatimInterpolatedStringTests.cs
@@ -20,19 +20,33 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-                @"var x = $@""[||]""",
+                """
+                var x = $@"[||]"
+                """,
                 "var x = $@\"\n[||]\"",
-                afterUndo: @"var x = $@""[||]""");
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestNewLineIntoVerbatimInterpolatedString2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-                @"var x = $@""[||]""",
-                "var x = $@\"\r\n[||]\"",
-                afterUndo: @"var x = $@""[||]""");
+                pasteText: """
+
+
+                """,
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"
+                [||]"
+                """,
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
@@ -40,29 +54,47 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t",
-                @"var x = $@""[||]""",
+                """
+                var x = $@"[||]"
+                """,
                 "var x = $@\"\t[||]\"",
-                afterUndo: @"var x = $@""[||]""");
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoVerbatimInterpolatedString()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-                @"var x = $@""[||]""",
-                @"var x = $@""'[||]""",
-                afterUndo: "var x = $@\"[||]\"");
+                pasteText: """'""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"'[||]"
+                """,
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoVerbatimInterpolatedString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-                @"var x = $@""[||]""",
-                "var x = $@\"\"\"[||]\"",
-                afterUndo: "var x = $@\"\"[||]\"");
+                pasteText: """
+                "
+                """,
+                """
+                var x = $@"[||]"
+                """,
+                """"
+                var x = $@"""[||]"
+                """",
+                afterUndo: """
+                var x = $@""[||]"
+                """);
         }
 
         [WpfFact]
@@ -70,123 +102,195 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t\"\"\t",
-                @"var x = $@""[||]""",
+                """
+                var x = $@"[||]"
+                """,
                 "var x = $@\"\t\"\"\t[||]\"",
-                afterUndo: @"var x = $@""[||]""");
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestVerbatimTextIntoVerbatimInterpolatedString()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-                @"var x = $@""[||]""",
-                @"var x = $@""abc[||]""",
-                afterUndo: @"var x = $@""[||]""");
+                pasteText: """abc""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"abc[||]"
+                """,
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoVerbatimInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-                @"var x = $@""[||]""",
-                @"var x = $@""{{[||]""",
-                afterUndo: "var x = $@\"{[||]\"");
+                pasteText: """{""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"{{[||]"
+                """,
+                afterUndo: """
+                var x = $@"{[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesIntoVerbatimInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{",
-                @"var x = $@""[||]""",
-                @"var x = $@""{{[||]""",
-                afterUndo: "var x = $@\"[||]\"");
+                pasteText: """{{""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"{{[||]"
+                """,
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesAndContentIntoVerbatimInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{0",
-                @"var x = $@""[||]""",
-                @"var x = $@""{{0[||]""",
-                afterUndo: "var x = $@\"[||]\"");
+                pasteText: """{{0""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"{{0[||]"
+                """,
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCloseCurlyIntoVerbatimInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "}",
-                @"var x = $@""[||]""",
-                @"var x = $@""}}[||]""",
-                afterUndo: "var x = $@\"}[||]\"");
+                pasteText: """}""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"}}[||]"
+                """,
+                afterUndo: """
+                var x = $@"}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesIntoVerbatimInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}",
-                @"var x = $@""[||]""",
-                @"var x = $@""}}[||]""",
-                afterUndo: "var x = $@\"[||]\"");
+                pasteText: """}}""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"}}[||]"
+                """,
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesAndContentIntoVerbatimInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}0",
-                @"var x = $@""[||]""",
-                @"var x = $@""}}0[||]""",
-                afterUndo: "var x = $@\"[||]\"");
+                pasteText: """}}0""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"}}0[||]"
+                """,
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCurlyWithContentIntoVerbatimInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{0}y",
-                @"var x = $@""[||]""",
-                @"var x = $@""x{0}y[||]""",
-                afterUndo: "var x = $@\"[||]\"");
+                pasteText: """x{0}y""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"x{0}y[||]"
+                """,
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCurliesWithContentIntoVerbatimInterpolatedString1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{{0}}y",
-                @"var x = $@""[||]""",
-                @"var x = $@""x{{0}}y[||]""",
-                afterUndo: "var x = $@\"[||]\"");
+                pasteText: """x{{0}}y""",
+                """
+                var x = $@"[||]"
+                """,
+                """
+                var x = $@"x{{0}}y[||]"
+                """,
+                afterUndo: """
+                var x = $@"[||]"
+                """);
         }
 
         #endregion
 
-        #region Paste from external source into verbatim interpolated string before hole
+#region Paste from external source into verbatim interpolated string before hole
 
         [WpfFact]
         public void TestNewLineIntoVerbatimInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-                @"var x = $@""[||]{0}""",
+                """
+                var x = $@"[||]{0}"
+                """,
                 "var x = $@\"\n[||]{0}\"",
-                afterUndo: @"var x = $@""[||]{0}""");
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestNewLineIntoVerbatimInterpolatedStringBeforeHole2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-                @"var x = $@""[||]{0}""",
-                "var x = $@\"\r\n[||]{0}\"",
-                afterUndo: @"var x = $@""[||]{0}""");
+                pasteText: """
+
+
+                """,
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"
+                [||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
@@ -194,29 +298,47 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t",
-                @"var x = $@""[||]{0}""",
+                """
+                var x = $@"[||]{0}"
+                """,
                 "var x = $@\"\t[||]{0}\"",
-                afterUndo: @"var x = $@""[||]{0}""");
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoVerbatimInterpolatedStringBeforeHole()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""'[||]{0}""",
-                afterUndo: "var x = $@\"[||]{0}\"");
+                pasteText: """'""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"'[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoVerbatimInterpolatedStringBeforeHole()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""""""[||]{0}""",
-                afterUndo: @"var x = $@""""[||]{0}""");
+                pasteText: """
+                "
+                """,
+                """
+                var x = $@"[||]{0}"
+                """,
+                """"
+                var x = $@"""[||]{0}"
+                """",
+                afterUndo: """
+                var x = $@""[||]{0}"
+                """);
         }
 
         [WpfFact]
@@ -224,123 +346,195 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t\"\"\t",
-                @"var x = $@""[||]{0}""",
+                """
+                var x = $@"[||]{0}"
+                """,
                 "var x = $@\"\t\"\"\t[||]{0}\"",
-                afterUndo: @"var x = $@""[||]{0}""");
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestVerbatimTextIntoVerbatimInterpolatedStringBeforeHole()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""abc[||]{0}""",
-                afterUndo: @"var x = $@""[||]{0}""");
+                pasteText: """abc""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"abc[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoVerbatimInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""{{[||]{0}""",
-                afterUndo: "var x = $@\"{[||]{0}\"");
+                pasteText: """{""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"{{[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"{[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesIntoVerbatimInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""{{[||]{0}""",
-                afterUndo: "var x = $@\"[||]{0}\"");
+                pasteText: """{{""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"{{[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesAndContentIntoVerbatimInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{0",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""{{0[||]{0}""",
-                afterUndo: "var x = $@\"[||]{0}\"");
+                pasteText: """{{0""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"{{0[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestCloseCurlyIntoVerbatimInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""}}[||]{0}""",
-                afterUndo: "var x = $@\"}[||]{0}\"");
+                pasteText: """}""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"}}[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"}[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesIntoVerbatimInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""}}[||]{0}""",
-                afterUndo: "var x = $@\"[||]{0}\"");
+                pasteText: """}}""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"}}[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesAndContentIntoVerbatimInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}0",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""}}0[||]{0}""",
-                afterUndo: "var x = $@\"[||]{0}\"");
+                pasteText: """}}0""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"}}0[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestCurlyWithContentIntoVerbatimInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{0}y",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""x{0}y[||]{0}""",
-                afterUndo: "var x = $@\"[||]{0}\"");
+                pasteText: """x{0}y""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"x{0}y[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         [WpfFact]
         public void TestCurliesWithContentIntoVerbatimInterpolatedStringBeforeHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{{0}}y",
-                @"var x = $@""[||]{0}""",
-                @"var x = $@""x{{0}}y[||]{0}""",
-                afterUndo: "var x = $@\"[||]{0}\"");
+                pasteText: """x{{0}}y""",
+                """
+                var x = $@"[||]{0}"
+                """,
+                """
+                var x = $@"x{{0}}y[||]{0}"
+                """,
+                afterUndo: """
+                var x = $@"[||]{0}"
+                """);
         }
 
         #endregion
 
-        #region Paste from external source into verbatim interpolated string after hole
+#region Paste from external source into verbatim interpolated string after hole
 
         [WpfFact]
         public void TestNewLineIntoVerbatimInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-                @"var x = $@""{0}[||]""",
+                """
+                var x = $@"{0}[||]"
+                """,
                 "var x = $@\"{0}\n[||]\"",
-                afterUndo: @"var x = $@""{0}[||]""");
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestNewLineIntoVerbatimInterpolatedStringAfterHole2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-                @"var x = $@""{0}[||]""",
-                "var x = $@\"{0}\r\n[||]\"",
-                afterUndo: @"var x = $@""{0}[||]""");
+                pasteText: """
+
+
+                """,
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}
+                [||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
@@ -348,29 +542,47 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t",
-                @"var x = $@""{0}[||]""",
+                """
+                var x = $@"{0}[||]"
+                """,
                 "var x = $@\"{0}\t[||]\"",
-                afterUndo: @"var x = $@""{0}[||]""");
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoVerbatimInterpolatedStringAfterHole()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}'[||]""",
-                afterUndo: "var x = $@\"{0}[||]\"");
+                pasteText: """'""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}'[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoVerbatimInterpolatedStringAfterHole()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}""""[||]""",
-                afterUndo: @"var x = $@""{0}""[||]""");
+                pasteText: """
+                "
+                """,
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}""[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}"[||]"
+                """);
         }
 
         [WpfFact]
@@ -378,101 +590,159 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t\"\"\t",
-                @"var x = $@""{0}[||]""",
+                """
+                var x = $@"{0}[||]"
+                """,
                 "var x = $@\"{0}\t\"\"\t[||]\"",
-                afterUndo: "var x = $@\"{0}[||]\"");
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestVerbatimTextIntoVerbatimInterpolatedStringAfterHole()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}abc[||]""",
-                afterUndo: @"var x = $@""{0}[||]""");
+                pasteText: """abc""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}abc[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestOpenCurlyIntoVerbatimInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}{{[||]""",
-                afterUndo: "var x = $@\"{0}{[||]\"");
+                pasteText: """{""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}{{[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}{[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesIntoVerbatimInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}{{[||]""",
-                afterUndo: "var x = $@\"{0}[||]\"");
+                pasteText: """{{""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}{{[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoOpenCurliesAndContentIntoVerbatimInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "{{0",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}{{0[||]""",
-                afterUndo: "var x = $@\"{0}[||]\"");
+                pasteText: """{{0""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}{{0[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCloseCurlyIntoVerbatimInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}}}[||]""",
-                afterUndo: "var x = $@\"{0}}[||]\"");
+                pasteText: """}""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}}}[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesIntoVerbatimInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}}}[||]""",
-                afterUndo: "var x = $@\"{0}[||]\"");
+                pasteText: """}}""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}}}[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestTwoCloseCurliesAndContentIntoVerbatimInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "}}0",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}}}0[||]""",
-                afterUndo: "var x = $@\"{0}[||]\"");
+                pasteText: """}}0""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}}}0[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCurlyWithContentIntoVerbatimInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{0}y",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}x{0}y[||]""",
-                afterUndo: "var x = $@\"{0}[||]\"");
+                pasteText: """x{0}y""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}x{0}y[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
         [WpfFact]
         public void TestCurliesWithContentIntoVerbatimInterpolatedStringAfterHole1()
         {
             TestPasteUnknownSource(
-                pasteText: "x{{0}}y",
-                @"var x = $@""{0}[||]""",
-                @"var x = $@""{0}x{{0}}y[||]""",
-                afterUndo: "var x = $@\"{0}[||]\"");
+                pasteText: """x{{0}}y""",
+                """
+                var x = $@"{0}[||]"
+                """,
+                """
+                var x = $@"{0}x{{0}}y[||]"
+                """,
+                afterUndo: """
+                var x = $@"{0}[||]"
+                """);
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoVerbatimStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoVerbatimStringTests.cs
@@ -15,19 +15,33 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\n",
-                @"var x = @""[||]""",
+                """
+                var x = @"[||]"
+                """,
                 "var x = @\"\n[||]\"",
-                afterUndo: @"var x = @""[||]""");
+                afterUndo: """
+                var x = @"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestNewLineIntoVerbatimString2()
         {
             TestPasteUnknownSource(
-                pasteText: "\r\n",
-                @"var x = @""[||]""",
-                "var x = @\"\r\n[||]\"",
-                afterUndo: @"var x = @""[||]""");
+                pasteText: """
+
+
+                """,
+                """
+                var x = @"[||]"
+                """,
+                """
+                var x = @"
+                [||]"
+                """,
+                afterUndo: """
+                var x = @"[||]"
+                """);
         }
 
         [WpfFact]
@@ -35,29 +49,47 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t",
-                @"var x = @""[||]""",
+                """
+                var x = @"[||]"
+                """,
                 "var x = @\"\t[||]\"",
-                afterUndo: @"var x = @""[||]""");
+                afterUndo: """
+                var x = @"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestSingleQuoteIntoVerbatimString()
         {
             TestPasteUnknownSource(
-                pasteText: "'",
-                @"var x = @""[||]""",
-                @"var x = @""'[||]""",
-                afterUndo: @"var x = @""[||]""");
+                pasteText: """'""",
+                """
+                var x = @"[||]"
+                """,
+                """
+                var x = @"'[||]"
+                """,
+                afterUndo: """
+                var x = @"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestDoubleQuoteIntoVerbatimString()
         {
             TestPasteUnknownSource(
-                pasteText: "\"",
-                @"var x = @""[||]""",
-                @"var x = @""""""[||]""",
-                afterUndo: @"var x = @""""[||]""");
+                pasteText: """
+                "
+                """,
+                """
+                var x = @"[||]"
+                """,
+                """"
+                var x = @"""[||]"
+                """",
+                afterUndo: """
+                var x = @""[||]"
+                """);
         }
 
         [WpfFact]
@@ -65,19 +97,29 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         {
             TestPasteUnknownSource(
                 pasteText: "\t\"\"\t",
-                @"var x = @""[||]""",
+                """
+                var x = @"[||]"
+                """,
                 "var x = @\"\t\"\"\t[||]\"",
-                afterUndo: @"var x = @""[||]""");
+                afterUndo: """
+                var x = @"[||]"
+                """);
         }
 
         [WpfFact]
         public void TestNormalTextIntoVerbatimString()
         {
             TestPasteUnknownSource(
-                pasteText: "abc",
-                @"var x = @""[||]""",
-                @"var x = @""abc[||]""",
-                afterUndo: @"var x = @""[||]""");
+                pasteText: """abc""",
+                """
+                var x = @"[||]"
+                """,
+                """
+                var x = @"abc[||]"
+                """,
+                afterUndo: """
+                var x = @"[||]"
+                """);
         }
     }
 }


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/61177

Cleans up the tests massively now htat we can use raw-string-literals in roslyn itself.