### PR TITLE
Use fast in-proc heuristic to implement HasChangesAsync

### DIFF
--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
 using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
 using Roslyn.Utilities;
@@ -38,8 +40,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private bool _disabled;
         private RemoteDebuggingSessionProxy? _debuggingSession;
 
-        private Solution? _pendingUpdatedSolution;
+        private Solution? _pendingUpdatedDesignTimeSolution;
         public event Action<Solution>? SolutionCommitted;
+
+        private Solution? _committedDesignTimeSolution;
 
         /// <summary>
         /// Import <see cref="IHostWorkspaceProvider"/> lazily so that the host does not need to implement it 
@@ -59,10 +63,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             _diagnosticUpdateSource = diagnosticUpdateSource;
         }
 
-        private Solution GetCurrentCompileTimeSolution()
+        private Solution GetCurrentCompileTimeSolution(Solution? currentDesignTimeSolution = null)
         {
             var workspace = WorkspaceProvider.Value.Workspace;
-            return workspace.Services.GetRequiredService<ICompileTimeSolutionProvider>().GetCompileTimeSolution(workspace.CurrentSolution);
+            return workspace.Services.GetRequiredService<ICompileTimeSolutionProvider>().GetCompileTimeSolution(currentDesignTimeSolution ?? workspace.CurrentSolution);
         }
 
         private RemoteDebuggingSessionProxy GetDebuggingSession()
@@ -93,7 +97,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             try
             {
                 var workspace = WorkspaceProvider.Value.Workspace;
-                var solution = GetCurrentCompileTimeSolution();
+                var solution = GetCurrentCompileTimeSolution(_committedDesignTimeSolution = workspace.CurrentSolution);
                 var openedDocumentIds = workspace.GetOpenDocumentIds().ToImmutableArray();
                 var proxy = new RemoteEditAndContinueServiceProxy(workspace);
 
@@ -180,9 +184,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         {
             try
             {
-                var committedSolution = Interlocked.Exchange(ref _pendingUpdatedSolution, null);
-                Contract.ThrowIfNull(committedSolution);
-                SolutionCommitted?.Invoke(committedSolution);
+                var committedDesignTimeSolution = Interlocked.Exchange(ref _pendingUpdatedDesignTimeSolution, null);
+                Contract.ThrowIfNull(committedDesignTimeSolution);
+                SolutionCommitted?.Invoke(committedDesignTimeSolution);
+
+                _committedDesignTimeSolution = committedDesignTimeSolution;
             }
             catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
@@ -205,7 +211,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return;
             }
 
-            _pendingUpdatedSolution = null;
+            _pendingUpdatedDesignTimeSolution = null;
 
             try
             {
@@ -245,24 +251,34 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         /// <summary>
         /// Returns true if any changes have been made to the source since the last changes had been applied.
+        /// For performance reasons it only implements a heuristic and may return both false positives and false negatives.
+        /// If the result is a false negative the debugger will not apply the changes unless the user explicitly triggers apply change command.
+        /// The background diagnostic analysis will still report rude edits for these ignored changes. It may also happen that these rude edits 
+        /// will disappear once the debuggee is resumed - if they are caused by presence of active statements around the change.
+        /// If the result is a false positive the debugger attempts to apply the changes, which will result in a delay but will correctly end up
+        /// with no actual deltas to be applied.
         /// </summary>
-        public async ValueTask<bool> HasChangesAsync(string? sourceFilePath, CancellationToken cancellationToken)
+        public ValueTask<bool> HasChangesAsync(string? sourceFilePath, CancellationToken cancellationToken)
         {
             try
             {
                 var debuggingSession = _debuggingSession;
                 if (debuggingSession == null)
                 {
-                    return false;
+                    return ValueTaskFactory.FromResult(false);
                 }
 
-                var solution = GetCurrentCompileTimeSolution();
-                var activeStatementSpanProvider = GetActiveStatementSpanProvider(solution);
-                return await debuggingSession.HasChangesAsync(solution, activeStatementSpanProvider, sourceFilePath, cancellationToken).ConfigureAwait(false);
+                Contract.ThrowIfNull(_committedDesignTimeSolution);
+                var oldSolution = _committedDesignTimeSolution;
+                var newSolution = WorkspaceProvider.Value.Workspace.CurrentSolution;
+
+                return (sourceFilePath != null) ?
+                    EditSession.HasChangesAsync(oldSolution, newSolution, sourceFilePath, cancellationToken) :
+                    EditSession.HasChangesAsync(oldSolution, newSolution, cancellationToken);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {
-                return true;
+                return ValueTaskFactory.FromResult(true);
             }
         }
 
@@ -273,10 +289,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return new ManagedModuleUpdates(ManagedModuleUpdateStatus.None, ImmutableArray<ManagedModuleUpdate>.Empty);
             }
 
-            var solution = GetCurrentCompileTimeSolution();
+            var workspace = WorkspaceProvider.Value.Workspace;
+            var solution = GetCurrentCompileTimeSolution(_pendingUpdatedDesignTimeSolution = workspace.CurrentSolution);
             var activeStatementSpanProvider = GetActiveStatementSpanProvider(solution);
             var (updates, _, _, _) = await GetDebuggingSession().EmitSolutionUpdateAsync(solution, activeStatementSpanProvider, _diagnosticService, _diagnosticUpdateSource, cancellationToken).ConfigureAwait(false);
-            _pendingUpdatedSolution = solution;
             return updates.FromContract();
         }
 
@@ -287,9 +303,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return new ManagedHotReloadUpdates(ImmutableArray<ManagedHotReloadUpdate>.Empty, ImmutableArray<ManagedHotReloadDiagnostic>.Empty);
             }
 
-            var solution = GetCurrentCompileTimeSolution();
+            var workspace = WorkspaceProvider.Value.Workspace;
+            var solution = GetCurrentCompileTimeSolution(_pendingUpdatedDesignTimeSolution);
             var (moduleUpdates, diagnosticData, rudeEdits, syntaxError) = await GetDebuggingSession().EmitSolutionUpdateAsync(solution, s_noActiveStatementSpanProvider, _diagnosticService, _diagnosticUpdateSource, cancellationToken).ConfigureAwait(false);
-            _pendingUpdatedSolution = solution;
 
             var updates = moduleUpdates.Updates.SelectAsArray(
                 update => new ManagedHotReloadUpdate(update.Module, update.ILDelta, update.MetadataDelta, update.PdbDelta, update.UpdatedTypes));

--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -41,9 +41,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private RemoteDebuggingSessionProxy? _debuggingSession;
 
         private Solution? _pendingUpdatedDesignTimeSolution;
