### PR TITLE
Use assignabiilty instead of subclass test in extension loader

### DIFF
--- a/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
+++ b/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis
 
                 foreach (var typeInfo in typeInfos)
                 {
-                    if (typeInfo.IsSubclassOf(typeof(TExtension)))
+                    if (typeof(TExtension).IsAssignableFrom(typeInfo))
                     {
                         try
                         {


### PR DESCRIPTION
Needed so we can support this system for loading extensions that implement an interface (As opposed to subclassing an abstract class). 