### PR TITLE
Emit CompilerFeaturesRequiredAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -283,15 +283,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             ImmutableInterlocked.InterlockedInitialize(ref customAttributes, loaded);
         }
 
-        internal void LoadCustomAttributesFilterCompilerAttributes(EntityHandle token,
-            ref ImmutableArray<CSharpAttributeData> customAttributes,
-            out bool foundExtension,
-            out bool foundReadOnly)
-        {
-            var loadedCustomAttributes = GetCustomAttributesFilterCompilerAttributes(token, out foundExtension, out foundReadOnly);
-            ImmutableInterlocked.InterlockedInitialize(ref customAttributes, loadedCustomAttributes);
-        }
-
         internal void LoadCustomAttributesFilterExtensions(EntityHandle token,
             ref ImmutableArray<CSharpAttributeData> customAttributes)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             out CustomAttributeHandle filteredOutAttribute1,
             AttributeDescription filterOut1)
         {
-            return GetCustomAttributesForToken(token, out filteredOutAttribute1, filterOut1, out _, default, out _, default, out _, default);
+            return GetCustomAttributesForToken(token, out filteredOutAttribute1, filterOut1, out _, default, out _, default, out _, default, out _, default);
         }
 
         /// <summary>
@@ -318,12 +318,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             out CustomAttributeHandle filteredOutAttribute3,
             AttributeDescription filterOut3,
             out CustomAttributeHandle filteredOutAttribute4,
-            AttributeDescription filterOut4)
+            AttributeDescription filterOut4,
+            out CustomAttributeHandle filteredOutAttribute5,
+            AttributeDescription filterOut5)
         {
             filteredOutAttribute1 = default;
             filteredOutAttribute2 = default;
             filteredOutAttribute3 = default;
             filteredOutAttribute4 = default;
+            filteredOutAttribute5 = default;
             ArrayBuilder<CSharpAttributeData> customAttributesBuilder = null;
 
             try
@@ -354,6 +357,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     if (matchesFilter(customAttributeHandle, filterOut4))
                     {
                         filteredOutAttribute4 = customAttributeHandle;
+                        continue;
+                    }
+
+                    if (matchesFilter(customAttributeHandle, filterOut5))
+                    {
+                        filteredOutAttribute5 = customAttributeHandle;
                         continue;
                     }
 
@@ -438,7 +447,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 filteredOutAttribute2: out CustomAttributeHandle isReadOnlyAttribute,
                 filterOut2: AttributeDescription.IsReadOnlyAttribute,
                 filteredOutAttribute3: out _, filterOut3: default,
-                filteredOutAttribute4: out _, filterOut4: default);
+                filteredOutAttribute4: out _, filterOut4: default,
+                filteredOutAttribute5: out _, filterOut5: default);
 
             foundExtension = !extensionAttribute.IsNil;
             foundReadOnly = !isReadOnlyAttribute.IsNil;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -679,7 +679,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     IsReadOnly ? AttributeDescription.IsReadOnlyAttribute : default,
                     out _,
                     // Filter out [IsByRefLike]
-                    IsRefLikeType ? AttributeDescription.IsByRefLikeAttribute : default);
+                    IsRefLikeType ? AttributeDescription.IsByRefLikeAttribute : default,
+                    out _,
+                    // Filter out [CompilerFeatureRequired]
+                    (IsRefLikeType && DeriveCompilerFeatureRequiredDiagnostic() is null) ? AttributeDescription.CompilerFeatureRequiredAttribute : default);
 
                 ImmutableInterlocked.InterlockedInitialize(ref uncommon.lazyCustomAttributes, loadedCustomAttributes);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -997,6 +997,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             out isReadOnlyAttribute,
                             filterIsReadOnlyAttribute ? AttributeDescription.IsReadOnlyAttribute : default,
                             out _,
+                            default,
+                            out _,
                             default);
 
                     if (!paramArrayAttribute.IsNil || !constantAttribute.IsNil)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1219,15 +1219,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var obsoleteData = methodToAttribute.ObsoleteAttributeData;
                 Debug.Assert(obsoleteData != ObsoleteAttributeData.Uninitialized, "getting synthesized attributes before attributes are decoded");
 
