### PR TITLE
Fix null ref in Razor excerpt service

### DIFF
--- a/src/Tools/ExternalAccess/Razor/RazorDocumentExcerptServiceWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDocumentExcerptServiceWrapper.cs
@@ -28,6 +28,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             };
 
             var result = await _impl.TryExcerptAsync(document, span, razorMode, new RazorClassificationOptionsWrapper(classificationOptions), cancellationToken).ConfigureAwait(false);
+
+            if (result is null)
+                return null;
+
             var razorExcerpt = result.Value;
             return new ExcerptResult(razorExcerpt.Content, razorExcerpt.MappedSpan, razorExcerpt.ClassifiedSpans, razorExcerpt.Document, razorExcerpt.Span);
         }


### PR DESCRIPTION
Reported as part of https://developercommunity.visualstudio.com/t/VS2022-Blazor-Components-used-in-razor-f/10034529

```
StreamJsonRpc.RemoteInvocationException: Nullable object must have a value.
at StreamJsonRpc.JsonRpc.<InvokeCoreAsync>d__1431.MoveNext() --- End of stack trace from previous location where exception was thrown --- at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) at Microsoft.CodeAnalysis.Remote.BrokeredServiceConnection1.<TryInvokeAsync>d__19.MoveNext()
RPC server exception:
StreamJsonRpc.RemoteInvocationException: Nullable object must have a value.
at StreamJsonRpc.JsonRpc.<InvokeCoreAsync>d__1431.MoveNext() --- End of stack trace from previous location where exception was thrown --- at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) at Microsoft.CodeAnalysis.Remote.RemoteCallback1.<InvokeAsync>d__2.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.CodeAnalysis.FindUsages.AbstractFindUsagesService.FindReferencesProgressAdapter.<OnReferenceFoundAsync>d__14.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<ProcessDocumentAsync>d__18.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<ProcessDocumentAsync>d__17.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<ProcessDocumentAsync>d__17.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<ProcessProjectAsync>d__15.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<ProcessProjectAsync>d__15.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__11.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__11.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at Microsoft.CodeAnalysis.FindSymbols.FindReferencesSearchEngine.<FindReferencesAsync>d__11.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.CodeAnalysis.FindSymbols.SymbolFinder.<FindReferencesAsync>d__34.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.CodeAnalysis.FindUsages.AbstractFindUsagesService.<FindReferencesAsync>d__15.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.CodeAnalysis.Remote.RemoteFindUsagesService.<>c__DisplayClass3_0.<<FindReferencesAsync>b__0>d.MoveNext()
— End of stack trace from previous location where exception was thrown —
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at Microsoft.CodeAnalysis.Remote.BrokeredServiceBase.<RunServiceImplAsync>d__15.MoveNext()
```