### PR TITLE
Require spaces within line span directives and relax LangVer check

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -2,7 +2,7 @@
 
 ## Required spaces in #line span directives
 
-***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***
+***Introduced in .NET SDK 6.0.400, Visual Studio 2022 version 17.3.***
 
 When the `#line` span directive was introduced in C# 10, it required no particular spacing.  
 For example, this would be valid: `#line(1,2)-(3,4)5"file.cs"`.

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -1,5 +1,16 @@
 # This document lists known breaking changes in Roslyn after .NET 6 all the way to .NET 7.
 
+## Required spaces in #line span directives
+
+***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***
+
+When the `#line` span directive was introduced in C# 10, it required no particular spacing.  
+For example, this would be valid: `#line(1,2)-(3,4)5"file.cs"`.
+
+In Visual Studio 17.3, the compiler requires spaces before the first parenthesis, the character
+offset and the file name.  
+So the above example fails to parse unless spaces are added: `#line (1,2)-(3,4) 5 "file.cs"`.
+
 ## Checked operators on System.IntPtr and System.UIntPtr
 
 ***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -8,7 +8,7 @@ When the `#line` span directive was introduced in C# 10, it required no particul
 For example, this would be valid: `#line(1,2)-(3,4)5"file.cs"`.
 
 In Visual Studio 17.3, the compiler requires spaces before the first parenthesis, the character
-offset and the file name.  
+offset, and the file name.  
 So the above example fails to parse unless spaces are added: `#line (1,2)-(3,4) 5 "file.cs"`.
 
 ## Checked operators on System.IntPtr and System.UIntPtr

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6682,6 +6682,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_LineSpanDirectiveEndLessThanStart" xml:space="preserve">
     <value>The #line directive end position must be greater than or equal to the start position</value>
   </data>
+  <data name="ERR_LineSpanDirectiveRequiresSpace" xml:space="preserve">
+    <value>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</value>
+  </data>
   <data name="WRN_DoNotCompareFunctionPointers" xml:space="preserve">
     <value>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6670,9 +6670,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureInferredDelegateType" xml:space="preserve">
     <value>inferred delegate type</value>
   </data>
-  <data name="IDS_FeatureLineSpanDirective" xml:space="preserve">
-    <value>line span directive</value>
-  </data>
   <data name="IDS_FeatureAutoDefaultStructs" xml:space="preserve">
     <value>auto default struct fields</value>
   </data>
@@ -6683,7 +6680,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The #line directive end position must be greater than or equal to the start position</value>
   </data>
   <data name="ERR_LineSpanDirectiveRequiresSpace" xml:space="preserve">
-    <value>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</value>
+    <value>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</value>
   </data>
   <data name="WRN_DoNotCompareFunctionPointers" xml:space="preserve">
     <value>Comparison of function pointers might yield an unexpected result, since pointers to the same function may be distinct.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2071,6 +2071,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_CannotBeConvertedToUTF8 = 9026,
         ERR_MisplacedUnchecked = 9027,
+        ERR_LineSpanDirectiveRequiresSpace = 9028,
 
         ERR_RequiredNameDisallowed = 9029,
         ERR_OverrideMustHaveRequired = 9030,
@@ -2087,8 +2088,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_UnsupportedCompilerFeature = 9041,
         WRN_ObsoleteMembersShouldNotBeRequired = 9042,
         ERR_RefReturningPropertiesCannotBeRequired = 9043,
-
-        ERR_LineSpanDirectiveRequiresSpace = 9028,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2088,6 +2088,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_ObsoleteMembersShouldNotBeRequired = 9042,
         ERR_RefReturningPropertiesCannotBeRequired = 9043,
 
+        ERR_LineSpanDirectiveRequiresSpace = 9028,
+
         #endregion
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureLambdaReturnType = MessageBase + 12804,
         IDS_AsyncMethodBuilderOverride = MessageBase + 12805,
         IDS_FeatureImplicitImplementationOfNonPublicMembers = MessageBase + 12806,
-        IDS_FeatureLineSpanDirective = MessageBase + 12807,
+        // IDS_FeatureLineSpanDirective = MessageBase + 12807, // feature no longer gated on LangVer
         IDS_FeatureImprovedInterpolatedStrings = MessageBase + 12808,
         IDS_FeatureFileScopedNamespace = MessageBase + 12809,
         IDS_FeatureParameterlessStructConstructors = MessageBase + 12810,
