### PR TITLE
Add support for frozen-partial projects, and have skeleton assemblies work effectively for them

### DIFF
--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -81,8 +81,19 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             ImmutableArray<(SymbolKey symbolKey, int lineNumber)> symbolKeyAndLineNumbers,
             CancellationToken cancellationToken)
         {
+            if (documentForGlobalImports != null)
+            {
+                documentForGlobalImports = documentForGlobalImports.WithFrozenPartialSemantics(cancellationToken);
+                project = documentForGlobalImports.Project;
+            }
+            else
+            {
+                project = project.WithFrozenPartialSemantics(cancellationToken);
+            }
+
             var solution = project.Solution;
             var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+
             using var _ = ArrayBuilder<InheritanceMarginItem>.GetInstance(out var builder);
 
             if (documentForGlobalImports != null)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis
             if (workspace.PartialSemanticsEnabled &&
                 this.Project.SupportsCompilation)
             {
-                var newSolution = this.Project.Solution.WithFrozenPartialCompilationIncludingSpecificDocument(this.Id, cancellationToken);
+                var newSolution = this.Project.Solution.WithFrozenPartialCompilationIncludingSpecificDocument(this.Id.ProjectId, this.Id, cancellationToken);
                 return newSolution.GetDocument(this.Id)!;
             }
             else

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1640,16 +1640,16 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Creates a branch of the solution that has its compilations frozen in whatever state they are in at the time, assuming a background compiler is
-        /// busy building this compilations.
-        /// 
-        /// A compilation for the project containing the specified document id will be guaranteed to exist with at least the syntax tree for the document.
-        /// 
+        /// Creates a branch of the solution that has its compilations frozen in whatever state they are in at the time,
+        /// assuming a background compiler is busy building this compilations.
+        /// <para/> If <paramref name="documentId"/> is provided, a compilation for the project containing the specified
+        /// document id will be guaranteed to exist with at least the syntax tree for the document.
+        /// <para/>
         /// This not intended to be the public API, use Document.WithFrozenPartialSemantics() instead.
         /// </summary>
-        internal Solution WithFrozenPartialCompilationIncludingSpecificDocument(DocumentId documentId, CancellationToken cancellationToken)
+        internal Solution WithFrozenPartialCompilationIncludingSpecificDocument(ProjectId projectId, DocumentId? documentId, CancellationToken cancellationToken)
         {
-            var newState = _state.WithFrozenPartialCompilationIncludingSpecificDocument(documentId, cancellationToken);
+            var newState = _state.WithFrozenPartialCompilationIncludingSpecificDocument(projectId, documentId, cancellationToken);
             return new Solution(newState);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.GeneratedFileReplacingCompilationTracker.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis
                 throw new NotImplementedException();
             }
 
-            public ICompilationTracker FreezePartialStateWithTree(SolutionState solution, DocumentState docState, SyntaxTree tree, CancellationToken cancellationToken)
+            public ICompilationTracker FreezePartialStateWithTree(SolutionState solution, DocumentState? docState, SyntaxTree? tree, CancellationToken cancellationToken)
             {
                 // Because we override SourceGeneratedDocument.WithFrozenPartialSemantics directly, we shouldn't be able to get here.
                 throw ExceptionUtilities.Unreachable;
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis
                     await UnderlyingTracker.GetDependentChecksumAsync(solution, cancellationToken).ConfigureAwait(false),
                     await _replacedGeneratedDocumentState.GetChecksumAsync(cancellationToken).ConfigureAwait(false));
 
-            public CompilationReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference)
+            public MetadataReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference)
             {
                 // This method is used if you're forking a solution with partial semantics, and used to quickly produce references.
                 // So this method should only be called if:

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.ICompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.ICompilationTracker.cs
@@ -34,14 +34,14 @@ namespace Microsoft.CodeAnalysis
             /// </remarks>
             bool ContainsAssemblyOrModuleOrDynamic(ISymbol symbol, bool primary);
             ICompilationTracker Fork(SolutionServices solutionServices, ProjectState newProject, CompilationAndGeneratorDriverTranslationAction? translate = null, CancellationToken cancellationToken = default);
-            ICompilationTracker FreezePartialStateWithTree(SolutionState solution, DocumentState docState, SyntaxTree tree, CancellationToken cancellationToken);
+            ICompilationTracker FreezePartialStateWithTree(SolutionState solution, DocumentState? docState, SyntaxTree? tree, CancellationToken cancellationToken);
             Task<Compilation> GetCompilationAsync(SolutionState solution, CancellationToken cancellationToken);
 
             Task<VersionStamp> GetDependentVersionAsync(SolutionState solution, CancellationToken cancellationToken);
             Task<VersionStamp> GetDependentSemanticVersionAsync(SolutionState solution, CancellationToken cancellationToken);
             Task<Checksum> GetDependentChecksumAsync(SolutionState solution, CancellationToken cancellationToken);
 
-            CompilationReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference);
+            MetadataReference? GetPartialMetadataReference(ProjectState fromProject, ProjectReference projectReference);
             ValueTask<TextDocumentStates<SourceGeneratedDocumentState>> GetSourceGeneratedDocumentStatesAsync(SolutionState solution, CancellationToken cancellationToken);
             ValueTask<ImmutableArray<Diagnostic>> GetSourceGeneratorDiagnosticsAsync(SolutionState solution, CancellationToken cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -101,6 +101,9 @@ internal partial class SolutionState
             }
         }
 
