### PR TITLE
[LSP] More correctly respect background analysis scope

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandler.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -120,24 +122,20 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                     return;
                 }
 
-                // if the project doesn't necessarily have an open file in it, then only include it if the user has full
-                // solution analysis on.
-                if (!isOpen)
+                var isFSAOn = globalOptions.GetBackgroundAnalysisScope(project.Language) == BackgroundAnalysisScope.FullSolution;
+                var documents = ImmutableArray<Document>.Empty;
+                // If FSA is on, then add all the documents in the project.  Other analysis scopes are handled by the document pull handler.
+                if (isFSAOn)
                 {
-                    if (globalOptions.GetBackgroundAnalysisScope(project.Language) != BackgroundAnalysisScope.FullSolution)
-                    {
-                        context.TraceInformation($"Skipping project '{project.Name}' as it has no open document and Full Solution Analysis is off");
-                        return;
-                    }
+                    documents = documents.AddRange(project.Documents);
                 }
 
-                // Otherwise, if the user has an open file from this project, or FSA is on, then include all the
-                // documents from it. If all features are enabled for source generated documents, make sure they are
-                // included as well.
-                var documents = project.Documents;
-                if (solution.Workspace.Services.GetService<IWorkspaceConfigurationService>()?.Options.EnableOpeningSourceGeneratedFiles == true)
+                // If all features are enabled for source generated documents, make sure they are included when FSA is on or a file in the project is open.
+                // This is done because for either scenario we've already run generators, so there shouldn't be much cost in getting the diagnostics.
+                if ((isFSAOn || isOpen) && solution.Workspace.Services.GetService<IWorkspaceConfigurationService>()?.Options.EnableOpeningSourceGeneratedFiles == true)
                 {
-                    documents = documents.Concat(await project.GetSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false));
+                    var sourceGeneratedDocuments = await project.GetSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false);
+                    documents = documents.AddRange(sourceGeneratedDocuments);
                 }
 
                 foreach (var document in documents)

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -579,6 +579,23 @@ class B {";
         }
 
         [Theory, CombinatorialData]
+        public async Task TestNoWorkspaceDiagnosticsForClosedFilesWithFSAOffWithFileInProjectOpen(bool useVSDiagnostics)
+        {
+            var markup1 =
+@"class A {";
+            var markup2 = "";
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(
+                new[] { markup1, markup2 }, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics, pullDiagnostics: false);
+
+            var firstDocument = testLspServer.GetCurrentSolution().Projects.Single().Documents.First();
+            await OpenDocumentAsync(testLspServer, firstDocument);
+
+            var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
+
+            Assert.Empty(results);
+        }
+
+        [Theory, CombinatorialData]
         public async Task TestWorkspaceDiagnosticsIncludesSourceGeneratorDiagnosticsClosedFSAOn(bool useVSDiagnostics)
         {
             var markup = "// Hello, World";
@@ -615,42 +632,6 @@ class B {";
 
             var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
             Assert.Empty(results);
-        }
-
-        [Theory, CombinatorialData]
-        public async Task TestWorkspaceDiagnosticsIncludesSourceGeneratorDiagnosticsClosedFSAOffAndFilesOpen(bool useVSDiagnostics)
-        {
-            // In this case, even though one file is open, we can still have diagnostics for the other file in the project, since by
-            // nature the generator had to run regardless.
-            var markup = "// Hello, World";
-            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(new[] { markup, markup }, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics, pullDiagnostics: true);
-
-            var documentWithDiagnostics = testLspServer.GetCurrentSolution().Projects.Single().Documents.First();
-            var documentToOpen = testLspServer.GetCurrentSolution().Projects.Single().Documents.Last();
-
-            Assert.NotSame(documentWithDiagnostics, documentToOpen);
-
-            // Calling GetTextBuffer will effectively open the file.
-            testLspServer.TestWorkspace.Documents.Single(id => id.Id == documentToOpen.Id).GetTextBuffer();
-
-            var documentTrackingService = (TestDocumentTrackingService)testLspServer.TestWorkspace.Services.GetRequiredService<IDocumentTrackingService>();
-            documentTrackingService.SetActiveDocument(documentToOpen.Id);
-
-            var generator = new DiagnosticProducingGenerator(
-                context => Location.Create(
-                    context.Compilation.SyntaxTrees.Single(t => t.FilePath == documentWithDiagnostics.FilePath),
-                    new TextSpan(0, 10)));
-
-            testLspServer.TestWorkspace.OnAnalyzerReferenceAdded(
-                documentWithDiagnostics.Project.Id,
-                new TestGeneratorReference(generator));
-
-            await OpenDocumentAsync(testLspServer, documentToOpen);
-
-            var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
-
-            var diagnostic = Assert.Single(results.Single().Diagnostics);
-            Assert.Equal(DiagnosticProducingGenerator.Descriptor.Id, diagnostic.Code);
         }
 
         [Theory, CombinatorialData]


### PR DESCRIPTION
Previously we were computing diagnostics for all files in a project if any of the files in that project were open with FSA off.  This did not match non-LSP behavior where the error list only shows errors directly from the open documents when FSA is off.

This changes the behavior in LSP to only compute workspace diagnostics for the project if FSA is on (matches non-LSP behavior).