@@ -396,7 +396,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_AsyncMethodBuilderOverride: // semantic check
                 case MessageID.IDS_FeatureConstantInterpolatedStrings: // semantic check
                 case MessageID.IDS_FeatureImplicitImplementationOfNonPublicMembers: // semantic check
-                case MessageID.IDS_FeatureLineSpanDirective:
                 case MessageID.IDS_FeatureFileScopedNamespace: // syntax check
                 case MessageID.IDS_FeatureParameterlessStructConstructors: // semantic check
                 case MessageID.IDS_FeatureStructFieldInitializers: // semantic check

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -406,11 +406,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             Debug.Assert(CurrentToken.Kind == SyntaxKind.OpenParenToken);
 
-            if (isActive)
-            {
-                lineKeyword = CheckFeatureAvailability(lineKeyword, MessageID.IDS_FeatureLineSpanDirective);
-            }
-
             bool reportError = isActive;
             var start = ParseLineDirectivePosition(ref reportError, out int startLine, out int startCharacter);
             if (noTriviaBetween(lineKeyword, start.GetFirstToken()))

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -413,6 +413,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             bool reportError = isActive;
             var start = ParseLineDirectivePosition(ref reportError, out int startLine, out int startCharacter);
+            if (noTriviaBetween(lineKeyword, start.GetFirstToken()))
+            {
+                start = this.AddError(start, ErrorCode.ERR_LineSpanDirectiveRequiresSpace);
+            }
 
             var minus = EatToken(SyntaxKind.MinusToken, reportError: reportError);
             if (minus.IsMissing) reportError = false;
@@ -428,11 +432,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 ParseLineDirectiveNumericLiteral(ref reportError, minValue: 1, maxValue: MaxCharacterValue, out _) :
                 null;
 
+            if (noTriviaBetween(end.GetLastToken(), characterOffset))
+            {
+                characterOffset = this.AddError(characterOffset, ErrorCode.ERR_LineSpanDirectiveRequiresSpace);
+            }
+
             var file = EatToken(SyntaxKind.StringLiteralToken, ErrorCode.ERR_MissingPPFile, reportError: reportError);
             if (file.IsMissing) reportError = false;
 
+            if (noTriviaBetween(characterOffset ?? end.GetLastToken(), file))
+            {
+                file = this.AddError(file, ErrorCode.ERR_LineSpanDirectiveRequiresSpace);
+            }
+
             var endOfDirective = this.ParseEndOfDirective(ignoreErrors: !reportError);
             return SyntaxFactory.LineSpanDirectiveTrivia(hash, lineKeyword, start, minus, end, characterOffset, file, endOfDirective, isActive);
+
+            static bool noTriviaBetween(SyntaxToken token1, SyntaxToken token2)
+            {
+                return token1 is { IsMissing: false }
+                    && token2 is { IsMissing: false }
+                    && LanguageParser.NoTriviaBetween(token1, token2);
+            }
         }
 
         private LineDirectivePositionSyntax ParseLineDirectivePosition(ref bool reportError, out int line, out int character)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4596,7 +4596,7 @@ tryAgain:
                 GetExpectedTokenError(kind, t1.Kind));
         }
 