+                CSharpCompilation declaringCompilation = methodToAttribute.DeclaringCompilation;
                 if (obsoleteData == null)
                 {
-                    CSharpCompilation declaringCompilation = methodToAttribute.DeclaringCompilation;
                     AddSynthesizedAttribute(ref attributes, declaringCompilation.TrySynthesizeAttribute(WellKnownMember.System_ObsoleteAttribute__ctor,
                         ImmutableArray.Create(
                             new TypedConstant(declaringCompilation.GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, PEModule.RequiredMembersMarker), // message
                             new TypedConstant(declaringCompilation.GetSpecialType(SpecialType.System_Boolean), TypedConstantKind.Primitive, true)) // error
                         ));
                 }
+
+                AddSynthesizedAttribute(ref attributes, declaringCompilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor,
+                    ImmutableArray.Create(new TypedConstant(declaringCompilation.GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, nameof(CompilerFeatureRequiredFeatures.RequiredMembers)))
+                    ));
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -10,9 +10,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    // PROTOTYPE(req): Add obsolete marker to constructors if required members and Obsolete hasn't already been emitted
-    // PROTOTYPE(req): Add poison type marker to constructors if required members and Obsolete hasn't already been emitted,
-    //                 pending framework design review
     internal sealed class SourceConstructorSymbol : SourceConstructorSymbolBase
     {
         private readonly bool _isExpressionBodied;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2428,6 +2428,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // Ensure that an error is reported if the required constructor isn't present.
                 _ = Binder.GetWellKnownTypeMember(DeclaringCompilation, WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor, diagnostics, Locations[0]);
+            }
+
+            if (HasAnyRequiredMembers)
+            {
+                _ = Binder.GetWellKnownTypeMember(DeclaringCompilation, WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor, diagnostics, Locations[0]);
+
                 if (this.IsRecord)
                 {
                     // Copy constructors need to emit SetsRequiredMembers on the ctor

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1557,17 +1557,24 @@ next:;
                 var obsoleteData = ObsoleteAttributeData;
                 Debug.Assert(obsoleteData != ObsoleteAttributeData.Uninitialized, "getting synthesized attributes before attributes are decoded");
 
-                // If user specified an Obsolete attribute, we cannot emit ours.
-                // NB: we do not check the kind of deprecation. 
-                //     we will not emit Obsolete even if Deprecated or Experimental was used.
-                //     we do not want to get into a scenario where different kinds of deprecation are combined together.
-                //
-                if (obsoleteData == null && !this.IsRestrictedType(ignoreSpanLikeTypes: true))
+                if (!this.IsRestrictedType(ignoreSpanLikeTypes: true))
                 {
-                    AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_ObsoleteAttribute__ctor,
-                        ImmutableArray.Create(
-                            new TypedConstant(compilation.GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, PEModule.ByRefLikeMarker), // message
-                            new TypedConstant(compilation.GetSpecialType(SpecialType.System_Boolean), TypedConstantKind.Primitive, true)), // error=true
+                    // If user specified an Obsolete attribute, we cannot emit ours.
+                    // NB: we do not check the kind of deprecation. 
+                    //     we will not emit Obsolete even if Deprecated or Experimental was used.
+                    //     we do not want to get into a scenario where different kinds of deprecation are combined together.
+                    //
+                    if (obsoleteData == null)
+                    {
+                        AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_ObsoleteAttribute__ctor,
+                            ImmutableArray.Create(
+                                new TypedConstant(compilation.GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, PEModule.ByRefLikeMarker), // message
+                                new TypedConstant(compilation.GetSpecialType(SpecialType.System_Boolean), TypedConstantKind.Primitive, true)), // error=true
+                            isOptionalUse: true));
+                    }
+
+                    AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor,
+                        ImmutableArray.Create(new TypedConstant(compilation.GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, nameof(CompilerFeatureRequiredFeatures.RefStructs))),
                         isOptionalUse: true));
                 }
             }

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_IsByRefLike.cs
@@ -21,8 +21,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class AttributeTests_IsByRefLike : CSharpTestBase
     {
-        [Fact]
-        public void IsByRefLikeIsWrittenToMetadata_SameAssembly()
+        [Theory]
+        [CombinatorialData]
+        public void IsByRefLikeIsWrittenToMetadata_SameAssembly(bool includeCompilerFeatureRequired)
         {
             var text = @"
 namespace System.Runtime.CompilerServices
@@ -38,32 +39,34 @@ class Test
             void validate(ModuleSymbol module)
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
-                AssertReferencedIsByRefLike(type);
+                AssertReferencedIsByRefLike(type, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
                 AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Public);
             }
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: validate);
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, verify: Verification.Passes, symbolValidator: validate);
         }
 
