### PR TITLE
Fix binding for checkbox text in rename dialogs

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -16,6 +16,7 @@
              GotKeyboardFocus="Adornment_GotKeyboardFocus"
              Focusable="False"
              UseLayoutRounding="True"
+             x:Name="control"
              Background="{DynamicResource {x:Static rename:InlineRenameColors.BackgroundBrushKey}}">
 
     <UserControl.Resources>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Dashboard/RenameDashboard.xaml
@@ -11,6 +11,7 @@
              MinWidth="300"
              Cursor="Arrow"
              Focusable="True"
+             x:Name="dashboard"
              AutomationProperties.AutomationId="Microsoft.CodeAnalysis.EditorFeatures.InlineRenameDialog" 
              UseLayoutRounding="True">
     <!-- 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornment.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornment.cs
@@ -11,13 +11,12 @@ using System.Windows.Controls;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
+    /// <summary>
+    /// A base class for rename controls. Needs to have a default constructor so the 
+    /// type can be used in ResourceDictionaries in XAML
+    /// </summary>
     internal class InlineRenameAdornment : UserControl, IDisposable
     {
-        public InlineRenameAdornment()
-            : base()
-        {
-        }
-
         public virtual void Dispose() { }
     }
 }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornment.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornment.cs
@@ -11,8 +11,13 @@ using System.Windows.Controls;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
-    internal abstract class InlineRenameAdornment : UserControl, IDisposable
+    internal class InlineRenameAdornment : UserControl, IDisposable
     {
-        public abstract void Dispose();
+        public InlineRenameAdornment()
+            : base()
+        {
+        }
+
+        public virtual void Dispose() { }
     }
 }


### PR DESCRIPTION
Previously text was bound to properties on the control type using `x:Name`. This restores that 