### PR TITLE
Allow creating SourceText from a StringBuilder

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/StringBuilderReaderTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/StringBuilderReaderTest.cs
@@ -1,0 +1,129 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Text
+{
+    public sealed class StringBuilderReaderTest
+    {
+        [Fact]
+        public void PeakRead()
+        {
+            var reader = CreateFromText("text");
+            Assert.Equal('t', reader.Read());
+            Assert.Equal('e', reader.Peek());
+            Assert.Equal('e', reader.Read());
+            Assert.Equal('x', reader.Read());
+            Assert.Equal('t', reader.Read());
+            Assert.Equal(-1, reader.Peek());
+            Assert.Equal(-1, reader.Read());
+        }
+
+        [Theory]
+        [InlineData(5, 0, 5, "bcdef", 5, 'g')]
+        [InlineData(5, 1, 2, "\0bc\0\0", 2, 'd')]
+        [InlineData(5, 2, 3, "\0\0bcd", 3, 'e')]
+        [InlineData(10, 2, 7, "\0\0bcdefgh\0", 7, -1)]
+        [InlineData(10, 2, 8, "\0\0bcdefgh\0", 7, -1)]
+        [InlineData(10, 3, 7, "\0\0\0bcdefgh", 7, -1)]
+        [InlineData(10, 3, 0, "\0\0\0\0\0\0\0\0\0\0", 0, 'b')]
+        [InlineData(10, 10, 0, "\0\0\0\0\0\0\0\0\0\0", 0, 'b')]
+        [InlineData(0, 0, 0, "", 0, 'b')]
+        public void ReadToArray(int bufferLength, int index, int count, string expected, int expectedResult, int expectedPeek)
+        {
+            testWithMethod(reader => reader.Read);
+            testWithMethod(reader => reader.ReadBlock);
+
+            void testWithMethod(Func<TextReader, ReadToArrayDelegate> readMethodAccessor)
+            {
+                using var reader = CreateFromText("abcdefgh");
+                var readMethod = readMethodAccessor(reader);
+
+                Assert.Equal('a', reader.Read());
+
+                var buffer = new char[bufferLength];
+                Assert.Equal(expectedResult, readMethod(buffer, index, count));
+                Assert.Equal(expected, new string(buffer));
+
+                Assert.Equal(expectedPeek, reader.Peek());
+            }
+        }
+
+#if NETCOREAPP
+        [Theory]
+        [InlineData(2, "bc", 2, 'd')]
+        [InlineData(7, "bcdefgh", 7, -1)]
+        [InlineData(10, "bcdefgh\0\0\0", 7, -1)]
+        [InlineData(0, "", 0, 'b')]
+        public void ReadToSpan(int bufferLength, string expected, int expectedResult, int expectedPeek)
+        {
+            testWithMethod(reader => reader.Read);
+            testWithMethod(reader => reader.ReadBlock);
+
+            void testWithMethod(Func<TextReader, ReadToSpanDelegate> readMethodAccessor)
+            {
+                using var reader = CreateFromText("abcdefgh");
+                var readMethod = readMethodAccessor(reader);
+
+                Assert.Equal('a', reader.Read());
+
+                var buffer = new char[bufferLength];
+                Assert.Equal(expectedResult, readMethod(buffer));
+                Assert.Equal(expected, new string(buffer));
+
+                Assert.Equal(expectedPeek, reader.Peek());
+            }
+        }
+#endif
+
+        [Fact]
+        public void ReadBufferInvalid()
+        {
+            testWithMethod(reader => reader.Read);
+            testWithMethod(reader => reader.ReadBlock);
+
+            void testWithMethod(Func<TextReader, ReadToArrayDelegate> readMethodAccessor)
+            {
+                using var reader = CreateFromText("abcdefgh");
+                var readMethod = readMethodAccessor(reader);
+
+                var buffer = new char[3];
+                Assert.ThrowsAny<ArgumentException>(() => readMethod(buffer, -1, 0));
+                Assert.ThrowsAny<ArgumentException>(() => readMethod(buffer, 0, -1));
+                Assert.ThrowsAny<ArgumentException>(() => readMethod(buffer, 0, 4));
+                Assert.ThrowsAny<ArgumentException>(() => readMethod(buffer, 3, 1));
+            }
+        }
+
+        [Fact]
+        public void ReadToEnd()
+        {
+            using (var reader1 = CreateFromText("text"))
+            {
+                Assert.Equal("text", reader1.ReadToEnd());
+                Assert.Equal(-1, reader1.Peek());
+                Assert.Equal("", reader1.ReadToEnd());
+            }
+
+            using (var reader2 = CreateFromText("text"))
+            {
+                Assert.Equal('t', reader2.Read());
+                Assert.Equal("ext", reader2.ReadToEnd());
+                Assert.Equal(-1, reader2.Peek());
+                Assert.Equal("", reader2.ReadToEnd());
+            }
+        }
+
+        private static StringBuilderReader CreateFromText(string text) =>
+            new(new StringBuilder(text));
+
+        private delegate int ReadToArrayDelegate(char[] buffer, int index, int count);
+        private delegate int ReadToSpanDelegate(Span<char> buffer);
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/Text/StringTextTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/StringTextTest.cs
@@ -49,9 +49,24 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void FromStringBuilder()
+        {
+            var data = SourceText.From(new StringBuilder("goo"), Encoding.UTF8);
+            Assert.Equal(1, data.Lines.Count);
+            Assert.Equal(3, data.Lines[0].Span.Length);
+        }
+
+        [Fact]
         public void FromString_DefaultEncoding()
         {
             var data = SourceText.From("goo");
+            Assert.Null(data.Encoding);
+        }
+
+        [Fact]
+        public void FromStringBuilder_DefaultEncoding()
+        {
+            var data = SourceText.From(new StringBuilder("goo"));
             Assert.Null(data.Encoding);
         }
 
@@ -64,17 +79,37 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void FromStringBuilderEmpty()
+        {
+            var data = SourceText.From(new StringBuilder());
+            Assert.Equal(1, data.Lines.Count);
+            Assert.Equal(0, data.Lines[0].Span.Length);
+        }
+
+        [Fact]
         public void FromString_Errors()
         {
-            Assert.Throws<ArgumentNullException>(() => SourceText.From((string)null, Encoding.UTF8));
+            Assert.Throws<ArgumentNullException>("text", () => SourceText.From((string)null, Encoding.UTF8));
+            Assert.Throws<ArgumentException>("checksumAlgorithm", () => SourceText.From("", Encoding.UTF8, checksumAlgorithm: SourceHashAlgorithm.None));
+            Assert.Throws<ArgumentException>("checksumAlgorithm", () => SourceText.From("", Encoding.UTF8, checksumAlgorithm: SourceHashAlgorithm.Sha256 + 1));
+        }
+
+        [Fact]
+        public void FromStringBuilder_Errors()
+        {
+            Assert.Throws<ArgumentNullException>("stringBuilder", () => SourceText.From((StringBuilder)null, Encoding.UTF8));
+            Assert.Throws<ArgumentException>("checksumAlgorithm", () => SourceText.From(new StringBuilder(), Encoding.UTF8, checksumAlgorithm: SourceHashAlgorithm.None));
+            Assert.Throws<ArgumentException>("checksumAlgorithm", () => SourceText.From(new StringBuilder(), Encoding.UTF8, checksumAlgorithm: SourceHashAlgorithm.Sha256 + 1));
         }
 
         [Fact]
         public void FromStream_Errors()
         {
-            Assert.Throws<ArgumentNullException>(() => SourceText.From((Stream)null, Encoding.UTF8));
-            Assert.Throws<ArgumentException>(() => SourceText.From(new TestStream(canRead: false, canSeek: true), Encoding.UTF8));
+            Assert.Throws<ArgumentNullException>("stream", () => SourceText.From((Stream)null, Encoding.UTF8));
+            Assert.Throws<ArgumentException>("stream", () => SourceText.From(new TestStream(canRead: false, canSeek: true), Encoding.UTF8));
             Assert.Throws<NotImplementedException>(() => SourceText.From(new TestStream(canRead: true, canSeek: false), Encoding.UTF8));
+            Assert.Throws<ArgumentException>("checksumAlgorithm", () => SourceText.From(new TestStream(canRead: true, canSeek: false), Encoding.UTF8, checksumAlgorithm: SourceHashAlgorithm.None));
+            Assert.Throws<ArgumentException>("checksumAlgorithm", () => SourceText.From(new TestStream(canRead: true, canSeek: false), Encoding.UTF8, checksumAlgorithm: SourceHashAlgorithm.Sha256 + 1));
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -66,6 +66,7 @@ const Microsoft.CodeAnalysis.WellKnownMemberNames.CheckedExplicitConversionName 
 Microsoft.CodeAnalysis.OperationKind.UTF8String = 124 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.Operations.IUTF8StringOperation
 Microsoft.CodeAnalysis.Operations.IUTF8StringOperation.Value.get -> string!
+static Microsoft.CodeAnalysis.Text.SourceText.From(System.Text.StringBuilder! stringBuilder, System.Text.Encoding? encoding = null, Microsoft.CodeAnalysis.Text.SourceHashAlgorithm checksumAlgorithm = Microsoft.CodeAnalysis.Text.SourceHashAlgorithm.Sha1) -> Microsoft.CodeAnalysis.Text.SourceText!
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor.VisitUTF8String(Microsoft.CodeAnalysis.Operations.IUTF8StringOperation! operation) -> void
 virtual Microsoft.CodeAnalysis.Operations.OperationVisitor<TArgument, TResult>.VisitUTF8String(Microsoft.CodeAnalysis.Operations.IUTF8StringOperation! operation, TArgument argument) -> TResult?
 virtual Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.DefaultVisit(Microsoft.CodeAnalysis.ISymbol! symbol, TArgument argument) -> TResult
@@ -89,5 +90,4 @@ virtual Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.VisitPointerTyp
 virtual Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.VisitProperty(Microsoft.CodeAnalysis.IPropertySymbol! symbol, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.VisitRangeVariable(Microsoft.CodeAnalysis.IRangeVariableSymbol! symbol, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.VisitTypeParameter(Microsoft.CodeAnalysis.ITypeParameterSymbol! symbol, TArgument argument) -> TResult
-
 Microsoft.CodeAnalysis.Operations.BinaryOperatorKind.UnsignedRightShift = 25 -> Microsoft.CodeAnalysis.Operations.BinaryOperatorKind

--- a/src/Compilers/Core/Portable/Text/StringBuilderReader.cs
+++ b/src/Compilers/Core/Portable/Text/StringBuilderReader.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.CodeAnalysis.Collections.Internal;
+
+namespace Microsoft.CodeAnalysis.Text
+{
+    internal sealed class StringBuilderReader : TextReader
+    {
+        private readonly StringBuilder _stringBuilder;
+        private int _position;
+
+        public StringBuilderReader(StringBuilder stringBuilder)
+        {
+            _stringBuilder = stringBuilder;
+            _position = 0;
+        }
+
+        public override int Peek()
+        {
+            if (_position == _stringBuilder.Length)
+                return -1;
+
+            return _stringBuilder[_position];
+        }
+
+        public override int Read()
+        {
+            if (_position == _stringBuilder.Length)
+                return -1;
+
+            return _stringBuilder[_position++];
+        }
+
+        public override int Read(char[] buffer, int index, int count)
+        {
+            var length = Math.Min(count, _stringBuilder.Length - _position);
+            _stringBuilder.CopyTo(_position, buffer, index, length);
+            _position += length;
+            return length;
+        }
+
+        public override int ReadBlock(char[] buffer, int index, int count) =>
+            Read(buffer, index, count);
+
+#if NETCOREAPP
+        public override int Read(Span<char> buffer)
+        {
+            var length = Math.Min(buffer.Length, _stringBuilder.Length - _position);
+            _stringBuilder.CopyTo(_position, buffer, length);
+            _position += length;
+            return length;
+        }
+
+        public override int ReadBlock(Span<char> buffer) =>
+            Read(buffer);
+#endif
+
+        public override string ReadToEnd()
+        {
+            var result = _position == 0
+                ? _stringBuilder.ToString()
+                : _stringBuilder.ToString(_position, _stringBuilder.Length - _position);
+
+            _position = _stringBuilder.Length;
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Alternative to #49689 (tagging @chsienki, @jaredpar, @jasonmalinowski)
Fixes #49082

Source generators often build up the source code using `StringBuilder`. There's currently no overload of `AddSource` or `SourceText.From` that takes a `StringBuilder`, so users either have to use `ToString()`, which can problematic for very large strings or provide their own `TextReader` over a `StringBuilder` to do it correctly.

#### Alternative to this PR
As opposed to being able to create a `SourceText` from a `StringBuilder`, `SourceTextWriter` could be improved and made public and users could be encouraged to build up the generated source code that way as opposed to using a `StringBuilder`. That way, we could avoid the final copy of the data from the builder to the final source code. In source generators, perf really matters, so this could be a worthwhile alternative.

#### Questions
In addition to this, should we also add an overload to `GeneratorExecutionContext.AddSource` that takes a `StringBuilder`, as the previous PR did? It could be a shortcut to `SourceText.From(StringBuilder)` for better discoverability when writing source generators.