### PR TITLE
IDE Support for Required Members

### DIFF
--- a/src/Analyzers/CSharp/Tests/OrderModifiers/OrderModifiersTests.cs
+++ b/src/Analyzers/CSharp/Tests/OrderModifiers/OrderModifiersTests.cs
@@ -431,5 +431,39 @@ static internal class C2
     static internal class Nested { }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsOrderModifiers)]
+        public async Task RequiredAfterAllOnProp()
+        {
+            await TestInRegularAndScriptAsync("""
+                class C
+                {
+                    [|required|] public virtual unsafe int Prop { get; init; }
+                }
+                """,
+                """
+                class C
+                {
+                    public virtual unsafe required int Prop { get; init; }
+                }
+                """);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsOrderModifiers)]
+        public async Task RequiredAfterAllButVolatileOnField()
+        {
+            await TestInRegularAndScriptAsync("""
+                class C
+                {
+                    [|required|] public unsafe volatile int Field;
+                }
+                """,
+                """
+                class C
+                {
+                    public unsafe required volatile int Field;
+                }
+                """);
+        }
     }
 }

--- a/src/CodeStyle/Core/Analyzers/PublicAPI.Unshipped.txt
+++ b/src/CodeStyle/Core/Analyzers/PublicAPI.Unshipped.txt
@@ -57,6 +57,7 @@ Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsNew(bool isNe
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsOverride(bool isOverride) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsReadOnly(bool isReadOnly) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsRef(bool isRef) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
+Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsRequired(bool isRequired) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsSealed(bool isSealed) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsStatic(bool isStatic) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsUnsafe(bool isUnsafe) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
@@ -64,7 +65,6 @@ Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsVirtual(bool 
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsVolatile(bool isVolatile) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsWriteOnly(bool isWriteOnly) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithPartial(bool isPartial) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
-Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithRequired(bool isRequired) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithWithEvents(bool withEvents) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 override Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.GetHashCode() -> int

--- a/src/CodeStyle/Core/Analyzers/PublicAPI.Unshipped.txt
+++ b/src/CodeStyle/Core/Analyzers/PublicAPI.Unshipped.txt
@@ -41,6 +41,7 @@ Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsOverride.get -> b
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsPartial.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsReadOnly.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsRef.get -> bool
+Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsRequired.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsSealed.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsStatic.get -> bool
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.IsUnsafe.get -> bool
@@ -63,6 +64,7 @@ Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsVirtual(bool 
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsVolatile(bool isVolatile) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithIsWriteOnly(bool isWriteOnly) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithPartial(bool isPartial) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
+Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithRequired(bool isRequired) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.WithWithEvents(bool withEvents) -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 override Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Equals(object obj) -> bool
 override Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.GetHashCode() -> int
@@ -84,6 +86,7 @@ static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Override.get
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Partial.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.ReadOnly.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Ref.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
+static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Required.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Sealed.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.Static.get -> Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers.TryParse(string value, out Microsoft.CodeAnalysis.Internal.Editing.DeclarationModifiers modifiers) -> bool

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -125,7 +125,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             AddAccessibilityIfNeeded(symbol);
             AddMemberModifiersIfNeeded(symbol);
 
-
             if (ShouldPropertyDisplayReadOnly(symbol))
             {
                 AddReadOnlyIfNeeded();

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             AddAccessibilityIfNeeded(symbol);
             AddMemberModifiersIfNeeded(symbol);
-            AddFieldModifiersIfRequired(symbol);
+            AddFieldModifiersIfNeeded(symbol);
 
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeType) &&
                 this.isFirstSymbolVisited &&
@@ -812,7 +812,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return value.GetType().GetTypeInfo().IsPrimitive || value is string || value is decimal;
         }
 
-        private void AddFieldModifiersIfRequired(IFieldSymbol symbol)
+        private void AddFieldModifiersIfNeeded(IFieldSymbol symbol)
         {
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeModifiers) &&
                 !IsEnumMember(symbol))

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitField(IFieldSymbol symbol)
         {
-            AddAccessibilityIfRequired(symbol);
-            AddMemberModifiersIfRequired(symbol);
+            AddAccessibilityIfNeeded(symbol);
+            AddMemberModifiersIfNeeded(symbol);
             AddFieldModifiersIfRequired(symbol);
 
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeType) &&
@@ -122,8 +122,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitProperty(IPropertySymbol symbol)
         {
-            AddAccessibilityIfRequired(symbol);
-            AddMemberModifiersIfRequired(symbol);
+            AddAccessibilityIfNeeded(symbol);
+            AddMemberModifiersIfNeeded(symbol);
+
 
             if (ShouldPropertyDisplayReadOnly(symbol))
             {
@@ -210,8 +211,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitEvent(IEventSymbol symbol)
         {
-            AddAccessibilityIfRequired(symbol);
-            AddMemberModifiersIfRequired(symbol);
+            AddAccessibilityIfNeeded(symbol);
+            AddMemberModifiersIfNeeded(symbol);
 
             var accessor = symbol.AddMethod ?? symbol.RemoveMethod;
             if (accessor is object && ShouldMethodDisplayReadOnly(accessor))
@@ -300,8 +301,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)symbol.ContainingType != null || (symbol.ContainingSymbol is ITypeSymbol))
             {
-                AddAccessibilityIfRequired(symbol);
-                AddMemberModifiersIfRequired(symbol);
+                AddAccessibilityIfNeeded(symbol);
+                AddMemberModifiersIfNeeded(symbol);
 
                 if (ShouldMethodDisplayReadOnly(symbol))
                 {
@@ -838,7 +839,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddMemberModifiersIfRequired(ISymbol symbol)
+        private void AddMemberModifiersIfNeeded(ISymbol symbol)
         {
             INamedTypeSymbol containingType = symbol.ContainingType;
 
@@ -850,6 +851,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                  (containingType.TypeKind != TypeKind.Interface && !IsEnumMember(symbol) && !IsLocalFunction(symbol))))
             {
                 var isConst = symbol is IFieldSymbol && ((IFieldSymbol)symbol).IsConst;
+                var isRequired = symbol is IFieldSymbol { IsRequired: true } or IPropertySymbol { IsRequired: true };
                 if (symbol.IsStatic && !isConst)
                 {
                     AddKeyword(SyntaxKind.StaticKeyword);
@@ -883,6 +885,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (symbol.IsVirtual)
                 {
                     AddKeyword(SyntaxKind.VirtualKeyword);
+                    AddSpace();
+                }
+
+                if (isRequired)
+                {
+                    AddKeyword(SyntaxKind.RequiredKeyword);
                     AddSpace();
                 }
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitFieldType(symbol);
                 AddSpace();
 
-                AddCustomModifiersIfRequired(symbol.CustomModifiers);
+                AddCustomModifiersIfNeeded(symbol.CustomModifiers);
             }
 
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeContainingType) &&
@@ -128,26 +128,26 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (ShouldPropertyDisplayReadOnly(symbol))
             {
-                AddReadOnlyIfRequired();
+                AddReadOnlyIfNeeded();
             }
 
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeType))
             {
                 if (symbol.ReturnsByRef)
                 {
-                    AddRefIfRequired();
+                    AddRefIfNeeded();
                 }
                 else if (symbol.ReturnsByRefReadonly)
                 {
-                    AddRefReadonlyIfRequired();
+                    AddRefReadonlyIfNeeded();
                 }
 
-                AddCustomModifiersIfRequired(symbol.RefCustomModifiers);
+                AddCustomModifiersIfNeeded(symbol.RefCustomModifiers);
 
                 symbol.Type.Accept(this.NotFirstVisitor);
                 AddSpace();
 
-                AddCustomModifiersIfRequired(symbol.TypeCustomModifiers);
+                AddCustomModifiersIfNeeded(symbol.TypeCustomModifiers);
             }
 
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeContainingType) &&
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (getMemberNameWithoutInterfaceName)
             {
-                AddExplicitInterfaceIfRequired(symbol.ExplicitInterfaceImplementations);
+                AddExplicitInterfaceIfNeeded(symbol.ExplicitInterfaceImplementations);
             }
 
             if (symbol.IsIndexer)
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (this.format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeParameters) && symbol.Parameters.Any())
             {
                 AddPunctuation(SyntaxKind.OpenBracketToken);
-                AddParametersIfRequired(hasThisParameter: false, isVarargs: false, parameters: symbol.Parameters);
+                AddParametersIfNeeded(hasThisParameter: false, isVarargs: false, parameters: symbol.Parameters);
                 AddPunctuation(SyntaxKind.CloseBracketToken);
             }
         }
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var accessor = symbol.AddMethod ?? symbol.RemoveMethod;
             if (accessor is object && ShouldMethodDisplayReadOnly(accessor))
             {
-                AddReadOnlyIfRequired();
+                AddReadOnlyIfNeeded();
             }
 
             if (format.KindOptions.IncludesOption(SymbolDisplayKindOptions.IncludeMemberKeyword))
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (symbol.Name.LastIndexOf('.') > 0)
             {
-                AddExplicitInterfaceIfRequired(symbol.ExplicitInterfaceImplementations);
+                AddExplicitInterfaceIfNeeded(symbol.ExplicitInterfaceImplementations);
 
                 this.builder.Add(CreatePart(SymbolDisplayPartKind.EventName, symbol,
                     ExplicitInterfaceHelpers.GetMemberNameWithoutInterfaceName(symbol.Name)));
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (ShouldMethodDisplayReadOnly(symbol))
                 {
-                    AddReadOnlyIfRequired();
+                    AddReadOnlyIfNeeded();
                 }
 
                 if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeType))
