### PR TITLE
do not attempt to add ErrorCode.WRN_ShouldNotReturn twice in ErrorFacts

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -47,7 +47,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             nullableWarnings.Add(GetId(ErrorCode.WRN_ConvertingNullableToNonNullable));
             nullableWarnings.Add(GetId(ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment));
             nullableWarnings.Add(GetId(ErrorCode.WRN_ParameterConditionallyDisallowsNull));
-            nullableWarnings.Add(GetId(ErrorCode.WRN_ShouldNotReturn));
 
             nullableWarnings.Add(GetId(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride));
             nullableWarnings.Add(GetId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride));


### PR DESCRIPTION
`ErrorCode.WRN_ShouldNotReturn` is attempted to be added to nullable warnings twice - on line 50 and 69