### PR TITLE
Prepare VB iterators for EnC support

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.vb
@@ -66,13 +66,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                            builder As FieldSymbol,
                            hoistedVariables As IReadOnlySet(Of Symbol),
                            nonReusableLocalProxies As Dictionary(Of Symbol, CapturedSymbolOrExpression),
-                           synthesizedLocalOrdinals As SynthesizedLocalOrdinalsDispenser,
                            slotAllocatorOpt As VariableSlotAllocator,
-                           nextFreeHoistedLocalSlot As Integer,
                            owner As AsyncRewriter,
                            diagnostics As BindingDiagnosticBag)
 
-                MyBase.New(F, state, hoistedVariables, nonReusableLocalProxies, synthesizedLocalOrdinals, slotAllocatorOpt, nextFreeHoistedLocalSlot, diagnostics)
+                MyBase.New(F, state, hoistedVariables, nonReusableLocalProxies, slotAllocatorOpt, diagnostics)
 
                 Me._method = method
                 Me._builder = builder

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
@@ -250,19 +250,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Sub GenerateMoveNext(moveNextMethod As MethodSymbol)
-            Dim rewriter = New AsyncMethodToClassRewriter(method:=Me.Method,
-                                                          F:=Me.F,
-                                                          state:=Me.StateField,
-                                                          builder:=Me._builderField,
-                                                          hoistedVariables:=Me.hoistedVariables,
-                                                          nonReusableLocalProxies:=Me.nonReusableLocalProxies,
-                                                          synthesizedLocalOrdinals:=Me.SynthesizedLocalOrdinals,
-                                                          slotAllocatorOpt:=Me.SlotAllocatorOpt,
-                                                          nextFreeHoistedLocalSlot:=Me.nextFreeHoistedLocalSlot,
-                                                          owner:=Me,
-                                                          diagnostics:=Diagnostics)
+            Dim rewriter = New AsyncMethodToClassRewriter(
+                method:=Method,
+                F:=F,
+                state:=StateField,
+                builder:=_builderField,
+                hoistedVariables:=hoistedVariables,
+                nonReusableLocalProxies:=nonReusableLocalProxies,
+                slotAllocatorOpt:=SlotAllocatorOpt,
+                owner:=Me,
+                diagnostics:=Diagnostics)
 
-            rewriter.GenerateMoveNext(Me.Body, moveNextMethod)
+            rewriter.GenerateMoveNext(Body, moveNextMethod)
         End Sub
 
         Friend Overrides Function RewriteBodyIfNeeded(body As BoundStatement, topMethod As MethodSymbol, currentMethod As MethodSymbol) As BoundStatement

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
@@ -24,20 +24,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private _methodValue As LocalSymbol
             Private _tryNestingLevel As Integer
 
