### PR TITLE
Move Spellcheck capabilities to be activated in all scenarios

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptInProcLanguageClient.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
             VSTypeScriptLspServiceProvider lspServiceProvider,
             IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
-            DefaultCapabilitiesProvider defaultCapabilitiesProvider,
+            ExperimentalCapabilitiesProvider defaultCapabilitiesProvider,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
             : base(lspServiceProvider, globalOptions, listenerProvider, lspLoggerFactory, threadingContext)

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptInProcLanguageClient.cs
@@ -41,7 +41,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
             VSTypeScriptLspServiceProvider lspServiceProvider,
             IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
-            ExperimentalCapabilitiesProvider defaultCapabilitiesProvider,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
             : base(lspServiceProvider, globalOptions, listenerProvider, lspLoggerFactory, threadingContext)

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
     [Export(typeof(AlwaysActivateInProcLanguageClient))]
     internal class AlwaysActivateInProcLanguageClient : AbstractInProcLanguageClient
     {
-        private readonly ExperimentalCapabilitiesProvider _defaultCapabilitiesProvider;
+        private readonly ExperimentalCapabilitiesProvider _experimentalCapabilitiesProvider;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             IThreadingContext threadingContext)
             : base(lspServiceProvider, globalOptions, listenerProvider, lspLoggerFactory, threadingContext)
         {
-            _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
+            _experimentalCapabilitiesProvider = defaultCapabilitiesProvider;
         }
 
         protected override ImmutableArray<string> SupportedLanguages => ProtocolConstants.RoslynLspLanguages;
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             var isLspEditorEnabled = GlobalOptions.GetOption(LspOptions.LspEditorFeatureFlag);
 
             var serverCapabilities = isLspEditorEnabled
-                ? (VSInternalServerCapabilities)_defaultCapabilitiesProvider.GetCapabilities(clientCapabilities)
+                ? (VSInternalServerCapabilities)_experimentalCapabilitiesProvider.GetCapabilities(clientCapabilities)
                 : new VSInternalServerCapabilities()
                 {
                     // Even if the flag is off, we want to include text sync capabilities.

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
@@ -103,6 +103,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
                 };
             }
 
+            serverCapabilities.SpellCheckingProvider = true;
+
             return serverCapabilities;
         }
 

--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActivateInProcLanguageClient.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
     [Export(typeof(AlwaysActivateInProcLanguageClient))]
     internal class AlwaysActivateInProcLanguageClient : AbstractInProcLanguageClient
     {
-        private readonly DefaultCapabilitiesProvider _defaultCapabilitiesProvider;
+        private readonly ExperimentalCapabilitiesProvider _defaultCapabilitiesProvider;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             CSharpVisualBasicLspServiceProvider lspServiceProvider,
             IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
-            DefaultCapabilitiesProvider defaultCapabilitiesProvider,
+            ExperimentalCapabilitiesProvider defaultCapabilitiesProvider,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
             : base(lspServiceProvider, globalOptions, listenerProvider, lspLoggerFactory, threadingContext)

--- a/src/EditorFeatures/Core/LanguageServer/LiveShareInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/LiveShareInProcLanguageClient.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
     [Export(typeof(ILanguageClient))]
     internal class LiveShareInProcLanguageClient : AbstractInProcLanguageClient
     {
-        private readonly ExperimentalCapabilitiesProvider _defaultCapabilitiesProvider;
+        private readonly ExperimentalCapabilitiesProvider _experimentalCapabilitiesProvider;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
@@ -33,12 +33,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             CSharpVisualBasicLspServiceProvider lspServiceProvider,
             IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
-            ExperimentalCapabilitiesProvider defaultCapabilitiesProvider,
+            ExperimentalCapabilitiesProvider experimentalCapabilitiesProvider,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
             : base(lspServiceProvider, globalOptions, listenerProvider, lspLoggerFactory, threadingContext)
         {
-            _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
+            _experimentalCapabilitiesProvider = experimentalCapabilitiesProvider;
         }
 
         protected override ImmutableArray<string> SupportedLanguages => ProtocolConstants.RoslynLspLanguages;
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
                 };
             }
 
