### PR TITLE
Move the semantics checks of Inheritance margin to OOP

### DIFF
--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -31,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
         private static Task VerifyNoItemForDocumentAsync(string markup, string languageName, TestHost testHost)
             => VerifyInSingleDocumentAsync(markup, languageName, testHost);
 
-        private static Task VerifyInSingleDocumentAsync(
+        private static async Task VerifyInSingleDocumentAsync(
             string markup,
             string languageName,
             TestHost testHost,
@@ -56,10 +57,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
                 composition: testHost == TestHost.InProcess ? s_inProcessComposition : s_outOffProcessComposition);
 
             var testHostDocument = testWorkspace.Documents[0];
-            return VerifyTestMemberInDocumentAsync(testWorkspace, testHostDocument, memberItems, cancellationToken);
+            await VerifyTestMemberInDocumentAsync(testWorkspace, testHostDocument, memberItems, cancellationToken).ConfigureAwait(false);
         }
 
-        private static Task VerifyInMultipleDocumentsAsync(
+        private static async Task VerifyInMultipleDocumentsAsync(
             string markup1,
             string markup2,
             string languageName,
@@ -85,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
                 composition: testHost == TestHost.InProcess ? s_inProcessComposition : s_outOffProcessComposition);
 
             var testHostDocument = testWorkspace.Documents[0];
-            return VerifyTestMemberInDocumentAsync(testWorkspace, testHostDocument, memberItems, cancellationToken);
+            await VerifyTestMemberInDocumentAsync(testWorkspace, testHostDocument, memberItems, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task VerifyTestMemberInDocumentAsync(

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -103,6 +103,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
                 document,
                 searchingSpan,
                 includeGlobalImports: true,
+                frozenPartialSemantics: true,
                 cancellationToken).ConfigureAwait(false);
 
             var sortedActualItems = actualItems.OrderBy(item => item.LineNumber).ToImmutableArray();

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService.cs
@@ -50,6 +50,10 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             var remoteClient = await RemoteHostClient.TryGetClientAsync(solution.Workspace.Services, cancellationToken).ConfigureAwait(false);
             if (remoteClient != null)
             {
+                // Also, make it clear to the remote side that they should be using frozen semantics, just like we are.
+                // we want results quickly, without waiting for the entire source generator pass to run.  The user will still get
+                // accurate results in the future because taggers are set to recompute when compilations are fully
+                // available on the OOP side.
                 var result = await remoteClient.TryInvokeAsync<IRemoteInheritanceMarginService, ImmutableArray<InheritanceMarginItem>>(
                     solution,
                     (service, solutionInfo, cancellationToken) =>

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 var result = await remoteClient.TryInvokeAsync<IRemoteInheritanceMarginService, ImmutableArray<InheritanceMarginItem>>(
                     solution,
                     (service, solutionInfo, cancellationToken) =>
-                        service.GetInheritanceMarginItemsAsync(solutionInfo, document.Id, spanToSearch, includeGlobalImports: includeGlobalImports, frozenPartialSemantics: true, cancellationToken),
+                        service.GetInheritanceMarginItemsAsync(solutionInfo, document.Id, spanToSearch, includeGlobalImports: includeGlobalImports, frozenPartialSemantics: frozenPartialSemantics, cancellationToken),
                     cancellationToken).ConfigureAwait(false);
 
                 if (!result.HasValue)
@@ -69,12 +69,12 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                     document,
                     spanToSearch,
                     includeGlobalImports: includeGlobalImports,
-                    frozenPartialSemantics: true,
+                    frozenPartialSemantics: frozenPartialSemantics,
                     cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async ValueTask<(Project remapped, SymbolAndLineNumberArray symbolAndLineNumbers)> GetMemberSymbolKeysAsync(
+        private async ValueTask<(Project remapped, SymbolAndLineNumberArray symbolAndLineNumbers)> GetMemberSymbolsAsync(
             Document document,
             TextSpan spanToSearch,
             CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName |
                 SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
 
-        private static async ValueTask<ImmutableArray<InheritanceMarginItem>> GetSymbolItemsInProcessAsync(
+        private static async ValueTask<ImmutableArray<InheritanceMarginItem>> GetSymbolInheritanceChainItemsInProcessAsync(
             Project project,
             Document? document,
             ImmutableArray<(ISymbol symbol, int lineNumber)> symbolAndLineNumbers,
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
             if (!symbolAndLineNumbers.IsEmpty)
             {
-                result.AddRange(await GetSymbolItemsInProcessAsync(
+                result.AddRange(await GetSymbolInheritanceChainItemsInProcessAsync(
                     remappedProject,
                     document: remapped ? null : document,
                     symbolAndLineNumbers,

--- a/src/Features/Core/Portable/InheritanceMargin/IInheritanceMarginService.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/IInheritanceMarginService.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             Document document,
             TextSpan spanToSearch,
             bool includeGlobalImports,
+            bool frozenPartialSemantics,
             CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/InheritanceMargin/IInheritanceMarginService.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/IInheritanceMarginService.cs
@@ -13,7 +13,9 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
     internal interface IInheritanceMarginService : ILanguageService
     {
         /// <summary>
-        /// Get the lines need to be have a margin and the member's information on that line.
+        /// Get information about
+        /// 1. The inheritance chain of the member in given span.
+        /// 2. The global imports for the document.
         /// </summary>
         ValueTask<ImmutableArray<InheritanceMarginItem>> GetInheritanceMemberItemsAsync(
             Document document,

--- a/src/Features/Core/Portable/InheritanceMargin/IRemoteInheritanceMarginService.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/IRemoteInheritanceMarginService.cs
@@ -12,18 +12,11 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 {
     internal interface IRemoteInheritanceMarginService
     {
-        ValueTask<ImmutableArray<InheritanceMarginItem>> GetGlobalImportItemsAsync(
+        ValueTask<ImmutableArray<InheritanceMarginItem>> GetInheritanceMarginItemsAsync(
             Checksum solutionChecksum,
             DocumentId documentId,
             TextSpan spanToSearch,
-            bool frozenPartialSemantics,
-            CancellationToken cancellationToken);
-
-        ValueTask<ImmutableArray<InheritanceMarginItem>> GetSymbolItemsAsync(
-            Checksum solutionChecksum,
-            ProjectId projectId,
-            DocumentId? documentId,
-            ImmutableArray<(SymbolKey symbolKey, int lineNumber)> symbolKeyAndLineNumbers,
+            bool includeGlobalImports,
             bool frozenPartialSemantics,
             CancellationToken cancellationToken);
     }

--- a/src/Tools/IdeBenchmarks/InheritanceMargin/BenchmarksHelpers.cs
+++ b/src/Tools/IdeBenchmarks/InheritanceMargin/BenchmarksHelpers.cs
@@ -27,7 +27,7 @@ namespace IdeBenchmarks.InheritanceMargin
                 {
                     var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                     var items = await languageService.GetInheritanceMemberItemsAsync(
-                        document, root.Span, includeGlobalImports: true, cancellationToken).ConfigureAwait(false);
+                        document, root.Span, includeGlobalImports: true, frozenPartialSemantics: true, cancellationToken).ConfigureAwait(false);
                     builder.AddRange(items);
                 }
             }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginTaggerProvider.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginTaggerProvider.cs
@@ -119,6 +119,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
                 document,
                 spanToSearch,
                 includeGlobalImports,
+                frozenPartialSemantics: true,
                 cancellationToken).ConfigureAwait(false);
             var elapsed = stopwatch.Elapsed;
 

--- a/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/InheritanceMargin/InheritanceMarginViewModelTests.vb
@@ -87,7 +87,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.InheritanceMargin
                 ' For these tests, we need to be on UI thread, so don't call ConfigureAwait(False)
                 Dim root = Await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(True)
                 Dim inheritanceItems = Await service.GetInheritanceMemberItemsAsync(
-                    document, root.FullSpan, includeGlobalImports:=True, cancellationToken).ConfigureAwait(True)
+                    document, root.FullSpan, includeGlobalImports:=True, frozenPartialSemantics:=True, cancellationToken).ConfigureAwait(True)
 
                 Dim acutalLineToTagDictionary = inheritanceItems.GroupBy(Function(item) item.LineNumber) _
                     .ToDictionary(Function(grouping) grouping.Key,

--- a/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
@@ -25,36 +25,19 @@ namespace Microsoft.CodeAnalysis.Remote
         {
         }
 
-        public ValueTask<ImmutableArray<InheritanceMarginItem>> GetGlobalImportItemsAsync(
+        public ValueTask<ImmutableArray<InheritanceMarginItem>> GetInheritanceMarginItemsAsync(
             Checksum solutionChecksum,
             DocumentId documentId,
             TextSpan spanToSearch,
+            bool includeGlobalImports,
             bool frozenPartialSemantics,
             CancellationToken cancellationToken)
         {
             return RunServiceAsync(solutionChecksum, solution =>
             {
                 var document = solution.GetRequiredDocument(documentId);
-                var service = (AbstractInheritanceMarginService)document.GetRequiredLanguageService<IInheritanceMarginService>();
-
-                return service.GetGlobalImportItemsAsync(document, spanToSearch, frozenPartialSemantics, cancellationToken);
-            }, cancellationToken);
-        }
-
-        public ValueTask<ImmutableArray<InheritanceMarginItem>> GetSymbolItemsAsync(
-            Checksum solutionChecksum,
-            ProjectId projectId,
-            DocumentId? documentId,
-            ImmutableArray<(SymbolKey symbolKey, int lineNumber)> symbolKeyAndLineNumbers,
-            bool frozenPartialSemantics,
-            CancellationToken cancellationToken)
-        {
-            return RunServiceAsync(solutionChecksum, solution =>
-            {
-                var project = solution.GetRequiredProject(projectId);
-                var document = solution.GetDocument(documentId);
-
-                return AbstractInheritanceMarginService.GetSymbolItemsAsync(project, document, symbolKeyAndLineNumbers, frozenPartialSemantics, cancellationToken);
+                var service = document.GetRequiredLanguageService<IInheritanceMarginService>();
+                return service.GetInheritanceMemberItemsAsync(document, spanToSearch, includeGlobalImports, cancellationToken);
             }, cancellationToken);
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 var document = solution.GetRequiredDocument(documentId);
                 var service = document.GetRequiredLanguageService<IInheritanceMarginService>();
-                return service.GetInheritanceMemberItemsAsync(document, spanToSearch, includeGlobalImports, cancellationToken);
+                return service.GetInheritanceMemberItemsAsync(document, spanToSearch, includeGlobalImports, frozenPartialSemantics, cancellationToken);
             }, cancellationToken);
         }
     }


### PR DESCRIPTION
This PR is a cleanup PR and a potential solution for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1528673/

Currently, the inheritance margin service would first get the declared symbols for the given document in devenv, then send all the symbols to OOP, then call FAR services and get the result back.
And as Cyrus mentioned in the issue, somehow this 'GetDeclarationSymbol' call is using a lot of memory. (maybe it hits some cache miss issue I guess)
Also, this is a little bit different from the 'Global imports' features (which is just sending a document and text span to the OOP), so it introduces some similar code.

This PR moves the 'GetDeclaredSymbol' part also to OOP and solves both problems.
