### PR TITLE
Make static respect modifier order

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/MakeMemberStatic/CSharpMakeMemberStaticCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MakeMemberStatic/CSharpMakeMemberStaticCodeFixProvider.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.LanguageServices;
-using Microsoft.CodeAnalysis.CSharp.OrderModifiers;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MakeMemberStatic;
@@ -23,11 +22,17 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMemberStatic
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpMakeMemberStaticCodeFixProvider()
-            : base(CSharpSyntaxFacts.Instance, CSharpCodeStyleOptions.PreferredModifierOrder, CSharpOrderModifiersHelper.Instance)
+            : base(CSharpSyntaxFacts.Instance, CSharpCodeStyleOptions.PreferredModifierOrder)
         {
         }
 
         protected override SyntaxToken StaticModifier => SyntaxFactory.Token(SyntaxKind.StaticKeyword);
+
+        protected override int GetKeywordRawKind(string trimmed)
+        {
+            var kind = SyntaxFacts.GetKeywordKind(trimmed);
+            return (int)(kind == SyntaxKind.None ? SyntaxFacts.GetContextualKeywordKind(trimmed) : kind);
+        }
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
             ImmutableArray.Create(

--- a/src/Analyzers/CSharp/CodeFixes/MakeMemberStatic/CSharpMakeMemberStaticCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MakeMemberStatic/CSharpMakeMemberStaticCodeFixProvider.cs
@@ -8,6 +8,9 @@ using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.LanguageServices;
+using Microsoft.CodeAnalysis.CSharp.OrderModifiers;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MakeMemberStatic;
@@ -20,8 +23,11 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMemberStatic
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpMakeMemberStaticCodeFixProvider()
+            : base(CSharpSyntaxFacts.Instance, CSharpCodeStyleOptions.PreferredModifierOrder, CSharpOrderModifiersHelper.Instance)
         {
         }
+
+        protected override SyntaxToken StaticModifier => SyntaxFactory.Token(SyntaxKind.StaticKeyword);
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
             ImmutableArray.Create(

--- a/src/Analyzers/CSharp/Tests/MakeMemberStatic/MakeMemberStaticTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeMemberStatic/MakeMemberStaticTests.cs
@@ -248,5 +248,25 @@ public static class Foo
 
             await TestAsync(testCode, fixedCode);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
+        public async Task TestNoOtherModifiers()
+        {
+            var testCode = @"
+public static class Foo
+{
+    void {|CS0708:Test|}() { }
+}
+";
+
+            var fixedCode = @"
+public static class Foo
+{
+    static void Test() { }
+}
+";
+
+            await TestAsync(testCode, fixedCode);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/MakeMemberStatic/MakeMemberStaticTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeMemberStatic/MakeMemberStaticTests.cs
@@ -268,5 +268,28 @@ public static class Foo
 
             await TestAsync(testCode, fixedCode);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
+        public async Task TestNoStaticDefined()
+        {
+            var testCode = @"
+public static class Foo
+{
+    public async System.Threading.Tasks.Task {|CS0708:Test|}() { }
+}
+";
+
+            var fixedCode = @"
+public static class Foo
+{
+    public async static System.Threading.Tasks.Task Test() { }
+}
+";
+
+            var customModifierOrder = "public, private, protected, internal, extern, new, virtual, abstract, " +
+                "sealed, override, readonly, unsafe, volatile, async";
+
+            await TestAsync(testCode, fixedCode, customModifierOrder);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/MakeMemberStatic/MakeMemberStaticTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeMemberStatic/MakeMemberStaticTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.MakeMemberStatic;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -18,6 +19,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MakeMemberStatic
 
     public class MakeMemberStaticTests
     {
+        private static async Task TestAsync(string testCode, string fixedCode, string? customModifierOrder = null)
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = testCode,
+                FixedCode = fixedCode,
+                Options =
+                {
+                    { CSharpCodeStyleOptions.PreferredModifierOrder,
+                        customModifierOrder ?? CSharpCodeStyleOptions.PreferredModifierOrder.DefaultValue.Value }
+                }
+            }.RunAsync();
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
         public async Task TestField()
         {
@@ -128,6 +143,70 @@ public static class Foo
         static event System.Action E;
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
+        public async Task TestModifierOrder_DefaultOrder()
+        {
+            var testCode = @"
+public static class Foo
+{
+    public void {|CS0708:Test|}() { }
+}
+";
+
+            var fixedCode = @"
+public static class Foo
+{
+    public static void Test() { }
+}
+";
+
+            await TestAsync(testCode, fixedCode);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
+        public async Task TestModifierOrder_CustomOrder1()
+        {
+            var testCode = @"
+public static class Foo
+{
+    public void {|CS0708:Test|}() { }
+}
+";
+
+            var fixedCode = @"
+public static class Foo
+{
+    static public void Test() { }
+}
+";
+            var customModifierOrder = "static, public, private, protected, internal, extern, new, virtual, " +
+                "abstract, sealed, override, readonly, unsafe, volatile, async";
+
+            await TestAsync(testCode, fixedCode, customModifierOrder);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
+        public async Task TestModifierOrder_CustomOrder2()
+        {
+            var testCode = @"
+public static class Foo
+{
+    public async System.Threading.Tasks.Task {|CS0708:Test|}() { }
+}
+";
+
+            var fixedCode = @"
+public static class Foo
+{
+    public async static System.Threading.Tasks.Task Test() { }
+}
+";
+            var customModifierOrder = "public, private, protected, internal, extern, new, virtual, abstract, " +
+                "sealed, override, readonly, unsafe, volatile, async, static";
+
+            await TestAsync(testCode, fixedCode, customModifierOrder);
         }
     }
 }

--- a/src/Analyzers/CSharp/Tests/MakeMemberStatic/MakeMemberStaticTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeMemberStatic/MakeMemberStaticTests.cs
@@ -146,7 +146,7 @@ public static class Foo
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
-        public async Task TestModifierOrder_DefaultOrder()
+        public async Task TestDefaultOrder()
         {
             var testCode = @"
 public static class Foo
@@ -166,7 +166,7 @@ public static class Foo
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
-        public async Task TestModifierOrder_CustomOrder1()
+        public async Task TestCustomOrderStart()
         {
             var testCode = @"
 public static class Foo
@@ -188,7 +188,7 @@ public static class Foo
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
-        public async Task TestModifierOrder_CustomOrder2()
+        public async Task TestCustomOrderEnd()
         {
             var testCode = @"
 public static class Foo
@@ -207,6 +207,46 @@ public static class Foo
                 "sealed, override, readonly, unsafe, volatile, async, static";
 
             await TestAsync(testCode, fixedCode, customModifierOrder);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
+        public async Task TestWrongInitialOrder()
+        {
+            var testCode = @"
+public static class Foo
+{
+    async public System.Threading.Tasks.Task {|CS0708:Test|}() { }
+}
+";
+
+            var fixedCode = @"
+public static class Foo
+{
+    async public static System.Threading.Tasks.Task Test() { }
+}
+";
+
+            await TestAsync(testCode, fixedCode);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMemberStatic)]
+        public async Task TestTriviaBetweenModifiers()
+        {
+            var testCode = @"
+public static class Foo
+{
+    public /* trivia */ async System.Threading.Tasks.Task {|CS0708:Test|}() { }
+}
+";
+
+            var fixedCode = @"
+public static class Foo
+{
+    public /* trivia */ static async System.Threading.Tasks.Task Test() { }
+}
+";
+
+            await TestAsync(testCode, fixedCode);
         }
     }
 }

--- a/src/Analyzers/Core/CodeFixes/MakeMemberStatic/AbstractMakeMemberStaticCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/MakeMemberStatic/AbstractMakeMemberStaticCodeFixProvider.cs
@@ -5,17 +5,40 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.OrderModifiers;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.MakeMemberStatic
 {
     internal abstract class AbstractMakeMemberStaticCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
+        private readonly ISyntaxFacts _syntaxFacts;
+        private readonly Option2<CodeStyleOption2<string>> _option;
+        private readonly AbstractOrderModifiersHelpers _helpers;
+
+        protected AbstractMakeMemberStaticCodeFixProvider(
+            ISyntaxFacts syntaxFacts,
+            Option2<CodeStyleOption2<string>> option,
+            AbstractOrderModifiersHelpers helpers)
+        {
+            _syntaxFacts = syntaxFacts;
+            _option = option;
+            _helpers = helpers;
+        }
+
+        protected abstract SyntaxToken StaticModifier { get; }
+
         protected abstract bool TryGetMemberDeclaration(SyntaxNode node, [NotNullWhen(true)] out SyntaxNode? memberDeclaration);
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
@@ -29,22 +52,44 @@ namespace Microsoft.CodeAnalysis.MakeMemberStatic
             return Task.CompletedTask;
         }
 
-        protected sealed override Task FixAllAsync(Document document, ImmutableArray<Diagnostic> diagnostics, SyntaxEditor editor,
+        protected sealed override async Task FixAllAsync(Document document, ImmutableArray<Diagnostic> diagnostics, SyntaxEditor editor,
             CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
         {
+            var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var option = document.Project.AnalyzerOptions.GetOption(_option, tree, cancellationToken);
+
+            if (!_helpers.TryGetOrComputePreferredOrder(option.Value, out var preferredOrder))
+            {
+                return;
+            }
+
             for (var i = 0; i < diagnostics.Length; i++)
             {
                 var declaration = diagnostics[i].Location.FindNode(cancellationToken);
 
                 if (TryGetMemberDeclaration(declaration, out var memberDeclaration))
                 {
-                    var generator = SyntaxGenerator.GetGenerator(document);
-                    var newNode = generator.WithModifiers(memberDeclaration, generator.GetModifiers(declaration).WithIsStatic(true));
+                    var modifiers = _syntaxFacts.GetModifiers(memberDeclaration).Add(StaticModifier);
+                    if (!AbstractOrderModifiersHelpers.IsOrdered(preferredOrder, modifiers))
+                    {
+                        modifiers = new SyntaxTokenList(modifiers.OrderBy(CompareModifiers)
+                            .Select((token, index) => token.WithTriviaFrom(modifiers[index])));
+                    }
+
+                    var newNode = _syntaxFacts.WithModifiers(memberDeclaration, modifiers);
                     editor.ReplaceNode(declaration, newNode);
                 }
             }
 
-            return Task.CompletedTask;
+            return;
+
+            // Local functions
+
+            int CompareModifiers(SyntaxToken t1, SyntaxToken t2)
+                => GetOrder(t1) - GetOrder(t2);
+
+            int GetOrder(SyntaxToken token)
+                => preferredOrder.TryGetValue(token.RawKind, out var value) ? value : int.MaxValue;
         }
     }
 }

--- a/src/Analyzers/Core/CodeFixes/MakeMemberStatic/AbstractMakeMemberStaticCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/MakeMemberStatic/AbstractMakeMemberStaticCodeFixProvider.cs
@@ -93,6 +93,8 @@ namespace Microsoft.CodeAnalysis.MakeMemberStatic
 
             if (!modifierBeforeStaticRawKind.HasValue)
             {
+                // When the static modifier is added at the beginning of the modifiers it needs to
+                // get the leading trivia from the previous first modifier
                 return new SyntaxTokenList(StaticModifier.WithLeadingTrivia(modifiers[0].LeadingTrivia),
                     modifiers[0].WithoutLeadingTrivia()).AddRange(modifiers.Skip(1));
             }


### PR DESCRIPTION
This pull request makes `AbstractMakeMemberStaticCodeFixProvider` take into account user defined preference `csharp_preferred_modifier_order` from .editorconfig file when adding the static modifiers. If no preference is provided, the default order for that rule is used. 

The current behavior is as follows:
- When `csharp_preferred_modifier_order` contains the modifier static, the code fix provider will add the modifier after the closest on the left modifier from the static keyword (eg. with preferred modifier order of `public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async` it tries to place the modifier static immediately after internal, if internal is not specified then protected gets checked next etc...)
- When `csharp_preferred_modifier_order` doesn't contain the modifier static (is that even valid?) it gets placed at the end of all modifiers

Added several tests for covering these scenarios.

Fixes #60903 

Please let me know if the behavior is not what you would expect, or if the code is not up to your standards.