-        public event Action<Solution>? SolutionCommitted;
-
         private Solution? _committedDesignTimeSolution;
+
+        public event Action<Solution>? SolutionCommitted;
 
         /// <summary>
         /// Import <see cref="IHostWorkspaceProvider"/> lazily so that the host does not need to implement it 
@@ -235,7 +235,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 var solution = GetCurrentCompileTimeSolution();
                 await GetDebuggingSession().EndDebuggingSessionAsync(solution, _diagnosticUpdateSource, _diagnosticService, cancellationToken).ConfigureAwait(false);
+
                 _debuggingSession = null;
+                _committedDesignTimeSolution = null;
+                _pendingUpdatedDesignTimeSolution = null;
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {

--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             var workspace = WorkspaceProvider.Value.Workspace;
-            var solution = GetCurrentCompileTimeSolution(_pendingUpdatedDesignTimeSolution);
+            var solution = GetCurrentCompileTimeSolution(_pendingUpdatedDesignTimeSolution = workspace.CurrentSolution);
             var (moduleUpdates, diagnosticData, rudeEdits, syntaxError) = await GetDebuggingSession().EmitSolutionUpdateAsync(solution, s_noActiveStatementSpanProvider, _diagnosticService, _diagnosticUpdateSource, cancellationToken).ConfigureAwait(false);
 
             var updates = moduleUpdates.Updates.SelectAsArray(

--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -261,14 +261,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// If the result is a false positive the debugger attempts to apply the changes, which will result in a delay but will correctly end up
         /// with no actual deltas to be applied.
         /// </summary>
-        public ValueTask<bool> HasChangesAsync(string? sourceFilePath, CancellationToken cancellationToken)
+        public async ValueTask<bool> HasChangesAsync(string? sourceFilePath, CancellationToken cancellationToken)
         {
             try
             {
                 var debuggingSession = _debuggingSession;
                 if (debuggingSession == null)
                 {
-                    return ValueTaskFactory.FromResult(false);
+                    return false;
                 }
 
                 Contract.ThrowIfNull(_committedDesignTimeSolution);
@@ -276,12 +276,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 var newSolution = WorkspaceProvider.Value.Workspace.CurrentSolution;
 
                 return (sourceFilePath != null) ?
-                    EditSession.HasChangesAsync(oldSolution, newSolution, sourceFilePath, cancellationToken) :
-                    EditSession.HasChangesAsync(oldSolution, newSolution, cancellationToken);
+                    await EditSession.HasChangesAsync(oldSolution, newSolution, sourceFilePath, cancellationToken).ConfigureAwait(false) :
+                    await EditSession.HasChangesAsync(oldSolution, newSolution, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {
-                return ValueTaskFactory.FromResult(true);
+                return true;
             }
         }
 

--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return;
             }
 
-            _pendingUpdatedDesignTimeSolution = null;
+            Contract.ThrowIfNull(Interlocked.Exchange(ref _pendingUpdatedDesignTimeSolution, null));
 
             try
             {

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -1332,7 +1332,7 @@ class C1
         }
 
         [Fact]
-        public async Task RudeEdits2()
+        public async Task DeferredApplyChangeWithActiveStatementRudeEdits()
         {
             var source1 = "class C { void M() { System.Console.WriteLine(1); } }";
             var source2 = "class C { void M() { System.Console.WriteLine(2); } }";

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -616,7 +616,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             Assert.Empty(diagnostics2);
 
             // validate solution update status and emit - changes made during run mode are ignored:
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
+            var (updates, _) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
 
             EndDebuggingSession(debuggingSession);
 
@@ -650,8 +651,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             solution = solution.WithDocumentText(document1.Id, SourceText.From("dummy2"));
 
             // validate solution update status and emit:
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             Assert.Empty(updates.Updates);
@@ -686,7 +685,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             Assert.Empty(diagnostics);
 
             // validate solution update status and emit - changes made in design-time-only documents are ignored:
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
+            var (updates, _) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
 
             EndDebuggingSession(debuggingSession);
 
@@ -724,9 +724,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             solution = solution.WithDocumentText(document1.Id, SourceText.From("class E {}"));
 
             // validate solution update status and emit:
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
+            Assert.Empty(updates.Updates);
+            Assert.Empty(emitDiagnostics);
+
+            (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             Assert.Empty(updates.Updates);
             Assert.Empty(emitDiagnostics);
@@ -784,8 +787,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             Assert.Empty(await service.GetDocumentDiagnosticsAsync(documentC2, s_noActiveSpans, CancellationToken.None));
 
             // validate solution update status and emit:
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             Assert.Empty(emitDiagnostics);
@@ -795,8 +796,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 LoadLibraryToDebuggee(moduleId);
 
                 // validate solution update status and emit:
-                Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
                 (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
                 Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
                 Assert.Empty(emitDiagnostics);
@@ -843,8 +842,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             // error not reported here since it might be intermittent and will be reported if the issue persist when applying the update:
             var diagnostics = await service.GetDocumentDiagnosticsAsync(document2, s_noActiveSpans, CancellationToken.None);
             Assert.Empty(diagnostics);
-
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
 
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.RestartRequired, updates.Status);
@@ -918,8 +915,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             Assert.Empty(diagnostics);
 
             // an error occurred so we need to call update to determine whether we have changes to apply or not:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             Assert.Empty(updates.Updates);
@@ -967,9 +962,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             Assert.Empty(diagnostics);
 
             // an error occurred so we need to call update to determine whether we have changes to apply or not:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
-            // try apply changes:
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             Assert.Empty(updates.Updates);
@@ -1031,8 +1023,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             var diagnostics2 = await service.GetDocumentDiagnosticsAsync(documentB, s_noActiveSpans, CancellationToken.None);
             Assert.Empty(diagnostics2);
-
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
 
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.Ready, updates.Status);
@@ -1215,8 +1205,6 @@ class C1
             AssertEx.Empty(diagnostics1);
 
             // validate solution update status and emit:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.RestartRequired, updates.Status);
             Assert.Empty(updates.Updates);
@@ -1269,7 +1257,8 @@ class C1
             await debuggingSession.OnSourceFileUpdatedAsync(currentDocument);
 
             // EnC service queries for a document, which triggers read of the source file from disk.
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
+            var (updates, _) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
 
             EndDebuggingSession(debuggingSession);
         }
@@ -1305,8 +1294,6 @@ class C1
                 diagnostics1.Select(d => $"{d.Id}: {d.GetMessage()}"));
 
             // validate solution update status and emit:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.RestartRequired, updates.Status);
             Assert.Empty(updates.Updates);
@@ -1429,8 +1416,6 @@ class C { int Y => 2; }
             Assert.Empty(diagnostics);
 
             // since the document is out-of-sync we need to call update to determine whether we have changes to apply or not:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             Assert.Empty(updates.Updates);
@@ -1444,7 +1429,10 @@ class C { int Y => 2; }
             Assert.Empty(diagnostics);
 
             // debugger query will trigger reload of out-of-sync file content:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
+            (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            Assert.Equal(ManagedModuleUpdateStatus.RestartRequired, updates.Status);
+            Assert.Empty(updates.Updates);
+            Assert.Empty(emitDiagnostics);
 
             // now we see the rude edit:
             diagnostics = await service.GetDocumentDiagnosticsAsync(document2, s_noActiveSpans, CancellationToken.None);
@@ -1524,8 +1512,6 @@ class C { int Y => 2; }
                 diagnostics.Select(d => $"{d.Id}: {d.GetMessage()}"));
 
             // validate solution update status and emit:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.RestartRequired, updates.Status);
             Assert.Empty(updates.Updates);
@@ -1569,8 +1555,6 @@ class C { int Y => 2; }
                 new[] { "ENC0020: " + string.Format(FeaturesResources.Renaming_0_requires_restarting_the_application, FeaturesResources.method) },
                 diagnostics.Select(d => $"{d.Id}: {d.GetMessage()}"));
 
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.RestartRequired, updates.Status);
             Assert.Empty(updates.Updates);