@@ -334,14 +334,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             if (symbol.ReturnsByRef)
                             {
-                                AddRefIfRequired();
+                                AddRefIfNeeded();
                             }
                             else if (symbol.ReturnsByRefReadonly)
                             {
-                                AddRefReadonlyIfRequired();
+                                AddRefReadonlyIfNeeded();
                             }
 
-                            AddCustomModifiersIfRequired(symbol.RefCustomModifiers);
+                            AddCustomModifiersIfNeeded(symbol.RefCustomModifiers);
 
                             if (symbol.ReturnsVoid)
                             {
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
 
                             AddSpace();
-                            AddCustomModifiersIfRequired(symbol.ReturnTypeCustomModifiers);
+                            AddCustomModifiersIfNeeded(symbol.ReturnTypeCustomModifiers);
                             break;
                     }
                 }
@@ -477,7 +477,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case MethodKind.ExplicitInterfaceImplementation:
                     {
-                        AddExplicitInterfaceIfRequired(symbol.ExplicitInterfaceImplementations);
+                        AddExplicitInterfaceIfNeeded(symbol.ExplicitInterfaceImplementations);
 
                         if (!format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.UseMetadataMethodNames) &&
                             symbol.GetSymbol()?.OriginalDefinition is SourceUserDefinedOperatorSymbolBase sourceUserDefinedOperatorSymbolBase)
@@ -602,11 +602,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     AddParameterRefKind(param.RefKind);
 
-                    AddCustomModifiersIfRequired(param.RefCustomModifiers);
+                    AddCustomModifiersIfNeeded(param.RefCustomModifiers);
 
                     param.Type.Accept(this.NotFirstVisitor);
 
-                    AddCustomModifiersIfRequired(param.CustomModifiers, leadingSpace: true, trailingSpace: false);
+                    AddCustomModifiersIfNeeded(param.CustomModifiers, leadingSpace: true, trailingSpace: false);
 
                     AddPunctuation(SyntaxKind.CommaToken);
                     AddSpace();
@@ -621,11 +621,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     AddRefReadonly();
                 }
 
-                AddCustomModifiersIfRequired(symbol.RefCustomModifiers);
+                AddCustomModifiersIfNeeded(symbol.RefCustomModifiers);
 
                 symbol.ReturnType.Accept(this.NotFirstVisitor);
 
-                AddCustomModifiersIfRequired(symbol.ReturnTypeCustomModifiers, leadingSpace: true, trailingSpace: false);
+                AddCustomModifiersIfNeeded(symbol.ReturnTypeCustomModifiers, leadingSpace: true, trailingSpace: false);
 
                 AddPunctuation(SyntaxKind.GreaterThanToken);
             }