-        private static bool NoTriviaBetween(SyntaxToken token1, SyntaxToken token2)
+        internal static bool NoTriviaBetween(SyntaxToken token1, SyntaxToken token2)
             => token1.GetTrailingTriviaWidth() == 0 && token2.GetLeadingTriviaWidth() == 0;
 
 #nullable disable

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -837,6 +837,11 @@
         <target state="translated">Hodnota direktivy #line chybí nebo je mimo rozsah.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">Vzory seznamů nelze použít pro hodnotu typu {0}. Nenašla se žádná vhodná vlastnost Length nebo Count.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">návratový typ lambda</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">direktiva line span</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">Lambda-Rückgabetyp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">Zeilenabstand-Anweisung</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -837,6 +837,11 @@
         <target state="translated">Der Wert der #line-Anweisung fehlt oder liegt außerhalb des gültigen Bereichs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">Listenmuster dürfen nicht für einen Wert vom Typ „{0}“ verwendet werden. Es wurde keine geeignete Längen- oder Anzahl-Eigenschaft gefunden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">tipo de valor devuelto de lambda</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">directiva de intervalo de línea</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -837,6 +837,11 @@
         <target state="translated">Falta el valor de directiva #line o está fuera del rango</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">No se pueden usar patrones de lista para un valor de tipo \"{0}\". No se encontró ninguna propiedad \"Length\" o \"Count\" adecuada.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -837,6 +837,11 @@
         <target state="translated">La valeur de directive #line est manquante ou hors limites</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">Les modèles de liste ne peuvent pas être utilisés pour une valeur de type '{0}'. Aucune propriété 'Longueur' ou 'Compte' appropriée n’a été trouvée.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">type de retour lambda</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">directive de l’étendue de ligne</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">tipo restituito dell'espressione lambda</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">direttiva per intervallo di riga</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -837,6 +837,11 @@
         <target state="translated">Il valore della direttiva #line manca oppure non è compreso nell'intervallo</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">I criteri di elenco non possono essere utilizzati per un valore di tipo '{0}'. Non è stata trovata alcuna proprietà 'Length' o 'Count' appropriata.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -837,6 +837,11 @@
         <target state="translated">#line ディレクティブの値が見つからないか、範囲外です</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">リスト パターンは、型 '{0}' の値には使用できません。適切な 'Length' または 'Count' プロパティが見つかりませんでした。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">ラムダ戻り値の型</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">line span ディレクティブ</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -837,6 +837,11 @@
         <target state="translated">#line 지시문 값이 없거나 범위를 벗어났습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">목록 패턴은 '{0}' 형식의 값에 사용할 수 없습니다. 적합한 'Length' 또는 'Count' 속성을 찾을 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">람다 반환 유형</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">라인 범위 지시문</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">zwracany typ lambda</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">dyrektywa zakresu wierszy</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -837,6 +837,11 @@
         <target state="translated">Brak wartości dyrektywy #line lub jest ona poza zakresem</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">Wzorce listy nie mogą być używane dla wartości typu „{0}”. Nie znaleziono odpowiedniej właściwości „Długość” ani „Liczba”.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -837,6 +837,11 @@
         <target state="translated">O valor da diretiva de #line está ausente ou fora do intervalo</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">Padrões de lista não podem ser usados para um valor do tipo “{0}”. Nenhuma propriedade “Length” ou “Count” adequada foi encontrada.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">tipo de retorno de lambda</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">diretiva de extensão de linha</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -837,6 +837,11 @@
         <target state="translated">Значение директивы #line отсутствует или находится за пределами допустимого диапазона</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">Шаблоны списка не могут использоваться для значения типа {0}. Подходящее свойство \"Length\" или \"Count\" не найдено.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">тип возвращаемого значения лямбда</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">директива line span</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -837,6 +837,11 @@
         <target state="translated">#line yönerge değeri eksik veya aralık dışı</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">Liste desenleri, '{0}' türündeki bir değer için kullanılamaz. Uygun 'Length' veya 'Count' özelliği bulunamadı.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">lambda dönüş türü</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">satır aralığı yönergesi</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -837,6 +837,11 @@
         <target state="translated">#line 指令值缺失或超出范围</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">列表模式不能用于 '{0}' 类型的值。找不到合适的 \"Length\" 或 \"Count\" 属性。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">lambda 返回类型</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">行跨度指令</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -837,6 +837,11 @@
         <target state="translated">#Line 指示詞值遺漏或超出範圍</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
+        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
         <source>List patterns may not be used for a value of type '{0}'. No suitable 'Length' or 'Count' property was found.</source>
         <target state="translated">清單模式不能用於型別 '{0}' 的值。找不到適當的 'Length' 或 'Count' 屬性。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -838,8 +838,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_LineSpanDirectiveRequiresSpace">
-        <source>The #line span directive requires space before the first parenthesis, before the character offset and before the file name</source>
-        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset and before the file name</target>
+        <source>The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</source>
+        <target state="new">The #line span directive requires space before the first parenthesis, before the character offset, and before the file name</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_ListPatternRequiresLength">
@@ -1580,11 +1580,6 @@
       <trans-unit id="IDS_FeatureLambdaReturnType">
         <source>lambda return type</source>
         <target state="translated">lambda 傳回型別</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IDS_FeatureLineSpanDirective">
-        <source>line span directive</source>
-        <target state="translated">line span 指示詞</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureListPattern">

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
@@ -234,10 +234,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source = @"#line(1,2)-(3,4)""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,6): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // (1,6): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset, and before the file name
                 // #line(1,2)-(3,4)"file.cs"
                 Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "(1,2)").WithLocation(1, 6),
