### PR TITLE
Disable smart copy/paste when line-copy is involved.

### DIFF
--- a/src/EditorFeatures/CSharp/StringCopyPaste/StringCopyPasteCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/StringCopyPaste/StringCopyPasteCommandHandler.cs
@@ -121,6 +121,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.StringCopyPaste
             if (documentBeforePaste == null || documentAfterPaste == null)
                 return;
 
+            // See if we can determine the information about the code the user copied from.
+            var copyPasteService = documentBeforePaste.Project.Solution.Workspace.Services.GetService<IStringCopyPasteService>();
+            if (copyPasteService is null)
+                return;
+
+            // If that last thing copied was a line copy (or we can't even figure out what it was), don't do
+            // anything.  There is special handling for line copy/paste that we don't want to interfere with.
+            var lastCopyIsLineCopy = copyPasteService.LastCopyWasLineCopy();
+            if (lastCopyIsLineCopy is true or null)
+                return;
+
             var cancellationToken = executionContext.OperationContext.UserCancellationToken;
 
             // When pasting, only do anything special if the user selections were entirely inside a single string
@@ -209,10 +220,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.StringCopyPaste
                 if (selectionsBeforePaste.Count != 1)
                     return default;
 
-                // See if we can determine the information about the code the user copied from.
-                var service = documentBeforePaste.Project.Solution.Workspace.Services.GetService<IStringCopyPasteService>();
-
-                var clipboardData = service?.TryGetClipboardData(KeyAndVersion);
+                var clipboardData = copyPasteService?.TryGetClipboardData(KeyAndVersion);
                 var copyPasteData = StringCopyPasteData.FromJson(clipboardData);
 
                 if (copyPasteData == null)

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/TestStringCopyPasteService.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/TestStringCopyPasteService.cs
@@ -19,6 +19,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
         private string? _key;
         private string? _data;
 
+        public bool? LastCopyWasLineCopyData;
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public TestStringCopyPasteService()
@@ -34,5 +36,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
 
         public string? TryGetClipboardData(string key)
             => _key == key ? _data : null;
+
+        public bool? LastCopyWasLineCopy
+            => this.LastCopyWasLineCopyData;
     }
 }

--- a/src/EditorFeatures/Core.Wpf/StringCopyPaste/WpfStringCopyPasteService.cs
+++ b/src/EditorFeatures/Core.Wpf/StringCopyPaste/WpfStringCopyPasteService.cs
@@ -13,6 +13,10 @@ namespace Microsoft.CodeAnalysis.Editor.StringCopyPaste
     [ExportWorkspaceService(typeof(IStringCopyPasteService), ServiceLayer.Host), Shared]
     internal class WpfStringCopyPasteService : IStringCopyPasteService
     {
+        // Value from:
+        // https://devdiv.visualstudio.com/DevDiv/_git/VS-Platform?path=/src/Editor/Text/Impl/EditorOperations/EditorOperations.cs&version=GBmain&line=84&lineEnd=85&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
+        private const string ClipboardLineBasedCutCopyTag = "VisualStudioEditorOperationsLineCutCopyClipboardTag";
+
         private const string RoslynFormat = nameof(RoslynFormat);
 
         [ImportingConstructor]
@@ -23,6 +27,25 @@ namespace Microsoft.CodeAnalysis.Editor.StringCopyPaste
 
         private static string GetFormat(string key)
             => $"{RoslynFormat}-{key}";
+
+        public bool? LastCopyWasLineCopy
+        {
+            get
+            {
+                try
+                {
+                    var dataObject = Clipboard.GetDataObject();
+
+                    return dataObject.GetDataPresent(ClipboardLineBasedCutCopyTag) &&
+                        dataObject.GetData(ClipboardLineBasedCutCopyTag) is bool value && value;
+                }
+                catch (Exception ex) when (FatalError.ReportAndCatch(ex, ErrorSeverity.Critical))
+                {
+                }
+
+                return null;
+            }
+        }
 
         public bool TrySetClipboardData(string key, string data)
         {

--- a/src/EditorFeatures/Core/StringCopyPaste/IStringCopyPasteService.cs
+++ b/src/EditorFeatures/Core/StringCopyPaste/IStringCopyPasteService.cs
@@ -11,6 +11,12 @@ namespace Microsoft.CodeAnalysis.Editor.StringCopyPaste
 {
     internal interface IStringCopyPasteService : IWorkspaceService
     {
+        /// <summary>
+        /// Returns true or false if the last copy is known to be a line copy or not.  Returns null if it can't be
+        /// determined.
+        /// </summary>
+        bool? LastCopyWasLineCopy { get; }
+
         bool TrySetClipboardData(string key, string data);
         string? TryGetClipboardData(string key);
     }
@@ -34,5 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.StringCopyPaste
 
         public string? TryGetClipboardData(string key)
             => null;
+
+        public bool? LastCopyWasLineCopy => null;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/61316.

We're definitely not doing the right thing now.  Disabling the featuer entirely when line copy/paste is involved to not mess the user up.  If we can think of something smart to do here in the future, we can add support for this then.