### PR TITLE
Unify the final state management processing in inline-rename.

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
-            internal void Disconnect(bool documentIsClosed)
+            internal void DisconnectAndRollbackEdits(bool documentIsClosed)
             {
                 _session._threadingContext.ThrowIfNotOnUIThread();
 

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
-            internal void Disconnect(bool documentIsClosed, bool rollbackTemporaryEdits)
+            internal void Disconnect(bool documentIsClosed)
             {
                 _session._threadingContext.ThrowIfNotOnUIThread();
 
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // Remove any old read only regions we had
                 UpdateReadOnlyRegions(removeOnly: true);
 
-                if (rollbackTemporaryEdits && !documentIsClosed)
+                if (!documentIsClosed)
                 {
                     _session.UndoManager.UndoTemporaryEdits(_subjectBuffer, disconnect: true);
                 }

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -12,7 +12,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -21,7 +20,6 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -367,34 +365,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _previewChanges = value;
         }
 
-        private void DismissUIAndRollbackEdits()
-        {
-            _dismissed = true;
-            _workspace.WorkspaceChanged -= OnWorkspaceChanged;
-            _textBufferAssociatedViewService.SubjectBuffersConnected -= OnSubjectBuffersConnected;
-
-            // Reenable completion now that the inline rename session is done
-            _completionDisabledToken.Dispose();
-
-            foreach (var textBuffer in _openTextBuffers.Keys)
-            {
-                var document = textBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-                var isClosed = document == null;
-
-                var openBuffer = _openTextBuffers[textBuffer];
-                openBuffer.DisconnectAndRollbackEdits(isClosed);
-            }
-
-            this.UndoManager.Disconnect();
-
-            if (_triggerView != null && !_triggerView.IsClosed)
-            {
-                _triggerView.Selection.Clear();
-            }
-
-            RenameService.ActiveSession = null;
-        }
-
         private void VerifyNotDismissed()
         {
             if (_dismissed)
@@ -664,9 +634,65 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _threadingContext.ThrowIfNotOnUIThread();
             VerifyNotDismissed();
 
-            LogRenameSession(RenameLogMessage.UserActionOutcome.Canceled, previewChanges: false);
+            DismissUIAndRollbackEditsAndEndRenameSession(RenameLogMessage.UserActionOutcome.Canceled, previewChanges: false);
+        }
+
+        private void DismissUIAndRollbackEditsAndEndRenameSession(
+            RenameLogMessage.UserActionOutcome outcome,
+            bool previewChanges,
+            Action finalCommitAction = null)
+        {
+            // Note: this entire sequence of steps is not cancellable.  We must perform it all to get back to a correct
+            // state for all the editors the user is interacting with.
+
+            // Remove all our adornments and restore all buffer texts to their initial state.
             DismissUIAndRollbackEdits();
-            EndRenameSession();
+
+            // We're about to perform the final commit action.  No need to do any of our BG work to find-refs or compute conflicts.
+            _cancellationTokenSource.Cancel();
+            _conflictResolutionTaskCancellationSource.Cancel();
+
+            // Perform the actual commit step if we've been asked to.
+            finalCommitAction?.Invoke();
+
+            // Log the result so we know how well rename is going in practice.
+            LogRenameSession(outcome, previewChanges);
+
+            // Remove all our rename trackers from the text buffer properties.
+            RenameTrackingDismisser.DismissRenameTracking(_workspace, _workspace.GetOpenDocumentIds());
+
+            // Log how long the full rename took.
+            _inlineRenameSessionDurationLogBlock.Dispose();
+
+            return;
+
+            void DismissUIAndRollbackEdits()
+            {
+                _dismissed = true;
+                _workspace.WorkspaceChanged -= OnWorkspaceChanged;
+                _textBufferAssociatedViewService.SubjectBuffersConnected -= OnSubjectBuffersConnected;
+
+                // Reenable completion now that the inline rename session is done
+                _completionDisabledToken.Dispose();
+
+                foreach (var textBuffer in _openTextBuffers.Keys)
+                {
+                    var document = textBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+                    var isClosed = document == null;
+
+                    var openBuffer = _openTextBuffers[textBuffer];
+                    openBuffer.DisconnectAndRollbackEdits(isClosed);
+                }
+
+                this.UndoManager.Disconnect();
+
+                if (_triggerView != null && !_triggerView.IsClosed)
+                {
+                    _triggerView.Selection.Clear();
+                }
+
+                RenameService.ActiveSession = null;
+            }
         }
 
         public void Commit(bool previewChanges = false)
@@ -706,27 +732,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             if (result == UIThreadOperationStatus.Canceled)
             {
-                LogRenameSession(RenameLogMessage.UserActionOutcome.Canceled | RenameLogMessage.UserActionOutcome.Committed, previewChanges);
-                DismissUIAndRollbackEdits();
-                EndRenameSession();
-
+                DismissUIAndRollbackEditsAndEndRenameSession(
+                    RenameLogMessage.UserActionOutcome.Canceled | RenameLogMessage.UserActionOutcome.Committed, previewChanges);
                 return false;
             }
 
             return true;
-        }
-
-        private void EndRenameSession()
-        {
-            CancelAllOpenDocumentTrackingTasks();
-            RenameTrackingDismisser.DismissRenameTracking(_workspace, _workspace.GetOpenDocumentIds());
-            _inlineRenameSessionDurationLogBlock.Dispose();
-        }
-
-        private void CancelAllOpenDocumentTrackingTasks()
-        {
-            _cancellationTokenSource.Cancel();
-            _conflictResolutionTaskCancellationSource.Cancel();
         }
 
         private void CommitCore(IUIThreadOperationContext operationContext, bool previewChanges)