@@ -724,7 +724,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeParameters))
             {
                 AddPunctuation(SyntaxKind.OpenParenToken);
-                AddParametersIfRequired(
+                AddParametersIfNeeded(
                     hasThisParameter: symbol.IsExtensionMethod && symbol.MethodKind != MethodKind.ReducedExtension,
                     isVarargs: symbol.IsVararg,
                     parameters: symbol.Parameters);
@@ -756,8 +756,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (includeType)
             {
-                AddParameterRefKindIfRequired(symbol.RefKind);
-                AddCustomModifiersIfRequired(symbol.RefCustomModifiers, leadingSpace: false, trailingSpace: true);
+                AddParameterRefKindIfNeeded(symbol.RefKind);
+                AddCustomModifiersIfNeeded(symbol.RefCustomModifiers, leadingSpace: false, trailingSpace: true);
 
                 if (symbol.IsParams && format.ParameterOptions.IncludesOption(SymbolDisplayParameterOptions.IncludeParamsRefOut))
                 {
@@ -766,7 +766,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 symbol.Type.Accept(this.NotFirstVisitor);
-                AddCustomModifiersIfRequired(symbol.CustomModifiers, leadingSpace: true, trailingSpace: false);
+                AddCustomModifiersIfNeeded(symbol.CustomModifiers, leadingSpace: true, trailingSpace: false);
             }
 
             if (includeName)
@@ -896,7 +896,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddParametersIfRequired(bool hasThisParameter, bool isVarargs, ImmutableArray<IParameterSymbol> parameters)
+        private void AddParametersIfNeeded(bool hasThisParameter, bool isVarargs, ImmutableArray<IParameterSymbol> parameters)
         {
             if (format.ParameterOptions == SymbolDisplayParameterOptions.None)
             {
@@ -956,7 +956,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!ShouldPropertyDisplayReadOnly(property) && ShouldMethodDisplayReadOnly(method, property))
                 {
-                    AddReadOnlyIfRequired();
+                    AddReadOnlyIfNeeded();
                 }
 
                 AddKeyword(keyword);
@@ -964,7 +964,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddExplicitInterfaceIfRequired<T>(ImmutableArray<T> implementedMembers) where T : ISymbol
+        private void AddExplicitInterfaceIfNeeded<T>(ImmutableArray<T> implementedMembers) where T : ISymbol
         {
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeExplicitInterface) && !implementedMembers.IsEmpty)
             {
@@ -980,7 +980,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddCustomModifiersIfRequired(ImmutableArray<CustomModifier> customModifiers, bool leadingSpace = false, bool trailingSpace = true)
+        private void AddCustomModifiersIfNeeded(ImmutableArray<CustomModifier> customModifiers, bool leadingSpace = false, bool trailingSpace = true)
         {
             if (this.format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeCustomModifiers) && !customModifiers.IsEmpty)
             {
@@ -1005,7 +1005,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddRefIfRequired()
+        private void AddRefIfNeeded()
         {
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeRef))
             {
@@ -1019,7 +1019,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AddSpace();
         }
 
-        private void AddRefReadonlyIfRequired()
+        private void AddRefReadonlyIfNeeded()
         {
             if (format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeRef))
             {
@@ -1035,7 +1035,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AddSpace();
         }
 
-        private void AddReadOnlyIfRequired()
+        private void AddReadOnlyIfNeeded()
         {
             // 'readonly' in this context is effectively a 'ref' modifier
             // because it affects whether the 'this' parameter is 'ref' or 'in'.
@@ -1046,7 +1046,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddParameterRefKindIfRequired(RefKind refKind)
+        private void AddParameterRefKindIfNeeded(RefKind refKind)
         {
             if (format.ParameterOptions.IncludesOption(SymbolDisplayParameterOptions.IncludeParamsRefOut))
             {

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (!this.isFirstSymbolVisited)
                 {
-                    AddCustomModifiersIfRequired(arrayType.CustomModifiers, leadingSpace: true);
+                    AddCustomModifiersIfNeeded(arrayType.CustomModifiers, leadingSpace: true);
                 }
 
                 AddArrayRank(arrayType);
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!this.isFirstSymbolVisited)
             {
-                AddCustomModifiersIfRequired(symbol.CustomModifiers, leadingSpace: true);
+                AddCustomModifiersIfNeeded(symbol.CustomModifiers, leadingSpace: true);
             }
             AddPunctuation(SyntaxKind.AsteriskToken);
         }
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (this.isFirstSymbolVisited)
             {
-                AddTypeParameterVarianceIfRequired(symbol);
+                AddTypeParameterVarianceIfNeeded(symbol);
             }
 
             //variance and constraints are handled by methods and named types
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (typeArg.TypeKind != TypeKind.Pointer)
                     {
                         typeArg.Accept(this.NotFirstVisitor);
-                        AddCustomModifiersIfRequired(symbol.GetTypeArgumentCustomModifiers(0), leadingSpace: true, trailingSpace: false);
+                        AddCustomModifiersIfNeeded(symbol.GetTypeArgumentCustomModifiers(0), leadingSpace: true, trailingSpace: false);
 
                         AddPunctuation(SyntaxKind.QuestionToken);
 
@@ -233,11 +233,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var invokeMethod = symbol.DelegateInvokeMethod;
                     if (invokeMethod.ReturnsByRef)
                     {
-                        AddRefIfRequired();
+                        AddRefIfNeeded();
                     }
                     else if (invokeMethod.ReturnsByRefReadonly)
                     {
-                        AddRefReadonlyIfRequired();
+                        AddRefReadonlyIfNeeded();
                     }
 
                     if (invokeMethod.ReturnsVoid)
@@ -426,7 +426,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var method = symbol.DelegateInvokeMethod;
                     AddPunctuation(SyntaxKind.OpenParenToken);
-                    AddParametersIfRequired(hasThisParameter: false, isVarargs: method.IsVararg, parameters: method.Parameters);
+                    AddParametersIfNeeded(hasThisParameter: false, isVarargs: method.IsVararg, parameters: method.Parameters);
                     AddPunctuation(SyntaxKind.CloseParenToken);
                 }
             }
@@ -731,7 +731,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddTypeParameterVarianceIfRequired(ITypeParameterSymbol symbol)
+        private void AddTypeParameterVarianceIfNeeded(ITypeParameterSymbol symbol)
         {
             if (format.GenericsOptions.IncludesOption(SymbolDisplayGenericsOptions.IncludeVariance))
             {
@@ -785,7 +785,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var typeParam = (ITypeParameterSymbol)typeArg;
 
-                        AddTypeParameterVarianceIfRequired(typeParam);
+                        AddTypeParameterVarianceIfNeeded(typeParam);
 
                         visitor = this.NotFirstVisitor;
                     }
@@ -798,7 +798,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (!modifiers.IsDefault)
                     {
-                        AddCustomModifiersIfRequired(modifiers[i], leadingSpace: true, trailingSpace: false);
+                        AddCustomModifiersIfNeeded(modifiers[i], leadingSpace: true, trailingSpace: false);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             builder.Add(CreatePart(SymbolDisplayPartKind.Keyword, null, SyntaxFacts.GetText(keywordKind)));
         }
 
-        private void AddAccessibilityIfRequired(ISymbol symbol)
+        private void AddAccessibilityIfNeeded(ISymbol symbol)
         {
             INamedTypeSymbol containingType = symbol.ContainingType;
 

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/FieldSymbol.cs
@@ -81,6 +81,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool IFieldSymbol.IsVolatile => _underlying.IsVolatile;
 
+        bool IFieldSymbol.IsRequired => _underlying.IsRequired;
+
         bool IFieldSymbol.IsFixedSizeBuffer => _underlying.IsFixedSizeBuffer;
 
         int IFieldSymbol.FixedSize => _underlying.FixedSize;

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/PropertySymbol.cs
@@ -91,6 +91,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
             get { return false; }
         }
 
+        bool IPropertySymbol.IsRequired => _underlying.IsRequired;
+
         ImmutableArray<CustomModifier> IPropertySymbol.TypeCustomModifiers
         {
             get { return _underlying.TypeWithAnnotations.CustomModifiers; }

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -2744,6 +2744,7 @@ namespace N1 {
                 globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeTypeConstraints,
                 memberOptions:
+                    SymbolDisplayMemberOptions.IncludeModifiers |
                     SymbolDisplayMemberOptions.IncludeRef |
                     SymbolDisplayMemberOptions.IncludeType |
                     SymbolDisplayMemberOptions.IncludeParameters |
@@ -7990,6 +7991,40 @@ class C
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ParameterName,
                 SymbolDisplayPartKind.Punctuation);
+        }
+
+        [Fact]
+        public void TestRequiredProperty()
+        {
+            var source = @"
+class C
+{
+    required int Prop { get; set; }
+}
+";
+
+            var comp = CreateCompilation(source);
+            var propertySymbol = comp.GetMember<PropertySymbol>("C.Prop").GetPublicSymbol();
+
+            Verify(propertySymbol.ToDisplayParts(s_memberSignatureDisplayFormat), "required int C.Prop { get; set; }",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ClassName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.PropertyName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation);
+
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -4506,4 +4506,26 @@ public class Derived : Base
             }
         }
     }
+
+    [Theory]
+    [CombinatorialData]
+    public void PublicAPITests(bool isRequired)
+    {
+        var requiredText = isRequired ? "required" : "";
+        var comp = CreateCompilationWithRequiredMembers($$"""
+            public class C
+            {
+                public {{requiredText}} int Field;
+                public {{requiredText}} int Property { get; set; }
+            }
+            """);
+
+        var c = comp.GlobalNamespace.GetTypeMember("C");
+
+        var field = c.GetField("Field").GetPublicSymbol();
+        Assert.Equal(isRequired, field.IsRequired);
+
+        var property = c.GetProperty("Property").GetPublicSymbol();
+        Assert.Equal(isRequired, property.IsRequired);
+    }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -1306,5 +1306,13 @@ class Derived : Base
             const string Text = @"/// Prefix <b    b=""y""a=""x""	>S_OK</b> suffix";
             TestNormalizeDeclaration(Text, Expected);
         }
+
+        [Fact]
+        public void TestRequiredKeywordNormalization()
+        {
+            const string Expected = @"public required partial int Field;";
+            const string Text = @"public  required  partial int Field;";
+            TestNormalizeDeclaration(Text, Expected);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 *REMOVED*override abstract Microsoft.CodeAnalysis.Diagnostic.Equals(object? obj) -> bool
 abstract Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.DefaultResult.get -> TResult
 Microsoft.CodeAnalysis.Compilation.GetTypesByMetadataName(string! fullyQualifiedMetadataName) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol!>
+Microsoft.CodeAnalysis.IFieldSymbol.IsRequired.get -> bool
 Microsoft.CodeAnalysis.IImportScope
 Microsoft.CodeAnalysis.IImportScope.Aliases.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IAliasSymbol!>
 Microsoft.CodeAnalysis.IImportScope.ExternAliases.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IAliasSymbol!>
@@ -48,6 +49,7 @@ Microsoft.CodeAnalysis.IOperation.OperationList.Reversed.Reversed() -> void
 Microsoft.CodeAnalysis.IOperation.OperationList.Reversed.Count.get -> int
 Microsoft.CodeAnalysis.IOperation.OperationList.Reversed.GetEnumerator() -> Microsoft.CodeAnalysis.IOperation.OperationList.Reversed.Enumerator
 Microsoft.CodeAnalysis.IOperation.OperationList.Reversed.ToImmutableArray() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation!>
+Microsoft.CodeAnalysis.IPropertySymbol.IsRequired.get -> bool
 Microsoft.CodeAnalysis.SemanticModel.GetImportScopes(int position, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IImportScope!>
 Microsoft.CodeAnalysis.ISymbol.Accept<TArgument, TResult>(Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>! visitor, TArgument argument) -> TResult
 Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>
@@ -90,5 +92,4 @@ virtual Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.VisitPointerTyp
 virtual Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.VisitProperty(Microsoft.CodeAnalysis.IPropertySymbol! symbol, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.VisitRangeVariable(Microsoft.CodeAnalysis.IRangeVariableSymbol! symbol, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>.VisitTypeParameter(Microsoft.CodeAnalysis.ITypeParameterSymbol! symbol, TArgument argument) -> TResult
-
 Microsoft.CodeAnalysis.Operations.BinaryOperatorKind.UnsignedRightShift = 25 -> Microsoft.CodeAnalysis.Operations.BinaryOperatorKind

--- a/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
@@ -42,6 +42,11 @@ namespace Microsoft.CodeAnalysis
         bool IsVolatile { get; }
 
         /// <summary>
+        /// True if this property is required to be set in an object initializer during construction.
+        /// </summary>
+        bool IsRequired { get; }
+
+        /// <summary>
         /// Returns true if this field was declared as "fixed".
         /// Note that for a fixed-size buffer declaration, this.Type will be a pointer type, of which
         /// the pointed-to type will be the declared element type of the fixed-size buffer.

--- a/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IFieldSymbol.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
         bool IsVolatile { get; }
 
         /// <summary>
-        /// True if this property is required to be set in an object initializer during construction.
+        /// True if this field is required to be set in an object initializer during construction.
         /// </summary>
         bool IsRequired { get; }
 

--- a/src/Compilers/Core/Portable/Symbols/IPropertySymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IPropertySymbol.cs
@@ -32,6 +32,11 @@ namespace Microsoft.CodeAnalysis
         bool IsWriteOnly { get; }
 
         /// <summary>
+        /// True if this property is required to be set in an object initializer during construction.
+        /// </summary>
+        bool IsRequired { get; }
+
+        /// <summary>
         /// Returns true if this property is an auto-created WithEvents property that takes place of
         /// a field member when the field is marked as WithEvents.
         /// </summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
@@ -418,6 +418,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property IFieldSymbol_IsRequired As Boolean Implements IFieldSymbol.IsRequired
+            Get
+                Return False
+            End Get
+        End Property
+
         Private ReadOnly Property IFieldSymbol_IsFixedSizeBuffer As Boolean Implements IFieldSymbol.IsFixedSizeBuffer
             Get
                 Return False

--- a/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
@@ -572,6 +572,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property IPropertySymbol_IsRequired As Boolean Implements IPropertySymbol.IsRequired
+            Get
+                Return False
+            End Get
+        End Property
+
         Private ReadOnly Property IPropertySymbol_ReturnsByRef As Boolean Implements IPropertySymbol.ReturnsByRef
             Get
                 Return Me.ReturnsByRef

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
@@ -643,20 +643,26 @@ $@"class C
             await VerifyItemIsAbsentAsync(markup, "required");
         }
 
-        [Fact]
-        public async Task DoNotSuggestRequiredOnStaticMembers()
+        [Theory]
+        [InlineData("static")]
+        [InlineData("const")]
+        [InlineData("readonly")]
+        public async Task DoNotSuggestRequiredOnFilteredKeywordMembers(string keyword)
         {
             var markup = $$"""
                 class C 
                 {
-                    static $$
+                    {{keyword}} $$
                 """;
 
             await VerifyItemIsAbsentAsync(markup, "required");
         }
 
-        [Fact]
-        public async Task DoNotSuggestStaticOnRequiredMembers()
+        [Theory]
+        [InlineData("static")]
+        [InlineData("const")]
+        [InlineData("readonly")]
+        public async Task DoNotSuggestFilteredKeywordsOnRequiredMembers(string keyword)
         {
             var markup = $$"""
                 class C 
@@ -664,7 +670,7 @@ $@"class C
                     required $$
                 """;
 
-            await VerifyItemIsAbsentAsync(markup, "static");
+            await VerifyItemIsAbsentAsync(markup, keyword);
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
@@ -616,5 +616,67 @@ $@"class C
                 await VerifyItemExistsAsync(markup, "nameof");
             }
         }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task SuggestRequiredInClassOrStruct(string type)
+        {
+            var markup = $$"""
+                {{type}} C
+                {
+                    $$
+                """;
+
+            await VerifyItemExistsAsync(markup, "required");
+        }
+
+        [Fact]
+        public async Task DontSuggestRequiredInInterface()
+        {
+            var markup = $$"""
+                interface I
+                {
+                    public $$
+                """;
+
+            await VerifyItemIsAbsentAsync(markup, "required");
+        }
+
+        [Fact]
+        public async Task DontSuggestRequiredOnStaticMembers()
+        {
+            var markup = $$"""
+                class C 
+                {
+                    static $$
+                """;
+
+            await VerifyItemIsAbsentAsync(markup, "required");
+        }
+
+        [Fact]
+        public async Task DontSuggestStaticOnRequiredMembers()
+        {
+            var markup = $$"""
+                class C 
+                {
+                    required $$
+                """;
+
+            await VerifyItemIsAbsentAsync(markup, "static");
+        }
+
+        [Fact]
+        public async Task DontSuggestRequiredOnRequiredMembers()
+        {
+            var markup = $$"""
+                class C 
+                {
+                    required $$
+                """;
+
+            await VerifyItemIsAbsentAsync(markup, "required");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/KeywordCompletionProviderTests.cs
@@ -632,7 +632,7 @@ $@"class C
         }
 
         [Fact]
-        public async Task DontSuggestRequiredInInterface()
+        public async Task DoNotSuggestRequiredInInterface()
         {
             var markup = $$"""
                 interface I
@@ -644,7 +644,7 @@ $@"class C
         }
 
         [Fact]
-        public async Task DontSuggestRequiredOnStaticMembers()
+        public async Task DoNotSuggestRequiredOnStaticMembers()
         {
             var markup = $$"""
                 class C 
@@ -656,7 +656,7 @@ $@"class C
         }
 
         [Fact]
-        public async Task DontSuggestStaticOnRequiredMembers()
+        public async Task DoNotSuggestStaticOnRequiredMembers()
         {
             var markup = $$"""
                 class C 
@@ -668,7 +668,7 @@ $@"class C
         }
 
         [Fact]
-        public async Task DontSuggestRequiredOnRequiredMembers()
+        public async Task DoNotSuggestRequiredOnRequiredMembers()
         {
             var markup = $$"""
                 class C 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -2700,6 +2700,148 @@ int bar;
             }
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CommitRequiredKeywordAdded()
+        {
+            var markupBeforeCommit = """
+                class Base
+                {
+                    public virtual required int Prop { get; }
+                }
+
+                class Derived : Base
+                {
+                    override $$
+                }
+                """;
+
+            var expectedCodeAfterCommit = """
+                class Base
+                {
+                    public virtual required int Prop { get; }
+                }
+
+                class Derived : Base
+                {
+                    public override required int Prop
+                    {
+                        get
+                        {
+                            return base.Prop;$$
+                        }
+                    }
+                }
+                """;
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "Prop", expectedCodeAfterCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CommitRequiredKeywordPreserved()
+        {
+            var markupBeforeCommit = """
+                class Base
+                {
+                    public virtual required int Prop { get; }
+                }
+
+                class Derived : Base
+                {
+                    required override $$
+                }
+                """;
+
+            var expectedCodeAfterCommit = """
+                class Base
+                {
+                    public virtual required int Prop { get; }
+                }
+
+                class Derived : Base
+                {
+                    public override required int Prop
+                    {
+                        get
+                        {
+                            return base.Prop;$$
+                        }
+                    }
+                }
+                """;
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "Prop", expectedCodeAfterCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CommitRequiredKeywordRemovedForMethods()
+        {
+            var markupBeforeCommit = """
+                class Base
+                {
+                    public virtual void M() { }
+                }
+
+                class Derived : Base
+                {
+                    required override $$
+                }
+                """;
+
+            var expectedCodeAfterCommit = """
+                class Base
+                {
+                    public virtual void M() { }
+                }
+
+                class Derived : Base
+                {
+                    public override void M()
+                    {
+                        base.M();$$
+                    }
+                }
+                """;
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "M()", expectedCodeAfterCommit);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CommitRequiredKeywordRemovedForIndexers()
+        {
+            var markupBeforeCommit = """
+                class Base
+                {
+                    public virtual int this[int i] { get { } set { } }
+                }
+
+                class Derived : Base
+                {
+                    required override $$
+                }
+                """;
+
+            var expectedCodeAfterCommit = """
+                class Base
+                {
+                    public virtual int this[int i] { get { } set { } }
+                }
+
+                class Derived : Base
+                {
+                    public override int this[int i]
+                    {
+                        get
+                        {
+                            return base[i];$$
+                        }
+
+                        set
+                        {
+                            base[i] = value;
+                        }
+                    }
+                }
+                """;
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "this[int i]", expectedCodeAfterCommit);
+        }
+
         #endregion
 
         #region "EditorBrowsable should be ignored"

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -623,6 +623,7 @@ using System;
 
 abstract class MyClass$$
 {
+    public required int RequiredProperty { get; set; }
     public void ExtractableMethod_Normal() { }
     public void ExtractableMethod_ParameterTypes(System.Diagnostics.CorrelationManager x, Nullable<Int32> y = 7, string z = ""42"") { }
     public abstract void ExtractableMethod_Abstract();
@@ -634,6 +635,8 @@ abstract class MyClass$$
 
 interface IMyClass
 {
+    int RequiredProperty { get; set; }
+
     void ExtractableMethod_Abstract();
     void ExtractableMethod_Normal();
     void ExtractableMethod_ParameterTypes(CorrelationManager x, int? y = 7, string z = ""42"");

--- a/src/EditorFeatures/CSharpTest/GenerateOverrides/GenerateOverridesTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateOverrides/GenerateOverridesTests.cs
@@ -250,5 +250,31 @@ class D : C
     }
 }", new[] { "M" });
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateOverrides)]
+        public async Task TestRequiredProperty()
+        {
+            await TestWithPickMembersDialogAsync(
+@"
+class Base
+{
+    public virtual required int Property { get; set; }
+}
+
+class Derived : Base
+{
+     [||]
+}",
+@"
+class Base
+{
+    public virtual required int Property { get; set; }
+}
+
+class Derived : Base
+{
+    public override required int Property { get => base.Property; set => base.Property = value; }
+}", new[] { "Property" });
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -2075,5 +2075,41 @@ class D : C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementAbstractClass)]
+        public async Task TestRequiredMember()
+        {
+            await TestAllOptionsOffAsync(
+                """
+                abstract class C
+                {
+                    public abstract required int Property { get; set; }
+                }
+                class [|D|] : C
+                {
+                }
+                """,
+                """
+                abstract class C
+                {
+                    public abstract required int Property { get; set; }
+                }
+                class D : C
+                {
+                    public override required int Property
+                    {
+                        get
+                        {
+                            throw new System.NotImplementedException();
+                        }
+
+                        set
+                        {
+                            throw new System.NotImplementedException();
+                        }
+                    }
+                }
+                """);
+        }
     }
 }

--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
@@ -861,7 +861,7 @@ csharp_prefer_simple_default_expression = true
 No editorconfig based code style option
 
 # IDE0036, PreferredModifierOrder
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
 
 # IDE0037, PreferInferredTupleNames
 dotnet_style_prefer_inferred_tuple_names = true

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
@@ -742,6 +742,77 @@ public class C
 
                 await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, expected: expected, signaturesOnly: signaturesOnly, languageVersion: "Preview", metadataLanguageVersion: "Preview");
             }
