### PR TITLE
Address feedback from numeric IntPtr feature review

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -4,14 +4,14 @@
 
 ***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***
 
-When the platform supports numeric `IntPtr` and `UIntPtr` types (as indicated by the presence of
+When the platform supports __numeric__ `IntPtr` and `UIntPtr` types (as indicated by the presence of
 `System.Runtime.CompilerServices.RuntimeFeature.NumericIntPtr`) the built-in operators from `nint`
 and `nuint` apply to those underlying types.
 This means that on such platforms, `IntPtr` and `UIntPtr` have built-in `checked` operators, which
 can now throw when an overflow occurs.
 
 ```csharp
-IntPtr M(IntPtr x, IntPtr y)
+IntPtr M(IntPtr x, int y)
 {
     checked
     {

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -2,7 +2,7 @@
 
 ## Checked operators on System.IntPtr and System.UIntPtr
 
-***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***
+***Introduced in .NET SDK 7.0.100 preview 5, Visual Studio 2022 version 17.3.***
 
 When the platform supports __numeric__ `IntPtr` and `UIntPtr` types (as indicated by the presence of
 `System.Runtime.CompilerServices.RuntimeFeature.NumericIntPtr`) the built-in operators from `nint`
@@ -30,7 +30,7 @@ conversions on such platforms. This can affect overload resolution in some cases
 
 ## Nameof operator in attribute on method or local function
 
-***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***
+***Introduced in .NET SDK 7.0.100 preview 4, Visual Studio 2022 version 17.3.***
 
 When the language version is C# 11 or later, a `nameof` operator in an attribute on a method
 brings the type parameters of that method in scope. The same applies for local functions.  

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -2,7 +2,7 @@
 
 ## Checked operators on System.IntPtr and System.UIntPtr
 
-***Introduced in .NET SDK 7.0.500, Visual Studio 2022 version 17.3.***
+***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***
 
 When the platform supports numeric `IntPtr` and `UIntPtr` types (as indicated by the presence of
 `System.Runtime.CompilerServices.RuntimeFeature.NumericIntPtr`) the built-in operators from `nint`

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -19,9 +19,9 @@ IntPtr M(IntPtr x, int y)
     }
 }
 
-IntPtr M2(ulong ul)
+unsafe IntPtr M2(void* ptr)
 {
-    return checked((IntPtr)ul); // may now throw
+    return checked((IntPtr)ptr); // may now throw
 }
 ```
 

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -1,5 +1,33 @@
 # This document lists known breaking changes in Roslyn after .NET 6 all the way to .NET 7.
 
+## Checked operators on System.IntPtr and System.UIntPtr
+
+***Introduced in .NET SDK 7.0.500, Visual Studio 2022 version 17.3.***
+
+When the platform supports numeric `IntPtr` and `UIntPtr` types (as indicated by the presence of
+`System.Runtime.CompilerServices.RuntimeFeature.NumericIntPtr`) the built-in operators from `nint`
+and `nuint` apply to those underlying types.
+This means that on such platforms, `IntPtr` and `UIntPtr` have built-in `checked` operators, which
+can now throw when an overflow occurs.
+
+```csharp
+IntPtr M(IntPtr x, IntPtr y)
+{
+    checked
+    {
+        return x + y; // may now throw
+    }
+}
+```
+
+Possible workarounds are:
+
+1. Specify `unchecked` context
+2. Downgrade to a platform/TFM without numeric `IntPtr`/`UIntPtr` types
+
+Also, implicit conversions between `IntPtr`/`UIntPtr` and other numeric types are treated as standard
+conversions on such platforms. This can affect overload resolution in some cases.
+
 ## Nameof operator in attribute on method or local function
 
 ***Introduced in .NET SDK 7.0.400, Visual Studio 2022 version 17.3.***

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -18,6 +18,11 @@ IntPtr M(IntPtr x, int y)
         return x + y; // may now throw
     }
 }
