### PR TITLE
Add lambda parameters in scope in nameof using proper binder

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var oldEnclosing = _enclosing;
 
                 WithTypeParametersBinder? withTypeParametersBinder;
-                WithParametersBinder? withParametersBinder;
+                Binder? withParametersBinder;
                 // The LangVer check will be removed before shipping .NET 7.
                 // Tracked by https://github.com/dotnet/roslyn/issues/60640
                 if (((_enclosing.Flags & BinderFlags.InContextualAttributeBinder) != 0) && _enclosing.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureExtendedNameofScope))
@@ -249,8 +249,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // We're bringing parameters in scope inside `nameof` in attributes on methods, their type parameters and parameters.
             // This also applies to local functions, lambdas, indexers and delegates.
-            static WithParametersBinder? getExtraWithParametersBinder(Binder enclosing, Symbol target)
+            static Binder? getExtraWithParametersBinder(Binder enclosing, Symbol target)
             {
+                if (target is LambdaSymbol lambda)
+                {
+                    // lambda parameters have some special rules around parameters named `_`
+                    return new WithLambdaParametersBinder(lambda, enclosing);
+                }
+
                 var parameters = target switch
                 {
                     SourcePropertyAccessorSymbol { MethodKind: MethodKind.PropertySet } setter => getSetterParameters(setter),

--- a/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/NameofBinder.cs
@@ -21,10 +21,10 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly SyntaxNode _nameofArgument;
         private readonly WithTypeParametersBinder? _withTypeParametersBinder;
-        private readonly WithParametersBinder? _withParametersBinder;
+        private readonly Binder? _withParametersBinder;
         private ThreeState _lazyIsNameofOperator;
 
-        internal NameofBinder(SyntaxNode nameofArgument, Binder next, WithTypeParametersBinder? withTypeParametersBinder, WithParametersBinder? withParametersBinder)
+        internal NameofBinder(SyntaxNode nameofArgument, Binder next, WithTypeParametersBinder? withTypeParametersBinder, Binder? withParametersBinder)
             : base(next)
         {
             _nameofArgument = nameofArgument;


### PR DESCRIPTION
The `NameofBinder` may introduce some type parameters and parameters into scope. For parameters,  it was always using a `WithParametersBinder`, but for lambda parameters it should have been using a `WithLambdaParametersBinder`.

Fixes https://github.com/dotnet/roslyn/issues/61143