+        public MetadataReference? TryGetAlreadyPresentMetadataReference(MetadataReferenceProperties properties)
+            => _skeletonReferenceSet?.TryGetAlreadyPresentMetadataReference(properties);
+
         public async Task<MetadataReference?> GetOrBuildReferenceAsync(
             ICompilationTracker compilationTracker,
             SolutionState solution,
@@ -265,6 +268,18 @@ internal partial class SolutionState
                 _documentationProvider = documentationProvider;
             }
 
+            public MetadataReference? TryGetAlreadyPresentMetadataReference(MetadataReferenceProperties properties)
+            {
+                // lookup first and eagerly return cached value if we have it.
+                lock (_metadataReferences)
+                {
+                    if (TryGetExisting_NoLock(properties, out var metadataReference))
+                        return metadataReference;
+                }
+
+                return null;
+            }
+
             public MetadataReference? GetMetadataReference(MetadataReferenceProperties properties)
             {
                 // lookup first and eagerly return cached value if we have it.
@@ -290,21 +305,21 @@ internal partial class SolutionState
 
                     return metadataReference;
                 }
+            }
 
-                bool TryGetExisting_NoLock(MetadataReferenceProperties properties, out MetadataReference? metadataReference)
-                {
-                    metadataReference = null;
-                    if (!_metadataReferences.TryGetValue(properties, out var weakMetadata))
-                        return false;
+            private bool TryGetExisting_NoLock(MetadataReferenceProperties properties, out MetadataReference? metadataReference)
+            {
+                metadataReference = null;
+                if (!_metadataReferences.TryGetValue(properties, out var weakMetadata))
+                    return false;
 
-                    // If we are pointing at a null-weak reference (not a weak reference that points to null), then we 
-                    // know we failed to create the metadata the last time around, and we can shortcircuit immediately,
-                    // returning null *with* success to bubble that up.
-                    if (weakMetadata == null)
-                        return true;
+                // If we are pointing at a null-weak reference (not a weak reference that points to null), then we 
+                // know we failed to create the metadata the last time around, and we can shortcircuit immediately,
+                // returning null *with* success to bubble that up.
+                if (weakMetadata == null)
+                    return true;
 
-                    return weakMetadata.TryGetTarget(out metadataReference);
-                }
+                return weakMetadata.TryGetTarget(out metadataReference);
             }
 
             private MetadataReference? CreateReference(ImmutableArray<string> aliases, bool embedInteropTypes, DocumentationProvider documentationProvider)


### PR DESCRIPTION
This PR has three main concepts:

The first is being able to get a frozen-partial solution from an initial Project instance, not just a Document instance.  This is needed by InheritanceMargin (which works on projects due to how it can work in a MAS context).  Specifically, inheritance margin may be initially invoked in a MAS document, but it operates on the solution snapshot the user created the MAS document from so it can find inherited symbols in teh users own solution.

The second is htat we now allow skeleton references to be reused in frozen-partial scenarios.  Now, if we have a frozen partial project, and it has a p2p reference to a different language, we'll just reuse whatever skeleton we built for that language last, not caring if it is up to date or not with teh compilation for that project.  This allows some amount of semantics to flow p2p, without taking on the full cost of producing the full skeleton.

The last is that the remote side of inheritance margin is now updated to use frozen-partial for the data it is operating on. This will hopefully get it to consume far less work producing skeletons in the p2p case.