### PR TITLE
Use AspNetCoreKey in external access assembly

### DIFF
--- a/src/Tools/ExternalAccess/AspNetCore/Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.csproj
+++ b/src/Tools/ExternalAccess/AspNetCore/Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.csproj
@@ -24,8 +24,8 @@
     <!--
       ⚠ ONLY ASP.NET CORE ASSEMBLIES MAY BE ADDED HERE ⚠
     -->
-    <InternalsVisibleTo Include="Microsoft.AspNetCore.Analyzers" />
-    <InternalsVisibleTo Include="Microsoft.AspNetCore.App.Analyzers" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Analyzers" Key="$(AspNetCoreKey)" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.App.Analyzers" Key="$(AspNetCoreKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.UnitTests" />
   </ItemGroup>
 


### PR DESCRIPTION
I get this error when referencing the new assembly:

> C:\Development\Source\aspnetcore\src\Framework\AspNetCoreAnalyzers\src\Analyzers\RouteEmbeddedLanguage\RouteEmbeddedLanguage.cs(12,38,12,75): error CS0281: Friend access was granted by 'Microsoft.CodeAnalysis.ExternalAccess.AspNetCore, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35', but the public key of the output assembly ('0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb') does not match that specified by the InternalsVisibleTo attribute in the granting assembly.

PR adds correct key to internals visible to. Key is already present in repo: https://github.com/dotnet/roslyn/blob/e520d873c251b8e490cca9411992d17f49f354b5/eng/targets/Settings.props#L74-L75