### PR TITLE
Semantic Snippets - Fix bug where trigger character and start of snippet intersect

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 var lspSnippetText = change.Properties[SnippetCompletionItem.LSPSnippetKey];
 
                 Contract.ThrowIfNull(lspSnippetText);
-                if (!_languageServerSnippetExpander.TryExpand(lspSnippetText, triggerSnapshotSpan, _textView))
+                if (!_languageServerSnippetExpander.TryExpand(lspSnippetText, mappedSpan, _textView))
                 {
                     FatalError.ReportAndCatch(new InvalidOperationException("The invoked LSP snippet expander came back as false."), ErrorSeverity.Critical);
                 }

--- a/src/EditorFeatures/Test/Snippets/RoslynLSPSnippetConvertTests.cs
+++ b/src/EditorFeatures/Test/Snippets/RoslynLSPSnippetConvertTests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Snippets
             using var workspace = CreateWorkspaceFromCode(testString);
             var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.First().Id);
             var lspSnippetString = RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, caretPosition: 12,
-                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(8, 0), "quux"), triggerLocation: 0, CancellationToken.None).Result;
+                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(8, 0), "quux"), triggerLocation: 12, CancellationToken.None).Result;
             AssertEx.EqualOrDiff("quux$0", lspSnippetString);
         }
 
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Snippets
             using var workspace = CreateWorkspaceFromCode(testString);
             var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.First().Id);
             var lspSnippetString = RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, caretPosition: 12,
-                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(4, 4), "bar quux"), triggerLocation: 0, CancellationToken.None).Result;
+                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(4, 4), "bar quux"), triggerLocation: 12, CancellationToken.None).Result;
             AssertEx.EqualOrDiff("bar quux$0", lspSnippetString);
         }
 

--- a/src/EditorFeatures/Test/Snippets/RoslynLSPSnippetConvertTests.cs
+++ b/src/EditorFeatures/Test/Snippets/RoslynLSPSnippetConvertTests.cs
@@ -402,7 +402,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Snippets
             var testString = "foo bar quux baz";
             using var workspace = CreateWorkspaceFromCode(testString);
             var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.First().Id);
-            var lspSnippetString = RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, 12, ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(8, 0), "quux"), CancellationToken.None).Result;
+            var lspSnippetString = RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, caretPosition: 12,
+                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(8, 0), newText: "quux"), 0, CancellationToken.None).Result;
             AssertEx.EqualOrDiff("quux$0", lspSnippetString);
         }
 
@@ -412,7 +413,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Snippets
             var testString = "foo bar quux baz";
             using var workspace = CreateWorkspaceFromCode(testString);
             var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.First().Id);
-            var lspSnippetString = RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, 12, ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(4, 4), "bar quux"), CancellationToken.None).Result;
+            var lspSnippetString = RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, caretPosition: 12,
+                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(4, 4), newText: "bar quux"), 0, CancellationToken.None).Result;
             AssertEx.EqualOrDiff("bar quux$0", lspSnippetString);
         }
 
@@ -494,7 +496,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Snippets
             using var workspace = CreateWorkspaceFromCode(markup);
             var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.First().Id);
 
-            var lspSnippetString = await RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, cursorPosition!.Value, placeholders, textChange, CancellationToken.None).ConfigureAwait(false);
+            var lspSnippetString = await RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, cursorPosition!.Value, placeholders, textChange, stringSpan.Start, CancellationToken.None).ConfigureAwait(false);
             AssertEx.EqualOrDiff(output, lspSnippetString);
         }
 

--- a/src/EditorFeatures/Test/Snippets/RoslynLSPSnippetConvertTests.cs
+++ b/src/EditorFeatures/Test/Snippets/RoslynLSPSnippetConvertTests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Snippets
             using var workspace = CreateWorkspaceFromCode(testString);
             var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.First().Id);
             var lspSnippetString = RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, caretPosition: 12,
-                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(8, 0), newText: "quux"), 0, CancellationToken.None).Result;
+                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(8, 0), "quux"), triggerLocation: 0, CancellationToken.None).Result;
             AssertEx.EqualOrDiff("quux$0", lspSnippetString);
         }
 
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Snippets
             using var workspace = CreateWorkspaceFromCode(testString);
             var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.First().Id);
             var lspSnippetString = RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(document, caretPosition: 12,
-                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(4, 4), newText: "bar quux"), 0, CancellationToken.None).Result;
+                ImmutableArray<SnippetPlaceholder>.Empty, new TextChange(new TextSpan(4, 4), "bar quux"), triggerLocation: 0, CancellationToken.None).Result;
             AssertEx.EqualOrDiff("bar quux$0", lspSnippetString);
         }
 

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -44,6 +44,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
             // Converts the snippet to an LSP formatted snippet string.
             var lspSnippet = await RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(allChangesDocument, snippet.CursorPosition, snippet.Placeholders, change, item.Span.Start, cancellationToken).ConfigureAwait(false);
 
+            // If the TextChanges retrieved starts after the trigger point of the CompletionItem,
+            // then we need to move the bounds backwards and encapsulate the trigger point.
             if (change.Span.Start > item.Span.Start)
             {
                 var textSpan = TextSpan.FromBounds(item.Span.Start, change.Span.End);

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -42,7 +42,16 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
             var change = Utilities.Collapse(allChangesText, allTextChanges.AsImmutable());
 
             // Converts the snippet to an LSP formatted snippet string.
-            var lspSnippet = await RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(allChangesDocument, snippet.CursorPosition, snippet.Placeholders, change, cancellationToken).ConfigureAwait(false);
+            var lspSnippet = await RoslynLSPSnippetConverter.GenerateLSPSnippetAsync(allChangesDocument, snippet.CursorPosition, snippet.Placeholders, change, item.Span.Start, cancellationToken).ConfigureAwait(false);
+
+            if (change.Span.Start > item.Span.Start)
+            {
+                var textSpan = TextSpan.FromBounds(item.Span.Start, change.Span.End);
+                var snippetText = change.NewText;
+                Contract.ThrowIfNull(snippetText);
+                change = new TextChange(textSpan, snippetText);
+            }
+
             var props = ImmutableDictionary<string, string>.Empty
                 .Add(SnippetCompletionItem.LSPSnippetKey, lspSnippet);
 


### PR DESCRIPTION
This makes sure the trigger position is always encapsulated by the TextChange