### PR TITLE
Switch backing store for callback-array to an immutable structure so it cannot change as we are enumerating over it.

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Workspaces/WpfTextBufferVisibilityTracker.cs
+++ b/src/EditorFeatures/Core.Wpf/Workspaces/WpfTextBufferVisibilityTracker.cs
@@ -112,6 +112,25 @@ namespace Microsoft.CodeAnalysis.Workspaces
             }
         }
 
+        public TestAccessor GetTestAccessor()
+            => new TestAccessor(this);
+
+        public struct TestAccessor
+        {
+            private readonly WpfTextBufferVisibilityTracker _visibilityTracker;
+
+            public TestAccessor(WpfTextBufferVisibilityTracker visibilityTracker)
+            {
+                _visibilityTracker = visibilityTracker;
+            }
+
+            public void TriggerCallbacks(ITextBuffer subjectBuffer)
+            {
+                var data = _visibilityTracker._subjectBufferToCallbacks[subjectBuffer];
+                data.TriggerCallbacks();
+            }
+        }
+
         private sealed class VisibleTrackerData : IDisposable
         {
             public readonly HashSet<ITextView> TextViews = new();
@@ -191,6 +210,11 @@ namespace Microsoft.CodeAnalysis.Workspaces
             }
 
             private void VisualElement_IsVisibleChanged(object sender, System.Windows.DependencyPropertyChangedEventArgs e)
+            {
+                TriggerCallbacks();
+            }
+
+            internal void TriggerCallbacks()
             {
                 _tracker._threadingContext.ThrowIfNotOnUIThread();
                 foreach (var callback in Callbacks)

--- a/src/EditorFeatures/Test2/Workspaces/WpfTextBufferVisibilityTrackerTests.vb
+++ b/src/EditorFeatures/Test2/Workspaces/WpfTextBufferVisibilityTrackerTests.vb
@@ -1,0 +1,44 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.Workspaces
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+    <UseExportProvider>
+    Public Class WpfTextBufferVisibilityTrackerTests
+        <WpfFact>
+        Public Sub TestMutationInCallback()
+            Using workspace = TestWorkspace.CreateCSharp("", composition:=EditorTestCompositions.EditorFeaturesWpf)
+                Dim visibilityTracker = DirectCast(workspace.ExportProvider.GetExportedValue(Of ITextBufferVisibilityTracker), WpfTextBufferVisibilityTracker)
+
+                Dim buffer = workspace.Documents.Single().GetTextBuffer()
+
+                Dim action1Called = False
+                Dim action2Called = False
+
+                Dim action1 As Action = Nothing
+                action1 = Sub()
+                              action1Called = True
+                              visibilityTracker.UnregisterForVisibilityChanges(buffer, action1)
+                          End Sub
+
+                Dim action2 = Sub()
+                                  action2Called = True
+                              End Sub
+
+                visibilityTracker.RegisterForVisibilityChanges(buffer, action1)
+                visibilityTracker.RegisterForVisibilityChanges(buffer, action2)
+
+                ' Getting the text view will cause it to become visible which will iterate and invoke the actions.  The first
+                ' action callback will then unregister itself.  This should must not break things, and we should still call action2.
+                Dim view = workspace.Documents.Single().GetTextView()
+
+                visibilityTracker.GetTestAccessor().TriggerCallbacks(buffer)
+
+                Assert.True(action1Called)
+                Assert.True(action2Called)
+            End Using
+        End Sub
+    End Class
+End Namespace


### PR DESCRIPTION
Fixes [AB#1545234](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1545234)

There's been an intermittent stability issue that was caused by the view-visibility work i added a while back.  The core issue here is that we were enumerating a mutable collection of callbacks, invoking them during iteration.  It was possible for the callback to then perform work that would cause a mutation of the collection being iterated.

An example of this was a callback that set a TaskCompletionSource to completed.  When completed, TPL *could* inline execution of the continuations of that task onto that thread, and those continuations *could* then register/unregister callbacks.  

Fix here is to switch to immutable collections so that iteration is always safe.  (Another option was to make a copy of the collection while iterating, but i felt this was cleaner).