-            var defaultCapabilities = _defaultCapabilitiesProvider.GetCapabilities(clientCapabilities);
+            var defaultCapabilities = _experimentalCapabilitiesProvider.GetCapabilities(clientCapabilities);
 
             // If the LSP semantic tokens feature flag is enabled, advertise no semantic tokens capabilities for this Live Share
             // LSP server as LSP semantic tokens requests will be serviced by the AlwaysActiveInProcLanguageClient in both local and

--- a/src/EditorFeatures/Core/LanguageServer/LiveShareInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/LiveShareInProcLanguageClient.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
     [Export(typeof(ILanguageClient))]
     internal class LiveShareInProcLanguageClient : AbstractInProcLanguageClient
     {
-        private readonly DefaultCapabilitiesProvider _defaultCapabilitiesProvider;
+        private readonly ExperimentalCapabilitiesProvider _defaultCapabilitiesProvider;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, true)]
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             CSharpVisualBasicLspServiceProvider lspServiceProvider,
             IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
-            DefaultCapabilitiesProvider defaultCapabilitiesProvider,
+            ExperimentalCapabilitiesProvider defaultCapabilitiesProvider,
             ILspLoggerFactory lspLoggerFactory,
             IThreadingContext threadingContext)
             : base(lspServiceProvider, globalOptions, listenerProvider, lspLoggerFactory, threadingContext)

--- a/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
     {
         public const string ClientName = ProtocolConstants.RazorCSharp;
 
-        private readonly DefaultCapabilitiesProvider _defaultCapabilitiesProvider;
+        private readonly ExperimentalCapabilitiesProvider _defaultCapabilitiesProvider;
 
         protected override ImmutableArray<string> SupportedLanguages => ProtocolConstants.RoslynLspLanguages;
 
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             CSharpVisualBasicLspServiceProvider lspServiceProvider,
             IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
-            DefaultCapabilitiesProvider defaultCapabilitiesProvider,
+            ExperimentalCapabilitiesProvider defaultCapabilitiesProvider,
             IThreadingContext threadingContext,
             ILspLoggerFactory lspLoggerFactory,
             [Import(AllowDefault = true)] AbstractLanguageClientMiddleLayer middleLayer)