+
+            [Theory, CombinatorialData, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+            public async Task TestRequiredProperty(bool signaturesOnly)
+            {
+                var metadataSource = """
+                    public class C { public required int Property { get; set; } }
+                    namespace System.Runtime.CompilerServices
+                    {
+                        public sealed class RequiredMemberAttribute : Attribute { }
+                        public sealed class CompilerFeatureRequiredAttribute : Attribute
+                        {
+                            public CompilerFeatureRequiredAttribute(string featureName)
+                            {
+                                FeatureName = featureName;
+                            }
+                            public string FeatureName { get; }
+                            public bool IsOptional { get; set; }
+                        }
+                    }
+
+                    """;
+                var symbolName = "C";
+
+                // ICSharpDecompiler does not yet support decoding required members nicely
+                var expected = signaturesOnly switch
+                {
+                    true => $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+// {CodeAnalysisResources.InMemoryAssembly}
+#endregion
+
+using System.Runtime.CompilerServices;
+
+[RequiredMember]
+public class [|C|]
+{{
+    public C();
+
+    [RequiredMember]
+    public required int Property {{ get; set; }}
+}}",
+                    false => $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+// {CodeAnalysisResources.InMemoryAssembly}
+// Decompiled with ICSharpCode.Decompiler {ICSharpCodeDecompilerVersion}
+#endregion
+
+using System;
+using System.Runtime.CompilerServices;
+
+[RequiredMember]
+public class [|C|]
+{{
+    [RequiredMember]
+    public int Property {{ get; set; }}
+
+    [Obsolete(""Constructors of types with required members are not supported in this version of your compiler."", true)]
+    [CompilerFeatureRequired(""RequiredMembers"")]
+    public C()
+    {{
+    }}
+}}
+#if false // {CSharpEditorResources.Decompilation_log}
+{string.Format(CSharpEditorResources._0_items_in_cache, 6)}
+------------------
+{string.Format(CSharpEditorResources.Resolve_0, "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")}
+{string.Format(CSharpEditorResources.Found_single_assembly_0, "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")}
+{string.Format(CSharpEditorResources.Load_from_0, "mscorlib.v4_6_1038_0.dll")}
+#endif",
+                };
+
+                await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, languageVersion: "Preview", metadataLanguageVersion: "Preview", expected: expected, signaturesOnly: signaturesOnly);
+            }
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -127,6 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 new RefKeywordRecommender(),
                 new RegionKeywordRecommender(),
                 new RemoveKeywordRecommender(),