-                // (1,17): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // (1,17): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset, and before the file name
                 // #line(1,2)-(3,4)"file.cs"
                 Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, @"""file.cs""").WithLocation(1, 17));
 
@@ -302,19 +302,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             EOF();
         }
 
-        [Fact]
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
         public void LineDirective_06()
         {
             string source = @"#line(1,2)-(3,4)5""file.cs""";
 
             UsingLineDirective(source, options: null,
-                // (1,6): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // (1,6): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset, and before the file name
                 // #line(1,2)-(3,4)5"file.cs"
                 Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "(1,2)").WithLocation(1, 6),
-                // (1,17): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // (1,17): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset, and before the file name
                 // #line(1,2)-(3,4)5"file.cs"
                 Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "5").WithLocation(1, 17),
-                // (1,18): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // (1,18): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset, and before the file name
                 // #line(1,2)-(3,4)5"file.cs"
                 Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, @"""file.cs""").WithLocation(1, 18)
                 );
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             EOF();
         }
 
-        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
+        [Fact]
         public void LineDirective_06_WithRequiredSpaces()
         {
             string source = @"#line (1,2)-(3,4) 5 ""file.cs""";
@@ -752,7 +752,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             EOF();
         }
 
-        [Fact]
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
         public void Incomplete_11()
         {
             string source = @"#line (1, 2) - (3, 4)";
@@ -789,7 +789,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             EOF();
         }
 
-        [Fact]
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
         public void Incomplete_12()
         {
             string source = @"#line (1, 2) - (3, 4) 5";
@@ -2350,7 +2350,7 @@ file.cs
             string source = @"#line(1, 2) - (3, 4) ""file.cs""";
 
             UsingLineDirective(source, TestOptions.Regular10,
-                // (1,6): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // (1,6): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset, and before the file name
                 // #line(1, 2) - (3, 4) "file.cs"
                 Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "(1, 2)").WithLocation(1, 6)
                 );
@@ -2388,7 +2388,7 @@ file.cs
             string source = @"#line (1, 2) - (3, 4)5 ""file.cs""";
 
             UsingLineDirective(source, TestOptions.Regular10,
-                // (1,22): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // (1,22): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset, and before the file name
                 // #line (1, 2) - (3, 4)5 "file.cs"
                 Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "5").WithLocation(1, 22)
                 );
@@ -2427,7 +2427,7 @@ file.cs
             string source = @"#line (1, 2) - (3, 4) 5""file.cs""";
 
             UsingLineDirective(source, TestOptions.Regular10,
-                // (1,24): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // (1,24): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset, and before the file name
                 // #line (1, 2) - (3, 4) 5"file.cs"
                 Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, @"""file.cs""").WithLocation(1, 24)
                 );
@@ -2466,7 +2466,7 @@ file.cs
             string source = @"#line (1, 2) - (3, 4)""file.cs""";
 
             UsingLineDirective(source, TestOptions.Regular10,
-                // (1,22): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // (1,22): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset, and before the file name
                 // #line (1, 2) - (3, 4)"file.cs"
                 Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, @"""file.cs""").WithLocation(1, 22)
                 );
@@ -2493,83 +2493,6 @@ file.cs
                     N(SyntaxKind.CloseParenToken);
                 }
                 N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
