### PR TITLE
Cache the AssemblyMetadata produced for any given compilation

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonPortableExecutableReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonPortableExecutableReference.cs
@@ -19,8 +19,8 @@ internal partial class SolutionState
         private readonly DocumentationProvider _documentationProvider;
 
         /// <summary>
-        /// Tie lifetime of stream to this metadata reference.  This way the stream will not be GC'ed while the reference is
-        /// alive.
+        /// Tie lifetime of the underlying direct memory to this metadata reference.  This way the memory will not be
+        /// GC'ed while this reference is alive.
         /// </summary>
         private readonly ISupportDirectMemoryAccess? _directMemoryAccess;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -177,6 +177,9 @@ internal partial class SolutionState
             SolutionState solution,
             CancellationToken cancellationToken)
         {
+            // It's acceptable for this computation to be something that multiple calling threads may hit at once.  The
+            // implementation inside the compilation tracker does an async-wait on a an internal semaphore to ensure 
+            // only one thread actually does the computation and the rest wait.
             var compilation = await compilationTracker.GetCompilationAsync(solution, cancellationToken).ConfigureAwait(false);
             var workspace = solution.Workspace;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Emit;
@@ -59,11 +61,20 @@ internal partial class SolutionState
         private static readonly EmitOptions s_metadataOnlyEmitOptions = new(metadataOnly: true);
 
         /// <summary>
-        /// Lock we take before emitting metadata.  Metadata emit is extremely expensive.  So we want to avoid cases
-        /// where N threads come in and try to get the skeleton for a particular project.  This way they will instead
-        /// yield if something else is computing and will then use the single instance computed once one thread succeeds.
+        /// Static conditional mapping from a compilation to the skeleton set produced for it.  This is valuable for a
+        /// couple of reasons. First, a compilation tracker may fork, but produce the same compilation.  As such, we
+        /// want to get the same skeleton set for it.  Second, consider the following scenario:
+        /// <list type="number">
+        /// <item>Project A is referenced by projects B and C (both have a different language than A).</item>
+        /// <item>Producing the compilation for 'B' produces the compilation for 'A' which produced the skeleton that 'B' references.</item>
+        /// <item>B's compilation is released and then GC'ed.</item> 
+        /// <item>Producing the compilation for 'B' produces the compilation for 'A'</item>
+        /// </list>
+        /// At this point we would not want to re-emit the assembly metadata for A's compilation.  We already did that
+        /// for 'B', and it can be enormously expensive to do so again.  So as long as A's compilation lives, we really
+        /// want to keep it's skeleton cache around.
         /// </summary>
-        private readonly SemaphoreSlim _emitGate = new(initialCount: 1);
+        private static readonly ConditionalWeakTable<Compilation, AsyncLazy<SkeletonReferenceSet?>> s_compilationToSkeletonSet = new();
 
         /// <summary>
         /// Lock around <see cref="_version"/> and <see cref="_skeletonReferenceSet"/> to ensure they are updated/read 
@@ -114,7 +125,7 @@ internal partial class SolutionState
         }
 
         public MetadataReference? TryGetAlreadyBuiltMetadataReference(MetadataReferenceProperties properties)
