### PR TITLE
Classify Throw as a control keyword in VB

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
@@ -5460,5 +5460,17 @@ End Try"
                 ControlKeyword("End"),
                 ControlKeyword("Try"))
         End Function
+
+        <Theory, CombinatorialData, WorkItem(61687, "https://github.com/dotnet/roslyn/issues/61687")>
+        Public Async Function TestThrow(testHost As TestHost) As Task
+            Dim code = "Throw New System.NotImplementedException"
+            Await TestInMethodAsync(code,
+                testHost,
+                ControlKeyword("Throw"),
+                Keyword("New"),
+                Identifier("System"),
+                Operators.Dot,
+                Identifier("NotImplementedException"))
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
+++ b/src/Workspaces/VisualBasic/Portable/Classification/ClassificationHelpers.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
             ElseIf token.IsKind(SyntaxKind.None, SyntaxKind.BadToken) Then
                 Return Nothing
             Else
-                throw ExceptionUtilities.UnexpectedValue(token.Kind())
+                Throw ExceptionUtilities.UnexpectedValue(token.Kind())
             End If
         End Function
 
@@ -107,6 +107,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                 SyntaxKind.EndIfKeyword,
                 SyntaxKind.GosubKeyword,
                 SyntaxKind.YieldKeyword,
+                SyntaxKind.ThrowKeyword,
                 SyntaxKind.ToKeyword
                     Return True
                 Case Else
@@ -313,7 +314,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
                 Case SyntaxKind.StructureStatement
                     Return ClassificationTypeNames.StructName
                 Case Else
-                    throw ExceptionUtilities.UnexpectedValue(identifier.Parent.Kind)
+                    Throw ExceptionUtilities.UnexpectedValue(identifier.Parent.Kind)
             End Select
         End Function
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/61687