-        [Fact]
-        public void IsByRefLikeIsWrittenToMetadata_NeedsToBeGenerated()
+        [Theory]
+        [CombinatorialData]
+        public void IsByRefLikeIsWrittenToMetadata_NeedsToBeGenerated(bool includeCompilerFeatureRequired)
         {
             var text = @"
 ref struct S1{}
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S1");
-                AssertReferencedIsByRefLike(type);
+                AssertReferencedIsByRefLike(type, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
             });
         }
 
-        [Fact]
-        public void IsByRefLikeIsWrittenToMetadata_NeedsToBeGeneratedNested()
+        [Theory]
+        [CombinatorialData]
+        public void IsByRefLikeIsWrittenToMetadata_NeedsToBeGeneratedNested(bool includeCompilerFeatureRequired)
         {
             var text = @"
 class Test
@@ -72,15 +75,16 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
-                AssertReferencedIsByRefLike(type);
+                AssertReferencedIsByRefLike(type, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
             });
         }
 
-        [Fact]
-        public void IsByRefLikeIsWrittenToMetadata_NeedsToBeGeneratedGeneric()
+        [Theory]
+        [CombinatorialData]
+        public void IsByRefLikeIsWrittenToMetadata_NeedsToBeGeneratedGeneric(bool includeCompilerFeatureRequired)
         {
             var text = @"
 class Test
@@ -92,18 +96,19 @@ class Test
             void validate(ModuleSymbol module)
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test+S1`1");
-                AssertReferencedIsByRefLike(type);
+                AssertReferencedIsByRefLike(type, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
 
                 var peModule = (PEModuleSymbol)module;
                 Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
                 AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Internal);
             }
 
-            CompileAndVerify(text, symbolValidator: validate);
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, symbolValidator: validate);
         }
 
-        [Fact]
-        public void IsByRefLikeIsWrittenToMetadata_NeedsToBeGeneratedNestedInGeneric()
+        [Theory]
+        [CombinatorialData]
+        public void IsByRefLikeIsWrittenToMetadata_NeedsToBeGeneratedNestedInGeneric(bool includeCompilerFeatureRequired)
         {
             var text = @"
 class Test<T>
@@ -112,15 +117,16 @@ class Test<T>
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test`1").GetTypeMember("S1");
-                AssertReferencedIsByRefLike(type);
+                AssertReferencedIsByRefLike(type, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
             });
         }
 
-        [Fact]
-        public void IsByRefLikeIsWrittenToMetadata_DifferentAssembly()
+        [Theory]
+        [CombinatorialData]
+        public void IsByRefLikeIsWrittenToMetadata_DifferentAssembly(bool includeCompilerFeatureRequired)
         {
             var codeA = @"
 namespace System.Runtime.CompilerServices
@@ -128,7 +134,7 @@ namespace System.Runtime.CompilerServices
     public class IsByRefLikeAttribute : System.Attribute { }
 }";
 
-            var referenceA = CreateCompilation(codeA).VerifyDiagnostics().ToMetadataReference();
+            var referenceA = CreateCompilation(new[] { codeA, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }).VerifyDiagnostics().ToMetadataReference();
 
             var codeB = @"
 class Test
@@ -141,8 +147,8 @@ class Test
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
 
-                AssertReferencedIsByRefLike(type);
-                AssertNoIsByRefLikeAttributeExists(module.ContainingAssembly);
+                AssertReferencedIsByRefLike(type, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
+                AssertNoIsByRefLikeAttributeOrCompilerFeatureRequiredAttributeExists(module.ContainingAssembly, includeCompilerFeatureRequired);
             });
         }
 
@@ -436,7 +442,7 @@ public class Test
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
 
                 AssertReferencedIsByRefLike(type);
-                AssertNoIsByRefLikeAttributeExists(module.ContainingAssembly);
+                AssertNoIsByRefLikeAttributeOrCompilerFeatureRequiredAttributeExists(module.ContainingAssembly, hasCompilerFeatureRequired: false);
             });
         }
 
@@ -609,7 +615,7 @@ class User
             void symbolValidator(ModuleSymbol module)
             {
                 // No attribute is copied
-                AssertNoIsByRefLikeAttributeExists(module.ContainingAssembly);
+                AssertNoIsByRefLikeAttributeOrCompilerFeatureRequiredAttributeExists(module.ContainingAssembly, hasCompilerFeatureRequired: false);
 
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test");
 
@@ -642,8 +648,9 @@ public class Test
                 );
         }
 
