### PR TITLE
Fix crash when a multi-line raw literal becomes a skipped token.

### DIFF
--- a/src/Workspaces/CSharpTest/EmbeddedLanguages/VirtualChars/CSharpVirtualCharServiceTests.cs
+++ b/src/Workspaces/CSharpTest/EmbeddedLanguages/VirtualChars/CSharpVirtualCharServiceTests.cs
@@ -106,6 +106,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.VirtualChars
             return true;
         }
 
+        [Fact, WorkItem(61270, "https://github.com/dotnet/roslyn/issues/61270")]
+        public void TestRawStringInSkippedToken()
+        {
+            var text = """"
+                namespace N
+                {
+                    """
+                    goo
+                    """
+                }
+                """";
+
+            var tree = SyntaxFactory.ParseSyntaxTree(text);
+            var compilationUnit = (CompilationUnitSyntax)tree.GetRoot();
+            var namespaceDeclaration = (NamespaceDeclarationSyntax)compilationUnit.Members[0];
+            var skippedTrivia = namespaceDeclaration.OpenBraceToken.TrailingTrivia.Single(t => t.Kind() is SyntaxKind.SkippedTokensTrivia);
+            var virtualChars = CSharpVirtualCharService.Instance.TryConvertToVirtualChars(skippedTrivia.Token);
+            Assert.True(virtualChars.IsDefault);
+        }
+
         [Fact]
         public void TestEmptyString()
             => Test("\"\"", "");

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/EmbeddedLanguages/VirtualChars/CSharpVirtualCharService.cs
@@ -78,7 +78,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.VirtualChars
 
                 case SyntaxKind.MultiLineRawStringLiteralToken:
                 case SyntaxKind.UTF8MultiLineRawStringLiteralToken:
-                    return TryConvertMultiLineRawStringToVirtualChars(token, (LiteralExpressionSyntax)token.GetRequiredParent(), tokenIncludeDelimiters: true);
+                    return token.GetRequiredParent() is LiteralExpressionSyntax literalExpression
+                        ? TryConvertMultiLineRawStringToVirtualChars(token, literalExpression, tokenIncludeDelimiters: true)
+                        : default;
 
                 case SyntaxKind.InterpolatedStringTextToken:
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/61270