### PR TITLE
Fixed collection and object initializer usage analysis not working in top-level code

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCollectionInitializer/UseCollectionInitializerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseCollectionInitialize
 
     public partial class UseCollectionInitializerTests
     {
-        private static async Task TestInRegularAndScriptAsync(string testCode, string fixedCode)
+        private static async Task TestInRegularAndScriptAsync(string testCode, string fixedCode, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
         {
             await new VerifyCS.Test
             {
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseCollectionInitialize
                 TestCode = testCode,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.Preview,
+                TestState = { OutputKind = outputKind }
             }.RunAsync();
         }
 
@@ -1343,6 +1344,21 @@ class C
         };
     }
 }");
+        }
+
+        [WorkItem(61066, "https://github.com/dotnet/roslyn/issues/61066")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestInTopLevelStatements()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System.Collections.Generic;
+
+var list = [|new|] List<int>();
+list.Add(1);",
+@"using System.Collections.Generic;
+
+var list = new List<int> { 1 };
+", OutputKind.ConsoleApplication);
         }
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseObjectInitializer/UseObjectInitializerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseObjectInitializer/UseObjectInitializerTests.cs
@@ -18,13 +18,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
 
     public partial class UseObjectInitializerTests
     {
-        private static async Task TestInRegularAndScript1Async(string testCode, string fixedCode)
+        private static async Task TestInRegularAndScriptAsync(string testCode, string fixedCode, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
         {
             await new VerifyCS.Test
             {
                 TestCode = testCode,
                 FixedCode = fixedCode,
                 LanguageVersion = LanguageVersion.Preview,
+                TestState = { OutputKind = outputKind }
             }.RunAsync();
         }
 
@@ -45,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestOnVariableDeclarator()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -73,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestDoNotUpdateAssignmentThatReferencesInitializedValue1Async()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -119,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestDoNotUpdateAssignmentThatReferencesInitializedValue3Async()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -168,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestOnAssignmentExpression()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -198,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestStopOnDuplicateMember()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -228,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestComplexInitializer()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -260,7 +261,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestNotOnCompoundAssignment()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -293,7 +294,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [WorkItem(39146, "https://github.com/dotnet/roslyn/issues/39146")]
         public async Task TestWithExistingInitializer()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -325,7 +326,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [WorkItem(39146, "https://github.com/dotnet/roslyn/issues/39146")]
         public async Task TestWithExistingInitializerComma()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -360,7 +361,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [WorkItem(39146, "https://github.com/dotnet/roslyn/issues/39146")]
         public async Task TestWithExistingInitializerNotIfAlreadyInitialized()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -413,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestFixAllInDocument1()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -458,7 +459,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestFixAllInDocument2()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -497,7 +498,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestFixAllInDocument3()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -537,7 +538,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestTrivia1()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"
 class C
 {
@@ -570,7 +571,7 @@ class C
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestTriviaRemoveLeadingBlankLinesForFirstProperty()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"
 class C
 {
@@ -662,7 +663,7 @@ public class Goo
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestAvailableInsidePreprocessorDirective()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"
 public class Goo
 {
@@ -697,7 +698,7 @@ public class Goo
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestKeepBlankLinesAfter()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"
 class Goo
 {
@@ -789,7 +790,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestWithExplicitImplementedInterfaceMembers3()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"
 interface IExample {
     string Name { get; set; }
@@ -858,7 +859,7 @@ class MyClass
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestImplicitObject()
         {
-            await TestInRegularAndScript1Async(
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     int i;
@@ -881,6 +882,29 @@ class MyClass
         };
     }
 }");
+        }
+
+        [WorkItem(61066, "https://github.com/dotnet/roslyn/issues/61066")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestInTopLevelStatements()
+        {
+            await TestInRegularAndScriptAsync(
+@"MyClass cl = [|new|]();
+cl.MyProperty = 5;
+
+class MyClass
+{
+    public int MyProperty { get; set; }
+}",
+@"MyClass cl = new()
+{
+    MyProperty = 5
+};
+
+class MyClass
+{
+    public int MyProperty { get; set; }
+}", OutputKind.ConsoleApplication);
         }
     }
 }

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UseCollectionInitializerAnalyzer.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
 
             foreach (var child in containingBlockOrCompilationUnit.ChildNodes())
             {
-                var extractedChild = _syntaxFacts.ExtractGlobalStatementOrSelf(child);
+                var extractedChild = _syntaxFacts.IsGlobalStatement(child) ? _syntaxFacts.GetStatementOfGlobalStatement(child) : child;
 
                 if (!foundStatement)
                 {

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UseCollectionInitializerAnalyzer.cs
@@ -57,8 +57,8 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
 
         protected override void AddMatches(ArrayBuilder<TExpressionStatementSyntax> matches)
         {
-            // If containig statement is inside a block (e.g. method), than we need to iterate through its child statements.
-            // If containig statement is in top-level code, than we need to iterate through through child statements of containing compilation unit.
+            // If containing statement is inside a block (e.g. method), than we need to iterate through its child statements.
+            // If containing statement is in top-level code, than we need to iterate through child statements of containing compilation unit.
             var containingBlockOrCompilationUnit = _containingStatement.GetRequiredParent();
 
             // In case of top-level code parent of the statement will be GlobalStatementSyntax,

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UseCollectionInitializerAnalyzer.cs
@@ -81,9 +81,13 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 seenInvocation = !seenIndexAssignment;
             }
 
-            foreach (var child in containingBlockOrCompilationUnit.ChildNodes())
+            foreach (var child in containingBlockOrCompilationUnit.ChildNodesAndTokens())
             {
-                var extractedChild = _syntaxFacts.IsGlobalStatement(child) ? _syntaxFacts.GetStatementOfGlobalStatement(child) : child;
+                if (child.IsToken)
+                    continue;
+
+                var childNode = child.AsNode();
+                var extractedChild = _syntaxFacts.IsGlobalStatement(childNode) ? _syntaxFacts.GetStatementOfGlobalStatement(childNode) : childNode;
 
                 if (!foundStatement)
                 {

--- a/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
@@ -59,8 +59,8 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
 
         protected override void AddMatches(ArrayBuilder<Match<TExpressionSyntax, TStatementSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax>> matches)
         {
-            // If containig statement is inside a block (e.g. method), than we need to iterate through its child statements.
-            // If containig statement is in top-level code, than we need to iterate through child statements of containing compilation unit.
+            // If containing statement is inside a block (e.g. method), than we need to iterate through its child statements.
+            // If containing statement is in top-level code, than we need to iterate through child statements of containing compilation unit.
             var containingBlockOrCompilationUnit = _containingStatement.Parent;
 
             // In case of top-level code parent of the statement will be GlobalStatementSyntax,

--- a/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
 
             foreach (var child in containingBlockOrCompilationUnit.ChildNodes())
             {
-                var extractedChild = _syntaxFacts.ExtractGlobalStatementOrSelf(child);
+                var extractedChild = _syntaxFacts.IsGlobalStatement(child) ? _syntaxFacts.GetStatementOfGlobalStatement(child) : child;
 
                 if (!foundStatement)
                 {

--- a/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseObjectInitializer/UseNamedMemberInitializerAnalyzer.cs
@@ -87,9 +87,13 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 }
             }
 
-            foreach (var child in containingBlockOrCompilationUnit.ChildNodes())
+            foreach (var child in containingBlockOrCompilationUnit.ChildNodesAndTokens())
             {
-                var extractedChild = _syntaxFacts.IsGlobalStatement(child) ? _syntaxFacts.GetStatementOfGlobalStatement(child) : child;
+                if (child.IsToken)
+                    continue;
+
+                var childNode = child.AsNode();
+                var extractedChild = _syntaxFacts.IsGlobalStatement(childNode) ? _syntaxFacts.GetStatementOfGlobalStatement(childNode) : childNode;
 
                 if (!foundStatement)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -229,8 +229,8 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public bool IsGlobalStatement([NotNullWhen(true)] SyntaxNode? node)
            => node is GlobalStatementSyntax;
 
-        public SyntaxNode ExtractGlobalStatementOrSelf(SyntaxNode node)
-            => node is GlobalStatementSyntax globalStatement ? globalStatement.Statement : node;
+        public SyntaxNode GetStatementOfGlobalStatement(SyntaxNode node)
+            => ((GlobalStatementSyntax)node).Statement;
 
         public bool AreStatementsInSameContainer(SyntaxNode firstStatement, SyntaxNode secondStatement)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -229,6 +229,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
         public bool IsGlobalStatement([NotNullWhen(true)] SyntaxNode? node)
            => node is GlobalStatementSyntax;
 
+        public SyntaxNode ExtractGlobalStatementOrSelf(SyntaxNode node)
+            => node is GlobalStatementSyntax globalStatement ? globalStatement.Statement : node;
+
         public bool AreStatementsInSameContainer(SyntaxNode firstStatement, SyntaxNode secondStatement)
         {
             Debug.Assert(IsStatement(firstStatement));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -337,14 +337,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsStatement([NotNullWhen(true)] SyntaxNode? node);
         bool IsExecutableStatement([NotNullWhen(true)] SyntaxNode? node);
         bool IsGlobalStatement([NotNullWhen(true)] SyntaxNode? node);
-
-        /// <summary>
-        /// If the given node is a global statement then returns its containing statement.
-        /// Otherwise just returns the given input
-        /// </summary>
-        /// <param name="node"></param>
-        /// <returns></returns>
-        SyntaxNode ExtractGlobalStatementOrSelf(SyntaxNode node);
+        SyntaxNode GetStatementOfGlobalStatement(SyntaxNode node);
         bool AreStatementsInSameContainer(SyntaxNode firstStatement, SyntaxNode secondStatement);
 
         bool IsDeconstructionAssignment([NotNullWhen(true)] SyntaxNode? node);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -337,6 +337,14 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsStatement([NotNullWhen(true)] SyntaxNode? node);
         bool IsExecutableStatement([NotNullWhen(true)] SyntaxNode? node);
         bool IsGlobalStatement([NotNullWhen(true)] SyntaxNode? node);
+
+        /// <summary>
+        /// If the given node is a global statement then returns its containing statement.
+        /// Otherwise just returns the given input
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        SyntaxNode ExtractGlobalStatementOrSelf(SyntaxNode node);
         bool AreStatementsInSameContainer(SyntaxNode firstStatement, SyntaxNode secondStatement);
 
         bool IsDeconstructionAssignment([NotNullWhen(true)] SyntaxNode? node);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -215,11 +215,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
         End Function
 
         Public Function IsGlobalStatement(node As SyntaxNode) As Boolean Implements ISyntaxFacts.IsGlobalStatement
+            ' Global statements doesn't exist in VB
             Return False
         End Function
 
         Public Function GetStatementOfGlobalStatement(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetStatementOfGlobalStatement
-            Return Nothing
+            ' Global statements doesn't exist in VB
+            Throw New InvalidOperationException()
         End Function
 
         Public Function AreStatementsInSameContainer(firstStatement As SyntaxNode, secondStatement As SyntaxNode) As Boolean Implements ISyntaxFacts.AreStatementsInSameContainer

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -218,8 +218,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return False
         End Function
 
-        Public Function ExtractGlobalStatementOrSelf(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.ExtractGlobalStatementOrSelf
-            Return node
+        Public Function GetStatementOfGlobalStatement(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetStatementOfGlobalStatement
+            Return Nothing
         End Function
 
         Public Function AreStatementsInSameContainer(firstStatement As SyntaxNode, secondStatement As SyntaxNode) As Boolean Implements ISyntaxFacts.AreStatementsInSameContainer

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -218,6 +218,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageServices
             Return False
         End Function
 
+        Public Function ExtractGlobalStatementOrSelf(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.ExtractGlobalStatementOrSelf
+            Return node
+        End Function
+
         Public Function AreStatementsInSameContainer(firstStatement As SyntaxNode, secondStatement As SyntaxNode) As Boolean Implements ISyntaxFacts.AreStatementsInSameContainer
             Debug.Assert(IsStatement(firstStatement))
             Debug.Assert(IsStatement(secondStatement))


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/61066

Need help with tests here. Tried to add this test for object initializers:
```cs
        [WorkItem(61066, "https://github.com/dotnet/roslyn/issues/61066")]
        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
        public async Task TestInTopLevelStatements()
        {
            await TestInRegularAndScript1Async(
@"MyClass cl = [|new|]();
cl.MyProperty = 5;

class MyClass
{
    public int MyProperty { get; set; }
}",
@"MyClass cl = new()
{
    MyProperty = 5
}

class MyClass
{
    public int MyProperty { get; set; }
}");
        }
```
... and got `CS8805` compiler error for some reason:
![devenv_a3hS9BUnso](https://user-images.githubusercontent.com/70431552/170866391-fe01d29a-f612-4fd1-9342-de69e5f76b1f.png)