### PR TITLE
Allow SyntaxOffset in EnC state machine map to be negative

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -94,8 +94,8 @@
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.4.0</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderConverterVersion>1.1.0-beta2-22273-03</MicrosoftDiaSymReaderConverterVersion>
-    <MicrosoftDiaSymReaderConverterXmlVersion>1.1.0-beta2-22273-03</MicrosoftDiaSymReaderConverterXmlVersion>
+    <MicrosoftDiaSymReaderConverterVersion>1.1.0-beta2-22302-02</MicrosoftDiaSymReaderConverterVersion>
+    <MicrosoftDiaSymReaderConverterXmlVersion>1.1.0-beta2-22302-02</MicrosoftDiaSymReaderConverterXmlVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.0.0-beta1.21524.1</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.7.0-beta-21528-01</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftExtensionsLoggingVersion>5.0.0</MicrosoftExtensionsLoggingVersion>


### PR DESCRIPTION
Use the same pattern for encoding the blob as other EnC debug infos with syntax offsets: Negative syntax offsets are rare - only when the syntax node is in an initializer of a field or property. To optimize for size calculates the base offset and adds it to all syntax offsets. In common cases (no negative offsets) this base offset is gonna be 0. Otherwise it's gonna be the lowest negative offset.

TODO:

 - [x] SymReader.Converter package reference needs to be updated to one published by https://dev.azure.com/dnceng/internal/_build/results?buildId=1803506&view=results for the tests to pass