### PR TITLE
Remove obsolete external access API now that intellicode has switched over

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/IntelliCode/Api/IIntentSourceProvider.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/IntelliCode/Api/IIntentSourceProvider.cs
@@ -76,13 +76,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.IntelliCode.Api
         public readonly string Title { get; }
 
         /// <summary>
-        /// The text changes that should be applied to the <see cref="IntentRequestContext.CurrentSnapshotSpan"/>
-        /// TODO - Remove once intellicode switches over to reading <see cref="DocumentChanges"/> instead.
-        /// </summary>
-        [Obsolete("Use DocumentChanges instead")]
-        public readonly ImmutableArray<TextChange> TextChanges { get; }
-
-        /// <summary>
         /// The text changes that should be applied to each document.
         /// </summary>
         public readonly ImmutableDictionary<DocumentId, ImmutableArray<TextChange>> DocumentChanges;
@@ -94,11 +87,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.IntelliCode.Api
         /// </summary>
         public readonly string ActionName { get; }
 
-        public IntentSource(string title, ImmutableArray<TextChange> textChanges, string actionName, ImmutableDictionary<DocumentId, ImmutableArray<TextChange>> documentChanges)
+        public IntentSource(string title, string actionName, ImmutableDictionary<DocumentId, ImmutableArray<TextChange>> documentChanges)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            TextChanges = textChanges;
-#pragma warning restore CS0618 // Type or member is obsolete
             Title = title ?? throw new ArgumentNullException(nameof(title));
             ActionName = actionName ?? throw new ArgumentNullException(nameof(actionName));
             DocumentChanges = documentChanges;

--- a/src/EditorFeatures/Core/ExternalAccess/IntelliCode/IntentProcessor.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/IntelliCode/IntentProcessor.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.IntelliCode
                 }
             }
 
-            return new IntentSource(processorResult.Title, results[originalDocument.Id], processorResult.ActionName, results.ToImmutableDictionary());
+            return new IntentSource(processorResult.Title, processorResult.ActionName, results.ToImmutableDictionary());
         }
 
         private static async Task<ImmutableArray<TextChange>?> GetTextChangesForDocumentAsync(


### PR DESCRIPTION
The old implementation could sometimes throw if there were no actual document changes (results[originalDocument.Id] would not be added to the dictionary in that case).  We don't need to access it when they're using the new property, so just remove it.
```
Exception when processing workflow System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at System.ThrowHelper.ThrowKeyNotFoundException()
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Microsoft.CodeAnalysis.ExternalAccess.IntelliCode.IntentSourceProvider.<ConvertToIntelliCodeResultAsync>d__5.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.CodeAnalysis.ExternalAccess.IntelliCode.IntentSourceProvider.<ComputeIntentsAsync>d__4.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.VisualStudio.IntelliCode.Refactorings.Csharp.RefactoringIntent.<GetResultsAsync>d__11.MoveNext()
```