### PR TITLE
Change VB language version Roslyn.sln uses to "latest"

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -173,7 +173,7 @@
     <!-- VB specific settings -->
     <When Condition="'$(Language)' == 'VB'">
       <PropertyGroup>
-        <LangVersion>16</LangVersion>
+        <LangVersion>latest</LangVersion>
         <NoWarn>$(NoWarn);40057</NoWarn>
         <VBRuntime>Embed</VBRuntime>
       </PropertyGroup>


### PR DESCRIPTION
To allow us to use the latest VB features, such as setting init-only properties.