### PR TITLE
Add AspNetCoreCSharpVirtualCharService

### DIFF
--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreCSharpVirtualCharService.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreCSharpVirtualCharService.cs
@@ -11,7 +11,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
 {
     internal sealed class AspNetCoreCSharpVirtualCharService
     {
-        private static AspNetCoreCSharpVirtualCharService? _instance;
+        private static readonly AspNetCoreCSharpVirtualCharService _instance =
+            new AspNetCoreCSharpVirtualCharService(CSharpVirtualCharService.Instance);
+
         private readonly IVirtualCharService _virtualCharService;
 
         private AspNetCoreCSharpVirtualCharService(IVirtualCharService virtualCharService)
@@ -20,7 +22,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         }
 
         /// <inheritdoc cref="CSharpVirtualCharService.Instance"/>
-        public static AspNetCoreCSharpVirtualCharService Instance => _instance ??= new AspNetCoreCSharpVirtualCharService(CSharpVirtualCharService.Instance);
+        public static AspNetCoreCSharpVirtualCharService Instance => _instance;
 
         /// <inheritdoc cref="IVirtualCharService.TryConvertToVirtualChars"/>
         public AspNetCoreVirtualCharSequence TryConvertToVirtualChars(SyntaxToken token) =>

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreCSharpVirtualCharService.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreCSharpVirtualCharService.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
+{
+    internal sealed class AspNetCoreCSharpVirtualCharService
+    {
+        private static AspNetCoreCSharpVirtualCharService? _instance;
+        private readonly IVirtualCharService _virtualCharService;
+
+        private AspNetCoreCSharpVirtualCharService(IVirtualCharService virtualCharService)
+        {
+            _virtualCharService = virtualCharService;
+        }
+
+        /// <inheritdoc cref="CSharpVirtualCharService.Instance"/>
+        public static AspNetCoreCSharpVirtualCharService Instance => _instance ??= new AspNetCoreCSharpVirtualCharService(CSharpVirtualCharService.Instance);
+
+        /// <inheritdoc cref="IVirtualCharService.TryConvertToVirtualChars"/>
+        public AspNetCoreVirtualCharSequence TryConvertToVirtualChars(SyntaxToken token) =>
+            new(_virtualCharService.TryConvertToVirtualChars(token));
+    }
+}

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreEmbeddedLanguageClassificationContext.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreEmbeddedLanguageClassificationContext.cs
@@ -13,11 +13,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         private readonly EmbeddedLanguageClassificationContext _context;
 
         internal AspNetCoreEmbeddedLanguageClassificationContext(
-            EmbeddedLanguageClassificationContext context,
-            AspNetCoreVirtualCharSequence virtualCharSequence)
+            EmbeddedLanguageClassificationContext context)
         {
             _context = context;
-            VirtualCharSequence = virtualCharSequence;
         }
 
         /// <inheritdoc cref="EmbeddedLanguageClassificationContext.SyntaxToken"/>
@@ -25,9 +23,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
 
         /// <inheritdoc cref="EmbeddedLanguageClassificationContext.SemanticModel"/>
         public SemanticModel SemanticModel => _context.SemanticModel;
-
-        /// <inheritdoc cref="Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars.VirtualCharSequence"/>
-        public AspNetCoreVirtualCharSequence VirtualCharSequence { get; }
 
         /// <inheritdoc cref="EmbeddedLanguageClassificationContext.CancellationToken"/>
         public CancellationToken CancellationToken => _context.CancellationToken;

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
@@ -28,5 +28,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
 
         /// <inheritdoc cref="VirtualChar.Value"/>
         public int Value => _virtualChar.Value;
+
+        /// <inheritdoc cref="VirtualChar.ToString"/>
+        public override string ToString() => _virtualChar.ToString();
     }
 }

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         /// <inheritdoc cref="VirtualChar.Value"/>
         public int Value => _virtualChar.Value;
 
-        /// <inheritdoc cref="VirtualChar.ToString"/>
+        /// <inheritdoc/>
         public override string ToString() => _virtualChar.ToString();
     }
 }

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         /// <inheritdoc cref="VirtualChar.Value"/>
         public int Value => _virtualChar.Value;
 
-        /// <inheritdoc/>
+        /// <inheritdoc cref="VirtualChar.ToString"/>
         public override string ToString() => _virtualChar.ToString();
     }
 }

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
@@ -40,5 +40,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         public static AspNetCoreVirtualCharSequence FromBounds(
             AspNetCoreVirtualCharSequence chars1, AspNetCoreVirtualCharSequence chars2) =>
             new(VirtualCharSequence.FromBounds(chars1._virtualCharSequence, chars2._virtualCharSequence));
+
+        public override string ToString()
+        {
+            return _virtualCharSequence.ToString();
+        }
     }
 }

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
@@ -40,10 +40,5 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         public static AspNetCoreVirtualCharSequence FromBounds(
             AspNetCoreVirtualCharSequence chars1, AspNetCoreVirtualCharSequence chars2) =>
             new(VirtualCharSequence.FromBounds(chars1._virtualCharSequence, chars2._virtualCharSequence));
-
-        public override string ToString()
-        {
-            return _virtualCharSequence.ToString();
-        }
     }
 }

--- a/src/Tools/ExternalAccess/AspNetCore/Internal/EmbeddedLanguages/AspNetCoreEmbeddedLanguageClassifier.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/Internal/EmbeddedLanguages/AspNetCoreEmbeddedLanguageClassifier.cs
@@ -31,12 +31,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.Internal.EmbeddedLang
             if (classifiers.Length == 0)
                 return;
 
-            var virtualChars = context.VirtualCharService.TryConvertToVirtualChars(context.SyntaxToken);
-            if (virtualChars.IsDefaultOrEmpty)
-                return;
-
-            var aspContext = new AspNetCoreEmbeddedLanguageClassificationContext(
-                context, new AspNetCoreVirtualCharSequence(virtualChars));
+            var aspContext = new AspNetCoreEmbeddedLanguageClassificationContext(context);
             foreach (var classifier in classifiers)
                 classifier.RegisterClassifications(aspContext);
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs
@@ -131,6 +131,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars
 
         #region string operations
 
+        /// <inheritdoc cref="object.ToString"/>
         public override string ToString()
             => SurrogateChar != 0 ? SurrogateChar.ToString() : Rune.ToString();
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars
 
         #region string operations
 
-        /// <inheritdoc cref="object.ToString"/>
+        /// <inheritdoc/>
         public override string ToString()
             => SurrogateChar != 0 ? SurrogateChar.ToString() : Rune.ToString();
 


### PR DESCRIPTION
Need to access virtual chars from more places than just classifier: also unit tests and analyzer.

PR removes virtual chars property from context and adds a static instance that can be used anywhere. It's ok that this is tied to CSharp as VB currently isn't a goal. If VB is desired then we can consider a more complicated approach in the future, but this type will still be useful for getting virtual chars in unit tests.