### PR TITLE
EnC: Implements support for adding and removing await/yield return in C# - IDE

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -9418,7 +9418,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "yield return 1;", CSharpFeaturesResources.yield_return_statement));
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "static IEnumerable<int> F()"));
         }
 
         [Fact]
@@ -9512,7 +9512,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "await", CSharpFeaturesResources.await_expression));
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "static async Task<int> F()"));
         }
 
         [Fact]
@@ -9544,7 +9544,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "await foreach (var x in AsyncIter())", CSharpFeaturesResources.asynchronous_foreach_statement));
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "static async Task<int> F()"));
         }
 
         [Fact]
@@ -9576,8 +9576,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "x = new AsyncDisposable()", CSharpFeaturesResources.asynchronous_using_declaration),
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "y = new AsyncDisposable()", CSharpFeaturesResources.asynchronous_using_declaration));
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "static async Task<int> F()"));
         }
 
         [Fact]
@@ -9825,7 +9824,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "await", CSharpFeaturesResources.await_expression));
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "()"));
         }
 
         [Fact]
@@ -9922,7 +9921,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "await", CSharpFeaturesResources.await_expression));
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "f"));
         }
 
         [Fact]
@@ -9951,7 +9950,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifySemanticDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "await", CSharpFeaturesResources.await_expression));
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "f"));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
@@ -1472,6 +1472,88 @@ var q = from a in await seq1
         public void Yields()
         {
             var src1 = @"
+yield return 0;
+yield return 1;
+";
+            var src2 = @"
+yield break;
+yield return 1;
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Iterator);
+            var actual = ToMatchingPairs(match);
+
+            // yield return should not match yield break
+            var expected = new MatchingPairs()
+            {
+                { "yield return 1;", "yield return 1;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void YieldReturn_Add()
+        {
+            var src1 = @"
+yield return /*1*/ 1;
+yield return /*2*/ 2;
+";
+            var src2 = @"
+yield return /*3*/ 3;
+yield return /*1*/ 1;
+yield return /*2*/ 2;
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Iterator);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "yield return /*1*/ 1;", "yield return /*1*/ 1;" },
+                { "yield return /*2*/ 2;", "yield return /*2*/ 2;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void YieldReturn_Swap1()
+        {
+            var src1 = @"
+A();
+yield return /*1*/ 1;
+B();
+yield return /*2*/ 2;
+C();
+";
+            var src2 = @"
+B();
+yield return /*2*/ 2;
+A();
+yield return /*1*/ 1;
+C();
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Iterator);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "A();", "A();" },
+                { "yield return /*1*/ 1;", "yield return /*1*/ 1;" },
+                { "B();", "B();" },
+                { "yield return /*2*/ 2;", "yield return /*2*/ 2;" },
+                { "C();", "C();" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void YieldReturn_Swap2()
+        {
+            var src1 = @"
 yield return /*1*/ 1;
 
 {
@@ -1489,14 +1571,267 @@ foreach (var x in y) { yield return /*3*/ 2; }
             var match = GetMethodMatches(src1, src2, kind: MethodKind.Iterator);
             var actual = ToMatchingPairs(match);
 
-            // note that yield returns are matched in source order, regardless of the yielded expressions:
             var expected = new MatchingPairs
             {
                 { "yield return /*1*/ 1;", "yield return /*1*/ 1;" },
                 { "{     yield return /*2*/ 2; }", "{ yield return /*3*/ 2; }" },
-                { "yield return /*2*/ 2;", "yield return /*2*/ 3;" },
-                { "foreach (var x in y) { yield return /*3*/ 3; }", "foreach (var x in y) { yield return /*3*/ 2; }" },
-                { "yield return /*3*/ 3;", "yield return /*3*/ 2;" },
+                { "yield return /*2*/ 2;", "yield return /*3*/ 2;" },
+                { "foreach (var x in y) { yield return /*3*/ 3; }", "foreach (var x in y) { yield return /*3*/ 2; }" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        #endregion
+
+        #region Async
+
+        [Fact]
+        public void Awaits()
+        {
+            var src1 = @"
+await x;
+await using (expr) {}
+await using (D y = new D()) {}
+await using D y = new D();
+await foreach (var z in w) {} 
+await foreach (var (u, v) in w) {}
+";
+            var src2 = @"
+await foreach (var (u, v) in w) {}
+await foreach (var z in w) {} 
+await using D y = new D();
+await using (D y = new D()) {}
+await using (expr) {}
+await x;
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "await x;", "await x;" },
+                { "await x", "await x" },
+                { "await using (expr) {}", "await using (expr) {}" },
+                { "{}", "{}" },
+                { "await using (D y = new D()) {}", "await using (D y = new D()) {}" },
+                { "D y = new D()", "D y = new D()" },
+                { "y = new D()", "y = new D()" },
+                { "{}", "{}" },
+                { "await using D y = new D();", "await using D y = new D();" },
+                { "D y = new D()", "D y = new D()" },
+                { "y = new D()", "y = new D()" },
+                { "await foreach (var z in w) {}", "await foreach (var z in w) {}" },
+                { "{}", "{}" },
+                { "await foreach (var (u, v) in w) {}", "await foreach (var (u, v) in w) {}" },
+                { "u", "u" },
+                { "v", "v" },
+                { "{}", "{}" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void Await_To_AwaitUsingExpression()
+        {
+            var src1 = @"
+await x;
+";
+            var src2 = @"
+await using (expr) {}
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs();
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void Await_To_AwaitUsingDecl()
+        {
+            var src1 = @"
+await x;
+";
+            var src2 = @"
+await using D y = new D();
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            // empty - treated as different awaits as the await using awaits at the end of the scope
+            var expected = new MatchingPairs();
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void AwaitUsingDecl_To_AwaitUsingStatement()
+        {
+            var src1 = @"
+await using D y = new D();
+";
+            var src2 = @"
+await using (D y = new D()) { }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs();
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void AwaitUsingExpression_To_AwaitUsingStatementWithSingleVariable()
+        {
+            var src1 = @"
+await using (y = new D()) { }
+";
+            var src2 = @"
+await using (D y = new D()) { }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            // Using with a single variable could match using with an expression because they both generate a single try-finally block,
+            // but to simplify logic we do not match them currently.
+            var expected = new MatchingPairs
+            {
+                { "{ }", "{ }" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void AwaitUsingExpression_To_AwaitUsingStatementWithMultipleVariables()
+        {
+            var src1 = @"
+await using (y = new D()) { }
+";
+            var src2 = @"
+await using (D y = new D(), z = new D()) { }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            // Using with multiple variables should not match using with an expression because they generate different number of try-finally blocks.
+            var expected = new MatchingPairs
+            {
+                { "{ }", "{ }" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void AwaitUsingMatchesUSing()
+        {
+            var src1 = "await x;foreach (T x in y) {}";
+            var src2 = "await x;await foreach (T x in y) {}";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs()
+            {
+                { "await x;", "await x;" },
+                { "await x", "await x" },
+                { "foreach (T x in y) {}", "await foreach (T x in y) {}" },
+                { "{}", "{}" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void Await_To_AwaitForeach()
+        {
+            var src1 = @"
+await x;
+";
+            var src2 = @"
+await foreach (var x in y) {}
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            // empty - treated as different awaits as the foreach awaits in each loop iteration
+            var expected = new MatchingPairs();
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void Await_To_AwaitForeachVar()
+        {
+            var src1 = @"
+await x;
+";
+            var src2 = @"
+await foreach (var (x, y) in z) {}
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            // empty - treated as different awaits as the foreach awaits in each loop iteration
+            var expected = new MatchingPairs();
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void AwaitForeach_To_AwaitForeachVar()
+        {
+            var src1 = @"
+await foreach (var x in y) {}
+";
+            var src2 = @"
+await foreach (var (u, v) in y) {}
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "await foreach (var x in y) {}", "await foreach (var (u, v) in y) {}" },
+                { "{}", "{}" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void AwaitForeachMatchesForeach()
+        {
+            var src1 = "await x;foreach (T x in y) {}";
+            var src2 = "await x;await foreach (T x in y) {}";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
+            var actual = ToMatchingPairs(match);
+
+            // We do match await foreach to foreach, even though the latter does not represent state machine.
+            // This is ok since the previous version of the method won't have state machine state associated with the 
+            // foreach statement and thus matching state machine state for the await foreach won't succeed even though 
+            // the syntax nodes match.
+            var expected = new MatchingPairs()
+            {
+                { "await x;", "await x;" },
+                { "await x", "await x" },
+                { "foreach (T x in y) {}", "await foreach (T x in y) {}" },
+                { "{}", "{}" }
             };
 
             expected.AssertEqual(actual);

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxUtilitiesTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxUtilitiesTests.cs
@@ -260,7 +260,6 @@ class C
             AssertEx.Equal(new[]
             {
                 "yield return 1;",
-                "yield break;",
                 "await Task.FromResult(1)",
                 "await foreach (var x in F()) { }",
                 "await foreach (var (x, y) in F()) { }",

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -6472,9 +6472,9 @@ partial class C
                 new[]
                 {
                     DocumentResults(),
-                    DocumentResults(diagnostics: new[]
+                    DocumentResults(semanticEdits: new[]
                     {
-                        Diagnostic(RudeEditKind.Insert, "yield return 2;", CSharpFeaturesResources.yield_return_statement)
+                        SemanticEdit(SemanticEditKind.Update, c => c.GetMember("C.F"), preserveLocalVariables: true)
                     })
                 });
         }
@@ -8499,7 +8499,7 @@ class C
 
             edits.VerifySemanticDiagnostics();
 
-            VerifyPreserveLocalVariables(edits, preserveLocalVariables: true);
+            VerifyPreserveLocalVariables(edits, preserveLocalVariables: false);
         }
 
         [WorkItem(1087305, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1087305")]
@@ -16998,8 +16998,7 @@ await Task.Delay(200);
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "await", CSharpFeaturesResources.await_expression));
+            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true));
         }
 
         [Fact]
@@ -17019,8 +17018,7 @@ await Task.Delay(100);
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.Delete, null, CSharpFeaturesResources.await_expression));
+            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$"), preserveLocalVariables: true));
         }
 
         [Fact]
@@ -17232,8 +17230,7 @@ Console.Write(1);
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"),
-                Diagnostic(RudeEditKind.Delete, null, CSharpFeaturesResources.await_expression));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"));
         }
 
         [Fact]
@@ -17286,8 +17283,7 @@ Console.Write(1);
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"),
-                Diagnostic(RudeEditKind.Delete, null, CSharpFeaturesResources.await_expression));
+                Diagnostic(RudeEditKind.ChangeImplicitMainReturnType, "Console.Write(1);"));
         }
 
         [Fact]

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
@@ -94,7 +94,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             ForStatement,
             ForStatementPart,                 // tied to parent
             ForEachStatement,
-            UsingStatement,
+            UsingStatementWithExpression,
+            UsingStatementWithDeclarations,
             FixedStatement,
             LockStatement,
             WhileStatement,
@@ -109,7 +110,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             SwitchExpressionArm,               // tied to parent
             WhenClause,                        // tied to parent
 
-            YieldStatement,                    // tied to parent
+            YieldReturnStatement,              // tied to parent
+            YieldBreakStatement,               // tied to parent
             GotoStatement,
             GotoCaseStatement,
             BreakContinueStatement,
@@ -206,7 +208,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case Label.CatchFilterClause:
                 case Label.FinallyClause:
                 case Label.ForStatementPart:
-                case Label.YieldStatement:
+                case Label.YieldReturnStatement:
+                case Label.YieldBreakStatement:
                 case Label.FromClauseLambda:
                 case Label.LetClauseLambda:
                 case Label.WhereClauseLambda:
@@ -360,8 +363,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return Label.ExpressionStatement;
 
                 case SyntaxKind.YieldBreakStatement:
+                    // yield break is distinct from yield return as it does not suspend the state machine in a resumable state
+                    return Label.YieldBreakStatement;
+
                 case SyntaxKind.YieldReturnStatement:
-                    return Label.YieldStatement;
+                    return Label.YieldReturnStatement;
 
                 case SyntaxKind.DoStatement:
                     return Label.DoStatement;
@@ -377,7 +383,14 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return Label.ForEachStatement;
 
                 case SyntaxKind.UsingStatement:
-                    return Label.UsingStatement;
+                    // We need to distinguish using statements with no or single variable declaration from one with multiple variable declarations. 
+                    // The former generates a single try-finally block, the latter one for each variable. The finally blocks need to match since they
+                    // affect state machine state matching. For simplicity we do not match single-declaration to expression, we just treat usings
+                    // with declarations entirely separately from usings with expressions.
+                    //
+                    // The parent is not available only when comparing nodes for value equality.
+                    // In that case it doesn't matter what label the node has as long as it has some.
+                    return node is UsingStatementSyntax { Declaration: not null } ? Label.UsingStatementWithDeclarations : Label.UsingStatementWithExpression;
 
                 case SyntaxKind.FixedStatement:
                     return Label.FixedStatement;
@@ -843,12 +856,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.AnonymousMethodExpression:
                 case SyntaxKind.LocalFunctionStatement:
                     distance = ComputeWeightedDistanceOfNestedFunctions(leftNode, rightNode);
-                    return true;
-
-                case SyntaxKind.YieldBreakStatement:
-                case SyntaxKind.YieldReturnStatement:
-                    // Ignore the expression of yield return. The structure of the state machine is more important than the yielded values.
-                    distance = (leftNode.RawKind == rightNode.RawKind) ? 0.0 : 0.1;
                     return true;
 
                 case SyntaxKind.SingleVariableDesignation:

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxUtilities.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxUtilities.cs
@@ -287,35 +287,16 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         /// </summary>
         /// <returns>
         /// <see cref="AwaitExpressionSyntax"/> for await expressions,
-        /// <see cref="YieldStatementSyntax"/> for yield break and yield return statements,
+        /// <see cref="YieldStatementSyntax"/> for yield return statements,
         /// <see cref="CommonForEachStatementSyntax"/> for await foreach statements,
         /// <see cref="VariableDeclaratorSyntax"/> for await using declarators.
+        /// <see cref="UsingStatementSyntax"/> for await using statements.
         /// </returns>
         public static IEnumerable<SyntaxNode> GetSuspensionPoints(SyntaxNode body)
-            => body.DescendantNodesAndSelf(LambdaUtilities.IsNotLambda).Where(IsSuspensionPoint);
+            => body.DescendantNodesAndSelf(LambdaUtilities.IsNotLambda).Where(SyntaxBindingUtilities.BindsToResumableStateMachineState);
 
-        public static bool IsSuspensionPoint(SyntaxNode node)
-        {
-            if (node.IsKind(SyntaxKind.AwaitExpression) || node.IsKind(SyntaxKind.YieldBreakStatement) || node.IsKind(SyntaxKind.YieldReturnStatement))
-            {
-                return true;
-            }
-
-            // await foreach statement translates to two suspension points: await MoveNextAsync and await DisposeAsync
-            if (node is CommonForEachStatementSyntax foreachStatement && foreachStatement.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword))
-            {
-                return true;
-            }
-
-            // each declarator in the declaration translates to a suspension point: await DisposeAsync
-            if (node.IsKind(SyntaxKind.VariableDeclarator) &&
-                node.Parent.Parent.IsKind(SyntaxKind.LocalDeclarationStatement, out LocalDeclarationStatementSyntax localDecl) &&
-                localDecl.AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword))
-            {
-                return true;
-            }
-
-            return false;
-        }
+        // Presence of yield break or yield return indicates state machine, but yield break does not bind to a resumable state. 
+        public static bool IsIterator(SyntaxNode body)
+            => body.DescendantNodesAndSelf(LambdaUtilities.IsNotLambda).Any(n => n is YieldStatementSyntax);
     }
 }

--- a/src/Features/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Features.csproj
+++ b/src/Features/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Features.csproj
@@ -57,6 +57,7 @@
     <RestrictedInternalsVisibleTo Include="Microsoft.VisualStudio.IntelliCode.CSharp.Extraction" Partner="Pythia" Key="$(IntelliCodeCSharpKey)" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\Compilers\CSharp\Portable\Syntax\SyntaxBindingUtilities.cs" Link="InternalUtilities\SyntaxBindingUtilities.cs" />
     <Compile Include="..\..\..\Compilers\CSharp\Portable\Syntax\LambdaUtilities.cs">
       <Link>InternalUtilities\LambdaUtilities.cs</Link>
     </Compile>

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -241,9 +241,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         protected abstract bool StatementLabelEquals(SyntaxNode node1, SyntaxNode node2);
 
+        protected abstract bool SupportsStateMachineUpdates { get; }
+
+        protected abstract bool IsStateMachineResumableStateSyntax(SyntaxNode node);
+
         /// <summary>
         /// True if both nodes represent the same kind of suspension point 
-        /// (await expression, await foreach statement, await using declarator, yield return, yield break).
+        /// (await expression, await foreach statement, await using statement, await using local variable declarator, yield return).
         /// </summary>
         protected virtual bool StateMachineSuspensionPointKindEquals(SyntaxNode suspensionPoint1, SyntaxNode suspensionPoint2)
             => suspensionPoint1.RawKind == suspensionPoint2.RawKind;
@@ -1482,28 +1486,38 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
             else if (oldStateMachineSuspensionPoints.Length > 0)
             {
-                Debug.Assert(oldStateMachineSuspensionPoints.Length == newStateMachineSuspensionPoints.Length);
-
-                for (var i = 0; i < oldStateMachineSuspensionPoints.Length; i++)
+                if (SupportsStateMachineUpdates)
                 {
-                    var oldNode = oldStateMachineSuspensionPoints[i];
-                    var newNode = newStateMachineSuspensionPoints[i];
-
-                    // changing yield return to yield break, await to await foreach, yield to await, etc.
-                    if (StateMachineSuspensionPointKindEquals(oldNode, newNode))
+                    foreach (var (oldNode, newNode) in match.Matches)
                     {
-                        Debug.Assert(StatementLabelEquals(oldNode, newNode));
+                        ReportStateMachineSuspensionPointRudeEdits(diagnostics, oldNode, newNode);
                     }
-                    else
-                    {
-                        diagnostics.Add(new RudeEditDiagnostic(
-                            RudeEditKind.ChangingStateMachineShape,
-                            newNode.Span,
-                            newNode,
-                            new[] { GetSuspensionPointDisplayName(oldNode, EditKind.Update), GetSuspensionPointDisplayName(newNode, EditKind.Update) }));
-                    }
+                }
+                else
+                {
+                    Debug.Assert(oldStateMachineSuspensionPoints.Length == newStateMachineSuspensionPoints.Length);
 
-                    ReportStateMachineSuspensionPointRudeEdits(diagnostics, oldNode, newNode);
+                    for (var i = 0; i < oldStateMachineSuspensionPoints.Length; i++)
+                    {
+                        var oldNode = oldStateMachineSuspensionPoints[i];
+                        var newNode = newStateMachineSuspensionPoints[i];
+
+                        // changing yield return to yield break, await to await foreach, yield to await, etc.
+                        if (StateMachineSuspensionPointKindEquals(oldNode, newNode))
+                        {
+                            Debug.Assert(StatementLabelEquals(oldNode, newNode));
+                        }
+                        else
+                        {
+                            diagnostics.Add(new RudeEditDiagnostic(
+                                RudeEditKind.ChangingStateMachineShape,
+                                newNode.Span,
+                                newNode,
+                                new[] { GetSuspensionPointDisplayName(oldNode, EditKind.Update), GetSuspensionPointDisplayName(newNode, EditKind.Update) }));
+                        }
+
+                        ReportStateMachineSuspensionPointRudeEdits(diagnostics, oldNode, newNode);
+                    }
                 }
             }
             else if (activeNodes.Length > 0)
@@ -1582,6 +1596,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             ImmutableArray<SyntaxNode> oldStateMachineSuspensionPoints,
             ImmutableArray<SyntaxNode> newStateMachineSuspensionPoints)
         {
+            if (SupportsStateMachineUpdates)
+            {
+                return;
+            }
+
             // State machine suspension points (yield statements, await expressions, await foreach loops, await using declarations) 
             // determine the structure of the generated state machine.
             // Change of the SM structure is far more significant then changes of the value (arguments) of these nodes.

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -2612,6 +2612,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
 #Region "State Machines"
 
+        Protected Overrides ReadOnly Property SupportsStateMachineUpdates As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        Protected Overrides Function IsStateMachineResumableStateSyntax(node As SyntaxNode) As Boolean
+            Return node.IsKind(SyntaxKind.AwaitExpression, SyntaxKind.YieldStatement)
+        End Function
+
         Friend Overrides Function IsStateMachineMethod(declaration As SyntaxNode) As Boolean
             Return SyntaxUtilities.IsAsyncMethodOrLambda(declaration) OrElse
                    SyntaxUtilities.IsIteratorMethodOrLambda(declaration)
@@ -2634,7 +2644,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
         Friend Overrides Sub ReportStateMachineSuspensionPointRudeEdits(diagnostics As ArrayBuilder(Of RudeEditDiagnostic), oldNode As SyntaxNode, newNode As SyntaxNode)
             ' TODO: changes around suspension points (foreach, lock, using, etc.)
 
-            If newNode.IsKind(SyntaxKind.AwaitExpression) Then
+            If newNode.IsKind(SyntaxKind.AwaitExpression) AndAlso oldNode.IsKind(SyntaxKind.AwaitExpression) Then
                 Dim oldContainingStatementPart = FindContainingStatementPart(oldNode)
                 Dim newContainingStatementPart = FindContainingStatementPart(newNode)
 


### PR DESCRIPTION
Since the compiler does not implement VB support yet we need to keep the previous implementation in place and add a new code path for C# in the EnC analyzer. Once we add VB support this code path will be removed.