### PR TITLE
Add some APIs on AspNetCoreVirtualCharSequence

### DIFF
--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
@@ -18,6 +18,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
             _virtualCharSequence = virtualCharSequence;
         }
 
+        /// <inheritdoc cref="VirtualCharSequence.Empty"/>
+        public static readonly AspNetCoreVirtualCharSequence Empty = new(VirtualCharSequence.Empty);
+
         /// <inheritdoc cref="VirtualCharSequence.Length"/>
         public int Length => _virtualCharSequence.Length;
 
@@ -33,7 +36,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         /// <inheritdoc cref="VirtualCharSequence.CreateString"/>
         public string CreateString() => _virtualCharSequence.CreateString();
 
-        /// <inheritdoc cref="VirtualCharSequence.IsDefault"/>
-        public bool IsDefault => _virtualCharSequence.IsDefault;
+        /// <inheritdoc cref="VirtualCharSequence.FromBounds"/>
+        public static AspNetCoreVirtualCharSequence FromBounds(
+            AspNetCoreVirtualCharSequence chars1, AspNetCoreVirtualCharSequence chars2) =>
+            new(VirtualCharSequence.FromBounds(chars1._virtualCharSequence, chars2._virtualCharSequence));
     }
 }

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
 {
@@ -21,5 +23,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
 
         /// <inheritdoc cref="VirtualCharSequence.this"/>
         public AspNetCoreVirtualChar this[int index] => new(_virtualCharSequence[index]);
+
+        /// <inheritdoc cref="VirtualCharSequence.GetSubSequence"/>
+        public AspNetCoreVirtualCharSequence GetSubSequence(TextSpan span) => new(_virtualCharSequence.GetSubSequence(span));
+
+        /// <inheritdoc cref="VirtualCharSequence.Find"/>
+        public AspNetCoreVirtualChar? Find(int position) => (_virtualCharSequence.Find(position) is VirtualChar c) ? new(c) : null;
+
+        /// <inheritdoc cref="VirtualCharSequence.CreateString"/>
+        public string CreateString() => _virtualCharSequence.CreateString();
     }
 }

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
@@ -32,5 +32,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
 
         /// <inheritdoc cref="VirtualCharSequence.CreateString"/>
         public string CreateString() => _virtualCharSequence.CreateString();
+
+        /// <inheritdoc cref="VirtualCharSequence.IsDefault"/>
+        public bool IsDefault => _virtualCharSequence.IsDefault;
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
@@ -73,6 +73,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars
         /// </summary>
         public VirtualChar this[int index] => _leafCharacters[_span.Start + index];
 
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="VirtualCharSequence"/> was declared but not initialized.
+        /// </summary>
         public bool IsDefault => _leafCharacters == null;
         public bool IsEmpty => Length == 0;
         public bool IsDefaultOrEmpty => IsDefault || IsEmpty;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.cs
@@ -77,6 +77,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars
         public bool IsEmpty => Length == 0;
         public bool IsDefaultOrEmpty => IsDefault || IsEmpty;
 
+        /// <summary>
+        /// Retreives a sub-sequence from this <see cref="VirtualCharSequence"/>.
+        /// </summary>
         public VirtualCharSequence GetSubSequence(TextSpan span)
            => new(_leafCharacters, new TextSpan(_span.Start + span.Start, span.Length));
 
@@ -172,6 +175,9 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars
             return this.GetSubSequence(TextSpan.FromBounds(start, this.Length));
         }
 
+        /// <summary>
+        /// Create a <see cref="string"/> from the <see cref="VirtualCharSequence"/>.
+        /// </summary>
         public string CreateString()
         {
             using var _ = PooledStringBuilder.GetInstance(out var builder);


### PR DESCRIPTION
Builds on top of https://github.com/dotnet/roslyn/pull/61529

These are some APIs that either aren't possible, i.e. creating a new sequence via GetSubSequence, or reach into the internals of VirtualCharSequence. This PR exposes them on AspNetCoreVirtualCharSequence.