@@ -1584,8 +1568,6 @@ class C { int Y => 2; }
             AssertEx.Equal(
                 new[] { "ENC0020: " + string.Format(FeaturesResources.Renaming_0_requires_restarting_the_application, FeaturesResources.method) },
                 diagnostics.Select(d => $"{d.Id}: {d.GetMessage()}"));
-
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
 
             (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.RestartRequired, updates.Status);
@@ -1619,8 +1601,6 @@ class C { int Y => 2; }
             AssertEx.Empty(diagnostics1);
 
             // validate solution update status and emit:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.Blocked, updates.Status);
             Assert.Empty(updates.Updates);
@@ -1662,8 +1642,6 @@ class C { int Y => 2; }
 
             // The EnC analyzer does not check for and block on all semantic errors as they are already reported by diagnostic analyzer.
             // Blocking update on semantic errors would be possible, but the status check is only an optimization to avoid emitting.
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.Blocked, updates.Status);
             Assert.Empty(updates.Updates);
@@ -1686,7 +1664,7 @@ class C { int Y => 2; }
         }
 
         [Fact]
-        public async Task FileStatus_CompilationError()
+        public async Task HasChanges()
         {
             using var _ = CreateWorkspace(out var solution, out var service);
 
@@ -1704,18 +1682,74 @@ class C { int Y => 2; }
             EnterBreakState(debuggingSession);
 
             // change C.cs to have a compilation error:
+            var oldSolution = solution;
             var projectC = solution.GetProjectsByName("C").Single();
             var documentC = projectC.Documents.Single(d => d.Name == "C.cs");
             solution = solution.WithDocumentText(documentC.Id, SourceText.From("class C { void M() { "));
 
-            // Common.cs is included in projects B and C. Both of these projects must have no errors, otherwise update is blocked.
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: "Common.cs", CancellationToken.None));
+            Assert.True(await EditSession.HasChangesAsync(oldSolution, solution, CancellationToken.None));
 
-            // No changes in project containing file B.cs.
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: "B.cs", CancellationToken.None));
+            Assert.False(await EditSession.HasChangesAsync(oldSolution, solution, sourceFilePath: "Common.cs", CancellationToken.None));
+            Assert.False(await EditSession.HasChangesAsync(oldSolution, solution, sourceFilePath: "B.cs", CancellationToken.None));
+            Assert.True(await EditSession.HasChangesAsync(oldSolution, solution, sourceFilePath: "C.cs", CancellationToken.None));
+            Assert.False(await EditSession.HasChangesAsync(oldSolution, solution, sourceFilePath: "NonexistentFile.cs", CancellationToken.None));
 
             // All projects must have no errors.
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
+            var (updates, _) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            Assert.Equal(ManagedModuleUpdateStatus.Blocked, updates.Status);
+
+            // add a document:
+
+            oldSolution = solution;
+            projectC = solution.GetProjectsByName("C").Single();
+            var documentDId = DocumentId.CreateNewId(projectC.Id);
+            solution = solution.AddDocument(documentDId, "D", "class D {}", filePath: "D.cs");
+
+            Assert.True(await EditSession.HasChangesAsync(oldSolution, solution, CancellationToken.None));
+            Assert.True(await EditSession.HasChangesAsync(oldSolution, solution, sourceFilePath: "D.cs", CancellationToken.None));
+
+            // remove a document:
+
+            oldSolution = solution;
+            solution = solution.RemoveDocument(documentDId);
+
+            Assert.True(await EditSession.HasChangesAsync(oldSolution, solution, CancellationToken.None));
+            Assert.True(await EditSession.HasChangesAsync(oldSolution, solution, sourceFilePath: "D.cs", CancellationToken.None));
+
+            // add an additional document:
+
+            oldSolution = solution;
+            projectC = solution.GetProjectsByName("C").Single();
+            var documentXId = DocumentId.CreateNewId(projectC.Id);
+            solution = solution.AddAdditionalDocument(documentXId, "X", "xxx", filePath: "X");
+
+            Assert.True(await EditSession.HasChangesAsync(oldSolution, solution, CancellationToken.None));
+
+            // remove an additional document:
+            Assert.True(await EditSession.HasChangesAsync(solution, solution.RemoveAdditionalDocument(documentXId), CancellationToken.None));
+
+            // add a config document:
+
+            oldSolution = solution;
+            projectC = solution.GetProjectsByName("C").Single();
+            var documentYId = DocumentId.CreateNewId(projectC.Id);
+            solution = solution.AddAnalyzerConfigDocument(documentYId, "Y", SourceText.From("yyy"), filePath: "Y");
+
+            Assert.True(await EditSession.HasChangesAsync(oldSolution, solution, CancellationToken.None));
+
+            // remove a config document:
+            Assert.True(await EditSession.HasChangesAsync(solution, solution.RemoveAnalyzerConfigDocument(documentYId), CancellationToken.None));
+
+            // add a project:
+
+            oldSolution = solution;
+            var projectD = solution.AddProject("D", "D", "C#");
+            solution = projectD.Solution;
+
+            Assert.True(await EditSession.HasChangesAsync(oldSolution, solution, CancellationToken.None));
+
+            // remove a project:
+            Assert.True(await EditSession.HasChangesAsync(solution, solution.RemoveProject(projectD.Id), CancellationToken.None));
 
             EndDebuggingSession(debuggingSession);
         }
