### PR TITLE
Don't throw in logging when the document path contains curly braces (#61524)

### DIFF
--- a/src/VisualStudio/Core/Def/LanguageClient/LogHubLspLogger.cs
+++ b/src/VisualStudio/Core/Def/LanguageClient/LogHubLspLogger.cs
@@ -37,7 +37,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageClient
         }
 
         public void TraceInformation(string message)
-            => _traceSource.TraceInformation(message);
+        {
+            // Explicitly call TraceEvent here instead of TraceInformation.
+            // TraceInformation indirectly calls string.Format which throws if the message
+            // has unescaped curlies in it (can be a part of a URI for example).
+            // Since we have no need to call string.Format here, we don't.
+            _traceSource.TraceEvent(TraceEventType.Information, id: 0, message);
+        }
 
         public void TraceWarning(string message)
             => _traceSource.TraceEvent(TraceEventType.Warning, id: 0, message);


### PR DESCRIPTION
Port of https://github.com/dotnet/roslyn/pull/61524 to 17.2

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1514768

Needs to be backported because this affects Razor - @NTaylorMullen FYI