-            => _skeletonReferenceSet?.TryGetAlreadyBuiltMetadataReference(properties);
+            => _skeletonReferenceSet?.GetOrCreateMetadataReference(properties);
 
         public async Task<MetadataReference?> GetOrBuildReferenceAsync(
             ICompilationTracker compilationTracker,
@@ -128,7 +139,7 @@ internal partial class SolutionState
             if (referenceSet == null)
                 return null;
 
-            return await referenceSet.GetMetadataReferenceAsync(properties, cancellationToken).ConfigureAwait(false);
+            return referenceSet.GetOrCreateMetadataReference(properties);
         }
 
         private async Task<SkeletonReferenceSet?> TryGetOrCreateReferenceSetAsync(
@@ -142,33 +153,86 @@ internal partial class SolutionState
             if (TryReadSkeletonReferenceSetAtThisVersion(version, out var referenceSet))
                 return referenceSet;
 
-            // okay, we don't have anything cached with this version. so create one now.  Note: this is expensive
-            // so ensure only one thread is doing hte work to actually make the compilation and emit it.
-            using (await _emitGate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
+            // okay, we don't have anything cached with this version. so create one now.
+
+            var currentSkeletonReferenceSet = await CreateSkeletonReferenceSetAsync(compilationTracker, solution, cancellationToken).ConfigureAwait(false);
+
+            lock (_stateGate)
             {
-                // after taking the gate, another thread may have succeeded.  See if we can use their version if so:
-                if (TryReadSkeletonReferenceSetAtThisVersion(version, out referenceSet))
-                    return referenceSet;
+                // If we successfully created the metadata storage, then create the new set that points to it.
+                // if we didn't, that's ok too, we'll just say that for this requested version, that we can
+                // return any prior computed reference set (including 'null' if we've never successfully made
+                // a skeleton).
+                if (currentSkeletonReferenceSet != null)
+                    _skeletonReferenceSet = currentSkeletonReferenceSet;
 
-                // Ok, first thread to get in and actually do this work.  Build the compilation and try to emit it.
-                // Regardless of if we succeed or fail, store this result so this only happens once.
+                _version = version;
 
-                var compilation = await compilationTracker.GetCompilationAsync(solution, cancellationToken).ConfigureAwait(false);
-                var storage = TryCreateMetadataStorage(solution.Workspace, compilation, cancellationToken);
+                return _skeletonReferenceSet;
+            }
+        }
 
-                lock (_stateGate)
-                {
-                    // If we successfully created the metadata storage, then create the new set that points to it.
-                    // if we didn't, that's ok too, we'll just say that for this requested version, that we can
-                    // return any prior computed reference set (including 'null' if we've never successfully made
-                    // a skeleton).
-                    if (storage != null)
-                        _skeletonReferenceSet = new SkeletonReferenceSet(storage, compilation.AssemblyName, new DeferredDocumentationProvider(compilation));
+        private static async Task<SkeletonReferenceSet?> CreateSkeletonReferenceSetAsync(
+            ICompilationTracker compilationTracker,
+            SolutionState solution,
+            CancellationToken cancellationToken)
+        {
+            var compilation = await compilationTracker.GetCompilationAsync(solution, cancellationToken).ConfigureAwait(false);
+            var workspace = solution.Workspace;
 
-                    _version = version;
+            // note: computing the assembly metadata is actually synchronous.  However, this ensures we don't have N
+            // threads blocking on a lazy to compute the work.  Instead, we'll only occupy one thread, while any
+            // concurrent requests asynchronously wait for that work to be done.
 
-                    return _skeletonReferenceSet;
-                }
+            var lazy = s_compilationToSkeletonSet.GetValue(compilation,
+                compilation => new AsyncLazy<SkeletonReferenceSet?>(
+                    cancellationToken => Task.FromResult(CreateSkeletonSet(workspace, compilation, cancellationToken)),
+                    cacheResult: true));
+
+            return await lazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private static SkeletonReferenceSet? CreateSkeletonSet(
+            Workspace workspace, Compilation compilation, CancellationToken cancellationToken)
+        {
+            var storage = TryCreateMetadataStorage(workspace, compilation, cancellationToken);
+            if (storage == null)
+                return null;
+
+            var (metadata, directMemoryAccess) = ComputeMetadata(storage, cancellationToken);
+
+            // read in the stream and pass ownership of it to the metadata object.  When it is disposed it will dispose
+            // the stream as well.
+            return new SkeletonReferenceSet(
+                metadata,
+                directMemoryAccess,
+                compilation.AssemblyName,
+                new DeferredDocumentationProvider(compilation));
+        }
+
+        private static (AssemblyMetadata, ISupportDirectMemoryAccess?) ComputeMetadata(ITemporaryStreamStorage storage, CancellationToken cancellationToken)
+        {
+            // first see whether we can use native memory directly.
+            var stream = storage.ReadStream(cancellationToken);
+
+            if (stream is ISupportDirectMemoryAccess supportNativeMemory)
+            {
+                // this is unfortunate that if we give stream, compiler will just re-copy whole content to 
+                // native memory again. this is a way to get around the issue by we getting native memory ourselves and then
+                // give them pointer to the native memory. also we need to handle lifetime ourselves.
+                var metadata = AssemblyMetadata.Create(ModuleMetadata.CreateFromImage(supportNativeMemory.GetPointer(), (int)stream.Length));
+
+                return (metadata, supportNativeMemory);
+            }
+            else
+            {
+                // Otherwise, we just let it use stream. Unfortunately, if we give stream, compiler will
+                // internally copy it to native memory again. since compiler owns lifetime of stream,
+                // it would be great if compiler can be little bit smarter on how it deals with stream.
+
+                // We don't deterministically release the resulting metadata since we don't know 
+                // when we should. So we leave it up to the GC to collect it and release all the associated resources.
+                return (AssemblyMetadata.CreateFromStream(stream, leaveOpen: false), null);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceSet.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceSet.cs
@@ -14,7 +14,17 @@ internal partial class SolutionState
 {
     private sealed class SkeletonReferenceSet
     {
-        private readonly ITemporaryStreamStorage _storage;
+        /// <summary>
+        /// The actual assembly metadata produced from another compilation.
+        /// </summary>
+        private readonly AssemblyMetadata _metadata;
+
+        /// <summary>
+        /// Used to tie lifetime of the underlying direct memory to any metadata reference we pass out.  This way the
+        /// memory will not be GC'ed while this reference is alive.
+        /// </summary>
+        private readonly ISupportDirectMemoryAccess? _directMemoryAccess;
+
         private readonly string? _assemblyName;
 
         /// <summary>
@@ -25,87 +35,38 @@ internal partial class SolutionState
         private readonly DeferredDocumentationProvider _documentationProvider;
 
         /// <summary>
-        /// The actual assembly metadata produced from the data pointed to in <see cref="_storage"/>.
+        /// Lock this object while reading/writing from it.  Used so we can return the same reference for the same
+        /// properties.  While this is isn't strictly necessary (as the important thing to keep the same is the
+        /// AssemblyMetadata), this allows higher layers to see that reference instances are the same which allow
+        /// reusing the same higher level objects (for example, the set of references a compilation has).
         /// </summary>
-        private readonly AsyncLazy<(AssemblyMetadata metadata, ISupportDirectMemoryAccess? directMemoryAccess)> _metadataAndDirectMemoryAccess;
-
-        /// <summary>
-        /// Lock this object while reading/writing from it.
-        /// </summary>
-        private readonly Dictionary<(AssemblyMetadata, ISupportDirectMemoryAccess?, MetadataReferenceProperties), SkeletonPortableExecutableReference> _referenceMap = new();
+        private readonly Dictionary<MetadataReferenceProperties, SkeletonPortableExecutableReference> _referenceMap = new();
 
         public SkeletonReferenceSet(
-            ITemporaryStreamStorage storage,
+            AssemblyMetadata metadata,
+            ISupportDirectMemoryAccess? directMemoryAccess,
             string? assemblyName,
             DeferredDocumentationProvider documentationProvider)
         {
-            _storage = storage;
+            _metadata = metadata;
+            _directMemoryAccess = directMemoryAccess;
             _assemblyName = assemblyName;
             _documentationProvider = documentationProvider;
-
-            // note: computing the assembly metadata is actually synchronous.  However, this ensures we don't have N
-            // threads blocking on a lazy to compute the work.  Instead, we'll only occupy one thread, while any
-            // concurrent requests asynchronously wait for that work to be done.
-            _metadataAndDirectMemoryAccess = new AsyncLazy<(AssemblyMetadata, ISupportDirectMemoryAccess?)>(
-                c => Task.FromResult(ComputeMetadata(_storage, c)), cacheResult: true);
         }
 
-        private static (AssemblyMetadata, ISupportDirectMemoryAccess?) ComputeMetadata(ITemporaryStreamStorage storage, CancellationToken cancellationToken)
+        public PortableExecutableReference GetOrCreateMetadataReference(MetadataReferenceProperties properties)
         {
-            // first see whether we can use native memory directly.
-            var stream = storage.ReadStream(cancellationToken);
-
-            if (stream is ISupportDirectMemoryAccess supportNativeMemory)
-            {
-                // this is unfortunate that if we give stream, compiler will just re-copy whole content to 
-                // native memory again. this is a way to get around the issue by we getting native memory ourselves and then
-                // give them pointer to the native memory. also we need to handle lifetime ourselves.
-                var metadata = AssemblyMetadata.Create(ModuleMetadata.CreateFromImage(supportNativeMemory.GetPointer(), (int)stream.Length));
-
-                return (metadata, supportNativeMemory);
-            }
-            else
-            {
-                // Otherwise, we just let it use stream. Unfortunately, if we give stream, compiler will
-                // internally copy it to native memory again. since compiler owns lifetime of stream,
-                // it would be great if compiler can be little bit smarter on how it deals with stream.
-
-                // We don't deterministically release the resulting metadata since we don't know 
-                // when we should. So we leave it up to the GC to collect it and release all the associated resources.
-                return (AssemblyMetadata.CreateFromStream(stream, leaveOpen: false), null);
-            }
-        }
-
-        public MetadataReference? TryGetAlreadyBuiltMetadataReference(MetadataReferenceProperties properties)
-        {
-            _metadataAndDirectMemoryAccess.TryGetValue(out var tuple);
-            return CreateMetadataReference(properties, tuple.metadata, tuple.directMemoryAccess);
-        }
-
-        public async Task<MetadataReference?> GetMetadataReferenceAsync(MetadataReferenceProperties properties, CancellationToken cancellationToken)
-        {
-            var (metadata, directMemberAccess) = await _metadataAndDirectMemoryAccess.GetValueAsync(cancellationToken).ConfigureAwait(false);
-            return CreateMetadataReference(properties, metadata, directMemberAccess);
-        }
-
-        private SkeletonPortableExecutableReference? CreateMetadataReference(
-            MetadataReferenceProperties properties, AssemblyMetadata? metadata, ISupportDirectMemoryAccess? directMemoryAccess)
-        {
-            if (metadata == null)
-                return null;
-
-            var key = (metadata, directMemoryAccess, properties);
             lock (_referenceMap)
             {
-                if (!_referenceMap.TryGetValue(key, out var value))
+                if (!_referenceMap.TryGetValue(properties, out var value))
                 {
                     value = new SkeletonPortableExecutableReference(
-                        metadata,
+                        _metadata,
                         properties,
                         _documentationProvider,
                         _assemblyName,
-                        directMemoryAccess);
-                    _referenceMap.Add(key, value);
+                        _directMemoryAccess);
+                    _referenceMap.Add(properties, value);
                 }
 
                 return value;


### PR DESCRIPTION
This ensures that if we produce an AssemblyMetadata (and skeleton PEReference) to be consumed a downstream project, that we can then reuse that same data for a different downstream project, even if the first downstream project is GC'ed.

As long as the originating compilation is around, then we'll only build a skeleton for it at most once. This also benefits any scenarios that may exist where we might get a forked compilation-tracker but that tracker ends up producing the same compilation (@jasonmalinowski for if this is possible).

This will also get cleaner once https://github.com/dotnet/roslyn/pull/61630 goes in.