-        [Fact]
-        public void IsByRefLikeObsolete()
+        [Theory]
+        [CombinatorialData]
+        public void IsByRefLikeObsolete(bool includeCompilerFeatureRequired)
         {
             var text = @"
 namespace System.Runtime.CompilerServices
@@ -672,12 +679,14 @@ class Test
 
                 if (module is PEModuleSymbol peModule)
                 {
-                    Assert.True(peModule.Module.HasIsByRefLikeAttribute(((PENamedTypeSymbol)type).Handle));
+                    var peType = (PENamedTypeSymbol)type;
+                    Assert.True(peModule.Module.HasIsByRefLikeAttribute(peType.Handle));
                     AssertDeclaresType(peModule, WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute, Accessibility.Public);
+                    AssertHasCompilerFeatureRequired(includeCompilerFeatureRequired, peType, peModule, new MetadataDecoder(peModule));
                 }
             };
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: validate, sourceSymbolValidator: validate);
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, verify: Verification.Passes, symbolValidator: validate, sourceSymbolValidator: validate);
         }
 
         [Fact]
@@ -707,8 +716,9 @@ namespace System
             });
         }
 
-        [Fact]
-        public void IsByRefLikeDeprecated()
+        [Theory]
+        [CombinatorialData]
+        public void IsByRefLikeDeprecated(bool includeCompilerFeatureRequired)
         {
             var text = @"
 using System;
@@ -742,7 +752,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsRefLikeType);
@@ -750,11 +760,15 @@ class Test
                 var attribute = type.GetAttributes().Single();
                 Assert.Equal("Windows.Foundation.Metadata.DeprecatedAttribute", attribute.AttributeClass.ToDisplayString());
                 Assert.Equal(42u, attribute.ConstructorArguments.ElementAt(2).Value);
+
+                var peModule = (PEModuleSymbol)module;
+                AssertHasCompilerFeatureRequired(includeCompilerFeatureRequired, (PENamedTypeSymbol)type, peModule, new MetadataDecoder(peModule));
             });
         }
 
-        [Fact]
-        public void IsByRefLikeDeprecatedAndObsolete()
+        [Theory]
+        [CombinatorialData]
+        public void IsByRefLikeDeprecatedAndObsolete(bool includeCompilerFeatureRequired)
         {
             var text = @"
 using System;
@@ -789,7 +803,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("Test").GetTypeMember("S1");
                 Assert.True(type.IsRefLikeType);
@@ -802,6 +816,9 @@ class Test
                 var attribute = attributes[0];
                 Assert.Equal("System.ObsoleteAttribute", attribute.AttributeClass.ToDisplayString());
                 Assert.Equal(0, attribute.ConstructorArguments.Count());
+
+                var peModule = (PEModuleSymbol)module;
+                AssertHasCompilerFeatureRequired(includeCompilerFeatureRequired, (PENamedTypeSymbol)type, peModule, new MetadataDecoder(peModule));
             });
         }
 
@@ -845,15 +862,16 @@ class Test
                 );
         }
 
-        [Fact]
-        public void ObsoleteHasErrorEqualsTrue()
+        [Theory]
+        [CombinatorialData]
+        public void ObsoleteHasErrorEqualsTrue(bool includeCompilerFeatureRequired)
         {
             var text = @"public ref struct S {}";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("S");
-                AssertReferencedIsByRefLike(type);
+                AssertReferencedIsByRefLike(type, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
             });
         }
 
@@ -929,8 +947,9 @@ class C1
         }
 
         [WorkItem(22198, "https://github.com/dotnet/roslyn/issues/22198")]
-        [Fact]
-        public void SpecialTypes_CorLib()
+        [Theory]
+        [CombinatorialData]
+        public void SpecialTypes_CorLib(bool includeCompilerFeatureRequired)
         {
             var source1 =
 @"
@@ -955,28 +974,44 @@ namespace System
 
     public ref struct NotTypedReference { }
 }";
