### PR TITLE
Ensure we do string-copy-paste before format-on-paste

### DIFF
--- a/src/EditorFeatures/CSharp/StringCopyPaste/StringCopyPasteCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/StringCopyPaste/StringCopyPasteCommandHandler.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 using VSUtilities = Microsoft.VisualStudio.Utilities;
 
@@ -43,8 +44,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.StringCopyPaste
     /// doesn't want the change we made, they can always undo to get the prior paste behavior.
     /// </remarks>
     [Export(typeof(ICommandHandler))]
-    [VSUtilities.ContentType(ContentTypeNames.CSharpContentType)]
-    [VSUtilities.Name(nameof(StringCopyPasteCommandHandler))]
+    [ContentType(ContentTypeNames.CSharpContentType)]
+    [Name(PredefinedCommandHandlerNames.StringCopyPaste)]
+    [Order(After = PredefinedCommandHandlerNames.FormatDocument)]
     internal partial class StringCopyPasteCommandHandler :
         IChainedCommandHandler<CutCommandArgs>,
         IChainedCommandHandler<CopyCommandArgs>,

--- a/src/EditorFeatures/Core/Extensibility/Commands/PredefinedCommandHandlerNames.cs
+++ b/src/EditorFeatures/Core/Extensibility/Commands/PredefinedCommandHandlerNames.cs
@@ -148,6 +148,11 @@ namespace Microsoft.CodeAnalysis.Editor
         public const string SignatureHelpAfterCompletion = "Signature Help After Completion Command Handler";
 
         /// <summary>
+        /// Command handler name for String Copy Paste.
+        /// </summary>
+        public const string StringCopyPaste = "String Copy Paste";
+
+        /// <summary>
         /// Command handler name for Toggle Block Comments.
         /// </summary>
         /// <remarks></remarks>

--- a/src/EditorFeatures/Core/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Formatting/FormatCommandHandler.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Formatting
     [ContentType(ContentTypeNames.RoslynContentType)]
     [Name(PredefinedCommandHandlerNames.FormatDocument)]
     [Order(After = PredefinedCommandHandlerNames.Rename)]
+    [Order(Before = PredefinedCommandHandlerNames.StringCopyPaste)]
     [Order(Before = PredefinedCompletionNames.CompletionCommandHandler)]
     internal partial class FormatCommandHandler :
         ICommandHandler<FormatDocumentCommandArgs>,


### PR DESCRIPTION
Otherwise we have to contend with both the edits made by the user, and what format-on-paste changed them to be.  That makes fixing things up much more difficult.  

Will add tests for this soon.