+
+IntPtr M2(ulong ul)
+{
+    return checked((IntPtr)ul); // may now throw
+}
 ```
 
 Possible workarounds are:

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -2,7 +2,7 @@
 
 ## Checked operators on System.IntPtr and System.UIntPtr
 
-***Introduced in .NET SDK 7.0.100 preview 5, Visual Studio 2022 version 17.3.***
+***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***
 
 When the platform supports __numeric__ `IntPtr` and `UIntPtr` types (as indicated by the presence of
 `System.Runtime.CompilerServices.RuntimeFeature.NumericIntPtr`) the built-in operators from `nint`

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -30,7 +30,7 @@ conversions on such platforms. This can affect overload resolution in some cases
 
 ## Nameof operator in attribute on method or local function
 
-***Introduced in .NET SDK 7.0.400, Visual Studio 2022 version 17.3.***
+***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***
 
 When the language version is C# 11 or later, a `nameof` operator in an attribute on a method
 brings the type parameters of that method in scope. The same applies for local functions.  

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -30,7 +30,7 @@ conversions on such platforms. This can affect overload resolution in some cases
 
 ## Nameof operator in attribute on method or local function
 
-***Introduced in .NET SDK 7.0.100 preview 4, Visual Studio 2022 version 17.3.***
+***Introduced in .NET SDK 6.0.400, Visual Studio 2022 version 17.3.***
 
 When the language version is C# 11 or later, a `nameof` operator in an attribute on a method
 brings the type parameters of that method in scope. The same applies for local functions.  

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -10177,6 +10177,7 @@ public class C
         [Fact]
         public void OverflowPointerConversion()
         {
+            // Breaking change
             string source = """
 using System;
 class C

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -10175,6 +10175,33 @@ public class C
         }
 
         [Fact]
+        public void OverflowPointerConversion()
+        {
+            string source = """
+using System;
+ulong ul = ulong.MaxValue;
+
+try
+{
+    IntPtr i = checked((IntPtr)ul);
+}
+catch (System.OverflowException)
+{
+    Console.Write("RAN ");
+}
+
+IntPtr j = unchecked((IntPtr)ul);
+if (j == -1)
+{
+    Console.Write("RAN");
+}
+""";
+            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "RAN RAN");
+        }
+
+        [Fact]
         public void VariousMembersToDecodeOnRuntimeFeatureType()
         {
             var corlib_cs = @"

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -10179,26 +10179,36 @@ public class C
         {
             string source = """
 using System;
-ulong ul = ulong.MaxValue;
+class C
+{
+    public unsafe static void Main()
+    {
+        void* ptr = (void*)ulong.MaxValue;
 
-try
-{
-    IntPtr i = checked((IntPtr)ul);
-}
-catch (System.OverflowException)
-{
-    Console.Write("RAN ");
-}
+        try
+        {
+            IntPtr i = checked((IntPtr)ptr);
+        }
+        catch (System.OverflowException)
+        {
+            Console.Write("OVERFLOW ");
+        }
 
-IntPtr j = unchecked((IntPtr)ul);
-if (j == -1)
-{
-    Console.Write("RAN");
+        IntPtr j = unchecked((IntPtr)ptr);
+        if (j == (IntPtr)(-1))
+        {
+            Console.Write("RAN");
+        }
+    }
 }
 """;
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "RAN RAN");
+            CompileAndVerify(comp, expectedOutput: "OVERFLOW RAN", verify: Verification.Skipped);
+
+            comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "RAN", verify: Verification.Skipped);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -10100,7 +10100,7 @@ public class Derived : Base
             var baseNint = (PENamedTypeSymbol)baseM.ReturnType;
 
             var derivedM = (MethodSymbol)comp.GlobalNamespace.GetMember("Derived.M");
-            var derivedNint = (PENamedTypeSymbol)baseM.ReturnType;
+            var derivedNint = (PENamedTypeSymbol)derivedM.ReturnType;
 
             Assert.Equal("nint", derivedNint.ToTestDisplayString());
             Assert.Same(baseNint, derivedNint);
@@ -10131,10 +10131,11 @@ public class Derived : Base
             var baseNint = (PENamedTypeSymbol)baseM.ReturnType;
 
             var derivedM = (MethodSymbol)comp.GlobalNamespace.GetMember("Derived.M");
-            var derivedNint = (PENamedTypeSymbol)baseM.ReturnType;
+            var derivedNint = (NativeIntegerTypeSymbol)derivedM.ReturnType;
 
-            Assert.Equal("System.IntPtr", derivedNint.ToTestDisplayString());
-            Assert.Same(baseNint, derivedNint);
+            Assert.Equal("System.IntPtr", baseNint.ToTestDisplayString());
+            Assert.Equal("nint", derivedNint.ToTestDisplayString());
+            Assert.Same(baseNint, derivedNint.UnderlyingNamedType);
         }
 
         [Fact]


### PR DESCRIPTION
Relates to test plan https://github.com/dotnet/roslyn/issues/60578

Verified remove unnecessary cast works:
![image](https://user-images.githubusercontent.com/12466233/169413186-bddc3266-a040-4326-86ea-d6b46cb0bb0d.png)

Name simplification is missing (works on `Int32` but not `IntPtr`):
![image](https://user-images.githubusercontent.com/12466233/169413334-0bb3164a-d21f-4114-9380-df1c88b6bfb8.png)
Filed issue https://github.com/dotnet/roslyn/issues/61419