+                new RequiredKeywordRecommender(),
                 new RestoreKeywordRecommender(),
                 new ReturnKeywordRecommender(),
                 new SByteKeywordRecommender(),

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OverrideCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OverrideCompletionProvider.cs
@@ -85,6 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             var isUnsafe = false;
             var isSealed = false;
             var isAbstract = false;
+            var isRequired = false;
 
             while (IsOnStartLine(token.SpanStart, text, startLine) && !token.IsKind(SyntaxKind.None))
             {
@@ -103,6 +104,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         isAbstract = true;
                         break;
                     case SyntaxKind.ExternKeyword:
+                        break;
+                    case SyntaxKind.RequiredKeyword:
+                        isRequired = true;
                         break;
 
                     // Filter on the most recently typed accessibility; keep the first one we see
@@ -175,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 token = previousToken;
             }
 
-            modifiers = new DeclarationModifiers(isUnsafe: isUnsafe, isAbstract: isAbstract, isOverride: true, isSealed: isSealed);
+            modifiers = new DeclarationModifiers(isUnsafe: isUnsafe, isAbstract: isAbstract, isOverride: true, isSealed: isSealed, isRequired: isRequired);
             return overrideToken.IsKind(SyntaxKind.OverrideKeyword) && IsOnStartLine(overrideToken.Parent!.SpanStart, text, startLine);
         }
 

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RequiredKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RequiredKeywordRecommender.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.Utilities;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders;
+
+internal class RequiredKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+{
+    private static readonly ISet<SyntaxKind> s_validModifiers = SyntaxKindSet.AllMemberModifiers.Where(s => s is not (SyntaxKind.RequiredKeyword or SyntaxKind.StaticKeyword)).ToSet();
+
+    private static readonly ISet<SyntaxKind> s_validTypeDeclarations = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
+    {
+        SyntaxKind.StructDeclaration,
+        SyntaxKind.ClassDeclaration,
+    };
+
+    public RequiredKeywordRecommender()
+        : base(SyntaxKind.RequiredKeyword)
+    {
+    }
+
+    protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
+    {
+        return context.IsMemberDeclarationContext(s_validModifiers, s_validTypeDeclarations, canBePartial: true, cancellationToken);
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RequiredKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RequiredKeywordRecommender.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders;
 
 internal class RequiredKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
 {
-    private static readonly ISet<SyntaxKind> s_validModifiers = SyntaxKindSet.AllMemberModifiers.Where(s => s is not (SyntaxKind.RequiredKeyword or SyntaxKind.StaticKeyword)).ToSet();
+    private static readonly ISet<SyntaxKind> s_validModifiers = SyntaxKindSet.AllMemberModifiers.Where(s => s is not (SyntaxKind.RequiredKeyword or SyntaxKind.StaticKeyword or SyntaxKind.ReadOnlyKeyword or SyntaxKind.ConstKeyword)).ToSet();
 
     private static readonly ISet<SyntaxKind> s_validTypeDeclarations = new HashSet<SyntaxKind>(SyntaxFacts.EqualityComparer)
     {

--- a/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
+++ b/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.ImplementAbstractClass
             Compilation compilation, ISymbol member, ISymbol? throughMember, bool addUnsafe,
             ImplementTypePropertyGenerationBehavior propertyGenerationBehavior)
         {
-            var modifiers = new DeclarationModifiers(isOverride: true, isUnsafe: addUnsafe);
+            var modifiers = new DeclarationModifiers(isOverride: true, isUnsafe: addUnsafe, isRequired: member.IsRequired());
             var accessibility = member.ComputeResultantAccessibility(ClassType);
 
             // only call through one of members for this symbol if we can actually access the symbol

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedFieldSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedFieldSymbol.cs
@@ -39,6 +39,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public bool IsVolatile => _symbol.IsVolatile;
 
+            public bool IsRequired => _symbol.IsRequired;
+
             public bool IsFixedSizeBuffer => _symbol.IsFixedSizeBuffer;
 
             public int FixedSize => _symbol.FixedSize;

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
@@ -41,6 +41,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public bool IsWriteOnly => _symbol.IsWriteOnly;
 
+            public bool IsRequired => _symbol.IsRequired;
+
             public bool ReturnsByRef => _symbol.ReturnsByRef;
 
             public bool ReturnsByRefReadonly => _symbol.ReturnsByRefReadonly;

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -386,6 +386,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                             : "whereclause_CSharpKeyword";
 
                         return true;
+
+                    case SyntaxKind.RequiredKeyword:
+                        text = Keyword("required");
+                        return true;
                 }
             }
 

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1775,5 +1775,16 @@ class C
     }
 }", "checked");
         }
