### PR TITLE
Simplify RegexCharClass.IsWordChar

### DIFF
--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexLexer.cs
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
             }
 
             var start = Position;
-            while (Position < Text.Length && RegexCharClass.IsWordChar(this.CurrentChar))
+            while (Position < Text.Length && RegexCharClass.IsBoundaryWordChar(this.CurrentChar))
             {
                 Position++;
             }

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexParser.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/RegexParser.cs
@@ -1877,7 +1877,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.RegularExpressions
                 default:
                     var typeToken = ConsumeCurrentToken(allowTrivia: allowTriviaAfterEnd).With(kind: RegexKind.TextToken);
 
-                    if (!HasOption(_options, RegexOptions.ECMAScript) && RegexCharClass.IsWordChar(ch))
+                    if (!HasOption(_options, RegexOptions.ECMAScript) && RegexCharClass.IsBoundaryWordChar(ch))
                     {
                         typeToken = typeToken.AddDiagnosticIfNone(new EmbeddedDiagnostic(
                             string.Format(FeaturesResources.Unrecognized_escape_sequence_0, ch),


### PR DESCRIPTION
@CyrusNajmabadi mentioned to me yesterday that Roslyn contains a copy of RegexCharClass code from several years ago.  It's been overhauled since, and the implementation of IsWordChar (now renamed to IsBoundaryWordChar to better reflect what it is) was measurably improved.  Further, since Roslyn doesn't actually need all of the character set processing code, and IsBoundaryWordChar no longer uses that character set processing code, we can remove a bunch of unnecessary stuff.  This will now be simpler and faster.