### PR TITLE
Move off of IOperation in speculation analyzer.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
@@ -39,6 +39,10 @@ class Program
         [Fact, WorkItem(672396, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/672396")]
         public void SpeculationAnalyzerExtensionMethodExplicitInvocation()
         {
+            // We consider a change here to be a change in semantics as an instance call became a static call. In
+            // practice this is fine as the only thing that makes this change is complexification, and we don't test for
+            // semantics changed after that as the purpose of complexification is to put us in a safe place to make
+            // changes that won't break semantics.
             Test(@"
 static class Program
 {

--- a/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
@@ -47,7 +47,7 @@ static class Program
     {
         [|5.Vain()|];
     }
-}           ", "Vain(5)", false);
+}           ", "Vain(5)", semanticChanges: true);
         }
 
         [Fact]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
@@ -64,6 +64,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         protected override CodeAnalysis.LanguageServices.ISyntaxFacts SyntaxFactsService { get; } = CSharpSyntaxFacts.Instance;
 
+        protected override bool CanAccessInstanceMemberThrough(ExpressionSyntax expression)
+            => expression.Kind() is SyntaxKind.ThisExpression or SyntaxKind.BaseExpression;
+
         protected override SyntaxNode GetSemanticRootForSpeculation(ExpressionSyntax expression)
         {
             Debug.Assert(expression != null);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/SpeculationAnalyzer.cs
@@ -9,7 +9,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Xml.Serialization;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -31,6 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
         ArgumentSyntax,
         CommonForEachStatementSyntax,
         ThrowStatementSyntax,
+        InvocationExpressionSyntax,
         Conversion>
     {
         /// <summary>
@@ -58,6 +61,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             : base(expression, newExpression, semanticModel, cancellationToken, skipVerificationForReplacedNode, failOnOverloadResolutionFailuresInOriginalCode)
         {
         }
+
+        protected override CodeAnalysis.LanguageServices.ISyntaxFacts SyntaxFactsService { get; } = CSharpSyntaxFacts.Instance;
 
         protected override SyntaxNode GetSemanticRootForSpeculation(ExpressionSyntax expression)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -626,19 +626,10 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             if (originalInvocation is null && newInvocation is null)
                 return true;
 
-            // Invocations must stay invocations after update.
             if (originalInvocation is not null)
             {
                 // Invocations must stay invocations after update.
                 if (newInvocation is null)
-                    return false;
-
-                var originalInvokedExpr = this.SyntaxFactsService.GetExpressionOfInvocationExpression(originalInvocation);
-                var newInvokedExpr = this.SyntaxFactsService.GetExpressionOfInvocationExpression(newInvocation);
-
-                // Ensure we're still calling this off the same symbol.  If instance changed to static or vice/versa
-                // this will fail.
-                if (!SymbolsAreCompatible(originalInvokedExpr, newInvokedExpr, requireNonNullSymbols: false))
                     return false;
 
                 // Add more invocation tests here.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -622,7 +622,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             return true;
         }
 
-        private static bool IsStaticAccess(ISymbol symbol)
+        private static bool IsStaticAccess(ISymbol? symbol)
             => symbol is INamespaceOrTypeSymbol or { IsStatic: true };
 
         private bool InvocationsAreCompatible(TInvocationExpressionSyntax? originalInvocation, TInvocationExpressionSyntax? newInvocation)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -92,6 +92,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         }
 
         protected abstract ISyntaxFacts SyntaxFactsService { get; }
+        protected abstract bool CanAccessInstanceMemberThrough(TExpressionSyntax expression);
 
         /// <summary>
         /// Original expression to be replaced.
@@ -609,11 +610,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     !originalSymbol.IsStatic)
                 {
                     var originalExpressionOfMemberAccess = syntaxFacts.GetExpressionOfMemberAccessExpression(originalExpression);
-                    if (!syntaxFacts.IsThisExpression(originalExpressionOfMemberAccess) &&
-                            !syntaxFacts.IsBaseExpression(originalExpressionOfMemberAccess))
-                    {
+                    if (!CanAccessInstanceMemberThrough((TExpressionSyntax?)originalExpressionOfMemberAccess))
                         return false;
-                    }
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AbstractSpeculationAnalyzer.cs
@@ -631,7 +631,6 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             if (originalInvocation is null && newInvocation is null)
                 return true;
 
-
             if (originalInvocation is not null)
             {
                 // Invocations must stay invocations after update.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Utilities/SpeculationAnalyzer.vb
@@ -4,6 +4,7 @@
 
 Imports System.Collections.Immutable
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.VisualBasic.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
@@ -22,6 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
             ArgumentSyntax,
             ForEachStatementSyntax,
             ThrowStatementSyntax,
+            InvocationExpressionSyntax,
             Conversion)
 
         ''' <summary>
@@ -42,6 +44,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
         Public Sub New(expression As ExpressionSyntax, newExpression As ExpressionSyntax, semanticModel As SemanticModel, cancellationToken As CancellationToken, Optional skipVerificationForReplacedNode As Boolean = False, Optional failOnOverloadResolutionFailuresInOriginalCode As Boolean = False)
             MyBase.New(expression, newExpression, semanticModel, cancellationToken, skipVerificationForReplacedNode, failOnOverloadResolutionFailuresInOriginalCode)
         End Sub
+
+        Protected Overrides ReadOnly Property SyntaxFactsService As CodeAnalysis.LanguageServices.ISyntaxFacts = VisualBasicSyntaxFacts.Instance
 
         Protected Overrides Function GetSemanticRootForSpeculation(expression As ExpressionSyntax) As SyntaxNode
             Debug.Assert(expression IsNot Nothing)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Utilities/SpeculationAnalyzer.vb
@@ -46,6 +46,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
         End Sub
 
         Protected Overrides ReadOnly Property SyntaxFactsService As CodeAnalysis.LanguageServices.ISyntaxFacts = VisualBasicSyntaxFacts.Instance
+        Protected Overrides Function CanAccessInstanceMemberThrough(expression As ExpressionSyntax) As Boolean
+            ' vb can reference an instance member by just writing `.X` (when in a 'with' block), or by writing Me.X,
+            ' MyBase.X and MyClass.X (the latter is not just for accessing static members).
+            Return expression Is Nothing OrElse expression.IsKind(SyntaxKind.MeExpression, SyntaxKind.MyBaseExpression, SyntaxKind.MyClassExpression)
+        End Function
 
         Protected Overrides Function GetSemanticRootForSpeculation(expression As ExpressionSyntax) As SyntaxNode
             Debug.Assert(expression IsNot Nothing)


### PR DESCRIPTION
Fixes [AB#1531976](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1531976)

IOp is turning out to be too slow for our needs.  So this replaces the existing logic with logic that uses the old school syntax+semantic-model approach.