+
+        [Fact]
+        public async Task TestRequired()
+        {
+            await Test_KeywordAsync("""
+                public class C
+                {
+                    re[||]quired int Field;
+                }
+                """, "required");
+        }
     }
 }

--- a/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
+++ b/src/VisualStudio/Core/Test/Options/CSharpEditorConfigGeneratorTests.vb
@@ -123,7 +123,7 @@ csharp_style_prefer_parameter_null_checking = true
 
 # Modifier preferences
 csharp_prefer_static_local_function = true
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
 
 # Code-block preferences
 csharp_prefer_braces = true
@@ -361,7 +361,7 @@ csharp_style_prefer_parameter_null_checking = true
 
 # Modifier preferences
 csharp_prefer_static_local_function = true
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
 
 # Code-block preferences
 csharp_prefer_braces = true

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1376,6 +1376,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             DeclarationModifiers.Const |
             DeclarationModifiers.New |
             DeclarationModifiers.ReadOnly |
+            DeclarationModifiers.Required |
             DeclarationModifiers.Static |
             DeclarationModifiers.Unsafe |
             DeclarationModifiers.Volatile;
@@ -1405,6 +1406,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             DeclarationModifiers.New |
             DeclarationModifiers.Override |
             DeclarationModifiers.ReadOnly |
+            DeclarationModifiers.Required |
             DeclarationModifiers.Sealed |
             DeclarationModifiers.Static |
             DeclarationModifiers.Virtual |
@@ -1657,6 +1659,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             if (modifiers.IsExtern)
                 list.Add(SyntaxFactory.Token(SyntaxKind.ExternKeyword));
+
+            if (modifiers.IsRequired)
+                list.Add(SyntaxFactory.Token(SyntaxKind.RequiredKeyword));
 
             // partial and ref must be last
             if (modifiers.IsRef)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/FieldGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/FieldGenerator.cs
@@ -137,6 +137,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 {
                     tokens.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
                 }
+
+                if (field.IsRequired)
+                {
+                    tokens.Add(SyntaxFactory.Token(SyntaxKind.RequiredKeyword));
+                }
             }
 
             if (CodeGenerationFieldInfo.GetIsUnsafe(field))

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
@@ -397,6 +397,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     {
                         tokens.Add(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
                     }
+
+                    if (property.IsRequired)
+                    {
+                        tokens.Add(SyntaxFactory.Token(SyntaxKind.RequiredKeyword));
+                    }
                 }
             }
 

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -786,6 +786,10 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
             VerifySyntax<FieldDeclarationSyntax>(
                 Generator.FieldDeclaration("fld", Generator.TypeExpression(SpecialType.System_Int32), accessibility: Accessibility.NotApplicable, modifiers: DeclarationModifiers.Static | DeclarationModifiers.ReadOnly),
                 "static readonly int fld;");
+
+            VerifySyntax<FieldDeclarationSyntax>(
+                Generator.FieldDeclaration("fld", Generator.TypeExpression(SpecialType.System_Int32), accessibility: Accessibility.NotApplicable, modifiers: DeclarationModifiers.Required),
+                "required int fld;");
         }
 
         [Fact]
@@ -1010,6 +1014,10 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.Abstract),
                 "abstract x p { get; set; }");
