### PR TITLE
Update tests to reflect BCL behavior changes

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -5835,11 +5835,15 @@ class A                                                               \
             Assert.Equal(nameGuid, assemblyName.Name);
             Assert.Equal("0.0.0.0", assemblyName.Version.ToString());
             Assert.Equal(string.Empty, assemblyName.CultureName);
-#if NETCOREAPP
-            Assert.Null(assemblyName.GetPublicKeyToken());
-#else
-            Assert.Equal(Array.Empty<byte>(), assemblyName.GetPublicKeyToken());
-#endif
+
+            if (RuntimeUtilities.IsCoreClrRuntime && !RuntimeUtilities.IsCoreClr6Runtime)
+            {
+                Assert.Null(assemblyName.GetPublicKeyToken());
+            }
+            else
+            {
+                Assert.Equal(Array.Empty<byte>(), assemblyName.GetPublicKeyToken());
+            }
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/55727")]

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -191,6 +191,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void ConstantValueToStringTest01()
         {
+            Assert.False(true, $"JCOUV {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription} + {typeof(string).Assembly.Location}");
+
             var cv = ConstantValue.Create(null, ConstantValueTypeDiscriminator.Null);
             Assert.Equal($"ConstantValueNull(null: Null)", cv.ToString());
 

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -191,16 +191,11 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void ConstantValueToStringTest01()
         {
-            var value = "Null";
-#if NETCOREAPP
-            value = "Nothing";
-#endif
-
             var cv = ConstantValue.Create(null, ConstantValueTypeDiscriminator.Null);
-            Assert.Equal($"ConstantValueNull(null: {value})", cv.ToString());
+            Assert.Equal($"ConstantValueNull(null: Null)", cv.ToString());
 
             cv = ConstantValue.Create(null, ConstantValueTypeDiscriminator.String);
-            Assert.Equal($"ConstantValueNull(null: {value})", cv.ToString());
+            Assert.Equal($"ConstantValueNull(null: Null)", cv.ToString());
 
             // Never hit "ConstantValueString(null: Null)"
 

--- a/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CorLibTypesTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -191,13 +192,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void ConstantValueToStringTest01()
         {
-            Assert.False(true, $"JCOUV {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription} + {typeof(string).Assembly.Location}");
+            string value = (RuntimeUtilities.IsCoreClrRuntime && !RuntimeUtilities.IsCoreClr6Runtime)
+                ? "Nothing"
+                : "Null";
 
             var cv = ConstantValue.Create(null, ConstantValueTypeDiscriminator.Null);
-            Assert.Equal($"ConstantValueNull(null: Null)", cv.ToString());
+            Assert.Equal($"ConstantValueNull(null: {value})", cv.ToString());
 
             cv = ConstantValue.Create(null, ConstantValueTypeDiscriminator.String);
-            Assert.Equal($"ConstantValueNull(null: Null)", cv.ToString());
+            Assert.Equal($"ConstantValueNull(null: {value})", cv.ToString());
 
             // Never hit "ConstantValueString(null: Null)"
 

--- a/src/Compilers/Test/Core/Compilation/RuntimeUtilities.cs
+++ b/src/Compilers/Test/Core/Compilation/RuntimeUtilities.cs
@@ -27,6 +27,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 #endif
         internal static bool IsCoreClrRuntime => !IsDesktopRuntime;
 
+        internal static bool IsCoreClr6Runtime
+            => IsCoreClrRuntime && RuntimeInformation.FrameworkDescription.StartsWith(".NET 6.");
+
         internal static BuildPaths CreateBuildPaths(string workingDirectory, string sdkDirectory = null, string tempDirectory = null)
         {
             tempDirectory ??= Path.GetTempPath();

--- a/src/Compilers/Test/Core/Compilation/RuntimeUtilities.cs
+++ b/src/Compilers/Test/Core/Compilation/RuntimeUtilities.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         internal static bool IsCoreClrRuntime => !IsDesktopRuntime;
 
         internal static bool IsCoreClr6Runtime
-            => IsCoreClrRuntime && RuntimeInformation.FrameworkDescription.StartsWith(".NET 6.");
+            => IsCoreClrRuntime && RuntimeInformation.FrameworkDescription.StartsWith(".NET 6.", StringComparison.Ordinal);
 
         internal static BuildPaths CreateBuildPaths(string workingDirectory, string sdkDirectory = null, string tempDirectory = null)
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/61450

Also closes https://github.com/dotnet/roslyn/issues/61452 (This change to `AssemblyName.GetPublicKeyToken()` seems intentional, based on tests updated in https://github.com/dotnet/runtime/pull/69169)