@@ -2020,8 +2054,6 @@ class G
             AssertEx.Empty(diagnostics1);
 
             // validate solution update status and emit:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             AssertEx.Equal(new[] { $"{document2.FilePath}: (0,0)-(0,54): Error CS8055: {string.Format(CSharpResources.ERR_EncodinglessSyntaxTree)}" }, InspectDiagnostics(emitDiagnostics));
 
@@ -2038,7 +2070,9 @@ class G
             Assert.Empty(debuggingSession.EditSession.NonRemappableRegions);
 
             // solution update status after discarding an update (still has update ready):
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
+            (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            Assert.Equal(ManagedModuleUpdateStatus.Blocked, updates.Status);
+            AssertEx.Equal(new[] { $"{document2.FilePath}: (0,0)-(0,54): Error CS8055: {string.Format(CSharpResources.ERR_EncodinglessSyntaxTree)}" }, InspectDiagnostics(emitDiagnostics));
 
             EndDebuggingSession(debuggingSession);
 
@@ -2103,7 +2137,6 @@ class G
             }
 
             // EnC service queries for a document, which triggers read of the source file from disk.
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Empty(emitDiagnostics);
 
@@ -2118,18 +2151,15 @@ class G
             solution = solution.WithDocumentText(documentId, CreateSourceTextFromFile(sourceFile.Path));
             var document3 = solution.Projects.Single().Documents.Single();
 
-            var hasChanges = await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None);
             (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Empty(emitDiagnostics);
 
             if (saveDocument)
             {
-                Assert.False(hasChanges);
                 Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             }
             else
             {
-                Assert.True(hasChanges);
                 Assert.Equal(ManagedModuleUpdateStatus.Ready, updates.Status);
                 debuggingSession.DiscardSolutionUpdate();
             }
@@ -2184,8 +2214,6 @@ class G
             AssertEx.Empty(diagnostics);
 
             // since the document is out-of-sync we need to call update to determine whether we have changes to apply or not:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             AssertEx.Equal(new[] { $"{project.Id}: Warning ENC1005: {string.Format(FeaturesResources.DocumentIsOutOfSyncWithDebuggee, sourceFile.Path)}" }, InspectDiagnostics(emitDiagnostics));
@@ -2202,7 +2230,6 @@ class G
             Assert.Equal(CommittedSolution.DocumentState.OutOfSync, state);
             sourceFile.WriteAllText(source1);
 
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
             (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Empty(emitDiagnostics);
 
@@ -2270,8 +2297,6 @@ class G
             // AssertEx.Equal(new[] { $"({activeLineSpan1}, LeafFrame)" }, spans.Single().Select(s => s.ToString()));
 
             // No changes.
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
 
@@ -2312,8 +2337,6 @@ class G
             EnterBreakState(debuggingSession);
 
             // no changes have been made to the project
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             Assert.Empty(updates.Updates);
@@ -2327,8 +2350,6 @@ class G
             Assert.Empty(diagnostics);
 
             // the content of the file is now exactly the same as the compiled document, so there is no change to be applied:
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             Assert.Empty(emitDiagnostics);
@@ -2365,8 +2386,6 @@ class G
             AssertEx.Empty(diagnostics1);
 
             // validate solution update status and emit:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Empty(emitDiagnostics);
             Assert.Equal(ManagedModuleUpdateStatus.Ready, updates.Status);
@@ -2417,8 +2436,9 @@ class G
                 Assert.Same(newBaseline, debuggingSession.GetTestAccessor().GetProjectEmitBaseline(document2.Project.Id));
 
                 // solution update status after committing an update:
-                var commitedUpdateSolutionStatus = await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None);
-                Assert.False(commitedUpdateSolutionStatus);
+                (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+                Assert.Empty(emitDiagnostics);
+                Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
             }
             else
             {
@@ -2428,9 +2448,6 @@ class G
                 Assert.Null(debuggingSession.GetTestAccessor().GetPendingSolutionUpdate());
 
                 // solution update status after committing an update:
-                var discardedUpdateSolutionStatus = await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None);
-                Assert.True(discardedUpdateSolutionStatus);
-
                 (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
                 Assert.Empty(emitDiagnostics);
                 Assert.Equal(ManagedModuleUpdateStatus.Ready, updates.Status);
@@ -2507,8 +2524,6 @@ class G
             var document2 = solution.GetDocument(document1.Id);
 
             // validate solution update status and emit:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.Ready, updates.Status);
             Assert.Empty(emitDiagnostics);
@@ -2549,8 +2564,6 @@ class G
                 Assert.Same(newBaseline, debuggingSession.GetTestAccessor().GetProjectEmitBaseline(document2.Project.Id));
 
                 // solution update status after committing an update:
-                Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
                 ExitBreakState(debuggingSession);
 
                 // make another update:
@@ -2931,6 +2944,44 @@ class C { int Y => 1; }
             EndDebuggingSession(debuggingSession);
         }
 
+        [Fact]
+        public async Task RudeEdit()
+        {
+            var source1 = "class C { void M() { } }";
+            var source2 = "class C { void M() { var x = new { Goo = 1 }; } }";
+
+            using var _ = CreateWorkspace(out var solution, out var service);
+            solution = AddDefaultTestProject(solution, new[] { source1 });
+            var project = solution.Projects.Single();
+            solution = solution.WithProjectParseOptions(project.Id, new CSharpParseOptions(LanguageVersion.CSharp10));
+            var documentId = solution.Projects.Single().Documents.Single().Id;
+
+            EmitAndLoadLibraryToDebuggee(source1);
+
+            // attached to processes that doesn't allow creating new types
+            _debuggerService.GetCapabilitiesImpl = () => ImmutableArray.Create("Baseline");
+
+            // F5
+            var debuggingSession = await StartDebuggingSessionAsync(service, solution);
+
+            // update document:
+            solution = solution.WithDocumentText(documentId, SourceText.From(source2, Encoding.UTF8));
+            var document2 = solution.Projects.Single().Documents.Single();
+
+            // These errors aren't reported as document diagnostics
+            var diagnostics = await service.GetDocumentDiagnosticsAsync(solution.GetDocument(documentId), s_noActiveSpans, CancellationToken.None);
+            AssertEx.Empty(diagnostics);
+
+            // They are reported as emit diagnostics
+            var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            AssertEx.Equal(new[] { $"{document2.Project.Id}: Error ENC1007: {FeaturesResources.ChangesRequiredSynthesizedType}" }, InspectDiagnostics(emitDiagnostics));
+
+            // no emitted delta:
+            Assert.Empty(updates.Updates);
+
+            EndDebuggingSession(debuggingSession);
+        }
+
         /// <summary>
         /// Emulates two updates to Multi-TFM project.
         /// </summary>
@@ -2985,8 +3036,6 @@ class C { int Y => 1; }
             solution = solution.WithDocumentText(projectB.Documents.Single().Id, SourceText.From(source2, Encoding.UTF8));
 
             // validate solution update status and emit:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             var (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.Ready, updates.Status);
             Assert.Empty(emitDiagnostics);
@@ -3020,8 +3069,9 @@ class C { int Y => 1; }
             Assert.Same(newBaselineA1, debuggingSession.GetTestAccessor().GetProjectEmitBaseline(projectA.Id));
             Assert.Same(newBaselineB1, debuggingSession.GetTestAccessor().GetProjectEmitBaseline(projectB.Id));
 
-            // solution update status after committing an update:
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
+            // solution update status after committing an update:(updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            Assert.Empty(emitDiagnostics);
+            Assert.Equal(ManagedModuleUpdateStatus.Ready, updates.Status);
 
             ExitBreakState(debuggingSession);
             EnterBreakState(debuggingSession);
@@ -3034,8 +3084,6 @@ class C { int Y => 1; }
             solution = solution.WithDocumentText(projectB.Documents.Single().Id, SourceText.From(source3, Encoding.UTF8));
 
             // validate solution update status and emit:
-            Assert.True(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
-
             (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
             Assert.Equal(ManagedModuleUpdateStatus.Ready, updates.Status);
             Assert.Empty(emitDiagnostics);
@@ -3075,7 +3123,9 @@ class C { int Y => 1; }
             Assert.Same(newBaselineB2, debuggingSession.GetTestAccessor().GetProjectEmitBaseline(projectB.Id));
 
             // solution update status after committing an update:
-            Assert.False(await debuggingSession.EditSession.HasChangesAsync(solution, s_noActiveSpans, sourceFilePath: null, CancellationToken.None));
+            (updates, emitDiagnostics) = await EmitSolutionUpdateAsync(debuggingSession, solution);
+            Assert.Empty(emitDiagnostics);
+            Assert.Equal(ManagedModuleUpdateStatus.None, updates.Status);
 
             ExitBreakState(debuggingSession);
             EndDebuggingSession(debuggingSession);

--- a/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -177,16 +177,6 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
             var availability = await remoteDebuggeeModuleMetadataProvider!.GetAvailabilityAsync(moduleId1, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(new ManagedHotReloadAvailability(ManagedHotReloadAvailabilityStatus.NotAllowedForModule, "can't do enc"), availability);
 
-            // HasChanges
-
-            mockEncService.HasChangesImpl = (solution, activeStatementSpanProvider, sourceFilePath) =>
-            {
-                Assert.Equal("proj", solution.Projects.Single().Name);
-                Assert.Equal("test.cs", sourceFilePath);
-                AssertEx.Equal(activeSpans1, activeStatementSpanProvider(document1.Id, "test.cs", CancellationToken.None).AsTask().Result);
-                return true;
-            };
-
             // EmitSolutionUpdate
 
             var diagnosticDescriptor1 = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.ErrorReadingFile);

--- a/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -187,8 +187,6 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
                 return true;
             };
 
-            Assert.True(await sessionProxy.HasChangesAsync(localWorkspace.CurrentSolution, activeStatementSpanProvider, "test.cs", CancellationToken.None).ConfigureAwait(false));
-
             // EmitSolutionUpdate
 
             var diagnosticDescriptor1 = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.ErrorReadingFile);

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public Func<Solution, IManagedHotReloadService, ImmutableArray<DocumentId>, bool, bool, DebuggingSessionId>? StartDebuggingSessionImpl;
 
         public ActionOut<ImmutableArray<DocumentId>>? EndDebuggingSessionImpl;
-        public Func<Solution, ActiveStatementSpanProvider, string?, bool>? HasChangesImpl;
         public Func<Solution, ActiveStatementSpanProvider, EmitSolutionUpdateResults>? EmitSolutionUpdateImpl;
         public Func<Solution, ManagedInstructionId, bool?>? IsActiveStatementInExceptionRegionImpl;
         public Action<Document>? OnSourceFileUpdatedImpl;
@@ -76,9 +75,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
         public ValueTask<ImmutableArray<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken)
             => new((GetDocumentDiagnosticsImpl ?? throw new NotImplementedException()).Invoke(document, activeStatementSpanProvider));
