### PR TITLE
Update test to reflect new GetPublicKeyToken API behavior

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -5835,11 +5835,7 @@ class A                                                               \
             Assert.Equal(nameGuid, assemblyName.Name);
             Assert.Equal("0.0.0.0", assemblyName.Version.ToString());
             Assert.Equal(string.Empty, assemblyName.CultureName);
-#if NETCOREAPP
-            Assert.Null(assemblyName.GetPublicKeyToken());
-#else
             Assert.Equal(Array.Empty<byte>(), assemblyName.GetPublicKeyToken());
-#endif
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/55727")]


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/61452

This change to `AssemblyName.GetPublicKeyToken()` seems intentional (based on tests updated in https://github.com/dotnet/runtime/pull/69169)