### PR TITLE
Add an option to control if compilations are cloned when making skeletons

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
@@ -15,7 +15,8 @@ internal static class WorkspaceConfigurationOptionsStorage
             DisableProjectCacheService: globalOptions.GetOption(DisableProjectCacheService),
             DisableRecoverableTrees: globalOptions.GetOption(DisableRecoverableTrees),
             EnableOpeningSourceGeneratedFiles: globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspace) ??
-                                               globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspaceFeatureFlag));
+                                               globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspaceFeatureFlag),
+            DisableCloneWhenProducingSkeletonReferences: globalOptions.GetOption(DisableCloneWhenProducingSkeletonReferences));
 
     public static readonly Option2<StorageDatabase> Database = new(
         "FeatureManager/Storage", nameof(Database), WorkspaceConfigurationOptions.Default.CacheStorage,
@@ -35,6 +36,10 @@ internal static class WorkspaceConfigurationOptionsStorage
     public static readonly Option2<bool> DisableProjectCacheService = new(
         "WorkspaceConfigurationOptions", nameof(DisableProjectCacheService), WorkspaceConfigurationOptions.Default.DisableProjectCacheService,
         new FeatureFlagStorageLocation("Roslyn.DisableProjectCacheService"));
+
+    public static readonly Option2<bool> DisableCloneWhenProducingSkeletonReferences = new(
+        "WorkspaceConfigurationOptions", "DisableCloneWhenProducingSkeletonReferences", WorkspaceConfigurationOptions.Default.DisableCloneWhenProducingSkeletonReferences,
+        new FeatureFlagStorageLocation("Roslyn.DisableCloneWhenProducingSkeletonReferences"));
 
     /// <summary>
     /// This option allows the user to enable this. We are putting this behind a feature flag for now since we could have extensions

--- a/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
@@ -24,7 +24,8 @@ namespace Microsoft.CodeAnalysis.Host
         [property: DataMember(Order = 0)] StorageDatabase CacheStorage = StorageDatabase.SQLite,
         [property: DataMember(Order = 1)] bool DisableRecoverableTrees = false,
         [property: DataMember(Order = 2)] bool DisableProjectCacheService = false,
-        [property: DataMember(Order = 3)] bool EnableOpeningSourceGeneratedFiles = false)
+        [property: DataMember(Order = 3)] bool EnableOpeningSourceGeneratedFiles = false,
+        [property: DataMember(Order = 4)] bool DisableCloneWhenProducingSkeletonReferences = false)
     {
         public WorkspaceConfigurationOptions()
             : this(CacheStorage: StorageDatabase.SQLite)
@@ -41,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Host
             CacheStorage: StorageDatabase.None,
             DisableRecoverableTrees: false,
             DisableProjectCacheService: false,
-            EnableOpeningSourceGeneratedFiles: false);
+            EnableOpeningSourceGeneratedFiles: false,
+            DisableCloneWhenProducingSkeletonReferences: false);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -185,9 +185,12 @@ internal partial class SolutionState
                 using (Logger.LogBlock(FunctionId.Workspace_SkeletonAssembly_EmitMetadataOnlyImage, cancellationToken))
                 {
                     using var stream = SerializableBytes.CreateWritableStream();
-                    // note: cloning compilation so we don't retain all the generated symbols after its emitted.
-                    // * REVIEW * is cloning clone p2p reference compilation as well?
-                    var emitResult = compilation.Clone().Emit(stream, options: s_metadataOnlyEmitOptions, cancellationToken: cancellationToken);
+
+                    var optionsService = workspace.Services.GetService<IWorkspaceConfigurationService>();
+                    var doNotClone = optionsService != null && optionsService.Options.DisableCloneWhenProducingSkeletonReferences;
+
+                    var compilationToEmit = doNotClone ? compilation : compilation.Clone();
+                    var emitResult = compilationToEmit.Emit(stream, options: s_metadataOnlyEmitOptions, cancellationToken: cancellationToken);
 
                     if (emitResult.Success)
                     {


### PR DESCRIPTION
This will allow us to A/B test removing this to see if htere's any impact.

@jasonmalinowski and i were talking, and we think it's unlikely this is providing value.  The number of symbols created from top level code should be minor in practice.