### PR TITLE
ignore top level statements from move static member refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.MoveStaticMembers;
 using Microsoft.CodeAnalysis.Test.Utilities;

--- a/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.MoveStaticMembers;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -2581,6 +2582,14 @@ namespace TestNs1
             await TestNoRefactoringAsync(initialMarkup, hostServices: FeaturesTestCompositions.Features.GetHostServices()).ConfigureAwait(false);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task NoCodeActionForTopLevelStatement()
+        {
+            var initialMarkup = @"
+var x = 42;[||]";
+            await TestNoRefactoringAsync(initialMarkup).ConfigureAwait(false);
+        }
+
         private class Test : VerifyCS.Test
         {
             public Test(
@@ -2644,6 +2653,10 @@ namespace TestNs1
         {
             await new Test("", ImmutableArray<string>.Empty, hostServices: hostServices)
             {
+                TestState =
+                {
+                    OutputKind = OutputKind.ConsoleApplication
+                },
                 TestCode = initialMarkup,
                 FixedCode = initialMarkup,
             }.RunAsync().ConfigureAwait(false);

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -62,9 +62,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             /// <summary>
             /// Gets or sets the language version to use for the test. The default value is
-            /// <see cref="LanguageVersion.CSharp8"/>.
+            /// <see cref="LanguageVersion.CSharp9"/>.
             /// </summary>
-            public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.CSharp8;
+            public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.CSharp9;
 
             /// <inheritdoc cref="SharedVerifierState.Options"/>
             internal OptionsCollection Options => _sharedState.Options;

--- a/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
@@ -32,6 +32,12 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
                 return;
             }
 
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
+            if (syntaxFacts.IsGlobalStatement(memberDeclaration))
+            {
+                return;
+            }
+
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             if (semanticModel == null)
             {
@@ -52,8 +58,6 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
             {
                 return;
             }
-
-            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
             var action = new MoveStaticMembersWithDialogCodeAction(document, span, service, selectedType, context.Options, selectedMember: selectedMembers[0]);
 


### PR DESCRIPTION
Fixes #59470 

Move static members to another type is no longer suggested for a top-level statement.