### PR TITLE
Remove weak references in skeleton reference cache.

### DIFF
--- a/src/VisualStudio/Core/Def/Remote/VisualStudioWorkspaceServiceHubConnector.cs
+++ b/src/VisualStudio/Core/Def/Remote/VisualStudioWorkspaceServiceHubConnector.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         public void StopListening(Workspace workspace)
         {
-            if (!(workspace is VisualStudioWorkspace) || IVsShellExtensions.IsInCommandLineMode(_threadingContext.JoinableTaskFactory))
+            if (workspace is not VisualStudioWorkspace || IVsShellExtensions.IsInCommandLineMode(_threadingContext.JoinableTaskFactory))
             {
                 return;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonPortableExecutableReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonPortableExecutableReference.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Host;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis;
+
+internal partial class SolutionState
+{
+    /// <summary>
+    /// Special subclass so we can attach more data to the PEReference.
+    /// </summary>
+    private sealed class SkeletonPortableExecutableReference : PortableExecutableReference
+    {
+        private readonly AssemblyMetadata _metadata;
+        private readonly string? _display;
+        private readonly DocumentationProvider _documentationProvider;
+
+        /// <summary>
+        /// Tie lifetime of stream to this metadata reference.  This way the stream will not be GC'ed while the reference is
+        /// alive.
+        /// </summary>
+        private readonly ISupportDirectMemoryAccess? _directMemoryAccess;
+
+        public SkeletonPortableExecutableReference(
+            AssemblyMetadata metadata,
+            MetadataReferenceProperties properties,
+            DocumentationProvider documentationProvider,
+            string? display,
+            ISupportDirectMemoryAccess? directMemoryAccess)
+            : base(properties, fullPath: null, documentationProvider)
+        {
+            _metadata = metadata;
+            _display = display;
+            _documentationProvider = documentationProvider;
+            _directMemoryAccess = directMemoryAccess;
+        }
+
+        protected override Metadata GetMetadataImpl()
+        {
+            return _metadata;
+        }
+
+        protected override DocumentationProvider CreateDocumentationProvider()
+        {
+            // documentation provider is initialized in the constructor
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        protected override PortableExecutableReference WithPropertiesImpl(MetadataReferenceProperties properties)
+        {
+            return new SkeletonPortableExecutableReference(
+                _metadata,
+                properties,
+                _documentationProvider,
+                _display,
+                _directMemoryAccess);
+        }
+
+        public override string Display => _display ?? FilePath ?? "";
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -293,7 +293,7 @@ internal partial class SolutionState
 
                 // note: computing the assembly metadata is actually synchronous.  However, this ensures we don't have N
                 // threads blocking on a lazy to compute the work.  Instead, we'll only occupy one thread, while any
-                // concurrent requests asynchronously wait for that work to be one.
+                // concurrent requests asynchronously wait for that work to be done.
                 _metadata = new AsyncLazy<AssemblyMetadata?>(c => Task.FromResult(ComputeMetadata(_storage, c)), cacheResult: true);
             }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Emit;
@@ -245,92 +241,6 @@ internal partial class SolutionState
             finally
             {
                 workspace.LogTestMessage(static compilation => $"Done trying to create a skeleton assembly for {compilation.AssemblyName}", compilation);
-            }
-        }
-
-        private sealed class SkeletonReferenceSet
-        {
-            private readonly ITemporaryStreamStorage _storage;
-            private readonly string? _assemblyName;
-
-            /// <summary>
-            /// The documentation provider used to lookup xml docs for any metadata reference we pass out.  See
-            /// docs on <see cref="DeferredDocumentationProvider"/> for why this is safe to hold onto despite it
-            /// rooting a compilation internally.
-            /// </summary>
-            private readonly DeferredDocumentationProvider _documentationProvider;
-
-            /// <summary>
-            /// The actual assembly metadata produced from the data pointed to in <see cref="_storage"/>.
-            /// </summary>
-            private readonly AsyncLazy<(AssemblyMetadata metadata, ISupportDirectMemoryAccess? directMemoryAccess)> _metadataAndDirectMemoryAccess;
-
-            public SkeletonReferenceSet(
-                ITemporaryStreamStorage storage,
-                string? assemblyName,
-                DeferredDocumentationProvider documentationProvider)
-            {
-                _storage = storage;
-                _assemblyName = assemblyName;
-                _documentationProvider = documentationProvider;
-
-                // note: computing the assembly metadata is actually synchronous.  However, this ensures we don't have N
-                // threads blocking on a lazy to compute the work.  Instead, we'll only occupy one thread, while any
-                // concurrent requests asynchronously wait for that work to be done.
-                _metadataAndDirectMemoryAccess = new AsyncLazy<(AssemblyMetadata, ISupportDirectMemoryAccess?)>(
-                    c => Task.FromResult(ComputeMetadata(_storage, c)), cacheResult: true);
-            }
-
-            private static (AssemblyMetadata, ISupportDirectMemoryAccess?) ComputeMetadata(ITemporaryStreamStorage storage, CancellationToken cancellationToken)
-            {
-                // first see whether we can use native memory directly.
-                var stream = storage.ReadStream(cancellationToken);
-
-                if (stream is ISupportDirectMemoryAccess supportNativeMemory)
-                {
-                    // this is unfortunate that if we give stream, compiler will just re-copy whole content to 
-                    // native memory again. this is a way to get around the issue by we getting native memory ourselves and then
-                    // give them pointer to the native memory. also we need to handle lifetime ourselves.
-                    var metadata = AssemblyMetadata.Create(ModuleMetadata.CreateFromImage(supportNativeMemory.GetPointer(), (int)stream.Length));
-
-                    return (metadata, supportNativeMemory);
-                }
-                else
-                {
-                    // Otherwise, we just let it use stream. Unfortunately, if we give stream, compiler will
-                    // internally copy it to native memory again. since compiler owns lifetime of stream,
-                    // it would be great if compiler can be little bit smarter on how it deals with stream.
-
-                    // We don't deterministically release the resulting metadata since we don't know 
-                    // when we should. So we leave it up to the GC to collect it and release all the associated resources.
-                    return (AssemblyMetadata.CreateFromStream(stream, leaveOpen: false), null);
-                }
-            }
-
-            public MetadataReference? TryGetAlreadyBuiltMetadataReference(MetadataReferenceProperties properties)
-            {
-                _metadataAndDirectMemoryAccess.TryGetValue(out var tuple);
-                return CreateMetadataReference(properties, tuple.metadata, tuple.directMemoryAccess);
-            }
-
-            public async Task<MetadataReference?> GetMetadataReferenceAsync(MetadataReferenceProperties properties, CancellationToken cancellationToken)
-            {
-                var (metadata, directMemberAccess) = await _metadataAndDirectMemoryAccess.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                return CreateMetadataReference(properties, metadata, directMemberAccess);
-            }
-
-            private SkeletonPortableExecutableReference? CreateMetadataReference(
-                MetadataReferenceProperties properties, AssemblyMetadata? metadata, ISupportDirectMemoryAccess? directMemoryAccess)
-            {
-                if (metadata == null)
-                    return null;
-
-                return new SkeletonPortableExecutableReference(
-                    metadata,
-                    properties,
-                    _documentationProvider,
-                    _assemblyName,
-                    directMemoryAccess);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -322,25 +322,22 @@ internal partial class SolutionState
 
             public MetadataReference? TryGetAlreadyBuiltMetadataReference(MetadataReferenceProperties properties)
             {
-                if (!_metadata.TryGetValue(out var assemblyMetadata))
-                    return null;
-
-                return assemblyMetadata?.GetReference(
-                    documentation: _documentationProvider,
-                    aliases: properties.Aliases,
-                    embedInteropTypes: properties.EmbedInteropTypes,
-                    display: _assemblyName);
+                _metadata.TryGetValue(out var assemblyMetadata);
+                return CreateMetadataReference(properties, assemblyMetadata);
             }
 
             public async Task<MetadataReference?> GetMetadataReferenceAsync(MetadataReferenceProperties properties, CancellationToken cancellationToken)
             {
                 var metadata = await _metadata.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                return metadata?.GetReference(
+                return CreateMetadataReference(properties, metadata);
+            }
+
+            private MetadataReference? CreateMetadataReference(MetadataReferenceProperties properties, AssemblyMetadata? metadata)
+                => metadata?.GetReference(
                     documentation: _documentationProvider,
                     aliases: properties.Aliases,
                     embedInteropTypes: properties.EmbedInteropTypes,
                     display: _assemblyName);
-            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -286,7 +286,7 @@ internal partial class SolutionState
                 _metadata = new AsyncLazy<AssemblyMetadata?>(c => Task.FromResult(ComputeMetadata(_storage, c)), cacheResult: true);
             }
 
-            private static AssemblyMetadata? ComputeMetadata(ITemporaryStreamStorage? storage, CancellationToken cancellationToken)
+            private static AssemblyMetadata? ComputeMetadata(ITemporaryStreamStorage storage, CancellationToken cancellationToken)
             {
                 // first see whether we can use native memory directly.
                 var stream = storage.ReadStream(cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -256,7 +256,7 @@ internal partial class SolutionState
             /// </summary>
             private static readonly ConditionalWeakTable<AssemblyMetadata, ISupportDirectMemoryAccess> s_lifetime = new();
 
-            private readonly ITemporaryStreamStorage? _storage;
+            private readonly ITemporaryStreamStorage _storage;
             private readonly string? _assemblyName;
 
             /// <summary>
@@ -272,7 +272,7 @@ internal partial class SolutionState
             private readonly AsyncLazy<AssemblyMetadata?> _metadata;
 
             public SkeletonReferenceSet(
-                ITemporaryStreamStorage? storage,
+                ITemporaryStreamStorage storage,
                 string? assemblyName,
                 DeferredDocumentationProvider documentationProvider)
             {
@@ -288,9 +288,6 @@ internal partial class SolutionState
 
             private static AssemblyMetadata? ComputeMetadata(ITemporaryStreamStorage? storage, CancellationToken cancellationToken)
             {
-                if (storage == null)
-                    return null;
-
                 // first see whether we can use native memory directly.
                 var stream = storage.ReadStream(cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceSet.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis;
+
+internal partial class SolutionState
+{
+    private sealed class SkeletonReferenceSet
+    {
+        private readonly ITemporaryStreamStorage _storage;
+        private readonly string? _assemblyName;
+
+        /// <summary>
+        /// The documentation provider used to lookup xml docs for any metadata reference we pass out.  See
+        /// docs on <see cref="DeferredDocumentationProvider"/> for why this is safe to hold onto despite it
+        /// rooting a compilation internally.
+        /// </summary>
+        private readonly DeferredDocumentationProvider _documentationProvider;
+
+        /// <summary>
+        /// The actual assembly metadata produced from the data pointed to in <see cref="_storage"/>.
+        /// </summary>
+        private readonly AsyncLazy<(AssemblyMetadata metadata, ISupportDirectMemoryAccess? directMemoryAccess)> _metadataAndDirectMemoryAccess;
+
+        /// <summary>
+        /// Lock this object while reading/writing from it.
+        /// </summary>
+        private readonly Dictionary<(AssemblyMetadata, ISupportDirectMemoryAccess?, MetadataReferenceProperties), SkeletonPortableExecutableReference> _referenceMap = new();
+
+        public SkeletonReferenceSet(
+            ITemporaryStreamStorage storage,
+            string? assemblyName,
+            DeferredDocumentationProvider documentationProvider)
+        {
+            _storage = storage;
+            _assemblyName = assemblyName;
+            _documentationProvider = documentationProvider;
+
+            // note: computing the assembly metadata is actually synchronous.  However, this ensures we don't have N
+            // threads blocking on a lazy to compute the work.  Instead, we'll only occupy one thread, while any
+            // concurrent requests asynchronously wait for that work to be done.
+            _metadataAndDirectMemoryAccess = new AsyncLazy<(AssemblyMetadata, ISupportDirectMemoryAccess?)>(
+                c => Task.FromResult(ComputeMetadata(_storage, c)), cacheResult: true);
+        }
+
+        private static (AssemblyMetadata, ISupportDirectMemoryAccess?) ComputeMetadata(ITemporaryStreamStorage storage, CancellationToken cancellationToken)
+        {
+            // first see whether we can use native memory directly.
+            var stream = storage.ReadStream(cancellationToken);
+
+            if (stream is ISupportDirectMemoryAccess supportNativeMemory)
+            {
+                // this is unfortunate that if we give stream, compiler will just re-copy whole content to 
+                // native memory again. this is a way to get around the issue by we getting native memory ourselves and then
+                // give them pointer to the native memory. also we need to handle lifetime ourselves.
+                var metadata = AssemblyMetadata.Create(ModuleMetadata.CreateFromImage(supportNativeMemory.GetPointer(), (int)stream.Length));
+
+                return (metadata, supportNativeMemory);
+            }
+            else
+            {
+                // Otherwise, we just let it use stream. Unfortunately, if we give stream, compiler will
+                // internally copy it to native memory again. since compiler owns lifetime of stream,
+                // it would be great if compiler can be little bit smarter on how it deals with stream.
+
+                // We don't deterministically release the resulting metadata since we don't know 
+                // when we should. So we leave it up to the GC to collect it and release all the associated resources.
+                return (AssemblyMetadata.CreateFromStream(stream, leaveOpen: false), null);
+            }
+        }
+
+        public MetadataReference? TryGetAlreadyBuiltMetadataReference(MetadataReferenceProperties properties)
+        {
+            _metadataAndDirectMemoryAccess.TryGetValue(out var tuple);
+            return CreateMetadataReference(properties, tuple.metadata, tuple.directMemoryAccess);
+        }
+
+        public async Task<MetadataReference?> GetMetadataReferenceAsync(MetadataReferenceProperties properties, CancellationToken cancellationToken)
+        {
+            var (metadata, directMemberAccess) = await _metadataAndDirectMemoryAccess.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            return CreateMetadataReference(properties, metadata, directMemberAccess);
+        }
+
+        private SkeletonPortableExecutableReference? CreateMetadataReference(
+            MetadataReferenceProperties properties, AssemblyMetadata? metadata, ISupportDirectMemoryAccess? directMemoryAccess)
+        {
+            if (metadata == null)
+                return null;
+
+            var key = (metadata, directMemoryAccess, properties);
+            lock (_referenceMap)
+            {
+                if (!_referenceMap.TryGetValue(key, out var value))
+                {
+                    value = new SkeletonPortableExecutableReference(
+                        metadata,
+                        properties,
+                        _documentationProvider,
+                        _assemblyName,
+                        directMemoryAccess);
+                    _referenceMap.Add(key, value);
+                }
+
+                return value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Traces taken indicate we're consume lots of resources generating skeleton references in OOP.  Auditing the code i found the use of weak-references to hold onto skeletons highly suspect.  The presumption should be that if we've computed the skeleton for a compilation because a downstream project needs it, then we'll almost certainly continue to need that skeleton in the future as the downstream project changes.  We'd only want to actually let it get cleaned up when the compilatino-tracker owning hte skeleton actually goes away.