### PR TITLE
Add support for re-abstraction of operators in derived interfaces.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -195,6 +195,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            if (isExplicitInterfaceImplementation)
+            {
+                if ((result & DeclarationModifiers.Abstract) != 0)
+                {
+                    result |= DeclarationModifiers.Sealed;
+                }
+            }
+
             return result;
 
             static void reportModifierIfPresent(DeclarationModifiers result, DeclarationModifiers errorModifier, Location location, BindingDiagnosticBag diagnostics, CSharpRequiredLanguageVersion requiredVersionArgument, string availableVersionArgument)


### PR DESCRIPTION
https://github.com/dotnet/csharplang/blob/main/proposals/static-abstracts-in-interfaces.md

Test plan: https://github.com/dotnet/roslyn/issues/60968