@@ -757,35 +768,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     }
                 }
 
-                // The user hasn't cancelled by now, so we're done waiting for them. Off to
-                // rename!
+                // The user hasn't canceled by now, so we're done waiting for them. Off to rename!
                 using var _ = operationContext.AddScope(allowCancellation: false, EditorFeaturesResources.Updating_files);
 
-                DismissUIAndRollbackEdits();
-                CancelAllOpenDocumentTrackingTasks();
-
-                _triggerView.Caret.PositionChanged += LogPositionChanged;
-
-                ApplyRename(newSolution, operationContext);
-
-                LogRenameSession(RenameLogMessage.UserActionOutcome.Committed, previewChanges);
-
-                EndRenameSession();
-
-                _triggerView.Caret.PositionChanged -= LogPositionChanged;
-
-                void LogPositionChanged(object sender, CaretPositionChangedEventArgs e)
-                {
-                    try
-                    {
-                        throw new InvalidOperationException("Caret position changed during application of rename");
-                    }
-                    catch (InvalidOperationException ex) when (FatalError.ReportAndCatch(ex))
-                    {
-                        // Unreachable code due to ReportAndCatch
-                        Contract.ThrowIfTrue(true);
-                    }
-                }
+                DismissUIAndRollbackEditsAndEndRenameSession(
+                    RenameLogMessage.UserActionOutcome.Committed, previewChanges,
+                    () => ApplyRename(newSolution, operationContext));
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 var isClosed = document == null;
 
                 var openBuffer = _openTextBuffers[textBuffer];
-                openBuffer.Disconnect(isClosed);
+                openBuffer.DisconnectAndRollbackEdits(isClosed);
             }
 
             this.UndoManager.Disconnect();

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -648,6 +648,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             // Remove all our adornments and restore all buffer texts to their initial state.
             DismissUIAndRollbackEdits();
 
+            _triggerView.Caret.PositionChanged += LogPositionChanged;
+
             // We're about to perform the final commit action.  No need to do any of our BG work to find-refs or compute conflicts.
             _cancellationTokenSource.Cancel();
             _conflictResolutionTaskCancellationSource.Cancel();
@@ -663,6 +665,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             // Log how long the full rename took.
             _inlineRenameSessionDurationLogBlock.Dispose();
+
+            _triggerView.Caret.PositionChanged -= LogPositionChanged;
 
             return;
 
@@ -692,6 +696,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
 
                 RenameService.ActiveSession = null;
+            }
+
+            void LogPositionChanged(object sender, CaretPositionChangedEventArgs e)
+            {
+                try
+                {
+                    throw new InvalidOperationException("Caret position changed during application of rename");
+                }
+                catch (InvalidOperationException ex) when (FatalError.ReportAndCatch(ex))
+                {
+                    // Unreachable code due to ReportAndCatch
+                    Contract.ThrowIfTrue(true);
+                }
             }
         }
 

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -706,8 +706,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
                 catch (InvalidOperationException ex) when (FatalError.ReportAndCatch(ex))
                 {
-                    // Unreachable code due to ReportAndCatch
-                    Contract.ThrowIfTrue(true);
                 }
             }
         }

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _previewChanges = value;
         }
 
-        private void Dismiss(bool rollbackTemporaryEdits)
+        private void DismissUIAndRollbackEdits()
         {
             _dismissed = true;
             _workspace.WorkspaceChanged -= OnWorkspaceChanged;
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 var isClosed = document == null;
 
                 var openBuffer = _openTextBuffers[textBuffer];
-                openBuffer.Disconnect(isClosed, rollbackTemporaryEdits);
+                openBuffer.Disconnect(isClosed);
             }
 
             this.UndoManager.Disconnect();
@@ -660,15 +660,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         }
 
         public void Cancel()
-            => Cancel(rollbackTemporaryEdits: true);
-
-        private void Cancel(bool rollbackTemporaryEdits)
         {
             _threadingContext.ThrowIfNotOnUIThread();
             VerifyNotDismissed();
 
             LogRenameSession(RenameLogMessage.UserActionOutcome.Canceled, previewChanges: false);
-            Dismiss(rollbackTemporaryEdits);
+            DismissUIAndRollbackEdits();
             EndRenameSession();
         }
 
@@ -710,7 +707,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             if (result == UIThreadOperationStatus.Canceled)
             {
                 LogRenameSession(RenameLogMessage.UserActionOutcome.Canceled | RenameLogMessage.UserActionOutcome.Committed, previewChanges);
-                Dismiss(rollbackTemporaryEdits: true);
+                DismissUIAndRollbackEdits();
                 EndRenameSession();
 
                 return false;
@@ -764,7 +761,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // rename!
                 using var _ = operationContext.AddScope(allowCancellation: false, EditorFeaturesResources.Updating_files);
 
-                Dismiss(rollbackTemporaryEdits: true);
+                DismissUIAndRollbackEdits();
                 CancelAllOpenDocumentTrackingTasks();
 
                 _triggerView.Caret.PositionChanged += LogPositionChanged;


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/61509.

This takes the 3 codepaths that end up ending the rename-session and get them to use one common cleanup routine.  WIll doc inline.