+
+            VerifySyntax<PropertyDeclarationSyntax>(
+                Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.Required),
+                "required x p { get; set; }");
 
             VerifySyntax<PropertyDeclarationSyntax>(
                 Generator.PropertyDeclaration("p", Generator.IdentifierName("x"), modifiers: DeclarationModifiers.ReadOnly, getAccessorStatements: new[] { Generator.IdentifierName("y") }),
@@ -3621,6 +3629,17 @@ class C
 }");
         }
 
+        [Fact]
+        public void TestPropertyModifiers2()
+        {
+            TestModifiersAsync(DeclarationModifiers.ReadOnly | DeclarationModifiers.Required,
+                @"
+class C
+{
+    [|public required int X => 0;|]
+}");
+        }
+
         [Fact, WorkItem(1084965, " https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1084965")]
         public void TestFieldModifiers1()
         {
@@ -3629,6 +3648,17 @@ class C
 class C
 {
     public static int [|X|];
+}");
+        }
+
+        [Fact]
+        public void TestFieldModifiers2()
+        {
+            TestModifiersAsync(DeclarationModifiers.Required,
+                @"
+class C
+{
+    public required int [|X|];
 }");
         }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
@@ -78,6 +78,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public bool IsVolatile => false;
 
+        public bool IsRequired => Modifiers.IsRequired;
+
         public bool IsFixedSizeBuffer => false;
 
         public int FixedSize => 0;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
@@ -76,6 +76,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public bool IsWriteOnly => this.GetMethod == null && this.SetMethod != null;
 
+        public bool IsRequired => Modifiers.IsRequired;
+
         public new IPropertySymbol OriginalDefinition => this;
 
         public RefKind RefKind => _refKind;

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -37,7 +37,8 @@ namespace Microsoft.CodeAnalysis.Editing
             bool isWriteOnly = false,
             bool isRef = false,
             bool isVolatile = false,
-            bool isExtern = false)
+            bool isExtern = false,
+            bool isRequired = false)
             : this(
                   (isStatic ? Modifiers.Static : Modifiers.None) |
                   (isAbstract ? Modifiers.Abstract : Modifiers.None) |
@@ -54,7 +55,8 @@ namespace Microsoft.CodeAnalysis.Editing
                   (isWriteOnly ? Modifiers.WriteOnly : Modifiers.None) |
                   (isRef ? Modifiers.Ref : Modifiers.None) |
                   (isVolatile ? Modifiers.Volatile : Modifiers.None) |
-                  (isExtern ? Modifiers.Extern : Modifiers.None))
+                  (isExtern ? Modifiers.Extern : Modifiers.None) |
+                  (isRequired ? Modifiers.Required : Modifiers.None))
         {
         }
 
@@ -81,7 +83,8 @@ namespace Microsoft.CodeAnalysis.Editing
                     isUnsafe: symbol.RequiresUnsafeModifier(),
                     isVolatile: field?.IsVolatile == true,
                     isExtern: symbol.IsExtern,
-                    isAsync: method?.IsAsync == true);
+                    isAsync: method?.IsAsync == true,
+                    isRequired: field?.IsRequired == true || property?.IsRequired == true);
             }
 
             // Only named types, members of named types, and local functions have modifiers.
@@ -120,6 +123,8 @@ namespace Microsoft.CodeAnalysis.Editing
         public bool IsVolatile => (_modifiers & Modifiers.Volatile) != 0;
 
         public bool IsExtern => (_modifiers & Modifiers.Extern) != 0;
+
+        public bool IsRequired => (_modifiers & Modifiers.Required) != 0;
 
         public DeclarationModifiers WithIsStatic(bool isStatic)
             => new(SetFlag(_modifiers, Modifiers.Static, isStatic));
@@ -170,6 +175,9 @@ namespace Microsoft.CodeAnalysis.Editing
         public DeclarationModifiers WithIsExtern(bool isExtern)
             => new(SetFlag(_modifiers, Modifiers.Extern, isExtern));
 
+        public DeclarationModifiers WithRequired(bool isRequired)
+            => new(SetFlag(_modifiers, Modifiers.Required, isRequired));
+
         private static Modifiers SetFlag(Modifiers existing, Modifiers modifier, bool isSet)
             => isSet ? (existing | modifier) : (existing & ~modifier);
 
@@ -194,6 +202,7 @@ namespace Microsoft.CodeAnalysis.Editing
             Ref         = 1 << 13,
             Volatile    = 1 << 14,
             Extern      = 1 << 15,
+            Required    = 1 << 16,
 #pragma warning restore format
         }
 
@@ -215,6 +224,7 @@ namespace Microsoft.CodeAnalysis.Editing
         public static DeclarationModifiers Ref => new(Modifiers.Ref);
         public static DeclarationModifiers Volatile => new(Modifiers.Volatile);
         public static DeclarationModifiers Extern => new(Modifiers.Extern);
+        public static DeclarationModifiers Required => new(Modifiers.Required);
 
         public static DeclarationModifiers operator |(DeclarationModifiers left, DeclarationModifiers right)
             => new(left._modifiers | right._modifiers);

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editing
                     isVolatile: field?.IsVolatile == true,
                     isExtern: symbol.IsExtern,
                     isAsync: method?.IsAsync == true,
-                    isRequired: field?.IsRequired == true || property?.IsRequired == true);
+                    isRequired: symbol.IsRequired());
             }
 
             // Only named types, members of named types, and local functions have modifiers.

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Editing
         public DeclarationModifiers WithIsExtern(bool isExtern)
             => new(SetFlag(_modifiers, Modifiers.Extern, isExtern));
 
-        public DeclarationModifiers WithRequired(bool isRequired)
+        public DeclarationModifiers WithIsRequired(bool isRequired)
             => new(SetFlag(_modifiers, Modifiers.Required, isRequired));
 
         private static Modifiers SetFlag(Modifiers existing, Modifiers modifier, bool isSet)

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -2,9 +2,12 @@ Microsoft.CodeAnalysis.CodeFixes.DocumentBasedFixAllProvider.DocumentBasedFixAll
 Microsoft.CodeAnalysis.CodeFixes.FixAllContext.FixAllContext(Microsoft.CodeAnalysis.Document document, Microsoft.CodeAnalysis.Text.TextSpan? diagnosticSpan, Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider codeFixProvider, Microsoft.CodeAnalysis.CodeFixes.FixAllScope scope, string codeActionEquivalenceKey, System.Collections.Generic.IEnumerable<string> diagnosticIds, Microsoft.CodeAnalysis.CodeFixes.FixAllContext.DiagnosticProvider fixAllDiagnosticProvider, System.Threading.CancellationToken cancellationToken) -> void
 Microsoft.CodeAnalysis.CodeFixes.FixAllScope.ContainingMember = 4 -> Microsoft.CodeAnalysis.CodeFixes.FixAllScope
 Microsoft.CodeAnalysis.CodeFixes.FixAllScope.ContainingType = 5 -> Microsoft.CodeAnalysis.CodeFixes.FixAllScope
+Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsRequired.get -> bool
+Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithRequired(bool isRequired) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.SyntaxEditor.SyntaxEditor(Microsoft.CodeAnalysis.SyntaxNode root, Microsoft.CodeAnalysis.Host.HostWorkspaceServices services) -> void
 *REMOVED*static Microsoft.CodeAnalysis.Editing.SyntaxGenerator.DefaultRemoveOptions -> Microsoft.CodeAnalysis.SyntaxRemoveOptions
 static Microsoft.CodeAnalysis.CodeFixes.FixAllProvider.Create(System.Func<Microsoft.CodeAnalysis.CodeFixes.FixAllContext, Microsoft.CodeAnalysis.Document, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>, System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Document>> fixAllAsync, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CodeFixes.FixAllScope> supportedFixAllScopes) -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Required.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 static Microsoft.CodeAnalysis.Recommendations.Recommender.GetRecommendedSymbolsAtPositionAsync(Microsoft.CodeAnalysis.Document document, int position, Microsoft.CodeAnalysis.Options.OptionSet options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISymbol>>
 static readonly Microsoft.CodeAnalysis.Editing.SyntaxGenerator.DefaultRemoveOptions -> Microsoft.CodeAnalysis.SyntaxRemoveOptions
 Microsoft.CodeAnalysis.Rename.SymbolRenameOptions
@@ -27,5 +30,4 @@ Microsoft.CodeAnalysis.Rename.DocumentRenameOptions.RenameMatchingTypeInStrings.
 Microsoft.CodeAnalysis.Rename.DocumentRenameOptions.RenameMatchingTypeInComments.init -> void
 static Microsoft.CodeAnalysis.Rename.Renamer.RenameDocumentAsync(Microsoft.CodeAnalysis.Document document, Microsoft.CodeAnalysis.Rename.DocumentRenameOptions options, string newDocumentName, System.Collections.Generic.IReadOnlyList<string> newDocumentFolders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Rename.Renamer.RenameDocumentActionSet>
 static Microsoft.CodeAnalysis.Rename.Renamer.RenameSymbolAsync(Microsoft.CodeAnalysis.Solution solution, Microsoft.CodeAnalysis.ISymbol symbol, Microsoft.CodeAnalysis.Rename.SymbolRenameOptions options, string newName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Solution>
-
 Microsoft.CodeAnalysis.Editing.OperatorKind.UnsignedRightShift = 26 -> Microsoft.CodeAnalysis.Editing.OperatorKind

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,7 +3,7 @@ Microsoft.CodeAnalysis.CodeFixes.FixAllContext.FixAllContext(Microsoft.CodeAnaly
 Microsoft.CodeAnalysis.CodeFixes.FixAllScope.ContainingMember = 4 -> Microsoft.CodeAnalysis.CodeFixes.FixAllScope
 Microsoft.CodeAnalysis.CodeFixes.FixAllScope.ContainingType = 5 -> Microsoft.CodeAnalysis.CodeFixes.FixAllScope
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsRequired.get -> bool
-Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithRequired(bool isRequired) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
+Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsRequired(bool isRequired) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.SyntaxEditor.SyntaxEditor(Microsoft.CodeAnalysis.SyntaxNode root, Microsoft.CodeAnalysis.Host.HostWorkspaceServices services) -> void
 *REMOVED*static Microsoft.CodeAnalysis.Editing.SyntaxGenerator.DefaultRemoveOptions -> Microsoft.CodeAnalysis.SyntaxRemoveOptions
 static Microsoft.CodeAnalysis.CodeFixes.FixAllProvider.Create(System.Func<Microsoft.CodeAnalysis.CodeFixes.FixAllContext, Microsoft.CodeAnalysis.Document, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>, System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Document>> fixAllAsync, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CodeFixes.FixAllScope> supportedFixAllScopes) -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -33,7 +33,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 isUnsafe: symbol.RequiresUnsafeModifier(),
                 isVirtual: symbol.IsVirtual,
                 isOverride: symbol.IsOverride,
-                isSealed: symbol.IsSealed);
+                isSealed: symbol.IsSealed,
+                isRequired: symbol.IsRequired());
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -409,7 +409,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     codeFactory.IdentifierName("value")));
             }
 
-            modifiers = modifiers.WithRequired(overriddenProperty.IsRequired);
+            // The user can add required if they want, but if the property being overridden is required, this one needs to be as well.
+            modifiers = modifiers.WithRequired(modifiers.IsRequired || overriddenProperty.IsRequired);
 
             // Only generate a getter if the base getter is accessible.
             IMethodSymbol? accessorGet = null;
@@ -509,7 +510,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             Document newDocument,
             CancellationToken cancellationToken)
         {
-
             // Required is not a valid modifier for methods, so clear it if the user typed it
             modifiers = modifiers.WithRequired(false);
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -414,7 +414,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 ? false
                 : (modifiers.IsRequired || overriddenProperty.IsRequired));
 
-
             // Only generate a getter if the base getter is accessible.
             IMethodSymbol? accessorGet = null;
             if (overriddenProperty.GetMethod != null && overriddenProperty.GetMethod.IsAccessibleWithin(containingType))

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -410,7 +410,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
 
             // The user can add required if they want, but if the property being overridden is required, this one needs to be as well.
-            modifiers = modifiers.WithRequired(modifiers.IsRequired || overriddenProperty.IsRequired);
+            modifiers = modifiers.WithIsRequired(overriddenProperty.IsIndexer
+                ? false
+                : (modifiers.IsRequired || overriddenProperty.IsRequired));
+
 
             // Only generate a getter if the base getter is accessible.
             IMethodSymbol? accessorGet = null;
@@ -511,7 +514,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             CancellationToken cancellationToken)
         {
             // Required is not a valid modifier for methods, so clear it if the user typed it
-            modifiers = modifiers.WithRequired(false);
+            modifiers = modifiers.WithIsRequired(false);
 
             // Abstract: Throw not implemented
             if (overriddenMethod.IsAbstract)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -409,6 +409,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     codeFactory.IdentifierName("value")));
             }
 
+            modifiers = modifiers.WithRequired(overriddenProperty.IsRequired);
+
             // Only generate a getter if the base getter is accessible.
             IMethodSymbol? accessorGet = null;
             if (overriddenProperty.GetMethod != null && overriddenProperty.GetMethod.IsAccessibleWithin(containingType))
@@ -507,6 +509,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             Document newDocument,
             CancellationToken cancellationToken)
         {
+
+            // Required is not a valid modifier for methods, so clear it if the user typed it
+            modifiers = modifiers.WithRequired(false);
+
             // Abstract: Throw not implemented
             if (overriddenMethod.IsAbstract)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpIdeCodeStyleOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CodeStyle/CSharpIdeCodeStyleOptions.cs
@@ -25,6 +25,7 @@ internal sealed class CSharpIdeCodeStyleOptions : IdeCodeStyleOptions, IEquatabl
         SyntaxKind.VirtualKeyword, SyntaxKind.AbstractKeyword, SyntaxKind.SealedKeyword, SyntaxKind.OverrideKeyword,
         SyntaxKind.ReadOnlyKeyword,
         SyntaxKind.UnsafeKeyword,
+        SyntaxKind.RequiredKeyword,
         SyntaxKind.VolatileKeyword,
         SyntaxKind.AsyncKeyword);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
@@ -280,6 +280,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 _ => false,
             };
 
+        public static bool IsRequired([NotNullWhen(returnValue: true)] this ISymbol? symbol)
+            => symbol is IFieldSymbol { IsRequired: true } or IPropertySymbol { IsRequired: true };
+
         public static ITypeSymbol? GetMemberType(this ISymbol symbol)
             => symbol switch
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/SyntaxKindSet.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/SyntaxKindSet.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 SyntaxKind.PrivateKeyword,
                 SyntaxKind.ProtectedKeyword,
                 SyntaxKind.ReadOnlyKeyword,
+                SyntaxKind.RequiredKeyword,
                 SyntaxKind.SealedKeyword,
                 SyntaxKind.StaticKeyword,
                 SyntaxKind.UnsafeKeyword,


### PR DESCRIPTION
Initial support for `required` in the IDE. I've implemented and tested completion, property/field generation features (such as generate overrides), and symbol display. An open question I have: should we displaying `required` in QuickInfo? We don't display any modifiers there today, but maybe `required` is special here?

Spec: https://github.com/dotnet/csharplang/blob/main/proposals/required-members.md
Test plan: https://github.com/dotnet/roslyn/issues/57046.