### PR TITLE
[LSP] Disable GoToDef/GoToImpl integration tests 

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpClassification.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpClassification.cs
@@ -106,7 +106,7 @@ class Program : Attribute
             VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "class name");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification), Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
         public void VerifyProjectConfigChange()
         {
             VisualStudio.Editor.SetText(@"

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToDefinition.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToDefinition.cs
@@ -23,7 +23,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
         {
         }
 
-        [IdeFact, Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
+        [IdeFact]
         public async Task GoToClassDeclaration()
         {
             var project = ProjectName;
@@ -48,7 +48,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
             Assert.False(await TestServices.Shell.IsActiveTabProvisionalAsync(HangMitigatingCancellationToken));
         }
 
-        [IdeFact, Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
+        [IdeFact]
         public async Task GoToDefinitionOpensProvisionalTabIfDocumentNotAlreadyOpen()
         {
             var project = ProjectName;
@@ -74,7 +74,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
             Assert.True(await TestServices.Shell.IsActiveTabProvisionalAsync(HangMitigatingCancellationToken));
         }
 
-        [IdeFact, Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
+        [IdeFact]
         public async Task GoToDefinitionWithMultipleResults()
         {
             await SetUpEditorAsync(

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToImplementation.cs
@@ -26,7 +26,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
         {
         }
 
-        [IdeTheory, Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
+        [IdeTheory]
         [CombinatorialData]
         public async Task SimpleGoToImplementation(bool asyncNavigation)
         {
@@ -75,7 +75,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
             Assert.False(await TestServices.Shell.IsActiveTabProvisionalAsync(HangMitigatingCancellationToken));
         }
 
-        [IdeTheory, Trait(Traits.Editor, Traits.Editors.LanguageServerProtocol)]
+        [IdeTheory]
         [CombinatorialData]
         public async Task GoToImplementationOpensProvisionalTabIfDocumentNotOpen(bool asyncNavigation)
         {


### PR DESCRIPTION
Disabling GTD/GTI LSP integration tests in order to get the LSP pipeline back up and running in CI.

Tracking issue: https://github.com/dotnet/roslyn/issues/61188