-                N(SyntaxKind.EndOfDirectiveToken);
-            }
-            EOF();
-        }
-
-        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
-        public void RequireSpace_MissingFilename()
-        {
-            string source = @"#line (1, 2) - (3, 4) 5";
-
-            UsingLineDirective(source, TestOptions.Regular10,
-                // (1,24): error CS1578: Quoted file name, single-line comment or end-of-line expected
-                // #line (1, 2) - (3, 4) 5
-                Diagnostic(ErrorCode.ERR_MissingPPFile, "").WithLocation(1, 24)
-                );
-
-            N(SyntaxKind.LineSpanDirectiveTrivia);
-            {
-                N(SyntaxKind.HashToken);
-                N(SyntaxKind.LineKeyword);
-                N(SyntaxKind.LineDirectivePosition);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.NumericLiteralToken, "1");
-                    N(SyntaxKind.CommaToken);
-                    N(SyntaxKind.NumericLiteralToken, "2");
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.MinusToken);
-                N(SyntaxKind.LineDirectivePosition);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.NumericLiteralToken, "3");
-                    N(SyntaxKind.CommaToken);
-                    N(SyntaxKind.NumericLiteralToken, "4");
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.NumericLiteralToken, "5");
-                M(SyntaxKind.StringLiteralToken);
-                N(SyntaxKind.EndOfDirectiveToken);
-            }
-            EOF();
-        }
-
-        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
-        public void RequireSpace_MissingFilename_WithoutCharacterOffset()
-        {
-            string source = @"#line (1, 2) - (3, 4)";
-
-            UsingLineDirective(source, TestOptions.Regular10,
-                // (1,22): error CS1578: Quoted file name, single-line comment or end-of-line expected
-                // #line (1, 2) - (3, 4)
-                Diagnostic(ErrorCode.ERR_MissingPPFile, "").WithLocation(1, 22)
-                );
-
-            N(SyntaxKind.LineSpanDirectiveTrivia);
-            {
-                N(SyntaxKind.HashToken);
-                N(SyntaxKind.LineKeyword);
-                N(SyntaxKind.LineDirectivePosition);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.NumericLiteralToken, "1");
-                    N(SyntaxKind.CommaToken);
-                    N(SyntaxKind.NumericLiteralToken, "2");
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.MinusToken);
-                N(SyntaxKind.LineDirectivePosition);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.NumericLiteralToken, "3");
-                    N(SyntaxKind.CommaToken);
-                    N(SyntaxKind.NumericLiteralToken, "4");
-                    N(SyntaxKind.CloseParenToken);
-                }
-                M(SyntaxKind.StringLiteralToken);
                 N(SyntaxKind.EndOfDirectiveToken);
             }
             EOF();

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
@@ -43,10 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             UsingLineDirective(source, TestOptions.Regular9);
             verify();
 
