### PR TITLE
Avoid yield in ReadAsync/WriteAsync unless on main thread

### DIFF
--- a/src/EditorFeatures/Core/Shared/Utilities/WorkspaceThreadingService.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/WorkspaceThreadingService.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             _threadingContext = threadingContext;
         }
 
+        public bool IsOnMainThread => _threadingContext.JoinableTaskContext.IsOnMainThread;
+
         public TResult Run<TResult>(Func<Task<TResult>> asyncMethod)
         {
             return _threadingContext.JoinableTaskFactory.Run(asyncMethod);

--- a/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public async Task TestCreateFromTemporaryStorage()
         {
             var textFactory = CreateMockTextFactoryService();
-            var temporaryStorageService = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var temporaryStorageService = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
 
             var text = SourceText.From("Hello, World!");
 
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public async Task TestCreateFromTemporaryStorageWithEncoding()
         {
             var textFactory = CreateMockTextFactoryService();
-            var temporaryStorageService = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var temporaryStorageService = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
 
             var text = SourceText.From("Hello, World!", Encoding.ASCII);
 

--- a/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -13,9 +10,6 @@ using Microsoft.CodeAnalysis.Editor.Implementation.Workspaces;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Utilities;
-using Moq;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -29,7 +23,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         [Fact, WorkItem(1038018, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1038018"), WorkItem(1041792, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1041792")]
         public void TestCreateTextFallsBackToSystemDefaultEncoding()
         {
+            using var workspace = new AdhocWorkspace(EditorTestCompositions.EditorFeatures.GetHostServices());
+            var textFactoryService = Assert.IsType<EditorTextFactoryService>(workspace.Services.GetRequiredService<ITextFactoryService>());
+
             TestCreateTextInferredEncoding(
+                textFactoryService,
                 _nonUTF8StringBytes,
                 defaultEncoding: null,
                 expectedEncoding: Encoding.Default);
@@ -38,7 +36,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         [Fact, WorkItem(1038018, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1038018")]
         public void TestCreateTextFallsBackToUTF8Encoding()
         {
+            using var workspace = new AdhocWorkspace(EditorTestCompositions.EditorFeatures.GetHostServices());
+            var textFactoryService = Assert.IsType<EditorTextFactoryService>(workspace.Services.GetRequiredService<ITextFactoryService>());
+
             TestCreateTextInferredEncoding(
+                textFactoryService,
                 new ASCIIEncoding().GetBytes("Test"),
                 defaultEncoding: null,
                 expectedEncoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true));
@@ -47,7 +49,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         [Fact, WorkItem(1038018, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1038018")]
         public void TestCreateTextFallsBackToProvidedDefaultEncoding()
         {
+            using var workspace = new AdhocWorkspace(EditorTestCompositions.EditorFeatures.GetHostServices());
+            var textFactoryService = Assert.IsType<EditorTextFactoryService>(workspace.Services.GetRequiredService<ITextFactoryService>());
+
             TestCreateTextInferredEncoding(
+                textFactoryService,
                 new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true).GetBytes("Test"),
                 defaultEncoding: Encoding.GetEncoding(1254),
                 expectedEncoding: Encoding.GetEncoding(1254));
@@ -56,7 +62,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         [Fact, WorkItem(1038018, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1038018")]
         public void TestCreateTextUsesByteOrderMarkIfPresent()
         {
+            using var workspace = new AdhocWorkspace(EditorTestCompositions.EditorFeatures.GetHostServices());
+            var textFactoryService = Assert.IsType<EditorTextFactoryService>(workspace.Services.GetRequiredService<ITextFactoryService>());
+
             TestCreateTextInferredEncoding(
+                textFactoryService,
                 Encoding.UTF8.GetPreamble().Concat(new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true).GetBytes("Test")).ToArray(),
                 defaultEncoding: Encoding.GetEncoding(1254),
                 expectedEncoding: Encoding.UTF8);
@@ -65,8 +75,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         [Fact]
         public async Task TestCreateFromTemporaryStorage()
         {
-            var textFactory = CreateMockTextFactoryService();
-            var temporaryStorageService = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            using var workspace = new AdhocWorkspace(EditorTestCompositions.EditorFeatures.GetHostServices());
+
+            var temporaryStorageService = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
 
             var text = SourceText.From("Hello, World!");
 
@@ -86,8 +97,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         [Fact]
         public async Task TestCreateFromTemporaryStorageWithEncoding()
         {
-            var textFactory = CreateMockTextFactoryService();
-            var temporaryStorageService = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            using var workspace = new AdhocWorkspace(EditorTestCompositions.EditorFeatures.GetHostServices());
+
+            var temporaryStorageService = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
 
             var text = SourceText.From("Hello, World!", Encoding.ASCII);
 
@@ -104,53 +116,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             Assert.Equal(text2.Encoding, Encoding.ASCII);
         }
 
-        private static EditorTextFactoryService CreateMockTextFactoryService()
+        private static void TestCreateTextInferredEncoding(ITextFactoryService textFactoryService, byte[] bytes, Encoding? defaultEncoding, Encoding expectedEncoding)
         {
-            var mockTextBufferFactoryService = new Mock<ITextBufferFactoryService>(MockBehavior.Strict);
-            mockTextBufferFactoryService
-                .Setup(t => t.CreateTextBuffer(It.IsAny<TextReader>(), It.IsAny<IContentType>()))
-                .Returns<TextReader, IContentType>((reader, contentType) =>
-                {
-                    var text = reader.ReadToEnd();
-
-                    var mockImage = new Mock<ITextImage>(MockBehavior.Strict);
-                    mockImage.Setup(i => i.GetText(It.IsAny<Span>())).Returns(text);
-                    mockImage.Setup(i => i.Length).Returns(text.Length);
-
-                    var mockSnapshot = new Mock<ITextSnapshot2>(MockBehavior.Strict);
-                    mockSnapshot.Setup(s => s.TextImage).Returns(mockImage.Object);
-                    mockSnapshot.Setup(s => s.GetText()).Returns(text);
-
-                    var mockTextBuffer = new Mock<ITextBuffer>(MockBehavior.Strict);
-                    mockTextBuffer.Setup(b => b.CurrentSnapshot).Returns(mockSnapshot.Object);
-                    return mockTextBuffer.Object;
-                });
-
-            var mockUnknownContentType = new Mock<IContentType>(MockBehavior.Strict);
-            var mockContentTypeRegistryService = new Mock<IContentTypeRegistryService>(MockBehavior.Strict);
-            mockContentTypeRegistryService.Setup(r => r.UnknownContentType).Returns(mockUnknownContentType.Object);
-
-            return new EditorTextFactoryService(new FakeTextBufferCloneService(), mockTextBufferFactoryService.Object, mockContentTypeRegistryService.Object);
-        }
-
-        private static void TestCreateTextInferredEncoding(byte[] bytes, Encoding defaultEncoding, Encoding expectedEncoding)
-        {
-            var factory = CreateMockTextFactoryService();
             using var stream = new MemoryStream(bytes);
-            var text = factory.CreateText(stream, defaultEncoding);
+            var text = textFactoryService.CreateText(stream, defaultEncoding);
             Assert.Equal(expectedEncoding, text.Encoding);
-        }
-
-        private class FakeTextBufferCloneService : ITextBufferCloneService
-        {
-            public ITextBuffer CloneWithUnknownContentType(SnapshotSpan span) => throw new NotImplementedException();
-
-            public ITextBuffer CloneWithUnknownContentType(ITextImage textImage) => throw new NotImplementedException();
-
-            public ITextBuffer CloneWithRoslynContentType(SourceText sourceText) => throw new NotImplementedException();
-
-            public ITextBuffer Clone(SourceText sourceText, IContentType contentType) => throw new NotImplementedException();
-
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Utilities/IWorkspaceThreadingService.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/IWorkspaceThreadingService.cs
@@ -25,6 +25,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
     /// </remarks>
     internal interface IWorkspaceThreadingService
     {
+        bool IsOnMainThread { get; }
+
         TResult Run<TResult>(Func<Task<TResult>> asyncMethod);
     }
 

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Host
             _workspaceThreadingService = workspaceThreadingService;
         }
 
+        [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
             var textFactory = workspaceServices.GetRequiredService<ITextFactoryService>();
@@ -117,6 +118,7 @@ namespace Microsoft.CodeAnalysis.Host
             /// <seealso cref="_weakFileReference"/>
             private long _offset;
 
+            [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
             public TemporaryStorageService(IWorkspaceThreadingService? workspaceThreadingService, ITextFactoryService textFactory)
             {
                 _workspaceThreadingService = workspaceThreadingService;

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
@@ -23,10 +23,14 @@ namespace Microsoft.CodeAnalysis.Host
     [ExportWorkspaceServiceFactory(typeof(ITemporaryStorageService), ServiceLayer.Default), Shared]
     internal partial class TemporaryStorageServiceFactory : IWorkspaceServiceFactory
     {
+        private readonly IWorkspaceThreadingService? _workspaceThreadingService;
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public TemporaryStorageServiceFactory()
+        public TemporaryStorageServiceFactory(
+            [Import(AllowDefault = true)] IWorkspaceThreadingService? workspaceThreadingService)
         {
+            _workspaceThreadingService = workspaceThreadingService;
         }
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
@@ -37,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Host
             // and .NET Core Windows. For non-Windows .NET Core scenarios, we can return the TrivialTemporaryStorageService
             // until https://github.com/dotnet/runtime/issues/30878 is fixed.
             return PlatformInformation.IsWindows || PlatformInformation.IsRunningOnMono
-                ? new TemporaryStorageService(textFactory)
+                ? new TemporaryStorageService(_workspaceThreadingService, textFactory)
                 : TrivialTemporaryStorageService.Instance;
         }
 
@@ -67,6 +71,7 @@ namespace Microsoft.CodeAnalysis.Host
             /// <seealso cref="_weakFileReference"/>
             private const long MultiFileBlockSize = SingleFileThreshold * 32;
 
+            private readonly IWorkspaceThreadingService? _workspaceThreadingService;
             private readonly ITextFactoryService _textFactory;
 
             /// <summary>
@@ -112,8 +117,11 @@ namespace Microsoft.CodeAnalysis.Host
             /// <seealso cref="_weakFileReference"/>
             private long _offset;
 
-            public TemporaryStorageService(ITextFactoryService textFactory)
-                => _textFactory = textFactory;
+            public TemporaryStorageService(IWorkspaceThreadingService? workspaceThreadingService, ITextFactoryService textFactory)
+            {
+                _workspaceThreadingService = workspaceThreadingService;
+                _textFactory = textFactory;
+            }
 
             public ITemporaryTextStorage CreateTemporaryTextStorage(CancellationToken cancellationToken)
                 => new TemporaryTextStorage(this);
@@ -242,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Host
                     }
                 }
 
-                public Task<SourceText> ReadTextAsync(CancellationToken cancellationToken)
+                public async Task<SourceText> ReadTextAsync(CancellationToken cancellationToken)
                 {
                     // There is a reason for implementing it like this: proper async implementation
                     // that reads the underlying memory mapped file stream in an asynchronous fashion
@@ -254,7 +262,13 @@ namespace Microsoft.CodeAnalysis.Host
                     // of a page fault. Therefore, if we're going to be blocking a thread, we should
                     // just block one thread and do the whole thing at once vs. a fake "async"
                     // implementation which will continue to requeue work back to the thread pool.
-                    return Task.Factory.StartNew(() => ReadText(cancellationToken), cancellationToken, TaskCreationOptions.None, TaskScheduler.Default);
+                    if (_service._workspaceThreadingService is { IsOnMainThread: true })
+                    {
+                        await Task.Yield().ConfigureAwait(false);
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
+                    return ReadText(cancellationToken);
                 }
 
                 public void WriteText(SourceText text, CancellationToken cancellationToken)
@@ -281,10 +295,16 @@ namespace Microsoft.CodeAnalysis.Host
                     }
                 }
 
-                public Task WriteTextAsync(SourceText text, CancellationToken cancellationToken = default)
+                public async Task WriteTextAsync(SourceText text, CancellationToken cancellationToken)
                 {
                     // See commentary in ReadTextAsync for why this is implemented this way.
-                    return Task.Factory.StartNew(() => WriteText(text, cancellationToken), cancellationToken, TaskCreationOptions.None, TaskScheduler.Default);
+                    if (_service._workspaceThreadingService is { IsOnMainThread: true })
+                    {
+                        await Task.Yield().ConfigureAwait(false);
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
+                    WriteText(text, cancellationToken);
                 }
 
                 private static unsafe TextReader CreateTextReaderFromTemporaryStorage(ISupportDirectMemoryAccess accessor, int streamLength)

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,7 +25,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
 
             // test normal string
             var text = SourceText.From(new string(' ', 4096) + "public class A {}");
@@ -48,7 +46,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
             var temporaryStorage = service.CreateTemporaryStreamStorage(System.Threading.CancellationToken.None);
 
             using var data = SerializableBytes.CreateWritableStream();
@@ -91,7 +89,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
             var storage = service.CreateTemporaryTextStorage(CancellationToken.None);
 
             // Nothing has been written yet
@@ -112,7 +110,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             // Nothing has been written yet
@@ -135,7 +133,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             // 0 length streams are allowed
@@ -155,7 +153,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
             var buffer = new MemoryStream(257 * 1024 + 1);
             for (var i = 0; i < buffer.Length; i++)
             {
@@ -202,7 +200,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 using var workspace = new AdhocWorkspace();
                 var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-                var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+                var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
 
                 using var data = SerializableBytes.CreateWritableStream();
                 for (var i = 0; i < 1024 * 128; i++)
@@ -235,7 +233,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             using var expected = new MemoryStream();
@@ -262,7 +260,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             using var expected = new MemoryStream();
@@ -299,7 +297,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             using var expected = new MemoryStream();
@@ -336,7 +334,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
+            var service = Assert.IsType<TemporaryStorageServiceFactory.TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
 
             // test normal string
             var text = SourceText.From(new string(' ', 4096) + "public class A {}", Encoding.ASCII);

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
 
             // test normal string
             var text = SourceText.From(new string(' ', 4096) + "public class A {}");
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
             var temporaryStorage = service.CreateTemporaryStreamStorage(System.Threading.CancellationToken.None);
 
             using var data = SerializableBytes.CreateWritableStream();
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
             var storage = service.CreateTemporaryTextStorage(CancellationToken.None);
 
             // Nothing has been written yet
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             // Nothing has been written yet
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             // 0 length streams are allowed
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
             var buffer = new MemoryStream(257 * 1024 + 1);
             for (var i = 0; i < buffer.Length; i++)
             {
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 using var workspace = new AdhocWorkspace();
                 var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-                var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+                var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
 
                 using var data = SerializableBytes.CreateWritableStream();
                 for (var i = 0; i < 1024 * 128; i++)
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             using var expected = new MemoryStream();
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             using var expected = new MemoryStream();
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
             var storage = service.CreateTemporaryStreamStorage(CancellationToken.None);
 
             using var expected = new MemoryStream();
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(textFactory);
+            var service = new TemporaryStorageServiceFactory.TemporaryStorageService(workspaceThreadingService: null, textFactory);
 
             // test normal string
             var text = SourceText.From(new string(' ', 4096) + "public class A {}", Encoding.ASCII);


### PR DESCRIPTION
This change should improve the ability to investigate issues like [AB#1526707](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1526707) by reducing the amount of operation decoupling that occurs on paths that call `ReadTextAsync`.