-            Friend Sub New(method As MethodSymbol,
-                           F As SyntheticBoundNodeFactory,
+            Friend Sub New(F As SyntheticBoundNodeFactory,
                            state As FieldSymbol,
                            current As FieldSymbol,
                            hoistedVariables As IReadOnlySet(Of Symbol),
                            localProxies As Dictionary(Of Symbol, FieldSymbol),
-                           SynthesizedLocalOrdinals As SynthesizedLocalOrdinalsDispenser,
                            slotAllocatorOpt As VariableSlotAllocator,
-                           nextFreeHoistedLocalSlot As Integer,
                            diagnostics As BindingDiagnosticBag)
 
-                MyBase.New(F, state, hoistedVariables, localProxies, SynthesizedLocalOrdinals, slotAllocatorOpt, nextFreeHoistedLocalSlot, diagnostics)
+                MyBase.New(F, state, hoistedVariables, localProxies, slotAllocatorOpt, diagnostics)
 
-                Me._current = current
+                _current = current
             End Sub
 
             Public Sub GenerateMoveNextAndDispose(Body As BoundStatement,

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
@@ -341,16 +341,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         Private Sub GenerateMoveNextAndDispose(moveNextMethod As SynthesizedMethod, disposeMethod As SynthesizedMethod)
-            Dim rewriter = New IteratorMethodToClassRewriter(method:=Me.Method,
-                                                          F:=Me.F,
-                                                          state:=Me.StateField,
-                                                          current:=Me._currentField,
-                                                          hoistedVariables:=Me.hoistedVariables,
-                                                          localProxies:=Me.nonReusableLocalProxies,
-                                                          SynthesizedLocalOrdinals:=Me.SynthesizedLocalOrdinals,
-                                                          slotAllocatorOpt:=Me.SlotAllocatorOpt,
-                                                          nextFreeHoistedLocalSlot:=Me.nextFreeHoistedLocalSlot,
-                                                          diagnostics:=Diagnostics)
+            Dim rewriter = New IteratorMethodToClassRewriter(
+                F:=F,
+                state:=StateField,
+                current:=_currentField,
+                hoistedVariables:=hoistedVariables,
+                localProxies:=nonReusableLocalProxies,
+                slotAllocatorOpt:=SlotAllocatorOpt,
+                diagnostics:=Diagnostics)
 
             rewriter.GenerateMoveNextAndDispose(Body, moveNextMethod, disposeMethod)
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
@@ -16,7 +16,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Inherits MethodToClassRewriter(Of TProxy)
 
             Protected Friend ReadOnly F As SyntheticBoundNodeFactory
-            Protected NextState As Integer = 0
+            Protected NextState As Integer = StateMachineStates.InitialIteratorState
+            Protected NextFinalizerState As Integer = StateMachineStates.FirstIteratorFinalizeState
 
             ''' <summary>
             ''' The "state" of the state machine that is the translation of the iterator method.
@@ -145,8 +146,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If Not Me._hasFinalizerState Then
-                    Me._currentFinalizerState = Me.NextState
-                    Me.NextState += 1
+                    Me._currentFinalizerState = Me.NextFinalizerState
+                    Me.NextFinalizerState -= 1
                     Me._hasFinalizerState = True
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
@@ -64,16 +64,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ''' </summary>
             Private ReadOnly _hoistedVariables As IReadOnlySet(Of Symbol) = Nothing
 
-            Private ReadOnly _synthesizedLocalOrdinals As SynthesizedLocalOrdinalsDispenser
-            Private ReadOnly _nextFreeHoistedLocalSlot As Integer
-
             Public Sub New(F As SyntheticBoundNodeFactory,
                            stateField As FieldSymbol,
                            hoistedVariables As IReadOnlySet(Of Symbol),
                            initialProxies As Dictionary(Of Symbol, TProxy),
-                           synthesizedLocalOrdinals As SynthesizedLocalOrdinalsDispenser,
                            slotAllocatorOpt As VariableSlotAllocator,
-                           nextFreeHoistedLocalSlot As Integer,
                            diagnostics As BindingDiagnosticBag)
 
                 MyBase.New(slotAllocatorOpt, F.CompilationState, diagnostics, preserveOriginalLocals:=False)
@@ -82,15 +77,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(stateField IsNot Nothing)
                 Debug.Assert(hoistedVariables IsNot Nothing)
                 Debug.Assert(initialProxies IsNot Nothing)
-                Debug.Assert(nextFreeHoistedLocalSlot >= 0)
                 Debug.Assert(diagnostics IsNot Nothing)
 
                 Me.F = F
                 Me.StateField = stateField
                 Me.CachedState = F.SynthesizedLocal(F.SpecialType(SpecialType.System_Int32), SynthesizedLocalKind.StateMachineCachedState, F.Syntax)
                 Me._hoistedVariables = hoistedVariables
-                Me._synthesizedLocalOrdinals = synthesizedLocalOrdinals
-                Me._nextFreeHoistedLocalSlot = nextFreeHoistedLocalSlot
 
                 For Each p In initialProxies
                     Me.Proxies.Add(p.Key, p.Value)

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineStates.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineStates.vb
@@ -9,10 +9,19 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
-    Friend Module StateMachineStates
-        Public FinishedStateMachine As Integer = -2
-        Public NotStartedStateMachine As Integer = -1
-        Public FirstUnusedState As Integer = 0
-    End Module
+    Friend NotInheritable Class StateMachineStates
+        Public Const FirstIteratorFinalizeState As Integer = -3
+        Public Const InitialIteratorState As Integer = 0
+
+        ''' <summary>
+        ''' First state in iterator state machine that is used to resume the machine after Yield.
+        ''' Initial state is not used to resume state machine that yielded.
+        ''' </summary>
+        Public Const FirstResumableIteratorState = InitialIteratorState + 1
+
+        Public Const FinishedStateMachine As Integer = -2
+        Public Const NotStartedStateMachine As Integer = -1
+        Public Const FirstUnusedState As Integer = 0
+    End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineStates.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineStates.vb
@@ -12,13 +12,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend NotInheritable Class StateMachineStates
         Public Const FirstIteratorFinalizeState As Integer = -3
         Public Const InitialIteratorState As Integer = 0
-
-        ''' <summary>
-        ''' First state in iterator state machine that is used to resume the machine after Yield.
-        ''' Initial state is not used to resume state machine that yielded.
-        ''' </summary>
-        Public Const FirstResumableIteratorState = InitialIteratorState + 1
-
         Public Const FinishedStateMachine As Integer = -2
         Public Const NotStartedStateMachine As Integer = -1
         Public Const FirstUnusedState As Integer = 0

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -1628,7 +1628,7 @@ End Module
 
             c.VerifyIL("Form1.VB$StateMachine_1_f.MoveNext", <![CDATA[
 {
-  // Code size      233 (0xe9)
+  // Code size      239 (0xef)
   .maxstack  3
   .locals init (Integer V_0,
                 Integer V_1,
@@ -1641,103 +1641,105 @@ End Module
   .try
   {
     IL_0007:  ldloc.1
-    IL_0008:  ldc.i4.1
-    IL_0009:  pop
-    IL_000a:  pop
-    IL_000b:  nop
+    IL_0008:  ldc.i4.s   -3
+    IL_000a:  beq.s      IL_000e
+    IL_000c:  ldloc.1
+    IL_000d:  pop
+    IL_000e:  nop
     .try
     {
-      IL_000c:  ldloc.1
-      IL_000d:  brfalse.s  IL_0065
       IL_000f:  ldloc.1
-      IL_0010:  ldc.i4.1
-      IL_0011:  bne.un.s   IL_0021
-      IL_0013:  ldarg.0
-      IL_0014:  ldc.i4.m1
-      IL_0015:  dup
-      IL_0016:  stloc.1
-      IL_0017:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
-      IL_001c:  leave      IL_00e8
-      IL_0021:  ldstr      "2 "
-      IL_0026:  call       "Sub System.Console.Write(String)"
-      IL_002b:  call       "Function System.Threading.Tasks.Task.Yield() As System.Runtime.CompilerServices.YieldAwaitable"
-      IL_0030:  stloc.3
-      IL_0031:  ldloca.s   V_3
-      IL_0033:  call       "Function System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter() As System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-      IL_0038:  stloc.2
-      IL_0039:  ldloca.s   V_2
-      IL_003b:  call       "Function System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.get_IsCompleted() As Boolean"
-      IL_0040:  brtrue.s   IL_0081
-      IL_0042:  ldarg.0
-      IL_0043:  ldc.i4.0
-      IL_0044:  dup
-      IL_0045:  stloc.1
-      IL_0046:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
-      IL_004b:  ldarg.0
-      IL_004c:  ldloc.2
-      IL_004d:  stfld      "Form1.VB$StateMachine_1_f.$A0 As System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-      IL_0052:  ldarg.0
-      IL_0053:  ldflda     "Form1.VB$StateMachine_1_f.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
-      IL_0058:  ldloca.s   V_2
-      IL_005a:  ldarg.0
-      IL_005b:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Form1.VB$StateMachine_1_f)(ByRef System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ByRef Form1.VB$StateMachine_1_f)"
-      IL_0060:  leave      IL_00e8
-      IL_0065:  ldarg.0
-      IL_0066:  ldc.i4.m1
-      IL_0067:  dup
-      IL_0068:  stloc.1
-      IL_0069:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
-      IL_006e:  ldarg.0
-      IL_006f:  ldfld      "Form1.VB$StateMachine_1_f.$A0 As System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-      IL_0074:  stloc.2
-      IL_0075:  ldarg.0
-      IL_0076:  ldflda     "Form1.VB$StateMachine_1_f.$A0 As System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-      IL_007b:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-      IL_0081:  ldloca.s   V_2
-      IL_0083:  call       "Sub System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
-      IL_0088:  ldloca.s   V_2
-      IL_008a:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
-      IL_0090:  ldstr      "3 "
-      IL_0095:  call       "Sub System.Console.Write(String)"
-      IL_009a:  ldc.i4.s   123
-      IL_009c:  stloc.0
-      IL_009d:  leave.s    IL_00d2
+      IL_0010:  ldc.i4.s   -3
+      IL_0012:  beq.s      IL_0019
+      IL_0014:  ldloc.1
+      IL_0015:  brfalse.s  IL_006b
+      IL_0017:  br.s       IL_0027
+      IL_0019:  ldarg.0
+      IL_001a:  ldc.i4.m1
+      IL_001b:  dup
+      IL_001c:  stloc.1
+      IL_001d:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
+      IL_0022:  leave      IL_00ee
+      IL_0027:  ldstr      "2 "
+      IL_002c:  call       "Sub System.Console.Write(String)"
+      IL_0031:  call       "Function System.Threading.Tasks.Task.Yield() As System.Runtime.CompilerServices.YieldAwaitable"
+      IL_0036:  stloc.3
+      IL_0037:  ldloca.s   V_3
+      IL_0039:  call       "Function System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter() As System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+      IL_003e:  stloc.2
+      IL_003f:  ldloca.s   V_2
+      IL_0041:  call       "Function System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.get_IsCompleted() As Boolean"
+      IL_0046:  brtrue.s   IL_0087
+      IL_0048:  ldarg.0
+      IL_0049:  ldc.i4.0
+      IL_004a:  dup
+      IL_004b:  stloc.1
+      IL_004c:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
+      IL_0051:  ldarg.0
+      IL_0052:  ldloc.2
+      IL_0053:  stfld      "Form1.VB$StateMachine_1_f.$A0 As System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+      IL_0058:  ldarg.0
+      IL_0059:  ldflda     "Form1.VB$StateMachine_1_f.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
+      IL_005e:  ldloca.s   V_2
+      IL_0060:  ldarg.0
+      IL_0061:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).AwaitUnsafeOnCompleted(Of System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Form1.VB$StateMachine_1_f)(ByRef System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ByRef Form1.VB$StateMachine_1_f)"
+      IL_0066:  leave      IL_00ee
+      IL_006b:  ldarg.0
+      IL_006c:  ldc.i4.m1
+      IL_006d:  dup
+      IL_006e:  stloc.1
+      IL_006f:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
+      IL_0074:  ldarg.0
+      IL_0075:  ldfld      "Form1.VB$StateMachine_1_f.$A0 As System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+      IL_007a:  stloc.2
+      IL_007b:  ldarg.0
+      IL_007c:  ldflda     "Form1.VB$StateMachine_1_f.$A0 As System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+      IL_0081:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+      IL_0087:  ldloca.s   V_2
+      IL_0089:  call       "Sub System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+      IL_008e:  ldloca.s   V_2
+      IL_0090:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+      IL_0096:  ldstr      "3 "
+      IL_009b:  call       "Sub System.Console.Write(String)"
+      IL_00a0:  ldc.i4.s   123
+      IL_00a2:  stloc.0
+      IL_00a3:  leave.s    IL_00d8
     }
     finally
     {
-      IL_009f:  ldloc.1
-      IL_00a0:  ldc.i4.0
-      IL_00a1:  bge.s      IL_00ad
-      IL_00a3:  ldstr      "4 "
-      IL_00a8:  call       "Sub System.Console.Write(String)"
-      IL_00ad:  endfinally
+      IL_00a5:  ldloc.1
+      IL_00a6:  ldc.i4.0
+      IL_00a7:  bge.s      IL_00b3
+      IL_00a9:  ldstr      "4 "
+      IL_00ae:  call       "Sub System.Console.Write(String)"
+      IL_00b3:  endfinally
     }
   }
   catch System.Exception
   {
-    IL_00ae:  dup
-    IL_00af:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-    IL_00b4:  stloc.s    V_4
-    IL_00b6:  ldarg.0
-    IL_00b7:  ldc.i4.s   -2
-    IL_00b9:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
-    IL_00be:  ldarg.0
-    IL_00bf:  ldflda     "Form1.VB$StateMachine_1_f.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
-    IL_00c4:  ldloc.s    V_4
-    IL_00c6:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)"
-    IL_00cb:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-    IL_00d0:  leave.s    IL_00e8
+    IL_00b4:  dup
+    IL_00b5:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_00ba:  stloc.s    V_4
+    IL_00bc:  ldarg.0
+    IL_00bd:  ldc.i4.s   -2
+    IL_00bf:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
+    IL_00c4:  ldarg.0
+    IL_00c5:  ldflda     "Form1.VB$StateMachine_1_f.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
+    IL_00ca:  ldloc.s    V_4
+    IL_00cc:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetException(System.Exception)"
+    IL_00d1:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_00d6:  leave.s    IL_00ee
   }
-  IL_00d2:  ldarg.0
-  IL_00d3:  ldc.i4.s   -2
-  IL_00d5:  dup
-  IL_00d6:  stloc.1
-  IL_00d7:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
-  IL_00dc:  ldarg.0
-  IL_00dd:  ldflda     "Form1.VB$StateMachine_1_f.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
-  IL_00e2:  ldloc.0
-  IL_00e3:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)"
-  IL_00e8:  ret
+  IL_00d8:  ldarg.0
+  IL_00d9:  ldc.i4.s   -2
+  IL_00db:  dup
+  IL_00dc:  stloc.1
+  IL_00dd:  stfld      "Form1.VB$StateMachine_1_f.$State As Integer"
+  IL_00e2:  ldarg.0
+  IL_00e3:  ldflda     "Form1.VB$StateMachine_1_f.$Builder As System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer)"
+  IL_00e8:  ldloc.0
+  IL_00e9:  call       "Sub System.Runtime.CompilerServices.AsyncTaskMethodBuilder(Of Integer).SetResult(Integer)"
+  IL_00ee:  ret
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -627,7 +627,7 @@ End Module
 
             CompileAndVerify(source, expectedOutput:="12345").VerifyIL("Module1.VB$StateMachine_1_Goo.MoveNext", <![CDATA[
 {
-  // Code size      152 (0x98)
+  // Code size      175 (0xaf)
   .maxstack  3
   .locals init (Boolean V_0,
                 Integer V_1,
@@ -636,85 +636,88 @@ End Module
   IL_0001:  ldfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
-  IL_0008:  brfalse.s  IL_0012
-  IL_000a:  ldloc.1
-  IL_000b:  ldc.i4.1
-  IL_000c:  sub
-  IL_000d:  ldc.i4.1
-  IL_000e:  ble.un.s   IL_001b
-  IL_0010:  ldc.i4.0
-  IL_0011:  ret
-  IL_0012:  ldarg.0
-  IL_0013:  ldc.i4.m1
-  IL_0014:  dup
-  IL_0015:  stloc.1
-  IL_0016:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-  IL_001b:  nop
+  IL_0008:  ldc.i4.s   -3
+  IL_000a:  sub
+  IL_000b:  switch    (
+        IL_002f,
+        IL_0024,
+        IL_0024,
+        IL_0026,
+        IL_002f)
+  IL_0024:  ldc.i4.0
+  IL_0025:  ret
+  IL_0026:  ldarg.0
+  IL_0027:  ldc.i4.m1
+  IL_0028:  dup
+  IL_0029:  stloc.1
+  IL_002a:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+  IL_002f:  nop
   .try
   {
-    IL_001c:  ldloc.1
-    IL_001d:  ldc.i4.1
-    IL_001e:  beq.s      IL_0064
-    IL_0020:  ldloc.1
-    IL_0021:  ldc.i4.2
-    IL_0022:  bne.un.s   IL_0031
-    IL_0024:  ldarg.0
-    IL_0025:  ldc.i4.m1
-    IL_0026:  dup
-    IL_0027:  stloc.1
-    IL_0028:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-    IL_002d:  ldc.i4.1
-    IL_002e:  stloc.0
-    IL_002f:  leave.s    IL_0096
-    IL_0031:  ldarg.0
-    IL_0032:  ldarg.0
-    IL_0033:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$Local_x As System.Collections.Generic.IEnumerable(Of Integer)"
-    IL_0038:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)"
-    IL_003d:  stfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
-    IL_0042:  br.s       IL_006d
-    IL_0044:  ldarg.0
-    IL_0045:  ldfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
-    IL_004a:  callvirt   "Function System.Collections.Generic.IEnumerator(Of Integer).get_Current() As Integer"
-    IL_004f:  stloc.2
-    IL_0050:  ldarg.0
-    IL_0051:  ldloc.2
-    IL_0052:  stfld      "Module1.VB$StateMachine_1_Goo.$Current As Integer"
-    IL_0057:  ldarg.0
-    IL_0058:  ldc.i4.1
-    IL_0059:  dup
-    IL_005a:  stloc.1
-    IL_005b:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-    IL_0060:  ldc.i4.1
-    IL_0061:  stloc.0
-    IL_0062:  leave.s    IL_0096
-    IL_0064:  ldarg.0
-    IL_0065:  ldc.i4.m1
-    IL_0066:  dup
-    IL_0067:  stloc.1
-    IL_0068:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-    IL_006d:  ldarg.0
-    IL_006e:  ldfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
-    IL_0073:  callvirt   "Function System.Collections.IEnumerator.MoveNext() As Boolean"
-    IL_0078:  brtrue.s   IL_0044
-    IL_007a:  leave.s    IL_0094
+    IL_0030:  ldloc.1
+    IL_0031:  ldc.i4.s   -3
+    IL_0033:  beq.s      IL_003b
+    IL_0035:  ldloc.1
+    IL_0036:  ldc.i4.1
+    IL_0037:  beq.s      IL_007b
+    IL_0039:  br.s       IL_0048
+    IL_003b:  ldarg.0
+    IL_003c:  ldc.i4.m1
+    IL_003d:  dup
+    IL_003e:  stloc.1
+    IL_003f:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_0044:  ldc.i4.1
+    IL_0045:  stloc.0
+    IL_0046:  leave.s    IL_00ad
+    IL_0048:  ldarg.0
+    IL_0049:  ldarg.0
+    IL_004a:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$Local_x As System.Collections.Generic.IEnumerable(Of Integer)"
+    IL_004f:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)"
+    IL_0054:  stfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
+    IL_0059:  br.s       IL_0084
+    IL_005b:  ldarg.0
+    IL_005c:  ldfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
+    IL_0061:  callvirt   "Function System.Collections.Generic.IEnumerator(Of Integer).get_Current() As Integer"
+    IL_0066:  stloc.2
+    IL_0067:  ldarg.0
+    IL_0068:  ldloc.2
+    IL_0069:  stfld      "Module1.VB$StateMachine_1_Goo.$Current As Integer"
+    IL_006e:  ldarg.0
+    IL_006f:  ldc.i4.1
+    IL_0070:  dup
+    IL_0071:  stloc.1
+    IL_0072:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_0077:  ldc.i4.1
+    IL_0078:  stloc.0
+    IL_0079:  leave.s    IL_00ad
+    IL_007b:  ldarg.0
+    IL_007c:  ldc.i4.m1
+    IL_007d:  dup
+    IL_007e:  stloc.1
+    IL_007f:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_0084:  ldarg.0
+    IL_0085:  ldfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
+    IL_008a:  callvirt   "Function System.Collections.IEnumerator.MoveNext() As Boolean"
+    IL_008f:  brtrue.s   IL_005b
+    IL_0091:  leave.s    IL_00ab
   }
   finally
   {
-    IL_007c:  ldloc.1
-    IL_007d:  ldc.i4.0
-    IL_007e:  bge.s      IL_0093
-    IL_0080:  ldarg.0
-    IL_0081:  ldfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
-    IL_0086:  brfalse.s  IL_0093
-    IL_0088:  ldarg.0
-    IL_0089:  ldfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
-    IL_008e:  callvirt   "Sub System.IDisposable.Dispose()"
-    IL_0093:  endfinally
+    IL_0093:  ldloc.1
+    IL_0094:  ldc.i4.0
+    IL_0095:  bge.s      IL_00aa
+    IL_0097:  ldarg.0
+    IL_0098:  ldfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
+    IL_009d:  brfalse.s  IL_00aa
+    IL_009f:  ldarg.0
+    IL_00a0:  ldfld      "Module1.VB$StateMachine_1_Goo.$S0 As System.Collections.Generic.IEnumerator(Of Integer)"
+    IL_00a5:  callvirt   "Sub System.IDisposable.Dispose()"
+    IL_00aa:  endfinally
   }
-  IL_0094:  ldc.i4.0
-  IL_0095:  ret
-  IL_0096:  ldloc.0
-  IL_0097:  ret
+  IL_00ab:  ldc.i4.0
+  IL_00ac:  ret
+  IL_00ad:  ldloc.0
+  IL_00ae:  ret
 }
 ]]>).VerifyIL("Module1.VB$StateMachine_1_Goo.IEnumerable.GetEnumerator", <![CDATA[
 {
@@ -858,7 +861,7 @@ End Module
 
             CompileAndVerify(source, expectedOutput:="233").VerifyIL("Module1.VB$StateMachine_1_Goo.MoveNext", <![CDATA[
 {
-  // Code size      159 (0x9f)
+  // Code size      182 (0xb6)
   .maxstack  3
   .locals init (Boolean V_0,
                 Integer V_1,
@@ -867,90 +870,93 @@ End Module
   IL_0001:  ldfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
-  IL_0008:  brfalse.s  IL_0012
-  IL_000a:  ldloc.1
-  IL_000b:  ldc.i4.1
-  IL_000c:  sub
-  IL_000d:  ldc.i4.1
-  IL_000e:  ble.un.s   IL_0022
-  IL_0010:  ldc.i4.0
-  IL_0011:  ret
-  IL_0012:  ldarg.0
-  IL_0013:  ldc.i4.m1
-  IL_0014:  dup
-  IL_0015:  stloc.1
-  IL_0016:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-  IL_001b:  ldarg.0
-  IL_001c:  ldc.i4.1
-  IL_001d:  stfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
-  IL_0022:  nop
+  IL_0008:  ldc.i4.s   -3
+  IL_000a:  sub
+  IL_000b:  switch    (
+        IL_0036,
+        IL_0024,
+        IL_0024,
+        IL_0026,
+        IL_0036)
+  IL_0024:  ldc.i4.0
+  IL_0025:  ret
+  IL_0026:  ldarg.0
+  IL_0027:  ldc.i4.m1
+  IL_0028:  dup
+  IL_0029:  stloc.1
+  IL_002a:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+  IL_002f:  ldarg.0
+  IL_0030:  ldc.i4.1
+  IL_0031:  stfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
+  IL_0036:  nop
   .try
   {
-    IL_0023:  ldloc.1
-    IL_0024:  ldc.i4.1
-    IL_0025:  beq.s      IL_005f
-    IL_0027:  ldloc.1
-    IL_0028:  ldc.i4.2
-    IL_0029:  bne.un.s   IL_0038
-    IL_002b:  ldarg.0
-    IL_002c:  ldc.i4.m1
-    IL_002d:  dup
-    IL_002e:  stloc.1
-    IL_002f:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-    IL_0034:  ldc.i4.1
-    IL_0035:  stloc.0
-    IL_0036:  leave.s    IL_009d
-    IL_0038:  ldarg.0
-    IL_0039:  ldarg.0
-    IL_003a:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
-    IL_003f:  ldc.i4.1
-    IL_0040:  add.ovf
-    IL_0041:  stfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
-    IL_0046:  ldarg.0
-    IL_0047:  ldarg.0
-    IL_0048:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
-    IL_004d:  stfld      "Module1.VB$StateMachine_1_Goo.$Current As Integer"
-    IL_0052:  ldarg.0
-    IL_0053:  ldc.i4.1
-    IL_0054:  dup
-    IL_0055:  stloc.1
-    IL_0056:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-    IL_005b:  ldc.i4.1
-    IL_005c:  stloc.0
-    IL_005d:  leave.s    IL_009d
-    IL_005f:  ldarg.0
-    IL_0060:  ldc.i4.m1
-    IL_0061:  dup
-    IL_0062:  stloc.1
-    IL_0063:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-    IL_0068:  leave.s    IL_009b
+    IL_0037:  ldloc.1
+    IL_0038:  ldc.i4.s   -3
+    IL_003a:  beq.s      IL_0042
+    IL_003c:  ldloc.1
+    IL_003d:  ldc.i4.1
+    IL_003e:  beq.s      IL_0076
+    IL_0040:  br.s       IL_004f
+    IL_0042:  ldarg.0
+    IL_0043:  ldc.i4.m1
+    IL_0044:  dup
+    IL_0045:  stloc.1
+    IL_0046:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_004b:  ldc.i4.1
+    IL_004c:  stloc.0
+    IL_004d:  leave.s    IL_00b4
+    IL_004f:  ldarg.0
+    IL_0050:  ldarg.0
+    IL_0051:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
+    IL_0056:  ldc.i4.1
+    IL_0057:  add.ovf
+    IL_0058:  stfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
+    IL_005d:  ldarg.0
+    IL_005e:  ldarg.0
+    IL_005f:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
+    IL_0064:  stfld      "Module1.VB$StateMachine_1_Goo.$Current As Integer"
+    IL_0069:  ldarg.0
+    IL_006a:  ldc.i4.1
+    IL_006b:  dup
+    IL_006c:  stloc.1
+    IL_006d:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_0072:  ldc.i4.1
+    IL_0073:  stloc.0
+    IL_0074:  leave.s    IL_00b4
+    IL_0076:  ldarg.0
+    IL_0077:  ldc.i4.m1
+    IL_0078:  dup
+    IL_0079:  stloc.1
+    IL_007a:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_007f:  leave.s    IL_00b2
   }
   finally
   {
-    IL_006a:  ldloc.1
-    IL_006b:  ldc.i4.0
-    IL_006c:  bge.s      IL_009a
-    IL_006e:  ldarg.0
-    IL_006f:  ldarg.0
-    IL_0070:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
-    IL_0075:  ldc.i4.1
-    IL_0076:  add.ovf
-    IL_0077:  stfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
-    IL_007c:  ldarg.0
-    IL_007d:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
-    IL_0082:  stloc.2
-    IL_0083:  ldarg.0
-    IL_0084:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
-    IL_0089:  call       "Sub System.Console.Write(Integer)"
-    IL_008e:  ldloca.s   V_2
-    IL_0090:  call       "Function Integer.ToString() As String"
-    IL_0095:  call       "Sub System.Console.Write(String)"
-    IL_009a:  endfinally
+    IL_0081:  ldloc.1
+    IL_0082:  ldc.i4.0
+    IL_0083:  bge.s      IL_00b1
+    IL_0085:  ldarg.0
+    IL_0086:  ldarg.0
+    IL_0087:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
+    IL_008c:  ldc.i4.1
+    IL_008d:  add.ovf
+    IL_008e:  stfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
+    IL_0093:  ldarg.0
+    IL_0094:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
+    IL_0099:  stloc.2
+    IL_009a:  ldarg.0
+    IL_009b:  ldfld      "Module1.VB$StateMachine_1_Goo.$VB$ResumableLocal_x$0 As Integer"
+    IL_00a0:  call       "Sub System.Console.Write(Integer)"
+    IL_00a5:  ldloca.s   V_2
+    IL_00a7:  call       "Function Integer.ToString() As String"
+    IL_00ac:  call       "Sub System.Console.Write(String)"
+    IL_00b1:  endfinally
   }
-  IL_009b:  ldc.i4.0
-  IL_009c:  ret
-  IL_009d:  ldloc.0
-  IL_009e:  ret
+  IL_00b2:  ldc.i4.0
+  IL_00b3:  ret
+  IL_00b4:  ldloc.0
+  IL_00b5:  ret
 }
 ]]>).VerifyIL("Module1.VB$StateMachine_1_Goo.IEnumerable.GetEnumerator", <![CDATA[
 {
@@ -1002,7 +1008,7 @@ End Module
 
             CompileAndVerify(source, expectedOutput:="12").VerifyIL("Module1.VB$StateMachine_1_Goo.MoveNext", <![CDATA[
 {
-  // Code size      158 (0x9e)
+  // Code size      172 (0xac)
   .maxstack  3
   .locals init (Boolean V_0,
                 Integer V_1,
@@ -1011,85 +1017,90 @@ End Module
   IL_0001:  ldfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
-  IL_0008:  switch    (
-        IL_001f,
+  IL_0008:  ldc.i4.s   -3
+  IL_000a:  sub
+  IL_000b:  switch    (
+        IL_0035,
+        IL_0028,
+        IL_0028,
         IL_002a,
-        IL_002a,
-        IL_0091)
-  IL_001d:  ldc.i4.0
-  IL_001e:  ret
-  IL_001f:  ldarg.0
-  IL_0020:  ldc.i4.m1
-  IL_0021:  dup
-  IL_0022:  stloc.1
-  IL_0023:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-  IL_0028:  ldnull
-  IL_0029:  stloc.2
-  IL_002a:  nop
+        IL_0035,
+        IL_009f)
+  IL_0028:  ldc.i4.0
+  IL_0029:  ret
+  IL_002a:  ldarg.0
+  IL_002b:  ldc.i4.m1
+  IL_002c:  dup
+  IL_002d:  stloc.1
+  IL_002e:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+  IL_0033:  ldnull
+  IL_0034:  stloc.2
+  IL_0035:  nop
   .try
   {
-    IL_002b:  ldloc.1
-    IL_002c:  ldc.i4.1
-    IL_002d:  beq.s      IL_005d
-    IL_002f:  ldloc.1
-    IL_0030:  ldc.i4.2
-    IL_0031:  bne.un.s   IL_0040
-    IL_0033:  ldarg.0
-    IL_0034:  ldc.i4.m1
-    IL_0035:  dup
-    IL_0036:  stloc.1
-    IL_0037:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_0036:  ldloc.1
+    IL_0037:  ldc.i4.s   -3
+    IL_0039:  beq.s      IL_0041
+    IL_003b:  ldloc.1
     IL_003c:  ldc.i4.1
-    IL_003d:  stloc.0
-    IL_003e:  leave.s    IL_009c
-    IL_0040:  ldarg.0
-    IL_0041:  ldstr      "1"
-    IL_0046:  newobj     "Sub System.Exception..ctor(String)"
-    IL_004b:  stfld      "Module1.VB$StateMachine_1_Goo.$Current As System.Exception"
-    IL_0050:  ldarg.0
-    IL_0051:  ldc.i4.1
-    IL_0052:  dup
-    IL_0053:  stloc.1
-    IL_0054:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-    IL_0059:  ldc.i4.1
-    IL_005a:  stloc.0
-    IL_005b:  leave.s    IL_009c
-    IL_005d:  ldarg.0
-    IL_005e:  ldc.i4.m1
-    IL_005f:  dup
-    IL_0060:  stloc.1
-    IL_0061:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-    IL_0066:  ldstr      "2"
-    IL_006b:  newobj     "Sub System.Exception..ctor(String)"
-    IL_0070:  throw
+    IL_003d:  beq.s      IL_006b
+    IL_003f:  br.s       IL_004e
+    IL_0041:  ldarg.0
+    IL_0042:  ldc.i4.m1
+    IL_0043:  dup
+    IL_0044:  stloc.1
+    IL_0045:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_004a:  ldc.i4.1
+    IL_004b:  stloc.0
+    IL_004c:  leave.s    IL_00aa
+    IL_004e:  ldarg.0
+    IL_004f:  ldstr      "1"
+    IL_0054:  newobj     "Sub System.Exception..ctor(String)"
+    IL_0059:  stfld      "Module1.VB$StateMachine_1_Goo.$Current As System.Exception"
+    IL_005e:  ldarg.0
+    IL_005f:  ldc.i4.1
+    IL_0060:  dup
+    IL_0061:  stloc.1
+    IL_0062:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_0067:  ldc.i4.1
+    IL_0068:  stloc.0
+    IL_0069:  leave.s    IL_00aa
+    IL_006b:  ldarg.0
+    IL_006c:  ldc.i4.m1
+    IL_006d:  dup
+    IL_006e:  stloc.1
+    IL_006f:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+    IL_0074:  ldstr      "2"
+    IL_0079:  newobj     "Sub System.Exception..ctor(String)"
+    IL_007e:  throw
   }
   catch System.Exception
   {
-    IL_0071:  dup
-    IL_0072:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
-    IL_0077:  stloc.2
-    IL_0078:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
-    IL_007d:  leave.s    IL_007f
+    IL_007f:  dup
+    IL_0080:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_0085:  stloc.2
+    IL_0086:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_008b:  leave.s    IL_008d
   }
-  IL_007f:  ldarg.0
-  IL_0080:  ldloc.2
-  IL_0081:  stfld      "Module1.VB$StateMachine_1_Goo.$Current As System.Exception"
-  IL_0086:  ldarg.0
-  IL_0087:  ldc.i4.3
-  IL_0088:  dup
-  IL_0089:  stloc.1
-  IL_008a:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-  IL_008f:  ldc.i4.1
-  IL_0090:  ret
-  IL_0091:  ldarg.0
-  IL_0092:  ldc.i4.m1
-  IL_0093:  dup
-  IL_0094:  stloc.1
-  IL_0095:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
-  IL_009a:  ldc.i4.0
-  IL_009b:  ret
-  IL_009c:  ldloc.0
-  IL_009d:  ret
+  IL_008d:  ldarg.0
+  IL_008e:  ldloc.2
+  IL_008f:  stfld      "Module1.VB$StateMachine_1_Goo.$Current As System.Exception"
+  IL_0094:  ldarg.0
+  IL_0095:  ldc.i4.2
+  IL_0096:  dup
+  IL_0097:  stloc.1
+  IL_0098:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+  IL_009d:  ldc.i4.1
+  IL_009e:  ret
+  IL_009f:  ldarg.0
+  IL_00a0:  ldc.i4.m1
+  IL_00a1:  dup
+  IL_00a2:  stloc.1
+  IL_00a3:  stfld      "Module1.VB$StateMachine_1_Goo.$State As Integer"
+  IL_00a8:  ldc.i4.0
+  IL_00a9:  ret
+  IL_00aa:  ldloc.0
+  IL_00ab:  ret
 }
 ]]>)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.vb
@@ -590,7 +590,7 @@ End Class
             Dim v0 = CompileAndVerify(compilation:=compilation0)
             v0.VerifyIL("C.VB$StateMachine_2_M.MoveNext()", "
 {
-  // Code size      192 (0xc0)
+  // Code size      204 (0xcc)
   .maxstack  3
   .locals init (Boolean V_0,
                 Integer V_1)
@@ -598,104 +598,108 @@ End Class
   IL_0001:  ldfld      ""C.VB$StateMachine_2_M.$State As Integer""
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
-  IL_0008:  switch    (
-        IL_001f,
-        IL_0021,
-        IL_0021,
-        IL_0023)
-  IL_001d:  br.s       IL_0028
-  IL_001f:  br.s       IL_002a
-  IL_0021:  br.s       IL_0046
-  IL_0023:  br         IL_00b3
-  IL_0028:  ldc.i4.0
-  IL_0029:  ret
-  IL_002a:  ldarg.0
-  IL_002b:  ldc.i4.m1
-  IL_002c:  dup
-  IL_002d:  stloc.1
-  IL_002e:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-  IL_0033:  nop
-  IL_0034:  nop
+  IL_0008:  ldc.i4.s   -3
+  IL_000a:  sub
+  IL_000b:  switch    (
+        IL_002a,
+        IL_0033,
+        IL_0033,
+        IL_002c,
+        IL_002a,
+        IL_002e)
+  IL_0028:  br.s       IL_0033
+  IL_002a:  br.s       IL_0051
+  IL_002c:  br.s       IL_0035
+  IL_002e:  br         IL_00bf
+  IL_0033:  ldc.i4.0
+  IL_0034:  ret
   IL_0035:  ldarg.0
-  IL_0036:  ldarg.0
-  IL_0037:  ldfld      ""C.VB$StateMachine_2_M.$VB$Me As C""
-  IL_003c:  callvirt   ""Function C.F() As System.IDisposable""
-  IL_0041:  stfld      ""C.VB$StateMachine_2_M.$S0 As System.IDisposable""
-  IL_0046:  nop
+  IL_0036:  ldc.i4.m1
+  IL_0037:  dup
+  IL_0038:  stloc.1
+  IL_0039:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
+  IL_003e:  nop
+  IL_003f:  nop
+  IL_0040:  ldarg.0
+  IL_0041:  ldarg.0
+  IL_0042:  ldfld      ""C.VB$StateMachine_2_M.$VB$Me As C""
+  IL_0047:  callvirt   ""Function C.F() As System.IDisposable""
+  IL_004c:  stfld      ""C.VB$StateMachine_2_M.$S0 As System.IDisposable""
+  IL_0051:  nop
   .try
   {
-    IL_0047:  ldloc.1
-    IL_0048:  ldc.i4.1
-    IL_0049:  beq.s      IL_0053
-    IL_004b:  br.s       IL_004d
-    IL_004d:  ldloc.1
-    IL_004e:  ldc.i4.2
-    IL_004f:  beq.s      IL_0055
-    IL_0051:  br.s       IL_0057
-    IL_0053:  br.s       IL_007a
-    IL_0055:  br.s       IL_0059
-    IL_0057:  br.s       IL_0066
-    IL_0059:  ldarg.0
-    IL_005a:  ldc.i4.m1
-    IL_005b:  dup
-    IL_005c:  stloc.1
-    IL_005d:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-    IL_0062:  ldc.i4.1
-    IL_0063:  stloc.0
-    IL_0064:  leave.s    IL_00be
-    IL_0066:  ldarg.0
-    IL_0067:  ldc.i4.1
-    IL_0068:  stfld      ""C.VB$StateMachine_2_M.$Current As Integer""
-    IL_006d:  ldarg.0
+    IL_0052:  ldloc.1
+    IL_0053:  ldc.i4.s   -3
+    IL_0055:  beq.s      IL_005f
+    IL_0057:  br.s       IL_0059
+    IL_0059:  ldloc.1
+    IL_005a:  ldc.i4.1
+    IL_005b:  beq.s      IL_0061
+    IL_005d:  br.s       IL_0063
+    IL_005f:  br.s       IL_0065
+    IL_0061:  br.s       IL_0086
+    IL_0063:  br.s       IL_0072
+    IL_0065:  ldarg.0
+    IL_0066:  ldc.i4.m1
+    IL_0067:  dup
+    IL_0068:  stloc.1
+    IL_0069:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
     IL_006e:  ldc.i4.1
-    IL_006f:  dup
-    IL_0070:  stloc.1
-    IL_0071:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-    IL_0076:  ldc.i4.1
-    IL_0077:  stloc.0
-    IL_0078:  leave.s    IL_00be
-    IL_007a:  ldarg.0
-    IL_007b:  ldc.i4.m1
-    IL_007c:  dup
-    IL_007d:  stloc.1
-    IL_007e:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-    IL_0083:  leave.s    IL_00a1
+    IL_006f:  stloc.0
+    IL_0070:  leave.s    IL_00ca
+    IL_0072:  ldarg.0
+    IL_0073:  ldc.i4.1
+    IL_0074:  stfld      ""C.VB$StateMachine_2_M.$Current As Integer""
+    IL_0079:  ldarg.0
+    IL_007a:  ldc.i4.1
+    IL_007b:  dup
+    IL_007c:  stloc.1
+    IL_007d:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
+    IL_0082:  ldc.i4.1
+    IL_0083:  stloc.0
+    IL_0084:  leave.s    IL_00ca
+    IL_0086:  ldarg.0
+    IL_0087:  ldc.i4.m1
+    IL_0088:  dup
+    IL_0089:  stloc.1
+    IL_008a:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
+    IL_008f:  leave.s    IL_00ad
   }
   finally
   {
-    IL_0085:  ldloc.1
-    IL_0086:  ldc.i4.0
-    IL_0087:  bge.s      IL_00a0
-    IL_0089:  nop
-    IL_008a:  ldarg.0
-    IL_008b:  ldfld      ""C.VB$StateMachine_2_M.$S0 As System.IDisposable""
-    IL_0090:  brfalse.s  IL_009e
-    IL_0092:  ldarg.0
-    IL_0093:  ldfld      ""C.VB$StateMachine_2_M.$S0 As System.IDisposable""
-    IL_0098:  callvirt   ""Sub System.IDisposable.Dispose()""
-    IL_009d:  nop
-    IL_009e:  br.s       IL_00a0
-    IL_00a0:  endfinally
+    IL_0091:  ldloc.1
+    IL_0092:  ldc.i4.0
+    IL_0093:  bge.s      IL_00ac
+    IL_0095:  nop
+    IL_0096:  ldarg.0
+    IL_0097:  ldfld      ""C.VB$StateMachine_2_M.$S0 As System.IDisposable""
+    IL_009c:  brfalse.s  IL_00aa
+    IL_009e:  ldarg.0
+    IL_009f:  ldfld      ""C.VB$StateMachine_2_M.$S0 As System.IDisposable""
+    IL_00a4:  callvirt   ""Sub System.IDisposable.Dispose()""
+    IL_00a9:  nop
+    IL_00aa:  br.s       IL_00ac
+    IL_00ac:  endfinally
   }
-  IL_00a1:  ldarg.0
-  IL_00a2:  ldc.i4.2
-  IL_00a3:  stfld      ""C.VB$StateMachine_2_M.$Current As Integer""
-  IL_00a8:  ldarg.0
-  IL_00a9:  ldc.i4.3
-  IL_00aa:  dup
-  IL_00ab:  stloc.1
-  IL_00ac:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-  IL_00b1:  ldc.i4.1
-  IL_00b2:  ret
-  IL_00b3:  ldarg.0
-  IL_00b4:  ldc.i4.m1
-  IL_00b5:  dup
-  IL_00b6:  stloc.1
-  IL_00b7:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
-  IL_00bc:  ldc.i4.0
-  IL_00bd:  ret
-  IL_00be:  ldloc.0
-  IL_00bf:  ret
+  IL_00ad:  ldarg.0
+  IL_00ae:  ldc.i4.2
+  IL_00af:  stfld      ""C.VB$StateMachine_2_M.$Current As Integer""
+  IL_00b4:  ldarg.0
+  IL_00b5:  ldc.i4.2
+  IL_00b6:  dup
+  IL_00b7:  stloc.1
+  IL_00b8:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
+  IL_00bd:  ldc.i4.1
+  IL_00be:  ret
+  IL_00bf:  ldarg.0
+  IL_00c0:  ldc.i4.m1
+  IL_00c1:  dup
+  IL_00c2:  stloc.1
+  IL_00c3:  stfld      ""C.VB$StateMachine_2_M.$State As Integer""
+  IL_00c8:  ldc.i4.0
+  IL_00c9:  ret
+  IL_00ca:  ldloc.0
+  IL_00cb:  ret
 }
 ")
             v0.VerifyPdb("C+VB$StateMachine_2_M.MoveNext", "
@@ -713,19 +717,19 @@ End Class
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" document=""1"" />
-        <entry offset=""0x33"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""53"" document=""1"" />
-        <entry offset=""0x34"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
-        <entry offset=""0x46"" hidden=""true"" document=""1"" />
-        <entry offset=""0x47"" hidden=""true"" document=""1"" />
-        <entry offset=""0x66"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""20"" document=""1"" />
-        <entry offset=""0x83"" hidden=""true"" document=""1"" />
-        <entry offset=""0x85"" hidden=""true"" document=""1"" />
-        <entry offset=""0x89"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""18"" document=""1"" />
-        <entry offset=""0xa0"" hidden=""true"" document=""1"" />
-        <entry offset=""0xa1"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""16"" document=""1"" />
-        <entry offset=""0xbc"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""17"" document=""1"" />
+        <entry offset=""0x3e"" startLine=""8"" startColumn=""5"" endLine=""8"" endColumn=""53"" document=""1"" />
+        <entry offset=""0x3f"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" document=""1"" />
+        <entry offset=""0x51"" hidden=""true"" document=""1"" />
+        <entry offset=""0x52"" hidden=""true"" document=""1"" />
+        <entry offset=""0x72"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""20"" document=""1"" />
+        <entry offset=""0x8f"" hidden=""true"" document=""1"" />
+        <entry offset=""0x91"" hidden=""true"" document=""1"" />
+        <entry offset=""0x95"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""18"" document=""1"" />
+        <entry offset=""0xac"" hidden=""true"" document=""1"" />
+        <entry offset=""0xad"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""16"" document=""1"" />
+        <entry offset=""0xc8"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""17"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xc0"">
+      <scope startOffset=""0x0"" endOffset=""0xcc"">
         <importsforward declaringType=""C"" methodName=""F"" />
       </scope>
     </method>


### PR DESCRIPTION
Currently VB iterators are using the same number sequence for both resumable states (`Yield`) and finalizer states. That is, the state numbers are assigned as Yield/Try-Finally nodes are encountered during rewriting the tree.

This approach differs from C# which uses separate number sequences. `yield return` uses increasing state numbers (0,1,2,...) while finalizer states use decreasing numbers (-3, -4, -5, ...). This makes it easier for EnC to map states between generations (see https://github.com/dotnet/roslyn/pull/61356). 

This PR changes VB state iterator numbers to match C# behavior.
