### PR TITLE
Reduce release/64 limit for EndToEndTests.Constraints

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -281,7 +281,7 @@ $@"        if (F({i}))
                 (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 420,
                 (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1100,
                 (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 180,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 480,
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 460,
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
             };
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -278,10 +278,10 @@ $@"        if (F({i}))
         {
             int n = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
             {
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 420,
+                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 400,
                 (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1100,
                 (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 180,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 460,
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 440,
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
             };
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -278,10 +278,10 @@ $@"        if (F({i}))
         {
             int n = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
             {
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 400,
+                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 420,
                 (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1100,
                 (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 180,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 440,
+                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 400,
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
             };
 


### PR DESCRIPTION
Relates to https://github.com/dotnet/roslyn/issues/45815