-            var compilation1 = CreateEmptyCompilation(source1, assemblyName: GetUniqueName());
+
+            var compilerFeatureRequiredAttribute = includeCompilerFeatureRequired ?
+                """
+                namespace System.Runtime.CompilerServices
+                {
+                    public class CompilerFeatureRequiredAttribute : Attribute
+                    {
+                        public CompilerFeatureRequiredAttribute(string featureName)
+                        {
+                            FeatureName = featureName;
+                        }
+                        public string FeatureName { get; }
+                    }
+                }
+                """ : "";
+            var compilation1 = CreateEmptyCompilation(new[] { source1, compilerFeatureRequiredAttribute }, assemblyName: GetUniqueName());
 
             // PEVerify: Type load failed.
             CompileAndVerify(compilation1, verify: Verification.FailsPEVerify, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("System.TypedReference");
-                AssertReferencedIsByRefLike(type, hasObsolete: false);
+                AssertReferencedIsByRefLike(type, hasObsolete: false, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
 
                 type = module.ContainingAssembly.GetTypeByMetadataName("System.ArgIterator");
-                AssertReferencedIsByRefLike(type, hasObsolete: false);
+                AssertReferencedIsByRefLike(type, hasObsolete: false, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
 
                 type = module.ContainingAssembly.GetTypeByMetadataName("System.RuntimeArgumentHandle");
-                AssertReferencedIsByRefLike(type, hasObsolete: false);
+                AssertReferencedIsByRefLike(type, hasObsolete: false, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
 
                 // control case. Not a special type.
                 type = module.ContainingAssembly.GetTypeByMetadataName("System.NotTypedReference");
-                AssertReferencedIsByRefLike(type, hasObsolete: true);
+                AssertReferencedIsByRefLike(type, hasObsolete: true, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
             });
         }
 
-        [Fact]
-        public void SpecialTypes_NotCorLib()
+        [Theory]
+        [CombinatorialData]
+        public void SpecialTypes_NotCorLib(bool includeCompilerFeatureRequired)
         {
             var text = @"
 namespace System
@@ -985,24 +1020,25 @@ namespace System
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            CompileAndVerify(new[] { text, GetCompilerFeatureRequiredAttributeText(includeCompilerFeatureRequired) }, verify: Verification.Passes, symbolValidator: module =>
             {
                 var type = module.ContainingAssembly.GetTypeByMetadataName("System.TypedReference");
 
-                AssertReferencedIsByRefLike(type);
+                AssertReferencedIsByRefLike(type, hasCompilerFeatureRequired: includeCompilerFeatureRequired);
             });
         }
 
-        private static void AssertReferencedIsByRefLike(TypeSymbol type, bool hasObsolete = true)
+        private static void AssertReferencedIsByRefLike(TypeSymbol type, bool hasObsolete = true, bool hasCompilerFeatureRequired = false)
         {
             var peType = (PENamedTypeSymbol)type;
             Assert.True(peType.IsRefLikeType);
 
-            // there is no [Obsolete] or [IsByRef] attribute returned
+            // there is no [Obsolete], [IsByRef], or [CompilerFeatureRequired] attribute returned
             Assert.Empty(peType.GetAttributes());
 
             var peModule = (PEModuleSymbol)peType.ContainingModule;
-            var obsoleteAttribute = peModule.Module.TryGetDeprecatedOrExperimentalOrObsoleteAttribute(peType.Handle, new MetadataDecoder(peModule), ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false);
+            var decoder = new MetadataDecoder(peModule);
+            var obsoleteAttribute = peModule.Module.TryGetDeprecatedOrExperimentalOrObsoleteAttribute(peType.Handle, decoder, ignoreByRefLikeMarker: false, ignoreRequiredMemberMarker: false);
 
             if (hasObsolete)
             {
@@ -1014,6 +1050,18 @@ namespace System
             {
                 Assert.Null(obsoleteAttribute);
             }
+
+            AssertHasCompilerFeatureRequired(hasCompilerFeatureRequired, peType, peModule, decoder);
+        }
+
+        private static void AssertHasCompilerFeatureRequired(bool hasCompilerFeatureRequired, PENamedTypeSymbol peType, PEModuleSymbol peModule, MetadataDecoder decoder)
+        {
+            var compilerFeatureRequiredToken = peModule.Module.GetFirstUnsupportedCompilerFeatureFromToken(peType.Handle, decoder, CompilerFeatureRequiredFeatures.RefStructs);
+            Assert.Null(compilerFeatureRequiredToken);
+
+            compilerFeatureRequiredToken = peModule.Module.GetFirstUnsupportedCompilerFeatureFromToken(peType.Handle, decoder, CompilerFeatureRequiredFeatures.None);
+            var shouldHaveMarker = hasCompilerFeatureRequired && !peType.IsRestrictedType(ignoreSpanLikeTypes: true);
+            Assert.Equal(shouldHaveMarker ? nameof(CompilerFeatureRequiredFeatures.RefStructs) : null, compilerFeatureRequiredToken);
         }
 
         private static void AssertNotReferencedIsByRefLikeAttribute(ImmutableArray<CSharpAttributeData> attributes)
@@ -1024,10 +1072,12 @@ namespace System
             }
         }
 
-        private static void AssertNoIsByRefLikeAttributeExists(AssemblySymbol assembly)
+        private static void AssertNoIsByRefLikeAttributeOrCompilerFeatureRequiredAttributeExists(AssemblySymbol assembly, bool hasCompilerFeatureRequired)
         {
             var isByRefLikeAttributeTypeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute);
             Assert.Null(assembly.GetTypeByMetadataName(isByRefLikeAttributeTypeName));
+            var compilerFeatureRequiredAttributeTypeName = WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute);
+            Assert.Null(assembly.GetTypeByMetadataName(compilerFeatureRequiredAttributeTypeName));
         }
 
         private static void AssertGeneratedEmbeddedAttribute(AssemblySymbol assembly, string expectedTypeName)