--- a/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/RazorInProcLanguageClient.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
     {
         public const string ClientName = ProtocolConstants.RazorCSharp;
 
-        private readonly ExperimentalCapabilitiesProvider _defaultCapabilitiesProvider;
+        private readonly ExperimentalCapabilitiesProvider _experimentalCapabilitiesProvider;
 
         protected override ImmutableArray<string> SupportedLanguages => ProtocolConstants.RoslynLspLanguages;
 
@@ -50,25 +50,25 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             CSharpVisualBasicLspServiceProvider lspServiceProvider,
             IGlobalOptionService globalOptions,
             IAsynchronousOperationListenerProvider listenerProvider,
-            ExperimentalCapabilitiesProvider defaultCapabilitiesProvider,
+            ExperimentalCapabilitiesProvider experimentalCapabilitiesProvider,
             IThreadingContext threadingContext,
             ILspLoggerFactory lspLoggerFactory,
             [Import(AllowDefault = true)] AbstractLanguageClientMiddleLayer middleLayer)
             : base(lspServiceProvider, globalOptions, listenerProvider, lspLoggerFactory, threadingContext, middleLayer)
         {
-            _defaultCapabilitiesProvider = defaultCapabilitiesProvider;
+            _experimentalCapabilitiesProvider = experimentalCapabilitiesProvider;
         }
 
         protected override void Activate_OffUIThread()
         {
             // Ensure we let the default capabilities provider initialize off the UI thread to avoid
             // unnecessary MEF part loading during the GetCapabilities call, which is done on the UI thread
-            _defaultCapabilitiesProvider.Initialize();
+            _experimentalCapabilitiesProvider.Initialize();
         }
 
         public override ServerCapabilities GetCapabilities(ClientCapabilities clientCapabilities)
         {
-            var capabilities = _defaultCapabilitiesProvider.GetCapabilities(clientCapabilities);
+            var capabilities = _experimentalCapabilitiesProvider.GetCapabilities(clientCapabilities);
 
             // Razor doesn't use workspace symbols, so disable to prevent duplicate results (with LiveshareLanguageClient) in liveshare.
             capabilities.WorkspaceSymbolProvider = false;

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -557,7 +557,7 @@ namespace Roslyn.Test.Utilities
             private static LanguageServerTarget CreateLanguageServer(Stream inputStream, Stream outputStream, TestWorkspace workspace, WellKnownLspServerKinds serverKind)
             {
                 var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
-                var capabilitiesProvider = workspace.ExportProvider.GetExportedValue<DefaultCapabilitiesProvider>();
+                var capabilitiesProvider = workspace.ExportProvider.GetExportedValue<ExperimentalCapabilitiesProvider>();
                 var servicesProvider = workspace.ExportProvider.GetExportedValue<CSharpVisualBasicLspServiceProvider>();
 
                 var jsonRpc = new JsonRpc(new HeaderDelimitedMessageHandler(outputStream, inputStream, CreateJsonMessageFormatter()))

--- a/src/Features/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
+++ b/src/Features/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
@@ -16,14 +16,14 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer
 {
-    [Export(typeof(DefaultCapabilitiesProvider)), Shared]
-    internal class DefaultCapabilitiesProvider : ICapabilitiesProvider
+    [Export(typeof(ExperimentalCapabilitiesProvider)), Shared]
+    internal class ExperimentalCapabilitiesProvider : ICapabilitiesProvider
     {
         private readonly ImmutableArray<Lazy<CompletionProvider, CompletionProviderMetadata>> _completionProviders;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DefaultCapabilitiesProvider(
+        public ExperimentalCapabilitiesProvider(
             [ImportMany] IEnumerable<Lazy<CompletionProvider, CompletionProviderMetadata>> completionProviders)
         {
             _completionProviders = completionProviders

--- a/src/Features/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
+++ b/src/Features/LanguageServer/Protocol/DefaultCapabilitiesProvider.cs
@@ -105,7 +105,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 DocumentHighlightProvider = true,
                 ProjectContextProvider = true,
                 BreakableRangeProvider = true,
-                SpellCheckingProvider = true,
 
                 // Diagnostic requests are only supported from PullDiagnosticsInProcLanguageClient.
                 SupportsDiagnosticRequests = false,

--- a/src/Features/LanguageServer/ProtocolUnitTests/VSTypeScriptHandlerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/VSTypeScriptHandlerTests.cs
@@ -86,7 +86,7 @@ public class VSTypeScriptHandlerTests : AbstractLanguageServerProtocolTests
     private static LanguageServerTarget CreateLanguageServer(Stream inputStream, Stream outputStream, TestWorkspace workspace)
     {
         var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
-        var capabilitiesProvider = workspace.ExportProvider.GetExportedValue<DefaultCapabilitiesProvider>();
+        var capabilitiesProvider = workspace.ExportProvider.GetExportedValue<ExperimentalCapabilitiesProvider>();
         var servicesProvider = workspace.ExportProvider.GetExportedValue<VSTypeScriptLspServiceProvider>();
 
         var jsonRpc = new JsonRpc(new HeaderDelimitedMessageHandler(outputStream, inputStream))


### PR DESCRIPTION
cc @CyrusNajmabadi - this needs to be part of the specific capabilities of always activate in order to start running when the editor side is complete.