-            UsingLineDirective(source, TestOptions.Regular9.WithPreprocessorSymbols("IsActive"),
-                // (2,2): error CS8773: Feature 'line span directive' is not available in C# 9.0. Please use language version 10.0 or greater.
-                // #line (1, 2) - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion9, "line").WithArguments("line span directive", "10.0").WithLocation(2, 2));
+            UsingLineDirective(source, TestOptions.Regular9.WithPreprocessorSymbols("IsActive"));
             verify();
 
             void verify()
@@ -84,10 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             string source = @"#line (1, 2) - (3, 4) ""file.cs""";
 
-            UsingLineDirective(source, TestOptions.Regular9,
-                // (1,2): error CS8773: Feature 'line span directive' is not available in C# 9.0. Please use language version 10.0 or greater.
-                // #line (1, 2) - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion9, "line").WithArguments("line span directive", "10.0").WithLocation(1, 2));
+            UsingLineDirective(source, TestOptions.Regular9);
             verify();
 
             UsingLineDirective(source, TestOptions.Regular10);
@@ -128,10 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             string source = @"#line (1, 2) - (3, 4) 5 ""file.cs""";
 
-            UsingLineDirective(source, TestOptions.Regular9,
-                // (1,2): error CS8773: Feature 'line span directive' is not available in C# 9.0. Please use language version 10.0 or greater.
-                // #line (1, 2) - (3, 4) "file.cs"
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion9, "line").WithArguments("line span directive", "10.0").WithLocation(1, 2));
+            UsingLineDirective(source, TestOptions.Regular9);
             verify();
 
             UsingLineDirective(source, TestOptions.Regular10);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LineSpanDirectiveParsingTests.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -241,6 +242,46 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             string source = @"#line(1,2)-(3,4)""file.cs""";
 
+            UsingLineDirective(source, options: null,
+                // (1,6): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // #line(1,2)-(3,4)"file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "(1,2)").WithLocation(1, 6),
+                // (1,17): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // #line(1,2)-(3,4)"file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, @"""file.cs""").WithLocation(1, 17));
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LineDirective_05_WithRequiredSpaces()
+        {
+            string source = @"#line (1,2)-(3,4) ""file.cs""";
+
             UsingLineDirective(source, options: null);
 
             N(SyntaxKind.LineSpanDirectiveTrivia);
@@ -274,6 +315,51 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void LineDirective_06()
         {
             string source = @"#line(1,2)-(3,4)5""file.cs""";
+
+            UsingLineDirective(source, options: null,
+                // (1,6): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // #line(1,2)-(3,4)5"file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "(1,2)").WithLocation(1, 6),
+                // (1,17): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // #line(1,2)-(3,4)5"file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "5").WithLocation(1, 17),
+                // (1,18): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // #line(1,2)-(3,4)5"file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, @"""file.cs""").WithLocation(1, 18)
+                );
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "5");
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
+        public void LineDirective_06_WithRequiredSpaces()
+        {
+            string source = @"#line (1,2)-(3,4) 5 ""file.cs""";
 
             UsingLineDirective(source, options: null);
 
@@ -2238,6 +2324,237 @@ file.cs
                 // (1,21): error CS1578: Quoted file name, single-line comment or end-of-line expected
                 // #line (1, 2)-(3, 4) @"""file.cs"""u8
                 Diagnostic(ErrorCode.ERR_MissingPPFile, "@").WithLocation(1, 21)
+                );
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
+        public void RequireSpace_BeforeFirstParen()
+        {
+            string source = @"#line(1, 2) - (3, 4) ""file.cs""";
+
+            UsingLineDirective(source, TestOptions.Regular10,
+                // (1,6): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // #line(1, 2) - (3, 4) "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "(1, 2)").WithLocation(1, 6)
+                );
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
+        public void RequireSpace_BeforeCharacterOffset()
+        {
+            string source = @"#line (1, 2) - (3, 4)5 ""file.cs""";
+
+            UsingLineDirective(source, TestOptions.Regular10,
+                // (1,22): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // #line (1, 2) - (3, 4)5 "file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, "5").WithLocation(1, 22)
+                );
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "5");
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
+        public void RequireSpace_BeforeFilename()
+        {
+            string source = @"#line (1, 2) - (3, 4) 5""file.cs""";
+
+            UsingLineDirective(source, TestOptions.Regular10,
+                // (1,24): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // #line (1, 2) - (3, 4) 5"file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, @"""file.cs""").WithLocation(1, 24)
+                );
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "5");
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
+        public void RequireSpace_BeforeFilename_WithoutCharacterOffset()
+        {
+            string source = @"#line (1, 2) - (3, 4)""file.cs""";
+
+            UsingLineDirective(source, TestOptions.Regular10,
+                // (1,22): error CS9028: The #line span directive requires space before the first parenthesis, before the character offset and before the file name
+                // #line (1, 2) - (3, 4)"file.cs"
+                Diagnostic(ErrorCode.ERR_LineSpanDirectiveRequiresSpace, @"""file.cs""").WithLocation(1, 22)
+                );
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.StringLiteralToken, "\"file.cs\"");
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
+        public void RequireSpace_MissingFilename()
+        {
+            string source = @"#line (1, 2) - (3, 4) 5";
+
+            UsingLineDirective(source, TestOptions.Regular10,
+                // (1,24): error CS1578: Quoted file name, single-line comment or end-of-line expected
+                // #line (1, 2) - (3, 4) 5
+                Diagnostic(ErrorCode.ERR_MissingPPFile, "").WithLocation(1, 24)
+                );
+
+            N(SyntaxKind.LineSpanDirectiveTrivia);
+            {
+                N(SyntaxKind.HashToken);
+                N(SyntaxKind.LineKeyword);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "2");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.MinusToken);
+                N(SyntaxKind.LineDirectivePosition);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.NumericLiteralToken, "3");
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.NumericLiteralToken, "5");
+                M(SyntaxKind.StringLiteralToken);
+                N(SyntaxKind.EndOfDirectiveToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(61663, "https://github.com/dotnet/roslyn/issues/61663")]
+        public void RequireSpace_MissingFilename_WithoutCharacterOffset()
+        {
+            string source = @"#line (1, 2) - (3, 4)";
+
+            UsingLineDirective(source, TestOptions.Regular10,
+                // (1,22): error CS1578: Quoted file name, single-line comment or end-of-line expected
+                // #line (1, 2) - (3, 4)
+                Diagnostic(ErrorCode.ERR_MissingPPFile, "").WithLocation(1, 22)
                 );
 
             N(SyntaxKind.LineSpanDirectiveTrivia);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/61663
Addresses the most urgent scenario in https://github.com/dotnet/roslyn/issues/61094

Corresponding spec update: https://github.com/dotnet/csharplang/pull/6195

FYI @cston @chsienki 