@@ -1042,5 +1092,7 @@ namespace System
             Assert.Equal(WellKnownTypes.GetMetadataName(WellKnownType.System_Runtime_CompilerServices_CompilerGeneratedAttribute), attributes[0].AttributeClass.ToDisplayString());
             Assert.Equal(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName, attributes[1].AttributeClass.ToDisplayString());
         }
+
+        private static string GetCompilerFeatureRequiredAttributeText(bool hasAttribute) => hasAttribute ? CompilerFeatureRequiredAttribute : "";
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -613,6 +613,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_RequiredMemberAttribute:
                     case WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute:
                     case WellKnownType.System_MemoryExtensions:
+                    case WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute:
                         // Not yet in the platform.
                         continue;
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
@@ -974,6 +975,7 @@ namespace System
                     case WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T:
                     case WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T:
                     case WellKnownMember.System_MemoryExtensions__AsSpan_String:
+                    case WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -525,6 +525,8 @@ namespace Microsoft.CodeAnalysis
         System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
         System_MemoryExtensions__AsSpan_String,
 
+        System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor,
+
         Count
 
         // Remember to update the AllWellKnownTypeMembers tests when making changes here

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3606,6 +3606,14 @@ namespace Microsoft.CodeAnalysis
                     1,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Char,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
+
+                // System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -4057,6 +4065,7 @@ namespace Microsoft.CodeAnalysis
                 "SequenceEqual",                            // System_MemoryExtensions__SequenceEqual_Span_T
                 "SequenceEqual",                            // System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T
                 "AsSpan",                                   // System_MemoryExtensions__AsSpan_String
+                ".ctor",                                    // System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute_ctor
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -321,6 +321,8 @@ namespace Microsoft.CodeAnalysis
         System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute,
         System_MemoryExtensions,
 
+        System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute,
+
         NextAvailable,
         // Remember to update the AllWellKnownTypes tests when making changes here
     }
@@ -633,6 +635,7 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.CompilerServices.RequiredMemberAttribute",
             "System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute",
             "System.MemoryExtensions",
+            "System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute",
         };
 
         private static readonly Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -547,7 +547,8 @@ End Namespace
                          WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler,
                          WellKnownType.System_Runtime_CompilerServices_RequiredMemberAttribute,
                          WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute,
-                         WellKnownType.System_MemoryExtensions
+                         WellKnownType.System_MemoryExtensions,
+                         WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -616,7 +617,9 @@ End Namespace
                          WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler,
                          WellKnownType.System_Runtime_CompilerServices_RequiredMemberAttribute,
                          WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute,
-                         WellKnownType.System_MemoryExtensions
+                         WellKnownType.System_MemoryExtensions,
+                         WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute
+
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -709,7 +712,8 @@ End Namespace
                          WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
-                         WellKnownMember.System_MemoryExtensions__AsSpan_String
+                         WellKnownMember.System_MemoryExtensions__AsSpan_String,
+                         WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
@@ -858,7 +862,8 @@ End Namespace
                          WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
-                         WellKnownMember.System_MemoryExtensions__AsSpan_String
+                         WellKnownMember.System_MemoryExtensions__AsSpan_String,
+                         WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,


### PR DESCRIPTION
Support emitting CompilerFeatureRequiredAttribute for ref structs (when the attribute is present) and for required members (error if the attribute is not present).

Test plan: https://github.com/dotnet/roslyn/issues/57046.