### PR TITLE
Deprioritize 'extract base class' when on a member in a type

### DIFF
--- a/src/Features/CSharp/Portable/CodeRefactorings/ExtractClass/CSharpExtractClassCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/ExtractClass/CSharpExtractClassCodeRefactoringProvider.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ExtractClass
 {
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ExtractClass), Shared]
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.ExtractInterface)]
+    [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.UseExpressionBody)]
     internal class CSharpExtractClassCodeRefactoringProvider : AbstractExtractClassRefactoringProvider
     {
         [ImportingConstructor]

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -27,8 +27,8 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp,
-        Name = PredefinedCodeRefactoringProviderNames.UseExpressionBody), Shared]
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.UseExpressionBody), Shared]
+    [ExtensionOrder(Before = PredefinedCodeRefactoringProviderNames.ExtractClass)]
     internal class UseExpressionBodyCodeRefactoringProvider : SyntaxEditorBasedCodeRefactoringProvider
     {
         private static readonly ImmutableArray<UseExpressionBodyHelper> _helpers = UseExpressionBodyHelper.Helpers;

--- a/src/Features/Core/Portable/ExtractClass/AbstractExtractClassRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ExtractClass/AbstractExtractClassRefactoringProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.PullMemberUp;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExtractClass
 {
@@ -87,29 +88,29 @@ namespace Microsoft.CodeAnalysis.ExtractClass
 
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             var containingTypeDeclarationNode = selectedMemberNode.FirstAncestorOrSelf<SyntaxNode>(syntaxFacts.IsTypeDeclaration);
+            Contract.ThrowIfNull(containingTypeDeclarationNode);
 
-            return new ExtractClassWithDialogCodeAction(document, span, optionsService, containingType, containingTypeDeclarationNode!, context.Options, selectedMember);
+            // Treat the entire node's span as the span of interest here.  That way if the user's location is closer to
+            // a refactoring with a narrower span (for example, a span just on the name/parameters of a member, then it
+            // will take precedence over us).
+            return new ExtractClassWithDialogCodeAction(
+                document, selectedMemberNode.Span, optionsService, containingType, containingTypeDeclarationNode, context.Options, selectedMember);
         }
 
         private async Task<ExtractClassWithDialogCodeAction?> TryGetClassActionAsync(CodeRefactoringContext context, IExtractClassOptionsService optionsService)
         {
             var selectedClassNode = await GetSelectedClassDeclarationAsync(context).ConfigureAwait(false);
             if (selectedClassNode is null)
-            {
                 return null;
-            }
 
             var (document, span, cancellationToken) = context;
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var originalType = semanticModel.GetDeclaredSymbol(selectedClassNode, cancellationToken) as INamedTypeSymbol;
-
-            if (originalType is null)
-            {
+            if (semanticModel.GetDeclaredSymbol(selectedClassNode, cancellationToken) is not INamedTypeSymbol originalType)
                 return null;
-            }
 
-            return new ExtractClassWithDialogCodeAction(document, span, optionsService, originalType, selectedClassNode, context.Options);
+            return new ExtractClassWithDialogCodeAction(
+                document, span, optionsService, originalType, selectedClassNode, context.Options, selectedMember: null);
         }
     }
 }

--- a/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
@@ -34,6 +34,8 @@ namespace Microsoft.CodeAnalysis.ExtractClass
         public TextSpan Span { get; }
         public override string Title => FeaturesResources.Extract_base_class;
 
+        internal override CodeActionPriority Priority { get; }
+
         public ExtractClassWithDialogCodeAction(
             Document document,
             TextSpan span,
@@ -41,7 +43,7 @@ namespace Microsoft.CodeAnalysis.ExtractClass
             INamedTypeSymbol selectedType,
             SyntaxNode selectedTypeDeclarationNode,
             CleanCodeGenerationOptionsProvider fallbackOptions,
-            ISymbol? selectedMember = null)
+            ISymbol? selectedMember)
         {
             _document = document;
             _service = service;
@@ -50,6 +52,11 @@ namespace Microsoft.CodeAnalysis.ExtractClass
             _fallbackOptions = fallbackOptions;
             _selectedMember = selectedMember;
             Span = span;
+
+            // If the user brought up the lightbulb on a class itself, it's more likely that they want to extract a base
+            // class.  on a member however, we deprioritize this as there are likely more member-specific operations
+            // they'd prefer to invoke instead.
+            Priority = selectedMember is null ? CodeActionPriority.Medium : CodeActionPriority.Low;
         }
 
         public override object? GetOptions(CancellationToken cancellationToken)


### PR DESCRIPTION
Looks like this now:

![image](https://user-images.githubusercontent.com/4564579/171733217-bfbde420-e93f-46a9-ae07-9919225497e3.png)

Integration test incoming.