### PR TITLE
Work around project system bug

### DIFF
--- a/src/Compilers/CSharp/CommandLine/CscCommandLine.projitems
+++ b/src/Compilers/CSharp/CommandLine/CscCommandLine.projitems
@@ -31,10 +31,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Program.cs" />
 
     <None Include="$(MSBuildThisFileDirectory)App.config" />
-    <None Include="$(MSBuildThisFileDirectory)csc.rsp" Condition="'$(TargetFramework)' == 'net472'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests" />
     
     <ProjectReference Include="..\..\Core\Portable\Microsoft.CodeAnalysis.csproj" />

--- a/src/Compilers/CSharp/csc-arm64/csc-arm64.csproj
+++ b/src/Compilers/CSharp/csc-arm64/csc-arm64.csproj
@@ -10,5 +10,13 @@
     <TargetFramework>net472</TargetFramework>
     <DisableNullableWarnings>true</DisableNullableWarnings>
   </PropertyGroup>
+
+  <!-- Can't put this in shared project due to https://github.com/dotnet/project-system/issues/8157 -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\CommandLine\csc.rsp" Condition="'$(TargetFramework)' == 'net472'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <Import Project="..\CommandLine\CscCommandLine.projitems" Label="Shared" />
 </Project>

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -6,5 +6,13 @@
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
+  
+  <!-- Can't put this in shared project due to https://github.com/dotnet/project-system/issues/8157 -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\CommandLine\csc.rsp" Condition="'$(TargetFramework)' == 'net472'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <Import Project="..\CommandLine\CscCommandLine.projitems" Label="Shared" />
 </Project>

--- a/src/Compilers/VisualBasic/CommandLine/VbcCommandLine.projitems
+++ b/src/Compilers/VisualBasic/CommandLine/VbcCommandLine.projitems
@@ -31,9 +31,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Program.cs" />
 
     <None Include="$(MSBuildThisFileDirectory)App.config" />
-    <None Include="$(MSBuildThisFileDirectory)vbc.rsp" Condition="'$(TargetFramework)' == 'net472'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
 
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests" />
 

--- a/src/Compilers/VisualBasic/vbc-arm64/vbc-arm64.csproj
+++ b/src/Compilers/VisualBasic/vbc-arm64/vbc-arm64.csproj
@@ -10,5 +10,13 @@
     <AssemblyName>vbc</AssemblyName>
     <DisableNullableWarnings>true</DisableNullableWarnings>
   </PropertyGroup>
+  
+  <!-- Can't put this in shared project due to https://github.com/dotnet/project-system/issues/8157 -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\CommandLine\vbc.rsp" Condition="'$(TargetFramework)' == 'net472'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <Import Project="..\CommandLine\VbcCommandLine.projitems" Label="Shared" />
 </Project>

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -6,5 +6,13 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
+  
+  <!-- Can't put this in shared project due to https://github.com/dotnet/project-system/issues/8157 -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\CommandLine\vbc.rsp" Condition="'$(TargetFramework)' == 'net472'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <Import Project="..\CommandLine\VbcCommandLine.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
The project system is not handling `<CopyToOutputDirectory>` correctly
when it comes from a shared project. This is causing us to overbuild
when building from VS (up to date check always fails). Working around
that by moving the items to the normal project files

https://github.com/dotnet/project-system/issues/8157