### PR TITLE
Don't throw in logging when the document path contains curly braces

### DIFF
--- a/src/VisualStudio/Core/Def/LanguageClient/LogHubLspLogger.cs
+++ b/src/VisualStudio/Core/Def/LanguageClient/LogHubLspLogger.cs
@@ -37,7 +37,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         }
 
         public void TraceInformation(string message)
-            => _traceSource.TraceInformation(message);
+        {
+            // Explicitly call TraceEvent here instead of TraceInformation.
+            // TraceInformation indirectly calls string.Format which throws if the message
+            // has unescaped curlies in it (can be a part of a URI for example).
+            // Since we have no need to call string.Format here, we don't.
+            _traceSource.TraceEvent(TraceEventType.Information, id: 0, message);
+        }
 
         public void TraceWarning(string message)
             => _traceSource.TraceEvent(TraceEventType.Warning, id: 0, message);


### PR DESCRIPTION
Resolves https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1514768

See comment in the code - `TraceSource.TraceInformation` calls into a `TraceSource.TraceEvent` method and passes in a string to format along with null arguments.  This somehow(could not figure this part out) turns into an empty array of args by the time it gets passed to the `XmlWriterTraceListener`.  In older versions of .netframework, the `XmlWriterTraceListener` [only checks if the args are null before attempting to call](https://github.com/microsoft/referencesource/blob/master/System/compmod/system/diagnostics/XmlWriterTraceListener.cs#L69) `string.Format` on it.  Since null is not empty, it calls `string.Format` with an empty array of args. 

The call to string.Format fails when the string passed in has invalid curly braces (the exception you see in prism).  This generally only happesn in our LSP server if we're logging a document file path which contains curly braces.

We could attempt to sanitize all the URIs and file paths to escape curly braces, but that would require every consumer of the LSP logger to be extremely careful when they log things.  Instead it makes more sense to switch our logger to call `TraceSource.TraceEvent` which definitely never tries to call `string.Format` on the message we pass to it.

I can easily reproduce this inside VS, and verified this change resolves the problem.

Note that the `XmlWriterTraceListener` [does check for empty args in newer versions of dotnet](https://source.dot.net/#System.Diagnostics.TextWriterTraceListener/System/Diagnostics/XmlWriterTraceListener.cs,94).