### PR TITLE
Fix for Issue #55606: [EE] Format IAsyncEnumerable method names correctly.

### DIFF
--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -435,6 +435,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription AsyncMethodBuilderAttribute = new AttributeDescription("System.Runtime.CompilerServices", "AsyncMethodBuilderAttribute", s_signatures_HasThis_Void_Type_Only);
         internal static readonly AttributeDescription AsyncStateMachineAttribute = new AttributeDescription("System.Runtime.CompilerServices", "AsyncStateMachineAttribute", s_signatures_HasThis_Void_Type_Only);
         internal static readonly AttributeDescription IteratorStateMachineAttribute = new AttributeDescription("System.Runtime.CompilerServices", "IteratorStateMachineAttribute", s_signatures_HasThis_Void_Type_Only);
+        internal static readonly AttributeDescription AsyncIteratorStateMachineAttribute = new AttributeDescription("System.Runtime.CompilerServices", "AsyncIteratorStateMachineAttribute", s_signatures_HasThis_Void_Type_Only);
         internal static readonly AttributeDescription CompilationRelaxationsAttribute = new AttributeDescription("System.Runtime.CompilerServices", "CompilationRelaxationsAttribute", s_signaturesOfCompilationRelaxationsAttribute);
         internal static readonly AttributeDescription ReferenceAssemblyAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ReferenceAssemblyAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription RuntimeCompatibilityAttribute = new AttributeDescription("System.Runtime.CompilerServices", "RuntimeCompatibilityAttribute", s_signatures_HasThis_Void_Only);

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationExtensions.cs
@@ -44,7 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         methodHandle = candidateMethod.Handle;
                         string stateMachineTypeName;
                         if (module.HasStringValuedAttribute(methodHandle, AttributeDescription.AsyncStateMachineAttribute, out stateMachineTypeName) ||
-                            module.HasStringValuedAttribute(methodHandle, AttributeDescription.IteratorStateMachineAttribute, out stateMachineTypeName))
+                            module.HasStringValuedAttribute(methodHandle, AttributeDescription.IteratorStateMachineAttribute, out stateMachineTypeName) ||
+                            module.HasStringValuedAttribute(methodHandle, AttributeDescription.AsyncIteratorStateMachineAttribute, out stateMachineTypeName))
                         {
                             if (metadataDecoder.GetTypeSymbolForSerializedType(stateMachineTypeName).OriginalDefinition.Equals(containingType))
                             {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -3842,7 +3842,7 @@ class C
             });
         }
 
-        [WorkItem(55606, "[https://github.com/dotnet/roslyn/issues/55606](https://github.com/dotnet/roslyn/issues/55606)")]
+        [WorkItem(55606, "https://github.com/dotnet/roslyn/issues/55606")]
         [Fact]
         public void OrderOfArguments_ArgumentsOnly_Async()
         {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -3842,6 +3842,43 @@ class C
             });
         }
 
+        [WorkItem(55606, "[https://github.com/dotnet/roslyn/issues/55606](https://github.com/dotnet/roslyn/issues/55606)")]
+        [Fact]
+        public void OrderOfArguments_ArgumentsOnly_Async()
+        {
+            var source =
+@"using System.Collections.Generic;
+using System.Threading.Tasks;
+class C
+{
+    static async IAsyncEnumerable<object> F(object y, object x)
+    {
+        Task.Yield();
+        yield return x;
+#line 500
+        DummySequencePoint();
+        yield return y;
+    }
+    static void DummySequencePoint()
+    {
+    }
+}";
+            var references = TargetFrameworkUtil.Mscorlib461ExtendedReferences.Concat(new[] { TestMetadata.Net461.SystemThreadingTasks, TestMetadata.SystemThreadingTasksExtensions.PortableLib });
+            var comp = CreateEmptyCompilation(new[] { source, AsyncStreamsTypes }, references: references);
+            WithRuntimeInstance(comp, references, runtime =>
+            {
+                EvaluationContext context;
+                context = CreateMethodContext(runtime, "C.<F>d__0.MoveNext", atLineNumber: 500);
+                string unused;
+                var locals = new ArrayBuilder<LocalAndMethod>();
+                context.CompileGetLocals(locals, argumentsOnly: true, typeName: out unused, testData: null);
+                var names = locals.Select(l => l.LocalName).ToArray();
+                // The order must confirm the order of the arguments in the method signature.
+                Assert.Equal(names, new[] { "y", "x" });
+                locals.Free();
+            });
+        }
+
         /// <summary>
         /// CompileGetLocals should skip locals with errors.
         /// </summary>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
@@ -39,7 +39,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         methodHandle = candidateMethod.Handle
                         Dim stateMachineTypeName As String = Nothing
                         If [module].HasStringValuedAttribute(methodHandle, AttributeDescription.AsyncStateMachineAttribute, stateMachineTypeName) OrElse
-                            [module].HasStringValuedAttribute(methodHandle, AttributeDescription.IteratorStateMachineAttribute, stateMachineTypeName) _
+                            [module].HasStringValuedAttribute(methodHandle, AttributeDescription.IteratorStateMachineAttribute, stateMachineTypeName) OrElse
+                            [module].HasStringValuedAttribute(methodHandle, AttributeDescription.AsyncIteratorStateMachineAttribute, stateMachineTypeName) _
                         Then
                             If metadataDecoder.GetTypeSymbolForSerializedType(stateMachineTypeName).OriginalDefinition.Equals(containingType) Then
                                 Return candidateMethod


### PR DESCRIPTION
Fix for Issue #55606

Issue:
- Debugger doesn't show user-identifable name for IAsyncEnumerable async methods.

Changes:
1. AttributeDescription:
- Add AsyncIteratorStateMachineAttribute.

2. ExpressionCompiler:
- Check for AsyncIteratorStateMachineAttribute in addition to AsyncStateMachineAttribute and IteratorStateMachineAttribute to get the user-friendly name.

Verified with debugger Glass tests.