### PR TITLE
Record added node output states as new

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -959,7 +959,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 
             values = ImmutableArray.Create(1, 2, 3);
 
-            // second time we'll see that the "Input" step is modified, but the outputs of the "SelectMany" step are modified.
+            // second time we'll see that the "Input" step is modified, but the outputs of the "SelectMany" step are new.
             dstBuilder = GetBuilder(dstBuilder.ToImmutable(), trackIncrementalGeneratorSteps: true);
             var table = dstBuilder.GetLatestStateTableForNode(transformNode);
 
@@ -971,7 +971,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 
             Assert.All(step.Outputs, output =>
             {
-                Assert.Equal(IncrementalStepRunReason.Modified, output.Reason);
+                Assert.Equal(IncrementalStepRunReason.New, output.Reason);
             });
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis
                     (EntryState.Cached, EntryState.Cached) => IncrementalStepRunReason.Cached,
                     (EntryState.Removed, EntryState.Removed) => IncrementalStepRunReason.Removed,
                     (EntryState.Modified, EntryState.Removed) => IncrementalStepRunReason.Removed,
-                    (EntryState.Modified, EntryState.Added) => IncrementalStepRunReason.Modified,
+                    (EntryState.Modified, EntryState.Added) => IncrementalStepRunReason.New,
                     _ => throw ExceptionUtilities.UnexpectedValue((inputState, outputState))
                 };
             }


### PR DESCRIPTION
The `(EntryState.Modified, EntryState.Added) => IncrementalStepRunReason.Modified` state mapping was recently added in #61308, but it doesn't look correct to me. Since this value is used as the output status, and the outputs are new, I believe the correct state should be `IncrementalStepRunReason.New` instead.

Here's an example test where I tried to use the node states, but ran into the missing switch cases (and found the PR adding them): https://github.com/sbergen/GenSubstitute/blob/TestImprovements/src/Tests/IncrementalGenerationTests.cs#L22-L33
Since there's a new source file being generated with the modified input, I would expect to see the status for that output as `New`.