-
-        public ValueTask<bool> HasChangesAsync(DebuggingSessionId sessionId, Solution solution, ActiveStatementSpanProvider activeStatementSpanProvider, string? sourceFilePath, CancellationToken cancellationToken)
-            => new((HasChangesImpl ?? throw new NotImplementedException()).Invoke(solution, activeStatementSpanProvider, sourceFilePath));
 
         public ValueTask<bool?> IsActiveStatementInExceptionRegionAsync(DebuggingSessionId sessionId, Solution solution, ManagedInstructionId instructionId, CancellationToken cancellationToken)
             => new((IsActiveStatementInExceptionRegionImpl ?? throw new NotImplementedException()).Invoke(solution, instructionId));

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -131,11 +131,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             => _solution.ContainsDocument(documentId);
 
         /// <summary>
-        /// Captures the content of a file that is about to be overwritten by saving an open document,
-        /// if the document is currently out-of-sync and the content of the file matches the PDB.
-        /// If we didn't capture the content before the save we might never be able to find a document
-        /// snapshot that matches the PDB.
+        /// Observes the content of the specified document checks if it matches the PDB.
         /// </summary>
+        /// <remarks>
+        /// When the <see cref="DebuggingSession"/> is started we check the content of all open documents against the PDB.
+        /// Then we check the content whenever another document is opened. This approach gives us the opportunity to record the
+        /// document content state before the user has a chance to edit the files.
+        /// </remarks>
         public Task OnSourceFileUpdatedAsync(Document document, CancellationToken cancellationToken)
             => GetDocumentAndStateAsync(document.Id, document, cancellationToken, reloadOutOfSyncDocument: true);
 

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDocumentAnalysesCache.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             // Also check the base project snapshot since the analysis uses semantic information from the base project as well.
             // 
             // It would be possible to reuse analysis results of documents whose content does not change in between two solution snapshots.
-            // However, we'd need rather sophisticated caching logic. The smantic analysis gathers information from other documents when
+            // However, we'd need rather sophisticated caching logic. The semantic analysis gathers information from other documents when
             // calculating results for a specific document. In some cases it's easy to record the set of documents the analysis depends on.
             // For example, when analyzing a partial class we can record all documents its declaration spans. However, in other cases the analysis
             // checks for absence of a top-level type symbol. Adding a symbol to any document thus invalidates such analysis. It'd be possible

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -154,29 +154,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 cancellationToken);
         }
 
-        /// <summary>
-        /// Determine whether updates have been made to projects containing the specified file (or all projects that are built,
-        /// if <paramref name="sourceFilePath"/> is null).
-        /// </summary>
-        public ValueTask<bool> HasChangesAsync(
-            DebuggingSessionId sessionId,
-            Solution solution,
-            ActiveStatementSpanProvider activeStatementSpanProvider,
-            string? sourceFilePath,
-            CancellationToken cancellationToken)
-        {
-            // GetStatusAsync is called outside of edit session when the debugger is determining
-            // whether a source file checksum matches the one in PDB.
-            // The debugger expects no changes in this case.
-            var debuggingSession = TryGetDebuggingSession(sessionId);
-            if (debuggingSession == null)
-            {
-                return default;
-            }
-
-            return debuggingSession.EditSession.HasChangesAsync(solution, activeStatementSpanProvider, sourceFilePath, cancellationToken);
-        }
-
         public ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(
             DebuggingSessionId sessionId,
             Solution solution,

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -261,17 +261,132 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
+        public static async ValueTask<bool> HasChangesAsync(Solution oldSolution, Solution newSolution, string sourceFilePath, CancellationToken cancellationToken)
+        {
+            var newDocumentIds = newSolution.GetDocumentIdsWithFilePath(sourceFilePath);
+            if (newDocumentIds.IsEmpty)
+            {
+                // file does not exist or has been removed:
+                return !oldSolution.GetDocumentIdsWithFilePath(sourceFilePath).IsEmpty;
+            }
+
+            // it suffices to check the content of one of the document if there are multiple linked ones:
+            var documentId = newDocumentIds.First();
+            var oldDocument = oldSolution.GetDocument(documentId);
+            if (oldDocument == null)
+            {
+                // file has been added
+                return true;
+            }
+
+            var newDocument = newSolution.GetRequiredDocument(documentId);
+            return oldDocument != newDocument && !await ContentEqualsAsync(oldDocument, newDocument, cancellationToken).ConfigureAwait(false);
+        }
+
+        public static async ValueTask<bool> HasChangesAsync(Solution oldSolution, Solution newSolution, CancellationToken cancellationToken)
+        {
+            if (oldSolution == newSolution)
+            {
+                return false;
+            }
+
+            foreach (var newProject in newSolution.Projects)
+            {
+                var oldProject = oldSolution.GetProject(newProject.Id);
+                if (oldProject == null || await HasChangedOrAddedDocumentsAsync(oldProject, newProject, changedOrAddedDocuments: null, cancellationToken).ConfigureAwait(false))
+                {
+                    return true;
+                }
+            }
+
+            foreach (var oldProject in oldSolution.Projects)
+            {
+                var newProject = newSolution.GetProject(oldProject.Id);
+                if (newProject == null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static async ValueTask<bool> ContentEqualsAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken)
+        {
+            // Check if the currently observed document content has changed compared to the base document content.
+            // This is an important optimization that aims to avoid IO while stepping in sources that have not changed.
+            //
+            // We may be comparing out-of-date committed document content but we only make a decision based on that content
+            // if it matches the current content. If the current content is equal to baseline content that does not match
+            // the debuggee then the workspace has not observed the change made to the file on disk since baseline was captured
+            // (there had to be one as the content doesn't match). When we are about to apply changes it is ok to ignore this
+            // document because the user does not see the change yet in the buffer (if the doc is open) and won't be confused
+            // if it is not applied yet. The change will be applied later after it's observed by the workspace.
+            var oldSource = await oldDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var newSource = await newDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            return oldSource.ContentEquals(newSource);
+        }
+
+        private static async ValueTask<bool> HasChangedOrAddedDocumentsAsync(Project oldProject, Project newProject, ArrayBuilder<Document>? changedOrAddedDocuments, CancellationToken cancellationToken)
+        {
+            if (!newProject.SupportsEditAndContinue())
+            {
+                return false;
+            }
+
+            if (oldProject.State == newProject.State)
+            {
+                return false;
+            }
+
+            foreach (var documentId in newProject.State.DocumentStates.GetChangedStateIds(oldProject.State.DocumentStates, ignoreUnchangedContent: true))
+            {
+                var document = newProject.GetRequiredDocument(documentId);
+                if (document.State.Attributes.DesignTimeOnly)
+                {
+                    continue;
+                }
+
+                if (await ContentEqualsAsync(oldProject.GetRequiredDocument(documentId), document, cancellationToken).ConfigureAwait(false))
+                {
+                    continue;
+                }
+
+                if (changedOrAddedDocuments is null)
+                {
+                    return true;
+                }
+
+                changedOrAddedDocuments.Add(document);
+            }
+
+            foreach (var documentId in newProject.State.DocumentStates.GetAddedStateIds(oldProject.State.DocumentStates))
+            {
+                var document = newProject.GetRequiredDocument(documentId);
+                if (document.State.Attributes.DesignTimeOnly)
+                {
+                    continue;
+                }
+
+                if (changedOrAddedDocuments is null)
+                {
+                    return true;
+                }
+
+                changedOrAddedDocuments.Add(document);
+            }
+
+            // Any changes in non-generated documents might affect source generated documents as well,
+            // no need to check further in that case.
+            return changedOrAddedDocuments is { Count: > 0 } ||
+                   HasChangesThatMayAffectSourceGenerators(oldProject.State, newProject.State);
+        }
+
         private static async Task PopulateChangedAndAddedDocumentsAsync(CommittedSolution oldSolution, Project newProject, ArrayBuilder<Document> changedOrAddedDocuments, CancellationToken cancellationToken)
         {
             changedOrAddedDocuments.Clear();
 
-            if (!newProject.SupportsEditAndContinue())
-            {
-                return;
-            }
-
             var oldProject = oldSolution.GetProject(newProject.Id);
-
             if (oldProject == null)
             {
                 EditAndContinueWorkspaceService.Log.Write("EnC state of '{0}' [0x{1:X8}] queried: project not loaded", newProject.Id.DebugName, newProject.Id);
@@ -290,53 +405,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return;
             }
 
-            if (oldProject.State == newProject.State)
+            if (!await HasChangedOrAddedDocumentsAsync(oldProject, newProject, changedOrAddedDocuments, cancellationToken).ConfigureAwait(false))
             {
-                return;
-            }
-
-            foreach (var documentId in newProject.State.DocumentStates.GetChangedStateIds(oldProject.State.DocumentStates, ignoreUnchangedContent: true))
-            {
-                var document = newProject.GetRequiredDocument(documentId);
-                if (document.State.Attributes.DesignTimeOnly)
-                {
-                    continue;
-                }
-
-                // Check if the currently observed document content has changed compared to the base document content.
-                // This is an important optimization that aims to avoid IO while stepping in sources that have not changed.
-                //
-                // We may be comparing out-of-date committed document content but we only make a decision based on that content
-                // if it matches the current content. If the current content is equal to baseline content that does not match
-                // the debuggee then the workspace has not observed the change made to the file on disk since baseline was captured
-                // (there had to be one as the content doesn't match). When we are about to apply changes it is ok to ignore this
-                // document because the user does not see the change yet in the buffer (if the doc is open) and won't be confused
-                // if it is not applied yet. The change will be applied later after it's observed by the workspace.
-                var baseSource = await oldProject.GetRequiredDocument(documentId).GetTextAsync(cancellationToken).ConfigureAwait(false);
-                var source = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                if (baseSource.ContentEquals(source))
-                {
-                    continue;
-                }
-
-                changedOrAddedDocuments.Add(document);
-            }
-
-            foreach (var documentId in newProject.State.DocumentStates.GetAddedStateIds(oldProject.State.DocumentStates))
-            {
-                var document = newProject.GetRequiredDocument(documentId);
-                if (document.State.Attributes.DesignTimeOnly)
-                {
-                    continue;
-                }
-
-                changedOrAddedDocuments.Add(document);
-            }
-
-            // TODO: support document removal/rename (see https://github.com/dotnet/roslyn/issues/41144, https://github.com/dotnet/roslyn/issues/49013).
-            if (changedOrAddedDocuments.IsEmpty() && !HasChangesThatMayAffectSourceGenerators(oldProject.State, newProject.State))
-            {
-                // Based on the above assumption there are no changes in source generated files.
                 return;
             }
 
@@ -473,81 +543,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             lock (_documentsWithReportedDiagnosticsGuard)
             {
                 _documentsWithReportedDiagnostics.Add(documentId);
-            }
-        }
-
-        /// <summary>
-        /// Determines whether projects contain any changes that might need to be applied.
-        /// Checks only projects containing a given <paramref name="sourceFilePath"/> or all projects of the solution if <paramref name="sourceFilePath"/> is null.
-        /// Invoked by the debugger on every step. It is critical for stepping performance that this method returns as fast as possible in absence of changes.
-        /// </summary>
-        public async ValueTask<bool> HasChangesAsync(Solution solution, ActiveStatementSpanProvider solutionActiveStatementSpanProvider, string? sourceFilePath, CancellationToken cancellationToken)
-        {
-            try
-            {
-                var baseSolution = DebuggingSession.LastCommittedSolution;
-                if (baseSolution.HasNoChanges(solution))
-                {
-                    return false;
-                }
-
-                // TODO: source generated files?
-                var projects = (sourceFilePath == null) ? solution.Projects :
-                    from documentId in solution.GetDocumentIdsWithFilePath(sourceFilePath)
-                    select solution.GetProject(documentId.ProjectId)!;
-
-                using var _ = ArrayBuilder<Document>.GetInstance(out var changedOrAddedDocuments);
-
-                foreach (var project in projects)
-                {
-                    await PopulateChangedAndAddedDocumentsAsync(baseSolution, project, changedOrAddedDocuments, cancellationToken).ConfigureAwait(false);
-                    if (changedOrAddedDocuments.IsEmpty())
-                    {
-                        continue;
-                    }
-
-                    // Check MVID before analyzing documents as the analysis needs to read the PDB which will likely fail if we can't even read the MVID.
-                    var (mvid, mvidReadError) = await DebuggingSession.GetProjectModuleIdAsync(project, cancellationToken).ConfigureAwait(false);
-                    if (mvidReadError != null)
-                    {
-                        // Can't read MVID. This might be an intermittent failure, so don't report it here.
-                        // Report the project as containing changes, so that we proceed to EmitSolutionUpdateAsync where we report the error if it still persists.
-                        EditAndContinueWorkspaceService.Log.Write("EnC state of '{0}' [0x{1:X8}] queried: project not built", project.Id.DebugName, project.Id);
-                        return true;
-                    }
-
-                    if (mvid == Guid.Empty)
-                    {
-                        // Project not built. We ignore any changes made in its sources.
-                        EditAndContinueWorkspaceService.Log.Write("EnC state of '{0}' [0x{1:X8}] queried: project not built", project.Id.DebugName, project.Id);
-                        continue;
-                    }
-
-                    var (changedDocumentAnalyses, documentDiagnostics) = await AnalyzeDocumentsAsync(changedOrAddedDocuments, solutionActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);
-                    if (documentDiagnostics.Any())
-                    {
-                        EditAndContinueWorkspaceService.Log.Write("EnC state of '{0}' [0x{1:X8}] queried: out-of-sync documents present (diagnostic: '{2}')",
-                            project.Id.DebugName, project.Id, documentDiagnostics[0]);
-
-                        // Although we do not apply changes in out-of-sync/indeterminate documents we report that changes are present,
-                        // so that the debugger triggers emit of updates. There we check if these documents are still in a bad state and report warnings
-                        // that any changes in such documents are not applied.
-                        return true;
-                    }
-
-                    var projectSummary = GetProjectAnalysisSymmary(changedDocumentAnalyses);
-                    if (projectSummary != ProjectAnalysisSummary.NoChanges)
-                    {
-                        EditAndContinueWorkspaceService.Log.Write("EnC state of '{0}' [0x{1:X8}] queried: {2}", project.Id.DebugName, project.Id, projectSummary);
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-            catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
-            {
-                throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -299,16 +299,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
             }
 
-            foreach (var oldProject in oldSolution.Projects)
-            {
-                var newProject = newSolution.GetProject(oldProject.Id);
-                if (newProject == null)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return oldSolution.ProjectIds.Count != newSolution.ProjectIds.Count;
         }
 
         private static async ValueTask<bool> ContentEqualsAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -290,6 +290,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return false;
             }
 
+            if (oldSolution.ProjectIds.Count != newSolution.ProjectIds.Count)
+            {
+                return true;
+            }
+
             foreach (var newProject in newSolution.Projects)
             {
                 var oldProject = oldSolution.GetProject(newProject.Id);
@@ -299,7 +304,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
             }
 
-            return oldSolution.ProjectIds.Count != newSolution.ProjectIds.Count;
+            // The number of projects in both solution is the same and there are no new projects and no changes in existing projects.
+            // Therefore there are no changes.
+            return false;
         }
 
         private static async ValueTask<bool> ContentEqualsAsync(Document oldDocument, Document newDocument, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
@@ -14,7 +14,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     internal interface IEditAndContinueWorkspaceService : IWorkspaceService
     {
         ValueTask<ImmutableArray<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
-        ValueTask<bool> HasChangesAsync(DebuggingSessionId sessionId, Solution solution, ActiveStatementSpanProvider activeStatementSpanProvider, string? sourceFilePath, CancellationToken cancellationToken);
         ValueTask<EmitSolutionUpdateResults> EmitSolutionUpdateAsync(DebuggingSessionId sessionId, Solution solution, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
 
         void CommitSolutionUpdate(DebuggingSessionId sessionId, out ImmutableArray<DocumentId> documentsToReanalyze);

--- a/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         }
 
         ValueTask<ImmutableArray<DiagnosticData>> GetDocumentDiagnosticsAsync(Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DocumentId documentId, CancellationToken cancellationToken);
-        ValueTask<bool> HasChangesAsync(Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, string? sourceFilePath, CancellationToken cancellationToken);
         ValueTask<EmitSolutionUpdateResults.Data> EmitSolutionUpdateAsync(Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
@@ -93,23 +93,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             Dispose();
         }
 
-        public async ValueTask<bool> HasChangesAsync(Solution solution, ActiveStatementSpanProvider activeStatementSpanProvider, string? sourceFilePath, CancellationToken cancellationToken)
-        {
-            var client = await RemoteHostClient.TryGetClientAsync(_workspace, cancellationToken).ConfigureAwait(false);
-            if (client == null)
-            {
-                return await GetLocalService().HasChangesAsync(_sessionId, solution, activeStatementSpanProvider, sourceFilePath, cancellationToken).ConfigureAwait(false);
-            }
-
-            var result = await client.TryInvokeAsync<IRemoteEditAndContinueService, bool>(
-                solution,
-                (service, solutionInfo, callbackId, cancellationToken) => service.HasChangesAsync(solutionInfo, callbackId, _sessionId, sourceFilePath, cancellationToken),
-                callbackTarget: new ActiveStatementSpanProviderCallback(activeStatementSpanProvider),
-                cancellationToken).ConfigureAwait(false);
-
-            return result.HasValue ? result.Value : true;
-        }
-
         public async ValueTask<(
                 ManagedModuleUpdates updates,
                 ImmutableArray<DiagnosticData> diagnostics,

--- a/src/Tools/ExternalAccess/Debugger/GlassTestsHotReloadService.cs
+++ b/src/Tools/ExternalAccess/Debugger/GlassTestsHotReloadService.cs
@@ -82,17 +82,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Debugger
             _sessionId = default;
         }
 
-        public async ValueTask<bool> HasChangesAsync(Solution solution, string? sourceFilePath, CancellationToken cancellationToken)
-        {
-            var sessionId = _sessionId;
-            if (sessionId == default)
-            {
-                return false;
-            }
-
-            return await _encService.HasChangesAsync(sessionId, solution, s_noActiveStatementSpanProvider, sourceFilePath, cancellationToken).ConfigureAwait(false);
-        }
-
         public async ValueTask<ManagedModuleUpdates> GetEditAndContinueUpdatesAsync(Solution solution, CancellationToken cancellationToken)
         {
             var result = await _encService.EmitSolutionUpdateAsync(GetSessionId(), solution, s_noActiveStatementSpanProvider, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -118,17 +118,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <summary>
         /// Remote API.
         /// </summary>
-        public ValueTask<bool> HasChangesAsync(Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, string? sourceFilePath, CancellationToken cancellationToken)
-        {
-            return RunServiceAsync(solutionChecksum, async solution =>
-            {
-                return await GetService().HasChangesAsync(sessionId, solution, CreateActiveStatementSpanProvider(callbackId), sourceFilePath, cancellationToken).ConfigureAwait(false);
-            }, cancellationToken);
-        }
-
-        /// <summary>
-        /// Remote API.
-        /// </summary>
         public ValueTask<EmitSolutionUpdateResults.Data> EmitSolutionUpdateAsync(
             Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
`EditAndContinueLanguageService.HasChangesAsync` is called on UI thread when stepping to determine whether any changes have been made that the debugger needs to apply before resuming the execution of the debuggee. Previously we called to the EnC OOP service to determine the changes precisely. This determination may involve running code generators and checking document content against PDB checksums, which may cause long UI delays. 

@isadorasophia pointed out that precision is not required here and would only marginally degrade the user experience in rare cases. If any changes are missed during stepping (in rare cases) and the user observes the difference they can apply the changes explicitly via Apply Changes command. Skipping a change application may lead to interesting effects in certain corner cases, but it appears to be sound.

EnC service creates a series of `EditSession` instances. Each instance represents state of the session in between points that change some aspect of the session (inputs to the EnC analysis) . The first instance is created when the debugging/Hot Reload session starts (F5/Ctrl+F5). 

A new session is created, replacing the previous one (see `DebuggingSession.RestartEditSession`) at the following events:
1) When a change is applied and committed. The new session is initialized with non-remappable regions calculated based on the applied change. The latest committed solution snapshot is also captured at this point. All further delta analysis is based on this snapshot.
2) When a break state is entered
3) When a break state is exited
4) When capabilities change.

Prior to this change events [1] and [3] have been implicitly coupled. The debugger always applied changes before exiting the break state. However, we can also see them as independent. We do not necessarily need to apply changes made during break state before the break state ends. We can skip applying the changes at that point and apply them later - either while the app is running (if the user explicitly triggers Apply Changes) or at the next break state (automatically, if we detect them at that time). 

All delta analysis continues to use the latest committed solution without regard of the break state. The only impact of entering and exiting break state on the EnC analysis is consideration of active statements, which are only available while at break state. It may happen that the changes were considered rude during the break state (due to presence of an active statement) while they might be allowed while the application is running. The background EnC analysis will always report the correct rude edits (squiggles) at that point. It may happen, if we skip applying a change, that the squiggle is shown while at break state, disappears when break state is exited and appears again when the app is stopped at the next break state. 

Now that we determined that skipping change application during break state is sound, we can perform much faster check (heuristic) that only inspect readily available in-proc solution state. Ideally, we would avoid using solution snapshot entirely for this implementation, but that turns out to be tricky. We could, for example, track changes to open files that belong to Roslyn and ignore changes that were made outside of VS. However, determining whether a file belongs to Roslyn (i.e. can affect compilation) is not straightforward as it depends on data coming from the project system (especially for additional files, which can have arbitrary extension). In future we might want to investigate this approach further: https://github.com/dotnet/roslyn/issues/61692.

Fixes [AB#1540395](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1540395)
Fixes [AB#1370311](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1370311)
Fixes [AB#1240764](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1240764)
Fixes #55625