### PR TITLE
Remove delegate and capture allocations

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
         {
             // If other local functions are called the it can't be made static unles the
             // are static, or the local function is recursive, or its calling a child local function
-            return !dataFlow.UsedLocalFunctions.Any(lf => !lf.IsStatic && !IsChildOrSelf(localFunction, lf));
+            return !dataFlow.UsedLocalFunctions.Any(static (lf, localFunction) => !lf.IsStatic && !IsChildOrSelf(localFunction, lf), localFunction);
 
             static bool IsChildOrSelf(LocalFunctionStatementSyntax containingLocalFunction, ISymbol calledLocationFunction)
             {
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
         }
 
         private static bool HasCapturesThatArentThis(ImmutableArray<ISymbol> captures)
-            => !captures.IsEmpty && !captures.Any(s => s.IsThisParameter());
+            => !captures.IsEmpty && !captures.Any(static s => s.IsThisParameter());
 
         public static bool CanMakeLocalFunctionStaticBecauseNoCaptures(LocalFunctionStatementSyntax localFunction, SemanticModel semanticModel)
             => TryGetDataFlowAnalysis(localFunction, semanticModel, out var dataFLow)

--- a/src/Analyzers/CSharp/Analyzers/UseLocalFunction/CSharpUseLocalFunctionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseLocalFunction/CSharpUseLocalFunctionDiagnosticAnalyzer.cs
@@ -375,7 +375,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseLocalFunction
                 var typeParams = localEnclosingSymbol.GetTypeParameters();
                 if (typeParams.Any())
                 {
-                    if (typeParams.Any(p => delegateTypeParamNames.Contains(p.Name)))
+                    if (typeParams.Any(static (p, delegateTypeParamNames) => delegateTypeParamNames.Contains(p.Name), delegateTypeParamNames))
                     {
                         return false;
                     }

--- a/src/Analyzers/CSharp/Analyzers/UseSimpleUsingStatement/UseSimpleUsingStatementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseSimpleUsingStatement/UseSimpleUsingStatementDiagnosticAnalyzer.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
         }
 
         private static bool DeclaredLocalCausesCollision(ILookup<string, ISymbol> symbolNameToExistingSymbol, ImmutableArray<ILocalSymbol> locals)
-            => locals.Any(local => symbolNameToExistingSymbol[local.Name].Any(otherLocal => !local.Equals(otherLocal)));
+            => locals.Any(static (local, symbolNameToExistingSymbol) => symbolNameToExistingSymbol[local.Name].Any(otherLocal => !local.Equals(otherLocal)), symbolNameToExistingSymbol);
 
         private static bool PreservesSemantics(
             BlockSyntax parentBlock,

--- a/src/Analyzers/Core/Analyzers/ForEachCast/AbstractForEachCastDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/ForEachCast/AbstractForEachCastDiagnosticAnalyzer.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.ForEachCast
 
             // We can only fix this issue if the collection type implemented ienumerable and we have
             // System.Linq.Enumerable available.  Then we can add a .Cast call to their collection explicitly.
-            var isFixable = collectionType.Equals(ienumerableType) || collectionType.AllInterfaces.Any(i => i.Equals(ienumerableType)) &&
+            var isFixable = collectionType.Equals(ienumerableType) || collectionType.AllInterfaces.Any(static (i, ienumerableType) => i.Equals(ienumerableType), ienumerableType) &&
                 semanticModel.Compilation.GetBestTypeByMetadataName(typeof(Enumerable).FullName!) != null;
 
             var options = semanticModel.Compilation.Options;
@@ -141,6 +141,6 @@ namespace Microsoft.CodeAnalysis.ForEachCast
         private static bool IsStronglyTyped(INamedTypeSymbol ienumerableOfTType, ITypeSymbol collectionType, ITypeSymbol collectionElementType)
             => collectionElementType.SpecialType != SpecialType.System_Object ||
                collectionType.OriginalDefinition.Equals(ienumerableOfTType) ||
-               collectionType.AllInterfaces.Any(i => i.OriginalDefinition.Equals(ienumerableOfTType));
+               collectionType.AllInterfaces.Any(static (i, ienumerableOfTType) => i.OriginalDefinition.Equals(ienumerableOfTType), ienumerableOfTType);
     }
 }

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                     return;
                 }
 
-                if (symbolEndContext.Symbol.GetAttributes().Any(a => a.AttributeClass == _structLayoutAttributeType))
+                if (symbolEndContext.Symbol.GetAttributes().Any(static (a, self) => a.AttributeClass == self._structLayoutAttributeType, this))
                 {
                     // Bail out for types with 'StructLayoutAttribute' as the ordering of the members is critical,
                     // and removal of unused members might break semantics.
@@ -727,7 +727,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
             }
 
             private bool IsMethodWithSpecialAttribute(IMethodSymbol methodSymbol)
-                => methodSymbol.GetAttributes().Any(a => _attributeSetForMethodsToIgnore.Contains(a.AttributeClass));
+                => methodSymbol.GetAttributes().Any(static (a, self) => self._attributeSetForMethodsToIgnore.Contains(a.AttributeClass), this);
 
             private static bool IsShouldSerializeOrResetPropertyMethod(IMethodSymbol methodSymbol)
             {
@@ -747,7 +747,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                     {
                         var suffix = methodSymbol.Name[prefix.Length..];
                         return suffix.Length > 0 &&
-                            methodSymbol.ContainingType.GetMembers(suffix).Any(m => m is IPropertySymbol);
+                            methodSymbol.ContainingType.GetMembers(suffix).Any(static m => m is IPropertySymbol);
                     }
 
                     return false;

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -464,7 +464,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     //     We can analyze this correctly when we do points-to-analysis.
                     if (owningSymbol is IMethodSymbol method &&
                         (method.ReturnType.IsDelegateType() ||
-                         method.Parameters.Any(p => p.IsRefOrOut() && p.Type.IsDelegateType())))
+                         method.Parameters.Any(static p => p.IsRefOrOut() && p.Type.IsDelegateType())))
                     {
                         return false;
                     }

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 
                 // Ignore flagging parameters for methods with certain well-known attributes,
                 // which are known to have unused parameters in real world code.
-                if (method.GetAttributes().Any(a => _attributeSetForMethodsToIgnore.Contains(a.AttributeClass)))
+                if (method.GetAttributes().Any(static (a, self) => self._attributeSetForMethodsToIgnore.Contains(a.AttributeClass), this))
                 {
                     return false;
                 }

--- a/src/Analyzers/Core/Analyzers/SimplifyLinqExpression/AbstractSimplifyLinqExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/SimplifyLinqExpression/AbstractSimplifyLinqExpressionDiagnosticAnalyzer.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.SimplifyLinqExpression
                 => whereMethod.Equals(invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod.OriginalDefinition, SymbolEqualityComparer.Default);
 
             bool IsInvocationNonEnumerableReturningLinqMethod(IInvocationOperation invocation)
-                => linqMethods.Any(m => m.Equals(invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod.OriginalDefinition, SymbolEqualityComparer.Default));
+                => linqMethods.Any(static (m, invocation) => m.Equals(invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod.OriginalDefinition, SymbolEqualityComparer.Default), invocation);
 
             INamedTypeSymbol? TryGetSymbolOfMemberAccess(IInvocationOperation invocation)
             {

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UseCollectionInitializerAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/UseCollectionInitializerAnalyzer.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 name: WellKnownMemberNames.CollectionInitializerAddMethodName,
                 includeReducedExtensionMethods: true);
 
-            return addMethods.Any(m => m is IMethodSymbol methodSymbol && methodSymbol.Parameters.Any());
+            return addMethods.Any(static m => m is IMethodSymbol methodSymbol && methodSymbol.Parameters.Any());
         }
 
         private bool TryAnalyzeIndexAssignment(

--- a/src/Analyzers/Core/CodeFixes/PopulateSwitch/AbstractPopulateSwitchStatementCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/PopulateSwitch/AbstractPopulateSwitchStatementCodeFixProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
             if (cases.Length > 0)
             {
                 var lastCase = cases.Last();
-                if (lastCase.Clauses.Any(c => c.CaseKind == CaseKind.Default))
+                if (lastCase.Clauses.Any(static c => c.CaseKind == CaseKind.Default))
                 {
                     return cases.Length - 1;
                 }

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
@@ -571,7 +571,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
                     if (!otherAccessors.IsEmpty)
                     {
                         return !otherAccessors.Any(
-                            accessor => accessor.Body == null
+                            static accessor => accessor.Body == null
                                         && accessor.ExpressionBody == null
                                         && !accessor.SemicolonToken.IsMissing);
                     }

--- a/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_UpdateModel.cs
+++ b/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_UpdateModel.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                     if (name != null)
                     {
                         var comparer = isCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
-                        return item.Parameters.Any(p => comparer.Equals(p.Name, name));
+                        return item.Parameters.Any(static (p, arg) => arg.comparer.Equals(p.Name, arg.name), (comparer, name));
                     }
 
                     // An item is applicable if it has at least as many parameters as the selected

--- a/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller_TypeChar.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             else
             {
                 var computed = false;
-                if (allProviders.Any(p => p.IsRetriggerCharacter(args.TypedChar)))
+                if (allProviders.Any(static (p, args) => p.IsRetriggerCharacter(args.TypedChar), args))
                 {
                     // The user typed a character that might close the scope of the current model.
                     // In this case, we should requery all providers.

--- a/src/EditorFeatures/Core.Wpf/Workspaces/WpfTextBufferVisibilityTracker.cs
+++ b/src/EditorFeatures/Core.Wpf/Workspaces/WpfTextBufferVisibilityTracker.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Workspaces
             // determine the visibility of this buffer.  While unlikely to happen, this is possible with VS's
             // extensibility model, which allows for a plugin to host an ITextBuffer in their own impl of an ITextView.
             // For those cases, just assume these buffers are visible.
-            if (views.Any(v => v is not IWpfTextView))
+            if (views.Any(static v => v is not IWpfTextView))
                 return true;
 
             return views.OfType<IWpfTextView>().Any(v => v.VisualElement.IsVisible);

--- a/src/EditorFeatures/Core/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/CodeActions/CodeActionEditHandlerService.cs
@@ -241,9 +241,9 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 return null;
             }
 
-            if (changedDocuments.Any(id => newSolution.GetRequiredDocument(id).HasInfoChanged(oldSolution.GetRequiredDocument(id))) ||
-                changedAdditionalDocuments.Any(id => newSolution.GetRequiredAdditionalDocument(id).HasInfoChanged(oldSolution.GetRequiredAdditionalDocument(id))) ||
-                changedAnalyzerConfigDocuments.Any(id => newSolution.GetRequiredAnalyzerConfigDocument(id).HasInfoChanged(oldSolution.GetRequiredAnalyzerConfigDocument(id))))
+            if (changedDocuments.Any(static (id, arg) => arg.newSolution.GetRequiredDocument(id).HasInfoChanged(arg.oldSolution.GetRequiredDocument(id)), (oldSolution, newSolution)) ||
+                changedAdditionalDocuments.Any(static (id, arg) => arg.newSolution.GetRequiredAdditionalDocument(id).HasInfoChanged(arg.oldSolution.GetRequiredAdditionalDocument(id)), (oldSolution, newSolution)) ||
+                changedAnalyzerConfigDocuments.Any(static (id, arg) => arg.newSolution.GetRequiredAnalyzerConfigDocument(id).HasInfoChanged(arg.oldSolution.GetRequiredAnalyzerConfigDocument(id)), (oldSolution, newSolution)))
             {
                 return null;
             }

--- a/src/EditorFeatures/Core/CommentSelection/ToggleLineCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommentSelection/ToggleLineCommentCommandHandler.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CommentSelection
         }
 
         private static bool SelectionHasUncommentedLines(ImmutableArray<ITextSnapshotLine> linesInSelection, CommentSelectionInfo commentInfo)
-            => linesInSelection.Any(l => !IsLineCommentedOrEmpty(l, commentInfo));
+            => linesInSelection.Any(static (l, commentInfo) => !IsLineCommentedOrEmpty(l, commentInfo), commentInfo);
 
         private static bool IsLineCommentedOrEmpty(ITextSnapshotLine line, CommentSelectionInfo info)
         {

--- a/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -86,7 +86,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 && e.Workspace.Services.GetService<IWorkspaceConfigurationService>()?.Options.EnableOpeningSourceGeneratedFiles == true
                 && e.Solution.GetProject(e.DocumentId.ProjectId) is { } project)
             {
-                document = ThreadingContext.JoinableTaskFactory.Run(() => project.GetSourceGeneratedDocumentAsync(e.DocumentId, CancellationToken.None).AsTask());
+                var documentId = e.DocumentId;
+                document = ThreadingContext.JoinableTaskFactory.Run(() => project.GetSourceGeneratedDocumentAsync(documentId, CancellationToken.None).AsTask());
             }
 
             // Open documents *should* always have their SourceText available, but we cannot guarantee

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 var documents = textBuffer.AsTextContainer().GetRelatedDocuments();
 
-                if (!documents.Any(d => locationsByDocument.Contains(d.Id)))
+                if (!documents.Any(static (d, locationsByDocument) => locationsByDocument.Contains(d.Id), locationsByDocument))
                 {
                     _openTextBuffers[textBuffer].SetReferenceSpans(SpecializedCollections.EmptyEnumerable<TextSpan>());
                 }

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 // Capture the % of committed completion items that would have appeared in the "Target type matches" filter
                 // (regardless of whether that filter button was active at the time of commit).
                 AsyncCompletionLogger.LogCommitWithTargetTypeCompletionExperimentEnabled();
-                if (item.Filters.Any(f => f.DisplayText == FeaturesResources.Target_type_matches))
+                if (item.Filters.Any(static f => f.DisplayText == FeaturesResources.Target_type_matches))
                 {
                     AsyncCompletionLogger.LogCommitItemWithTargetTypeFilter();
                 }

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -777,7 +777,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     => ShouldBeFilteredOutOfCompletionList(item) || ShouldBeFilteredOutOfExpandedCompletionList(item);
 
                 private bool ShouldBeFilteredOutOfCompletionList(VSCompletionItem item)
-                    => _needToFilter && !item.Filters.Any(filter => _selectedNonExpanderFilters.Contains(filter));
+                    => _needToFilter && !item.Filters.Any(static (filter, self) => self._selectedNonExpanderFilters.Contains(filter), this);
 
                 private bool ShouldBeFilteredOutOfExpandedCompletionList(VSCompletionItem item)
                 {
@@ -812,7 +812,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                         // Telemetry: Want to know % of sessions with the "Target type matches" filter where that filter is actually enabled
                         if (_needToFilter &&
                             !sessionData.TargetTypeFilterSelected &&
-                            _selectedNonExpanderFilters.Any(f => f.DisplayText == FeaturesResources.Target_type_matches))
+                            _selectedNonExpanderFilters.Any(static f => f.DisplayText == FeaturesResources.Target_type_matches))
                         {
                             AsyncCompletionLogger.LogTargetTypeFilterChosenInSession();
 

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             if (sessionData.TargetTypeFilterExperimentEnabled)
             {
                 AsyncCompletionLogger.LogSessionHasTargetTypeFilterEnabled();
-                if (data.InitialList.Any(i => i.Filters.Any(f => f.DisplayText == FeaturesResources.Target_type_matches)))
+                if (data.InitialList.Any(static i => i.Filters.Any(static f => f.DisplayText == FeaturesResources.Target_type_matches)))
                     AsyncCompletionLogger.LogSessionContainsTargetTypeFilter();
             }
 

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     return TriggerIdentifierKind.NotRenamable;
                 }
 
-                return sourceSymbol.Locations.Any(loc => loc == token.GetLocation())
+                return sourceSymbol.Locations.Any(static (loc, token) => loc == token.GetLocation(), token)
                         ? TriggerIdentifierKind.RenamableDeclaration
                         : TriggerIdentifierKind.RenamableReference;
             }

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractTaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/AbstractTaggerEventSource.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         protected void RaiseChanged()
         {
             if (!_paused)
-                this.Changed?.Invoke(this, new TaggerEventArgs());
+                this.Changed?.Invoke(this, TaggerEventArgs.Empty);
         }
 
         public void Pause()

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
                         {
                             var relatedDocumentIds = e.NewSolution.GetRelatedDocumentIds(documentId);
 
-                            if (relatedDocumentIds.Any(d => d.ProjectId == e.ProjectId))
+                            if (relatedDocumentIds.Any(static (d, e) => d.ProjectId == e.ProjectId, e))
                             {
                                 RaiseChanged();
                             }

--- a/src/EditorFeatures/Core/Tagging/CompilationAvailableTaggerEventSource.cs
+++ b/src/EditorFeatures/Core/Tagging/CompilationAvailableTaggerEventSource.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             _subjectBuffer = subjectBuffer;
             _eventSource = new CompilationAvailableEventSource(asyncListener);
             _underlyingSource = TaggerEventSources.Compose(eventSources);
-            _onCompilationAvailable = () => this.Changed?.Invoke(this, new TaggerEventArgs());
+            _onCompilationAvailable = () => this.Changed?.Invoke(this, TaggerEventArgs.Empty);
         }
 
         public event EventHandler<TaggerEventArgs>? Changed;

--- a/src/EditorFeatures/Core/Tagging/TaggerEventArgs.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.CodeAnalysis.Editor.Tagging
@@ -14,7 +12,9 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
     /// </summary>
     internal class TaggerEventArgs : EventArgs
     {
-        public TaggerEventArgs()
+        public static new readonly TaggerEventArgs Empty = new();
+
+        private TaggerEventArgs()
         {
         }
     }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/MoveType/AbstractMoveTypeTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/MoveType/AbstractMoveTypeTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MoveType
 
                     if (actions.Length > 0)
                     {
-                        var renameFileAction = actions.Any(action => action.Title.StartsWith(RenameTypeCodeActionTitle));
+                        var renameFileAction = actions.Any(static (action, self) => action.Title.StartsWith(self.RenameTypeCodeActionTitle), this);
                         Assert.False(renameFileAction, "Rename Type to match file name code action was not expected, but shows up.");
                     }
                 }
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MoveType
 
                     if (actions.Length > 0)
                     {
-                        var renameFileAction = actions.Any(action => action.Title.StartsWith(RenameFileCodeActionTitle));
+                        var renameFileAction = actions.Any(static (action, self) => action.Title.StartsWith(self.RenameFileCodeActionTitle), this);
                         Assert.False(renameFileAction, "Rename File to match type code action was not expected, but shows up.");
                     }
                 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -493,7 +493,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     if (arguments.Count == 2 &&
                         arguments[0] is string namespaceName &&
                         arguments[1] is NamespaceSymbol containingNamespace &&
-                        containingNamespace.ConstituentNamespaces.Any(n => n.ContainingAssembly.Identity.IsWindowsAssemblyIdentity()))
+                        containingNamespace.ConstituentNamespaces.Any(static n => n.ContainingAssembly.Identity.IsWindowsAssemblyIdentity()))
                     {
                         // This is just a heuristic, but it has the advantage of being portable, particularly 
                         // across different versions of (desktop) windows.

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
             // If the variable is itself referenced in its own initializer then don't offer anything here.  This
             // practically does not occur (though the language allows it), and it only serves to add a huge amount
             // of complexity to this feature.
-            if (references.Any(r => variableDeclarator.Initializer.Span.Contains(r.Span)))
+            if (references.Any(static (r, variableDeclarator) => variableDeclarator.Initializer.Span.Contains(r.Span), variableDeclarator))
                 return;
 
             context.RegisterRefactoring(

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CSharpSuggestionModeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CSharpSuggestionModeCompletionProvider.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             // If we're an argument to a function with multiple overloads, 
             // open the builder if any overload takes a delegate at our argument position
             var inferredTypeInfo = typeInferrer.GetTypeInferenceInfo(semanticModel, position, cancellationToken: cancellationToken);
-            return inferredTypeInfo.Any(type => GetDelegateType(type, semanticModel.Compilation).IsDelegateType());
+            return inferredTypeInfo.Any(static (type, semanticModel) => GetDelegateType(type, semanticModel.Compilation).IsDelegateType(), semanticModel);
         }
 
         private static ITypeSymbol? GetDelegateType(TypeInferenceInfo typeInferenceInfo, Compilation compilation)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 using var _ = ArrayBuilder<(string name, SymbolKind kind)>.GetInstance(out var result);
 
                 // Suggest names from existing overloads.
-                if (nameInfo.PossibleSymbolKinds.Any(k => k.SymbolKind == SymbolKind.Parameter))
+                if (nameInfo.PossibleSymbolKinds.Any(static k => k.SymbolKind == SymbolKind.Parameter))
                 {
                     var (_, partialSemanticModel) = await document.GetPartialSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                     if (partialSemanticModel is not null)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectAndWithInitializerCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectAndWithInitializerCompletionProvider.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         protected override bool IsInitializable(ISymbol member, INamedTypeSymbol containingType)
         {
-            if (member is IPropertySymbol property && property.Parameters.Any(p => !p.IsOptional))
+            if (member is IPropertySymbol property && property.Parameters.Any(static p => !p.IsOptional))
             {
                 return false;
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         protected override CompletionItemRules GetCompletionItemRules(ImmutableArray<(ISymbol symbol, bool preselect)> symbols)
         {
-            var preselect = symbols.Any(t => t.preselect);
+            var preselect = symbols.Any(static t => t.preselect);
             if (!preselect)
                 return s_arrayRules;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
             // The base class applies a broad filter when finding candidates, but since C# requires
             // that all parts have the "partial" modifier, the results can be trimmed further here.
-            return candidates?.Where(symbol => symbol.DeclaringSyntaxReferences.Any(reference => IsPartialTypeDeclaration(reference.GetSyntax(cancellationToken))));
+            return candidates?.Where(symbol => symbol.DeclaringSyntaxReferences.Any(static (reference, cancellationToken) => IsPartialTypeDeclaration(reference.GetSyntax(cancellationToken)), cancellationToken));
         }
 
         private static bool IsPartialTypeDeclaration(SyntaxNode syntax)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         protected override CompletionItemRules GetCompletionItemRules(ImmutableArray<(ISymbol symbol, bool preselect)> symbols, CSharpSyntaxContext context)
         {
-            var preselect = symbols.Any(t => t.preselect);
+            var preselect = symbols.Any(static t => t.preselect);
             s_cachedRules.TryGetValue(ValueTuple.Create(context.IsLeftSideOfImportAliasDirective, preselect, context.IsPossibleTupleContext), out var rule);
 
             return rule ?? CompletionItemRules.Default;
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             // e.g. Action c = = Bar;
             if (symbol.IsKind(SymbolKind.Method) && !context.IsNameOfContext)
             {
-                var isInferredTypeDelegateOrFunctionPointer = context.InferredTypes.Any(type => type.IsDelegateType() || type.IsFunctionPointerType());
+                var isInferredTypeDelegateOrFunctionPointer = context.InferredTypes.Any(static type => type.IsDelegateType() || type.IsFunctionPointerType());
                 if (!isInferredTypeDelegateOrFunctionPointer)
                 {
                     item = SymbolCompletionItem.AddShouldProvideParenthesisCompletion(item);

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         protected abstract bool IsValidContextWorker(int position, CSharpSyntaxContext context, CancellationToken cancellationToken);
 
         protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)
-            => context.InferredTypes.Any(t => t.SpecialType == SpecialType);
+            => context.InferredTypes.Any(static (t, self) => t.SpecialType == self.SpecialType, this);
 
         protected sealed override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
             var outerType = context.SemanticModel.GetEnclosingNamedType(context.Position, cancellationToken);
-            return context.InferredTypes.Any(t => Equals(t, outerType));
+            return context.InferredTypes.Any(static (t, outerType) => Equals(t, outerType), outerType);
         }
     }
 }

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.Analyzer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
             //
             // When the 'break' moves into the switch, it will have different flow control impact.
             public override bool CanConvert(IConditionalOperation operation)
-                => !operation.SemanticModel.AnalyzeControlFlow(operation.Syntax).ExitPoints.Any(n => n.IsKind(SyntaxKind.BreakStatement));
+                => !operation.SemanticModel.AnalyzeControlFlow(operation.Syntax).ExitPoints.Any(static n => n.IsKind(SyntaxKind.BreakStatement));
 
             public override bool CanImplicitlyConvert(SemanticModel semanticModel, SyntaxNode syntax, ITypeSymbol targetType)
             {

--- a/src/Features/CSharp/Portable/ConvertLinq/CSharpConvertLinqQueryToForEachProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertLinq/CSharpConvertLinqQueryToForEachProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertLinq
                 // https://github.com/dotnet/roslyn/issues/25639
                 if ((TryConvertInternal(queryExpressionProcessingInfo, out documentUpdateInfo) ||
                     TryReplaceWithLocalFunction(queryExpressionProcessingInfo, out documentUpdateInfo)) &&  // second attempt: at least to a local function
-                    !_semanticModel.GetDiagnostics(_source.Span, _cancellationToken).Any(diagnostic => diagnostic.DefaultSeverity == DiagnosticSeverity.Error))
+                    !_semanticModel.GetDiagnostics(_source.Span, _cancellationToken).Any(static diagnostic => diagnostic.DefaultSeverity == DiagnosticSeverity.Error))
                 {
                     if (!documentUpdateInfo.Source.IsParentKind(SyntaxKind.Block) &&
                         documentUpdateInfo.Destinations.Length > 1)

--- a/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_ProgramMain.cs
+++ b/src/Features/CSharp/Portable/ConvertProgram/ConvertProgramTransform_ProgramMain.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertProgram
             var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
 
             // See if we have an existing part in another file.  If so, we'll have to generate our declaration as partial.
-            var hasExistingPart = programType.DeclaringSyntaxReferences.Any(d => d.GetSyntax(cancellationToken) is TypeDeclarationSyntax);
+            var hasExistingPart = programType.DeclaringSyntaxReferences.Any(static (d, cancellationToken) => d.GetSyntax(cancellationToken) is TypeDeclarationSyntax, cancellationToken);
 
             var method = (MethodDeclarationSyntax)generator.MethodDeclaration(
                 mainMethod, WellKnownMemberNames.EntryPointMethodName,

--- a/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
+++ b/src/Features/CSharp/Portable/EncapsulateField/CSharpEncapsulateFieldService.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EncapsulateField
         }
 
         private static bool IsNew(IFieldSymbol field)
-            => field.DeclaringSyntaxReferences.Any(d => d.GetSyntax().GetAncestor<FieldDeclarationSyntax>().Modifiers.Any(SyntaxKind.NewKeyword));
+            => field.DeclaringSyntaxReferences.Any(static d => d.GetSyntax().GetAncestor<FieldDeclarationSyntax>().Modifiers.Any(SyntaxKind.NewKeyword));
 
         private static string GenerateFieldName(string correspondingPropertyName)
             => char.ToLower(correspondingPropertyName[0]).ToString() + correspondingPropertyName.Substring(1);

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -630,7 +630,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 
                 if (CSharpSelectionResult.ShouldCallConfigureAwaitFalse())
                 {
-                    if (AnalyzerResult.ReturnType.GetMembers().Any(x => x is IMethodSymbol
+                    if (AnalyzerResult.ReturnType.GetMembers().Any(static x => x is IMethodSymbol
                         {
                             Name: nameof(Task.ConfigureAwait),
                             Parameters: { Length: 1 } parameters
@@ -854,7 +854,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 var localFunctionKind = new SymbolSpecification.SymbolKindOrTypeKind(MethodKind.LocalFunction);
                 if (LocalFunction)
                 {
-                    if (namingRules.Any(rule => rule.NamingStyle.CapitalizationScheme.Equals(Capitalization.CamelCase) && rule.SymbolSpecification.AppliesTo(localFunctionKind, CreateMethodModifiers(), null)))
+                    if (namingRules.Any(static (rule, arg) => rule.NamingStyle.CapitalizationScheme.Equals(Capitalization.CamelCase) && rule.SymbolSpecification.AppliesTo(arg.localFunctionKind, arg.self.CreateMethodModifiers(), null), (self: this, localFunctionKind)))
                     {
                         methodName = NewMethodCamelCaseStr;
                     }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             }
 
             // let's see whether this interface has coclass attribute
-            return info.ConvertedType.GetAttributes().Any(c => c.AttributeClass?.Equals(coclassSymbol) == true);
+            return info.ConvertedType.GetAttributes().Any(static (c, coclassSymbol) => c.AttributeClass?.Equals(coclassSymbol) == true, coclassSymbol);
         }
     }
 }

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
                 {
                     var typeParameter = GetUniqueTypeParameter(
                         genericName.TypeArgumentList.Arguments.First(),
-                        s => !State.TypeToGenerateIn.GetAllTypeParameters().Any(t => t.Name == s),
+                        s => !State.TypeToGenerateIn.GetAllTypeParameters().Any(static (t, s) => t.Name == s, s),
                         cancellationToken);
 
                     return ImmutableArray.Create(typeParameter);
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
                     {
                         var typeParameter = GetUniqueTypeParameter(
                             type,
-                            s => !usedIdentifiers.Contains(s) && !State.TypeToGenerateIn.GetAllTypeParameters().Any(t => t.Name == s),
+                            s => !usedIdentifiers.Contains(s) && !State.TypeToGenerateIn.GetAllTypeParameters().Any(static (t, s) => t.Name == s, s),
                             cancellationToken);
 
                         usedIdentifiers.Add(typeParameter.Name);

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementImplicitlyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementImplicitlyCodeRefactoringProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
             var containingTypeInterfaces = member.ContainingType.AllInterfaces;
             if (containingTypeInterfaces.Length == 0)
                 return false;
-            return memberInterfaceImplementations.Any(impl => containingTypeInterfaces.Contains(impl.ContainingType));
+            return memberInterfaceImplementations.Any(static (impl, containingTypeInterfaces) => containingTypeInterfaces.Contains(impl.ContainingType), containingTypeInterfaces);
         }
 
         // When converting to implicit, we don't need to update any references.

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -135,9 +135,9 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
 
         private static bool IsIterator(IMethodSymbol x)
         {
-            return x.Locations.Any(l => ContainsYield(l.FindNode(cancellationToken: default)));
+            return x.Locations.Any(static l => ContainsYield(l.FindNode(cancellationToken: default)));
 
-            bool ContainsYield(SyntaxNode node)
+            static bool ContainsYield(SyntaxNode node)
                 => node.DescendantNodes(n => n == node || !n.IsReturnableConstruct()).Any(n => IsYield(n));
 
             static bool IsYield(SyntaxNode node)

--- a/src/Features/CSharp/Portable/ReplaceDefaultLiteral/CSharpReplaceDefaultLiteralCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDefaultLiteral/CSharpReplaceDefaultLiteralCodeFixProvider.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplaceDefaultLiteral
         {
             var flagsAttribute = compilation.GetTypeByMetadataName(typeof(FlagsAttribute).FullName);
             return type.TypeKind == TypeKind.Enum &&
-                   type.GetAttributes().Any(attribute => attribute.AttributeClass.Equals(flagsAttribute));
+                   type.GetAttributes().Any(static (attribute, flagsAttribute) => attribute.AttributeClass.Equals(flagsAttribute), flagsAttribute);
         }
 
         private static bool IsZero(object o)

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProviderBase_MethodGroup.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProviderBase_MethodGroup.cs
@@ -57,12 +57,12 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
                 // SyntaxKind.SimpleMemberAccessExpression is for not imported types, e.g. "MyNamespace.MyClass.MyStaticMethod(...)"
                 // SyntaxKind.PredefinedType is for built-in types, e.g. "string.Equals(...)"
                 var includeInstance = !throughExpression.IsKind(SyntaxKind.IdentifierName, SyntaxKind.SimpleMemberAccessExpression, SyntaxKind.PredefinedType) ||
-                    semanticModel.LookupSymbols(throughExpression.SpanStart, name: throughSymbol?.Name).Any(s => s is not INamedTypeSymbol) ||
-                    (throughSymbol is not INamespaceOrTypeSymbol && semanticModel.LookupSymbols(throughExpression.SpanStart, container: throughSymbol?.ContainingType).Any(s => s is not INamedTypeSymbol));
+                    semanticModel.LookupSymbols(throughExpression.SpanStart, name: throughSymbol?.Name).Any(static s => s is not INamedTypeSymbol) ||
+                    (throughSymbol is not INamespaceOrTypeSymbol && semanticModel.LookupSymbols(throughExpression.SpanStart, container: throughSymbol?.ContainingType).Any(static s => s is not INamedTypeSymbol));
 
                 var includeStatic = throughSymbol is INamedTypeSymbol ||
                     (throughExpression.IsKind(SyntaxKind.IdentifierName) &&
-                    semanticModel.LookupNamespacesAndTypes(throughExpression.SpanStart, name: throughSymbol?.Name).Any(t => Equals(t.GetSymbolType(), throughType)));
+                    semanticModel.LookupNamespacesAndTypes(throughExpression.SpanStart, name: throughSymbol?.Name).Any(static (t, throughType) => Equals(t.GetSymbolType(), throughType), throughType));
 
                 Contract.ThrowIfFalse(includeInstance || includeStatic);
                 methodGroup = methodGroup.Where(m => (m.IsStatic && includeStatic) || (!m.IsStatic && includeInstance));

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             var currentNode = root.GetAnnotatedNodes(s_referenceAnnotation).Single();
             var diagnostics = updatedSemanticModel.GetDiagnostics(currentNode.Span, cancellationToken);
 
-            return diagnostics.Any(d => d.Id is CS0165 or CS0103);
+            return diagnostics.Any(static d => d.Id is CS0165 or CS0103);
         }
 
         public static SemanticModel ReplaceMatches(

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.State.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.State.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
 
                 return constructorParams.All(parameter => parameter.RefKind == RefKind.None) &&
                     !constructor.IsImplicitlyDeclared &&
-                    !constructorParams.Any(p => p.IsParams) &&
+                    !constructorParams.Any(static p => p.IsParams) &&
                     !SelectedMembersAlreadyExistAsParameters(parameterNamesForSelectedMembers, constructorParams);
             }
 

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -345,9 +345,9 @@ namespace Microsoft.CodeAnalysis.AddImport
             private bool HasAccessibleStaticFieldOrProperty(INamedTypeSymbol namedType, string fieldOrPropertyName)
             {
                 return namedType.GetMembers(fieldOrPropertyName)
-                                .Any(m => (m is IFieldSymbol || m is IPropertySymbol) &&
+                                .Any(static (m, self) => (m is IFieldSymbol || m is IPropertySymbol) &&
                                           m.IsStatic &&
-                                          m.IsAccessibleWithin(_semanticModel.Compilation.Assembly));
+                                          m.IsAccessibleWithin(self._semanticModel.Compilation.Assembly), this);
             }
 
             /// <summary>

--- a/src/Features/Core/Portable/AddParameter/AddParameterService.cs
+++ b/src/Features/Core/Portable/AddParameter/AddParameterService.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
                 ? await FindMethodDeclarationReferencesAsync(invocationDocument, method, cancellationToken).ConfigureAwait(false)
                 : method.GetAllMethodSymbolsOfPartialParts();
 
-            var anySymbolReferencesNotInSource = referencedSymbols.Any(symbol => !symbol.IsFromSource());
+            var anySymbolReferencesNotInSource = referencedSymbols.Any(static symbol => !symbol.IsFromSource());
             var locationsInSource = referencedSymbols.Where(symbol => symbol.IsFromSource());
 
             // Indexing Locations[0] is valid because IMethodSymbols have one location at most

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                 return new CannotChangeSignatureAnalyzedContext(ChangeSignatureFailureKind.IncorrectKind);
             }
 
-            if (symbol.Locations.Any(loc => loc.IsInMetadata))
+            if (symbol.Locations.Any(static loc => loc.IsInMetadata))
             {
                 return new CannotChangeSignatureAnalyzedContext(ChangeSignatureFailureKind.DefinedInMetadata);
             }
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                     continue;
                 }
 
-                if (symbol.Definition.Locations.Any(loc => loc.IsInMetadata))
+                if (symbol.Definition.Locations.Any(static loc => loc.IsInMetadata))
                 {
                     confirmationMessage = FeaturesResources.This_symbol_has_related_definitions_or_references_in_metadata_Changing_its_signature_may_result_in_build_errors_Do_you_want_to_continue;
                     continue;
@@ -556,7 +556,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                     break;
                 }
 
-                if (!arguments[i].IsNamed || updatedSignature.UpdatedConfiguration.ToListOfParameters().Any(p => p.Name == arguments[i].GetName()))
+                if (!arguments[i].IsNamed || updatedSignature.UpdatedConfiguration.ToListOfParameters().Any(static (p, arg) => p.Name == arg.arguments[arg.i].GetName(), (arguments, i)))
                 {
                     newArguments.Add(arguments[i]);
                 }

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureCodeStyle
             var language = diagnostic.Location.SourceTree.Options.Language;
             return IDEDiagnosticIdToOptionMappingHelper.TryGetMappedOptions(diagnostic.Id, language, out var options) &&
                !options.IsEmpty &&
-               options.All(o => o.StorageLocations.Any(l => l is IEditorConfigStorageLocation2));
+               options.All(o => o.StorageLocations.Any(static l => l is IEditorConfigStorageLocation2));
         }
 
         public FixAllProvider GetFixAllProvider()

--- a/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
@@ -85,6 +85,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             => HasCustomTag(diagnostic.Descriptor.ImmutableCustomTags(), SynthesizedExternalSourceDiagnosticTag);
 
         public static bool HasCustomTag(ImmutableArray<string> customTags, string tagToFind)
-            => customTags.Any(c => CultureInfo.InvariantCulture.CompareInfo.Compare(c, tagToFind) == 0);
+            => customTags.Any(static (c, tagToFind) => CultureInfo.InvariantCulture.CompareInfo.Compare(c, tagToFind) == 0, tagToFind);
     }
 }

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
                                           (definition as IMethodSymbol)?.MethodKind == MethodKind.Constructor;
             return (isImplicitlyDeclared && !isConstructorInvocation) ||
                    !reference.Location.IsInSource ||
-                   !definition.Locations.Any(loc => loc.IsInSource);
+                   !definition.Locations.Any(static loc => loc.IsInSource);
         }
 
         public void OnReferenceFound(ISymbol symbol, ReferenceLocation location)

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 
                 // compiler declared types, anonymous types, types defined in metadata should be filtered out.
                 if (SemanticDocument.SemanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken) is not INamedTypeSymbol typeSymbol ||
-                    typeSymbol.Locations.Any(loc => loc.IsInMetadata) ||
+                    typeSymbol.Locations.Any(static loc => loc.IsInMetadata) ||
                     typeSymbol.IsAnonymousType ||
                     typeSymbol.IsImplicitlyDeclared ||
                     typeSymbol.Name == string.Empty)

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -352,8 +352,8 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
 
             // If we found a linked document which is part of a project with different project file,
             // then it's an actual linked file (i.e. not a multi-targeting project). We don't support that for now.
-            if (linkedDocumentIds.Any(id =>
-                    !PathUtilities.PathsEqual(solution.GetRequiredDocument(id).Project.FilePath!, document.Project.FilePath!)))
+            if (linkedDocumentIds.Any(static (id, arg) =>
+                    !PathUtilities.PathsEqual(arg.solution.GetRequiredDocument(id).Project.FilePath!, arg.document.Project.FilePath!), (solution, document)))
             {
                 allDocumentIds = default;
                 return false;

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.MoveFileCodeAction.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.MoveFileCodeAction.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.SyncNamespace
 
                 // Invalid char can only appear in namespace name when there's error,
                 // which we have checked before creating any code actions.
-                Debug.Assert(parts.IsEmpty || parts.Any(s => s.IndexOfAny(Path.GetInvalidPathChars()) < 0));
+                Debug.Assert(parts.IsEmpty || parts.Any(static s => s.IndexOfAny(Path.GetInvalidPathChars()) < 0));
 
                 var projectRootFolder = FolderInfo.CreateFolderHierarchyForProject(document.Project);
                 var candidateFolders = FindCandidateFolders(projectRootFolder, parts, ImmutableArray<string>.Empty);

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 document, caretPosition, trigger, options, defaultItemSpan, triggeredProviders, sharedContext, cancellationToken).ConfigureAwait(false);
 
             // Nothing to do if we didn't even get any regular items back (i.e. 0 items or suggestion item only.)
-            if (!triggeredContexts.Any(cc => cc.Items.Count > 0))
+            if (!triggeredContexts.Any(static cc => cc.Items.Count > 0))
                 return CompletionList.Empty;
 
             // See if there were completion contexts provided that were exclusive. If so, then

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         private static bool InSameProject(INamedTypeSymbol symbol, Compilation compilation)
-            => symbol.DeclaringSyntaxReferences.Any(r => compilation.SyntaxTrees.Contains(r.SyntaxTree));
+            => symbol.DeclaringSyntaxReferences.Any(static (r, compilation) => compilation.SyntaxTrees.Contains(r.SyntaxTree), compilation);
 
         private static bool NotNewDeclaredMember(INamedTypeSymbol symbol, TSyntaxContext context)
         {

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         {
             var rules = GetCompletionItemRules(symbols, context);
 
-            var preselect = symbols.Any(t => t.preselect);
+            var preselect = symbols.Any(static t => t.preselect);
             var matchPriority = preselect ? ComputeSymbolMatchPriority(symbols[0].symbol) : MatchPriority.Default;
             rules = rules.WithMatchPriority(matchPriority);
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             TSyntaxContext context,
             SupportedPlatformData? supportedPlatformData)
         {
-            var preselect = symbols.Any(t => t.preselect);
+            var preselect = symbols.Any(static t => t.preselect);
             return SymbolCompletionItem.CreateWithSymbolId(
                 displayText: displayText,
                 displayTextSuffix: displayTextSuffix,

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         }
 
         private static bool HasGlobalAlias(ImmutableArray<string> aliases)
-            => aliases.IsEmpty || aliases.Any(alias => alias == MetadataReferenceProperties.GlobalAlias);
+            => aliases.IsEmpty || aliases.Any(static alias => alias == MetadataReferenceProperties.GlobalAlias);
 
         private static string? GetPEReferenceCacheKey(PortableExecutableReference peReference)
             => peReference.FilePath ?? peReference.Display;

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
@@ -100,11 +100,11 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
             bool supportsOrPattern, ImmutableArray<AnalyzedSwitchSection> sections)
         {
             // There must be a default case for an exhaustive switch expression
-            if (!sections.Any(section => section.Labels.IsDefault))
+            if (!sections.Any(static section => section.Labels.IsDefault))
                 return false;
 
             // There must be at least one return statement
-            if (!sections.Any(section => GetSwitchArmKind(section.Body) == OperationKind.Return))
+            if (!sections.Any(static section => GetSwitchArmKind(section.Body) == OperationKind.Return))
                 return false;
 
             if (!sections.All(section => CanConvertSectionForSwitchExpression(supportsOrPattern, section)))

--- a/src/Features/Core/Portable/ConvertLinq/ConvertForEachToLinqQuery/AbstractConvertForEachToLinqQueryProvider.cs
+++ b/src/Features/Core/Portable/ConvertLinq/ConvertForEachToLinqQuery/AbstractConvertForEachToLinqQueryProvider.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.ConvertLinq.ConvertForEachToLinqQuery
             }
 
             if (semanticModel.GetDiagnostics(forEachStatement.Span, cancellationToken)
-                .Any(diagnostic => diagnostic.DefaultSeverity == DiagnosticSeverity.Error))
+                .Any(static diagnostic => diagnostic.DefaultSeverity == DiagnosticSeverity.Error))
             {
                 return;
             }

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertConcatenationToInterpolatedStringRefactoringProvider.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
                 var firstStringToken = stringLiterals[0].GetFirstToken();
                 isVerbatimStringLiteral = syntaxFacts.IsVerbatimStringLiteral(firstStringToken);
                 if (stringLiterals.Any(
-                        lit => isVerbatimStringLiteral != syntaxFacts.IsVerbatimStringLiteral(lit.GetFirstToken())))
+                        static (lit, arg) => arg.isVerbatimStringLiteral != arg.syntaxFacts.IsVerbatimStringLiteral(lit.GetFirstToken()), (syntaxFacts, isVerbatimStringLiteral)))
                 {
                     return;
                 }

--- a/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertTupleToStruct/AbstractConvertTupleToStructCodeRefactoringProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
             // If it does, we can't convert this.  There is no way to describe this anonymous type
             // in the concrete type we create.
             var fields = tupleType.TupleElements;
-            var containsAnonymousType = fields.Any(p => p.Type.ContainsAnonymousType());
+            var containsAnonymousType = fields.Any(static p => p.Type.ContainsAnonymousType());
             if (containsAnonymousType)
             {
                 return;
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                 // If we captured any Method type-parameters, we can only replace the tuple types we
                 // find in the containing method.  No other tuple types in other members would be able
                 // to reference this type parameter.
-                if (!capturedTypeParameters.Any(tp => tp.TypeParameterKind == TypeParameterKind.Method))
+                if (!capturedTypeParameters.Any(static tp => tp.TypeParameterKind == TypeParameterKind.Method))
                 {
                     var containingType = tupleExprOrTypeNode.GetAncestor<TTypeBlockSyntax>();
                     if (containingType != null)
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.ConvertTupleToStruct
                     // If we captured any Type type-parameters, we can only replace the tuple
                     // types we find in the containing type.  No other tuple types in other
                     // types would be able to reference this type parameter.
-                    if (!capturedTypeParameters.Any(tp => tp.TypeParameterKind == TypeParameterKind.Type))
+                    if (!capturedTypeParameters.Any(static tp => tp.TypeParameterKind == TypeParameterKind.Type))
                     {
                         // To do a global find/replace of matching tuples, we need to search for documents
                         // containing tuples *and* which have the names of the tuple fields in them.  That means

--- a/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.cs
+++ b/src/Features/Core/Portable/Debugging/AbstractBreakpointResolver.cs
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.Debugging
 
             // Finally, check to make sure we have source, and if we've got a method symbol, make sure it
             // has a body to set a breakpoint on.
-            if ((methodOrProperty.Language == _language) && methodOrProperty.Locations.Any(location => location.IsInSource))
+            if ((methodOrProperty.Language == _language) && methodOrProperty.Locations.Any(static location => location.IsInSource))
             {
                 if (methodOrProperty.IsKind(SymbolKind.Method))
                 {

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
             // position the caller was asking for.  For example, if the user had `$$new X();` then 
             // SymbolFinder will consider that the symbol `X`. However, the doc highlights won't include
             // the `new` part, so it's not appropriate for us to highlight `X` in that case.
-            if (!tags.Any(t => t.HighlightSpans.Any(hs => hs.TextSpan.IntersectsWith(position))))
+            if (!tags.Any(static (t, position) => t.HighlightSpans.Any(static (hs, position) => hs.TextSpan.IntersectsWith(position), position), position))
                 return ImmutableArray<DocumentHighlights>.Empty;
 
             return tags;

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -1030,7 +1030,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
 
                 var oldActiveStatements = await baseActiveStatements.GetOldActiveStatementsAsync(analyzer, oldDocument, cancellationToken).ConfigureAwait(false);
-                if (oldActiveStatements.Any(s => s.Statement == activeStatement))
+                if (oldActiveStatements.Any(static (s, activeStatement) => s.Statement == activeStatement, activeStatement))
                 {
                     return documentId;
                 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeLanguageDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/DateAndTime/LanguageServices/DateAndTimeLanguageDetector.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.DateAndTime.Language
 
             var parameters = method.Parameters;
             if (argName != null)
-                return parameters.Any(p => p.Name == argName);
+                return parameters.Any(static (p, argName) => p.Name == argName, argName);
 
             var parameter = argIndex < parameters.Length ? parameters[argIndex.Value] : null;
             return parameter?.Name == FormatName;

--- a/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexLanguageDetector.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/RegularExpressions/LanguageServices/RegexLanguageDetector.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Features.EmbeddedLanguages.RegularExpressions.L
                     from method in regexType.GetMembers().OfType<IMethodSymbol>()
                     where method.DeclaredAccessibility == Accessibility.Public
                     where method.IsStatic
-                    where method.Parameters.Any(p => p.Name == _patternName)
+                    where method.Parameters.Any(static p => p.Name == _patternName)
                     select method.Name);
             }
 

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.Analyzer.cs
@@ -93,9 +93,9 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 }
 
                 var thisParameterBeingRead = (IParameterSymbol?)dataFlowAnalysisData.ReadInside.FirstOrDefault(s => IsThisParameter(s));
-                var isThisParameterWritten = dataFlowAnalysisData.WrittenInside.Any(s => IsThisParameter(s));
+                var isThisParameterWritten = dataFlowAnalysisData.WrittenInside.Any(static s => IsThisParameter(s));
 
-                var localFunctionCallsNotWithinSpan = symbolMap.Keys.Where(s => s.IsLocalFunction() && !s.Locations.Any(l => SelectionResult.FinalSpan.Contains(l.SourceSpan)));
+                var localFunctionCallsNotWithinSpan = symbolMap.Keys.Where(s => s.IsLocalFunction() && !s.Locations.Any(static (l, self) => self.SelectionResult.FinalSpan.Contains(l.SourceSpan), this));
 
                 // Checks to see if selection includes a local function call + if the given local function declaration is not included in the selection.
                 var containsAnyLocalFunctionCallNotWithinSpan = localFunctionCallsNotWithinSpan.Any();

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                     from c in containingType.InstanceConstructors
                     orderby c.Parameters.Length descending
                     where c.Parameters.Length > 0 && c.Parameters.Length < parameters.Length
-                    where c.Parameters.All(p => p.RefKind == RefKind.None) && !c.Parameters.Any(p => p.IsParams)
+                    where c.Parameters.All(p => p.RefKind == RefKind.None) && !c.Parameters.Any(static p => p.IsParams)
                     let constructorTypes = c.Parameters.Select(p => p.Type)
                     let symbolTypes = parameters.Take(c.Parameters.Length).Select(p => p.Type)
                     where constructorTypes.SequenceEqual(symbolTypes, SymbolEqualityComparer.Default)

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 
             using var _ = ArrayBuilder<PickMembersOption>.GetInstance(out var pickMemberOptions);
             var canAddNullCheck = viableMembers.Any(
-                m => m.GetSymbolType().CanAddNullCheck());
+                static m => m.GetSymbolType().CanAddNullCheck());
 
             if (canAddNullCheck)
             {

--- a/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
+++ b/src/Features/Core/Portable/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.State.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.GenerateDefaultConstructors
                 // See if the user didn't supply a constructor, and thus the compiler automatically generated
                 // one for them.   If so, also see if there's an accessible no-arg contructor in the base.
                 // If not, then the compiler will error and we want the code-fix to take over solving this problem.
-                if (classType.Constructors.Any(c => c.Parameters.Length == 0 && c.IsImplicitlyDeclared))
+                if (classType.Constructors.Any(static c => c.Parameters.Length == 0 && c.IsImplicitlyDeclared))
                 {
                     var baseNoArgConstructor = baseType.Constructors.FirstOrDefault(c => c.Parameters.Length == 0);
                     if (baseNoArgConstructor == null ||

--- a/src/Features/Core/Portable/GenerateMember/AbstractGenerateMemberService.cs
+++ b/src/Features/Core/Portable/GenerateMember/AbstractGenerateMemberService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember
             // TODO(cyrusn): Make sure that there is a totally visible part somewhere (i.e.
             // venus) that we can generate into.
             var locations = typeToGenerateIn.Locations;
-            return locations.Any(loc => loc.IsInSource);
+            return locations.Any(static loc => loc.IsInSource);
         }
 
         protected static bool TryDetermineTypeToGenerateIn(

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
 
                 var destinationProvider = _document.Project.Solution.Workspace.Services.GetLanguageServices(TypeToGenerateIn.Language);
                 var syntaxFacts = destinationProvider.GetRequiredService<ISyntaxFactsService>();
-                return TypeToGenerateIn.InstanceConstructors.Any(c => Matches(c, syntaxFacts));
+                return TypeToGenerateIn.InstanceConstructors.Any(static (c, arg) => arg.self.Matches(c, arg.syntaxFacts), (self: this, syntaxFacts));
             }
 
             private bool Matches(IMethodSymbol ctor, ISyntaxFactsService service)
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                     Token = token;
                     _arguments = arguments;
                     //// Attribute parameters are restricted to be constant values (simple types or string, etc).
-                    if (GetParameterTypes(cancellationToken).Any(t => !IsValidAttributeParameterType(t)))
+                    if (GetParameterTypes(cancellationToken).Any(static t => !IsValidAttributeParameterType(t)))
                         return false;
                 }
                 else
@@ -585,7 +585,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 var delegatingArguments = provider.GetService<SyntaxGenerator>().CreateArguments(_delegatedConstructor.Parameters);
 
                 var newParameters = _delegatedConstructor.Parameters.Concat(_parameters);
-                var generateUnsafe = !IsContainedInUnsafeType && newParameters.Any(p => p.RequiresUnsafeModifier());
+                var generateUnsafe = !IsContainedInUnsafeType && newParameters.Any(static p => p.RequiresUnsafeModifier());
 
                 var constructor = CodeGenerationSymbolFactory.CreateConstructorSymbol(
                     attributes: default,

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
 
                 // If the name bound with errors, then this is a candidate for generate method.
                 var semanticInfo = semanticModel.GetSymbolInfo(SimpleNameOrMemberAccessExpression, cancellationToken);
-                if (semanticInfo.GetAllSymbols().Any(s => s.Kind is SymbolKind.Local or SymbolKind.Parameter) &&
+                if (semanticInfo.GetAllSymbols().Any(static s => s.Kind is SymbolKind.Local or SymbolKind.Parameter) &&
                     !service.AreSpecialOptionsActive(semanticModel))
                 {
                     // if the name bound to something in scope then we don't want to generate the

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 var isUnsafe = false;
                 if (!State.IsContainedInUnsafeType)
                 {
-                    isUnsafe = returnType.RequiresUnsafeModifier() || parameters.Any(p => p.Type.RequiresUnsafeModifier());
+                    isUnsafe = returnType.RequiresUnsafeModifier() || parameters.Any(static p => p.Type.RequiresUnsafeModifier());
                 }
 
                 var method = CodeGenerationSymbolFactory.CreateMethodSymbol(

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 // caller.
                 if (_state.IsException &&
                     _state.BaseTypeOrInterfaceOpt.InstanceConstructors.Any(
-                        c => c.Parameters.Select(p => p.Type).SequenceEqual(parameterTypes, SymbolEqualityComparer.Default)))
+                        static (c, parameterTypes) => c.Parameters.Select(p => p.Type).SequenceEqual(parameterTypes, SymbolEqualityComparer.Default), parameterTypes))
                 {
                     return;
                 }

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                         var symbol = await SymbolFinder.FindSourceDefinitionAsync(TypeToGenerateInOpt, document.Project.Solution, cancellationToken).ConfigureAwait(false);
                         if (symbol == null ||
                             !symbol.IsKind(SymbolKind.NamedType) ||
-                            !symbol.Locations.Any(loc => loc.IsInSource))
+                            !symbol.Locations.Any(static loc => loc.IsInSource))
                         {
                             TypeToGenerateInOpt = null;
                             return;

--- a/src/Features/Core/Portable/GoToBase/AbstractGoToBaseService.cs
+++ b/src/Features/Core/Portable/GoToBase/AbstractGoToBaseService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.GoToBase
                     await context.OnDefinitionFoundAsync(definitionItem, cancellationToken).ConfigureAwait(false);
                     found = true;
                 }
-                else if (baseSymbol.Locations.Any(l => l.IsInMetadata))
+                else if (baseSymbol.Locations.Any(static l => l.IsInMetadata))
                 {
                     var definitionItem = baseSymbol.ToNonClassifiedDefinitionItem(
                         solution, FindReferencesSearchOptions.Default, includeHiddenLocations: true);

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 var result = document;
                 var compilation = await result.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 
-                var isComImport = unimplementedMembers.Any(t => t.type.IsComImport);
+                var isComImport = unimplementedMembers.Any(static t => t.type.IsComImport);
 
                 var memberDefinitions = GenerateMembers(
                     compilation, unimplementedMembers, Options.ImplementTypeOptions.PropertyGenerationBehavior);
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
             {
                 return
                     IdentifiersMatch(State.ClassOrStructType.Name, name) ||
-                    State.ClassOrStructType.TypeParameters.Any(t => IdentifiersMatch(t.Name, name));
+                    State.ClassOrStructType.TypeParameters.Any(static (t, arg) => arg.self.IdentifiersMatch(t.Name, arg.name), (self: this, name));
             }
 
             private string DetermineMemberName(ISymbol member, ArrayBuilder<ISymbol> implementedVisibleMembers)
@@ -392,8 +392,8 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
             private static bool IsUnexpressibleTypeParameter(ITypeParameterSymbol typeParameter)
             {
                 var condition1 = typeParameter.ConstraintTypes.Count(t => t.TypeKind == TypeKind.Class) >= 2;
-                var condition2 = typeParameter.ConstraintTypes.Any(ts => ts.IsUnexpressibleTypeParameterConstraint());
-                var condition3 = typeParameter.HasReferenceTypeConstraint && typeParameter.ConstraintTypes.Any(ts => ts.IsReferenceType && ts.SpecialType != SpecialType.System_Object);
+                var condition2 = typeParameter.ConstraintTypes.Any(static ts => ts.IsUnexpressibleTypeParameterConstraint());
+                var condition3 = typeParameter.HasReferenceTypeConstraint && typeParameter.ConstraintTypes.Any(static ts => ts.IsReferenceType && ts.SpecialType != SpecialType.System_Object);
 
                 return condition1 || condition2 || condition3;
             }

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.DisposePatternCodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.DisposePatternCodeAction.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
             var unimplementedMembers = explicitly
                 ? state.MembersWithoutExplicitImplementation
                 : state.MembersWithoutExplicitOrImplicitImplementationWhichCanBeImplicitlyImplemented;
-            if (!unimplementedMembers.Any(m => m.type.Equals(idisposableType)))
+            if (!unimplementedMembers.Any(static (m, idisposableType) => m.type.Equals(idisposableType), idisposableType))
                 return false;
 
             // The dispose pattern is only applicable if the implementing type does

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             // Ensure the user won't be able to see symbol outside the solution for derived symbols.
             // For example, if user is viewing 'IEnumerable interface' from metadata, we don't want to tell
             // the user all the derived types under System.Collections
-            var derivedSymbols = allDerivedSymbols.WhereAsArray(symbol => symbol.Locations.Any(l => l.IsInSource));
+            var derivedSymbols = allDerivedSymbols.WhereAsArray(symbol => symbol.Locations.Any(static l => l.IsInSource));
 
             if (baseSymbols.Any() || derivedSymbols.Any())
             {
@@ -340,7 +340,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 // For all implementing symbols, make sure it is in source.
                 // For example, if the user is viewing IEnumerable from metadata,
                 // then don't show the derived overriden & implemented types in System.Collections
-                var implementingSymbols = allImplementingSymbols.WhereAsArray(symbol => symbol.Locations.Any(l => l.IsInSource));
+                var implementingSymbols = allImplementingSymbols.WhereAsArray(symbol => symbol.Locations.Any(static l => l.IsInSource));
 
                 if (implementingSymbols.Any())
                 {
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 // For all overriding symbols, make sure it is in source.
                 // For example, if the user is viewing System.Threading.SynchronizationContext from metadata,
                 // then don't show the derived overriden & implemented method in the default implementation for System.Threading.SynchronizationContext in metadata
-                var overridingSymbols = allOverridingSymbols.WhereAsArray(symbol => symbol.Locations.Any(l => l.IsInSource));
+                var overridingSymbols = allOverridingSymbols.WhereAsArray(symbol => symbol.Locations.Any(static l => l.IsInSource));
 
                 if (overridingSymbols.Any() || overriddenSymbols.Any() || implementedSymbols.Any())
                 {

--- a/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             // If the assembly wants to suppress decompilation we respect that
             if (useDecompiler)
             {
-                useDecompiler = !symbol.ContainingAssembly.GetAttributes().Any(attribute => attribute.AttributeClass?.Name == nameof(SuppressIldasmAttribute)
+                useDecompiler = !symbol.ContainingAssembly.GetAttributes().Any(static attribute => attribute.AttributeClass?.Name == nameof(SuppressIldasmAttribute)
                     && attribute.AttributeClass.ToNameDisplayString() == typeof(SuppressIldasmAttribute).FullName);
             }
 
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             var metadataReference = compilation.GetMetadataReference(containingAssembly);
             var assemblyLocation = (metadataReference as PortableExecutableReference)?.FilePath;
 
-            var isReferenceAssembly = containingAssembly.GetAttributes().Any(attribute => attribute.AttributeClass?.Name == nameof(ReferenceAssemblyAttribute)
+            var isReferenceAssembly = containingAssembly.GetAttributes().Any(static attribute => attribute.AttributeClass?.Name == nameof(ReferenceAssemblyAttribute)
                 && attribute.AttributeClass.ToNameDisplayString() == typeof(ReferenceAssemblyAttribute).FullName);
 
             if (assemblyLocation is not null &&

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
         public bool IsNavigableMetadataSymbol(ISymbol symbol)
         {
-            if (!symbol.Locations.Any(l => l.IsInMetadata))
+            if (!symbol.Locations.Any(static l => l.IsInMetadata))
             {
                 return false;
             }

--- a/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
             var selectedMembers = selectedType.GetMembers()
                 .WhereAsArray(m => m.IsStatic &&
                     MemberAndDestinationValidator.IsMemberValid(m) &&
-                    m.DeclaringSyntaxReferences.Any(sr => memberDeclaration.FullSpan.Contains(sr.Span)));
+                    m.DeclaringSyntaxReferences.Any(static (sr, memberDeclaration) => memberDeclaration.FullSpan.Contains(sr.Span), memberDeclaration));
             if (selectedMembers.IsEmpty)
             {
                 return;

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentMetadataAsSourceFileProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
 
             // If this is a reference assembly then we won't have the right information available, so try to find
             // a better DLL, or bail out
-            var isReferenceAssembly = symbol.ContainingAssembly.GetAttributes().Any(attribute => attribute.AttributeClass?.Name == nameof(ReferenceAssemblyAttribute)
+            var isReferenceAssembly = symbol.ContainingAssembly.GetAttributes().Any(static attribute => attribute.AttributeClass?.Name == nameof(ReferenceAssemblyAttribute)
                 && attribute.AttributeClass.ToNameDisplayString() == typeof(ReferenceAssemblyAttribute).FullName);
             if (isReferenceAssembly &&
                 !MetadataAsSourceHelpers.TryGetImplementationAssemblyPath(dllPath, out dllPath))

--- a/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.PullMemberUp
             // Don't provide any refactoring option if the destination is not in source.
             // If the destination is generated code, also don't provide refactoring since we can't make sure if we won't break it.
             var isDestinationInSourceAndNotGeneratedCode =
-                destination.Locations.Any(location => location.IsInSource && !solution.GetDocument(location.SourceTree).IsGeneratedCode(cancellationToken));
+                destination.Locations.Any(static (location, arg) => location.IsInSource && !arg.solution.GetDocument(location.SourceTree).IsGeneratedCode(arg.cancellationToken), (solution, cancellationToken));
             return isDestinationInSourceAndNotGeneratedCode;
         }
 

--- a/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MembersPuller.cs
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
 
             // Change the destination to abstract class if needed.
             if (!result.Destination.IsAbstract &&
-                result.MemberAnalysisResults.Any(analysis => analysis.Member.IsAbstract || analysis.MakeMemberDeclarationAbstract))
+                result.MemberAnalysisResults.Any(static analysis => analysis.Member.IsAbstract || analysis.MakeMemberDeclarationAbstract))
             {
                 var modifiers = DeclarationModifiers.From(result.Destination).WithIsAbstract(true);
                 newDestination = destinationEditor.Generator.WithModifiers(newDestination, modifiers);

--- a/src/Features/Core/Portable/PullMemberUp/PullMembersUpOptions.cs
+++ b/src/Features/Core/Portable/PullMemberUp/PullMembersUpOptions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.PullMemberUp
         {
             Destination = destination;
             MemberAnalysisResults = memberAnalysisResults;
-            PullUpOperationNeedsToDoExtraChanges = MemberAnalysisResults.Any(result => result.PullMemberUpNeedsToDoExtraChanges);
+            PullUpOperationNeedsToDoExtraChanges = MemberAnalysisResults.Any(static result => result.PullMemberUpNeedsToDoExtraChanges);
         }
     }
 }

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/AbstractReplaceMethodWithPropertyService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
         {
             for (var current = method; current != null; current = current.OverriddenMethod)
             {
-                if (current.Locations.Any(loc => loc.IsInMetadata))
+                if (current.Locations.Any(static loc => loc.IsInMetadata))
                 {
                     return true;
                 }

--- a/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
+++ b/src/Features/Core/Portable/Shared/Utilities/ExtractTypeHelpers.cs
@@ -208,12 +208,12 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     return DoesTypeReferenceTypeParameter(@event.Type, typeParameter, checkedTypes);
                 case SymbolKind.Method:
                     var method = member as IMethodSymbol;
-                    return method.Parameters.Any(t => DoesTypeReferenceTypeParameter(t.Type, typeParameter, checkedTypes)) ||
-                        method.TypeParameters.Any(t => t.ConstraintTypes.Any(c => DoesTypeReferenceTypeParameter(c, typeParameter, checkedTypes))) ||
+                    return method.Parameters.Any(static (t, arg) => DoesTypeReferenceTypeParameter(t.Type, arg.typeParameter, arg.checkedTypes), (typeParameter, checkedTypes)) ||
+                        method.TypeParameters.Any(static (t, arg) => t.ConstraintTypes.Any(static (c, arg) => DoesTypeReferenceTypeParameter(c, arg.typeParameter, arg.checkedTypes), (arg.typeParameter, arg.checkedTypes)), (typeParameter, checkedTypes)) ||
                         DoesTypeReferenceTypeParameter(method.ReturnType, typeParameter, checkedTypes);
                 case SymbolKind.Property:
                     var property = member as IPropertySymbol;
-                    return property.Parameters.Any(t => DoesTypeReferenceTypeParameter(t.Type, typeParameter, checkedTypes)) ||
+                    return property.Parameters.Any(static (t, arg) => DoesTypeReferenceTypeParameter(t.Type, arg.typeParameter, arg.checkedTypes), (typeParameter, checkedTypes)) ||
                         DoesTypeReferenceTypeParameter(property.Type, typeParameter, checkedTypes);
                 case SymbolKind.Field:
                     var field = member as IFieldSymbol;
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             // We want to ignore nullability when comparing as T and T? both are references to the type parameter
             if (type.Equals(typeParameter, SymbolEqualityComparer.Default) ||
-                type.GetTypeArguments().Any(t => DoesTypeReferenceTypeParameter(t, typeParameter, checkedTypes)))
+                type.GetTypeArguments().Any(static (t, arg) => DoesTypeReferenceTypeParameter(t, arg.typeParameter, arg.checkedTypes), (typeParameter, checkedTypes)))
             {
                 return true;
             }

--- a/src/Features/Core/Portable/UnusedReferences/UnusedReferencesRemover.cs
+++ b/src/Features/Core/Portable/UnusedReferences/UnusedReferencesRemover.cs
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.UnusedReferences
 
                     // We will look at the project assemblies brought in directly by the
                     // references to see if they are used.
-                    if (!projectAssemblyFileNames.Any(usedProjectFileNames.Contains))
+                    if (!projectAssemblyFileNames.Any(static (name, usedProjectFileNames) => usedProjectFileNames.Contains(name), usedProjectFileNames))
                     {
                         // None of the project assemblies brought into this compilation are in the
                         // used assemblies list, so we will consider the reference unused.
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.UnusedReferences
                 {
                     // We will look at the compilation assemblies brought in directly by the
                     // references to see if they are used.
-                    if (!reference.CompilationAssemblies.Any(usedAssemblyFilePaths.Contains))
+                    if (!reference.CompilationAssemblies.Any(static (name, usedAssemblyFilePaths) => usedAssemblyFilePaths.Contains(name), usedAssemblyFilePaths))
                     {
                         // None of the assemblies brought into this compilation are in the
                         // used assemblies list, so we will consider the reference unused.
@@ -237,12 +237,12 @@ namespace Microsoft.CodeAnalysis.UnusedReferences
 
         internal static bool ContainsAnyCompilationAssembly(ReferenceInfo reference, HashSet<string> usedAssemblyFilePaths)
         {
-            if (reference.CompilationAssemblies.Any(usedAssemblyFilePaths.Contains))
+            if (reference.CompilationAssemblies.Any(static (name, usedAssemblyFilePaths) => usedAssemblyFilePaths.Contains(name), usedAssemblyFilePaths))
             {
                 return true;
             }
 
-            return reference.Dependencies.Any(dependency => ContainsAnyCompilationAssembly(dependency, usedAssemblyFilePaths));
+            return reference.Dependencies.Any(static (dependency, usedAssemblyFilePaths) => ContainsAnyCompilationAssembly(dependency, usedAssemblyFilePaths), usedAssemblyFilePaths);
         }
 
         internal static void RemoveAllCompilationAssemblies(ReferenceInfo reference, HashSet<string> usedAssemblyFilePaths)

--- a/src/Features/Core/Portable/ValueTracking/ValueTracker.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTracker.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.ValueTracking
 
                 // If the selection is within a declaration of the symbol, we want to include
                 // all declarations and assignments of the symbol
-                if (declaringSyntaxReferences.Any(r => r.Span.IntersectsWith(selection)))
+                if (declaringSyntaxReferences.Any(static (r, selection) => r.Span.IntersectsWith(selection), selection))
                 {
                     // Add all initializations of the symbol. Those are not caught in 
                     // the reference finder but should still show up in the tree
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.ValueTracking
 
             static bool HasAnOutOrRefParam(IMethodSymbol methodSymbol)
             {
-                return methodSymbol.Parameters.Any(p => p.IsRefOrOut());
+                return methodSymbol.Parameters.Any(static p => p.IsRefOrOut());
             }
         }
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_UpdateSource.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var ev = _eventMap.GetEventHandlers<EventHandler<DiagnosticsUpdatedArgs>>(DiagnosticsUpdatedEventName);
             if (ev.HasHandlers)
             {
-                _eventQueue.ScheduleTask(nameof(RaiseDiagnosticsUpdated), () => ev.RaiseEvent(handler => handler(this, args)), CancellationToken.None);
+                _eventQueue.ScheduleTask(nameof(RaiseDiagnosticsUpdated), () => ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args)), CancellationToken.None);
             }
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // we do this bulk update to reduce number of tasks (with captured data) enqueued.
                 // we saw some "out of memory" due to us having long list of pending tasks in memory. 
                 // this is to reduce for such case to happen.
-                void raiseEvents(DiagnosticsUpdatedArgs args) => ev.RaiseEvent(handler => handler(this, args));
+                void raiseEvents(DiagnosticsUpdatedArgs args) => ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
 
                 _eventQueue.ScheduleTask(nameof(RaiseDiagnosticsUpdated), () => eventAction(raiseEvents), CancellationToken.None);
             }
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // we do this bulk update to reduce number of tasks (with captured data) enqueued.
                 // we saw some "out of memory" due to us having long list of pending tasks in memory. 
                 // this is to reduce for such case to happen.
-                void raiseEvents(DiagnosticsUpdatedArgs args) => ev.RaiseEvent(handler => handler(this, args));
+                void raiseEvents(DiagnosticsUpdatedArgs args) => ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
 
                 _eventQueue.ScheduleTask(nameof(RaiseDiagnosticsUpdated), () => eventActionAsync(raiseEvents), CancellationToken.None);
             }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticService.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     return;
                 }
 
-                ev.RaiseEvent(handler => handler(source, args));
+                ev.RaiseEvent(static (handler, arg) => handler(arg.source, arg.args), (source, args));
             }, CancellationToken.None);
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // listener should have already created since all events are done in the serialized queue
                 foreach (var args in removed)
                 {
-                    ev.RaiseEvent(handler => handler(source, args));
+                    ev.RaiseEvent(static (handler, arg) => handler(arg.source, arg.args), (source, args));
                 }
             }, CancellationToken.None);
         }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor_Helpers.cs
@@ -408,7 +408,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     var lineSpan = diagnostic.Location.GetLineSpan();
 
                     var documentIds = targetTextDocument.Project.Solution.GetDocumentIdsWithFilePath(lineSpan.Path);
-                    return documentIds.Any(id => id == targetTextDocument.Id);
+                    return documentIds.Any(static (id, targetTextDocument) => id == targetTextDocument.Id, targetTextDocument);
                 }
 
                 return false;

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 => _activeFileStates.GetOrAdd(documentId, id => new ActiveFileState(id));
 
             public ProjectState GetOrCreateProjectState(ProjectId projectId)
-                => _projectStates.GetOrAdd(projectId, id => new ProjectState(this, id));
+                => _projectStates.GetOrAdd(projectId, static (id, self) => new ProjectState(self, id), this);
 
             public async Task<bool> OnDocumentOpenedAsync(TextDocument document)
             {

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                     // Skip analyzer if none of its reported diagnostics should be included.
                     if (shouldIncludeDiagnostic != null &&
-                        !owner.DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(analyzer).Any(a => shouldIncludeDiagnostic(a.Id)))
+                        !owner.DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(analyzer).Any(static (a, shouldIncludeDiagnostic) => shouldIncludeDiagnostic(a.Id), shouldIncludeDiagnostic))
                     {
                         return false;
                     }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -437,7 +437,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             var descriptors = DiagnosticAnalyzerInfoCache.GetDiagnosticDescriptors(analyzer);
             var analyzerConfigOptions = project.GetAnalyzerConfigOptions();
 
-            return descriptors.Any(d => d.GetEffectiveSeverity(project.CompilationOptions!, analyzerConfigOptions?.AnalyzerOptions, analyzerConfigOptions?.TreeOptions) != ReportDiagnostic.Hidden);
+            return descriptors.Any(static (d, arg) => d.GetEffectiveSeverity(arg.project.CompilationOptions!, arg.analyzerConfigOptions?.AnalyzerOptions, arg.analyzerConfigOptions?.TreeOptions) != ReportDiagnostic.Hidden, (project, analyzerConfigOptions));
         }
 
         private void RaiseProjectDiagnosticsIfNeeded(

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
@@ -672,7 +672,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 }
 
                 var diagnostics = script.Compile();
-                if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+                if (diagnostics.Any(static d => d.Severity == DiagnosticSeverity.Error))
                 {
                     DisplayInteractiveErrors(diagnostics, Console.Error);
                     return null;

--- a/src/Scripting/Core/Hosting/AssemblyLoader/MetadataShadowCopyProvider.cs
+++ b/src/Scripting/Core/Hosting/AssemblyLoader/MetadataShadowCopyProvider.cs
@@ -394,7 +394,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 return false;
             }
 
-            return !_noShadowCopyDirectories.Any(dir => directory.StartsWith(dir, StringComparison.Ordinal));
+            return !_noShadowCopyDirectories.Any(static (dir, directory) => directory.StartsWith(dir, StringComparison.Ordinal), directory);
         }
 
         private CacheEntry<MetadataShadowCopy> CreateMetadataShadowCopy(string originalPath, MetadataImageKind kind)

--- a/src/Tools/AnalyzerRunner/DiagnosticAnalyzerRunner.cs
+++ b/src/Tools/AnalyzerRunner/DiagnosticAnalyzerRunner.cs
@@ -271,7 +271,7 @@ namespace AnalyzerRunner
                 }
                 else if (options.AnalyzerNames.Count == 0)
                 {
-                    if (analyzer.SupportedDiagnostics.Any(diagnosticDescriptor => diagnosticDescriptor.IsEnabledByDefault))
+                    if (analyzer.SupportedDiagnostics.Any(static diagnosticDescriptor => diagnosticDescriptor.IsEnabledByDefault))
                     {
                         yield return analyzer;
                     }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -182,7 +182,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             }
 
             // Local: return the name if it's the declaration, otherwise the type
-            if (symbol is ILocalSymbol localSymbol && !symbol.DeclaringSyntaxReferences.Any(d => d.GetSyntax().DescendantTokens().Contains(token)))
+            if (symbol is ILocalSymbol localSymbol && !symbol.DeclaringSyntaxReferences.Any(static (d, token) => d.GetSyntax().DescendantTokens().Contains(token), token))
             {
                 symbol = localSymbol.Type;
             }

--- a/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
+++ b/src/VisualStudio/Core/Def/ColorSchemes/ColorSchemeApplier.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.ColorSchemes
         {
             return _colorSchemes.Values.Any(
                 scheme => scheme.Themes.Any(
-                    theme => theme.Guid == themeId));
+                    static (theme, themeId) => theme.Guid == themeId, themeId));
         }
 
         public async Task<bool> IsThemeCustomizedAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginHelpers.cs
@@ -47,47 +47,47 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         public static ImageMoniker GetMoniker(InheritanceRelationship inheritanceRelationship)
         {
             //  If there are multiple targets and we have the corresponding compound image, use it
-            if (s_relationships_Shown_As_I_Up_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag))
-                && s_relationships_Shown_As_O_Down_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag)))
+            if (s_relationships_Shown_As_I_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship)
+                && s_relationships_Shown_As_O_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
             {
                 return KnownMonikers.ImplementingOverridden;
             }
 
-            if (s_relationships_Shown_As_I_Up_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag))
-                && s_relationships_Shown_As_O_Up_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag)))
+            if (s_relationships_Shown_As_I_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship)
+                && s_relationships_Shown_As_O_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
             {
                 return KnownMonikers.ImplementingOverriding;
             }
 
-            if (s_relationships_Shown_As_I_Up_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag))
-                && s_relationships_Shown_As_I_Down_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag)))
+            if (s_relationships_Shown_As_I_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship)
+                && s_relationships_Shown_As_I_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
             {
                 return KnownMonikers.ImplementingImplemented;
             }
 
-            if (s_relationships_Shown_As_O_Up_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag))
-                && s_relationships_Shown_As_O_Down_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag)))
+            if (s_relationships_Shown_As_O_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship)
+                && s_relationships_Shown_As_O_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
             {
                 return KnownMonikers.OverridingOverridden;
             }
 
             // Otherwise, show the image based on this preference
-            if (s_relationships_Shown_As_I_Up_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag)))
+            if (s_relationships_Shown_As_I_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
             {
                 return KnownMonikers.Implementing;
             }
 
-            if (s_relationships_Shown_As_I_Down_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag)))
+            if (s_relationships_Shown_As_I_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
             {
                 return KnownMonikers.Implemented;
             }
 
-            if (s_relationships_Shown_As_O_Up_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag)))
+            if (s_relationships_Shown_As_O_Up_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
             {
                 return KnownMonikers.Overriding;
             }
 
-            if (s_relationships_Shown_As_O_Down_Arrow.Any(flag => inheritanceRelationship.HasFlag(flag)))
+            if (s_relationships_Shown_As_O_Down_Arrow.Any(static (flag, inheritanceRelationship) => inheritanceRelationship.HasFlag(flag), inheritanceRelationship))
             {
                 return KnownMonikers.Overridden;
             }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginGlyph.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/MarginGlyph/InheritanceMarginGlyph.cs
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         private void ContextMenu_OnOpen(object sender, RoutedEventArgs e)
         {
             if (e.OriginalSource is ContextMenu { DataContext: InheritanceMarginGlyphViewModel inheritanceMarginViewModel }
-                && inheritanceMarginViewModel.MenuItemViewModels.Any(vm => vm is TargetMenuItemViewModel))
+                && inheritanceMarginViewModel.MenuItemViewModels.Any(static vm => vm is TargetMenuItemViewModel))
             {
                 // We have two kinds of context menu. e.g.
                 // 1. [margin] -> Header

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractListItemFactory.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractListItemFactory.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         private static bool IncludeSymbol(ISymbol symbol)
         {
             return symbol.IsErrorType()
-                || symbol.Locations.Any(l => l.IsInSource || l.IsInMetadata);
+                || symbol.Locations.Any(static l => l.IsInSource || l.IsInMetadata);
         }
 
         private static bool IncludeMemberSymbol(ISymbol symbol, IAssemblySymbol assemblySymbol)
@@ -145,12 +145,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                 return false;
             }
 
-            if (symbol.Locations.Any(l => l.IsInSource))
+            if (symbol.Locations.Any(static l => l.IsInSource))
             {
                 return true;
             }
 
-            if (symbol.Locations.Any(l => l.IsInMetadata))
+            if (symbol.Locations.Any(static l => l.IsInMetadata))
             {
                 // We want to display protected members because we don't really have through
                 // type to pass along for protected checks. Besides, protected members are 
@@ -575,12 +575,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                 return false;
             }
 
-            if (typeMember.Locations.Any(l => l.IsInSource))
+            if (typeMember.Locations.Any(static l => l.IsInSource))
             {
                 return true;
             }
 
-            if (typeMember.Locations.Any(l => l.IsInMetadata))
+            if (typeMember.Locations.Any(static l => l.IsInMetadata))
             {
                 return typeMember.IsAccessibleWithin(assemblySymbol);
             }

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/SymbolListItem.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/SymbolListItem.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             _searchText = searchText;
 
             _supportsGoToDefinition = symbol.Kind != SymbolKind.Namespace
-                ? symbol.Locations.Any(l => l.IsInSource)
+                ? symbol.Locations.Any(static l => l.IsInSource)
                 : false;
 
             _supportsFindAllReferences = symbol.Kind != SymbolKind.Namespace;

--- a/src/VisualStudio/Core/Def/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/MoveToNamespace/MoveToNamespaceDialogViewModel.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
@@ -44,7 +45,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 
         public void OnNamespaceUpdated()
         {
-            var isNewNamespace = !AvailableNamespaces.Any(i => i.Namespace == NamespaceName);
+            var isNewNamespace = !AvailableNamespaces.Any(static (i, self) => i.Namespace == self.NamespaceName, this);
             var isValidName = !isNewNamespace || IsValidNamespace(NamespaceName);
 
             if (isNewNamespace && isValidName)

--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
 
             // We may need to look up source code within this solution
-            if (preferredLocation == null && symbol.Locations.Any(loc => loc.IsInMetadata))
+            if (preferredLocation == null && symbol.Locations.Any(static loc => loc.IsInMetadata))
             {
                 var newSymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, contextProject.Solution, cancellationToken).ConfigureAwait(false);
                 if (newSymbol != null)

--- a/src/VisualStudio/Core/Def/Progression/GraphNodeIdCreation.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphNodeIdCreation.cs
@@ -467,7 +467,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             if (containingSymbol is IMethodSymbol method && method.AssociatedSymbol != null && method.AssociatedSymbol.Kind == SymbolKind.Property)
             {
                 var property = (IPropertySymbol)method.AssociatedSymbol;
-                if (property.Parameters.Any(p => p.Name == symbol.Name))
+                if (property.Parameters.Any(static (p, symbol) => p.Name == symbol.Name, symbol))
                 {
                     containingSymbol = property;
                 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             => _metadataCache.ClearCache();
 
         private bool VsSmartScopeCandidate(string fullPath)
-            => _runtimeDirectories.Any(d => fullPath.StartsWith(d, StringComparison.OrdinalIgnoreCase));
+            => _runtimeDirectories.Any(static (d, fullPath) => fullPath.StartsWith(d, StringComparison.OrdinalIgnoreCase), fullPath);
 
         internal static IEnumerable<string> GetReferencePaths()
         {

--- a/src/VisualStudio/Core/Def/PullMemberUp/WarningDialog/PullMemberUpWarningViewModel.cs
+++ b/src/VisualStudio/Core/Def/PullMemberUp/WarningDialog/PullMemberUpWarningViewModel.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PullMemberUp.Wa
             var warningMessagesBuilder = ImmutableArray.CreateBuilder<string>();
 
             if (!options.Destination.IsAbstract &&
-                options.MemberAnalysisResults.Any(result => result.ChangeDestinationTypeToAbstract))
+                options.MemberAnalysisResults.Any(static result => result.ChangeDestinationTypeToAbstract))
             {
                 Logger.Log(FunctionId.PullMembersUpWarning_ChangeTargetToAbstract);
                 warningMessagesBuilder.Add(string.Format(ServicesVSResources._0_will_be_changed_to_abstract, options.Destination.Name));

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerToolWindow.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerToolWindow.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServices.StackTraceExplorer
             // where the window shows on code that parses as a stack frame but may not be. The explorer
             // should still handle those cases if explicitly pasted in, but can lead to false positives 
             // when automatically opening.
-            return firstNodeOrToken.Token.LeadingTrivia.Any(t => t.Kind == StackFrameKind.AtTrivia);
+            return firstNodeOrToken.Token.LeadingTrivia.Any(static t => t.Kind == StackFrameKind.AtTrivia);
         }
 
         public void InitializeIfNeeded(RoslynPackage roslynPackage)

--- a/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
@@ -92,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
                 return;
 
             // If feature isn't enabled for any registered language, do nothing.
-            var languageEnabled = _registeredLanguages.Any(lang => _perLanguageOptions.Any(option => _globalOptions.GetOption(option, lang)));
+            var languageEnabled = _registeredLanguages.Any(lang => _perLanguageOptions.Any(static (option, arg) => arg.self._globalOptions.GetOption(option, arg.lang), (self: this, lang)));
             if (!languageEnabled)
                 return;
 

--- a/src/VisualStudio/Core/Def/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
             private void OnDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs e)
             {
-                using (Logger.LogBlock(FunctionId.LiveTableDataSource_OnDiagnosticsUpdated, a => GetDiagnosticUpdatedMessage(GlobalOptions, a), e, CancellationToken.None))
+                using (Logger.LogBlock(FunctionId.LiveTableDataSource_OnDiagnosticsUpdated, static arg => GetDiagnosticUpdatedMessage(arg.globalOptions, arg.e), (globalOptions: GlobalOptions, e), CancellationToken.None))
                 {
                     if (_workspace != e.Workspace)
                     {

--- a/src/VisualStudio/Core/Def/Workspace/SourceGeneratedFileManager.cs
+++ b/src/VisualStudio/Core/Def/Workspace/SourceGeneratedFileManager.cs
@@ -346,7 +346,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     else
                     {
                         // The file isn't there anymore; do we still have the generator at all?
-                        if (project.AnalyzerReferences.Any(a => a.GetGenerators(project.Language).Any(g => SourceGeneratedDocumentIdentity.GetGeneratorAssemblyName(g) == _documentIdentity.GeneratorAssemblyName)))
+                        if (project.AnalyzerReferences.Any(a => a.GetGenerators(project.Language).Any(static (g, self) => SourceGeneratedDocumentIdentity.GetGeneratorAssemblyName(g) == self._documentIdentity.GeneratorAssemblyName, this)))
                         {
                             windowFrameMessageToShow = string.Format(ServicesVSResources.The_generator_0_that_generated_this_file_has_stopped_generating_this_file, GeneratorDisplayName);
                             windowFrameImageMonikerToShow = KnownMonikers.StatusError;

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/ExternalNamespaceEnumerator.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/ExternalNamespaceEnumerator.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
 
                     if (namedType.IsAccessibleWithin(containingAssembly))
                     {
-                        if (namedType.Locations.Any(l => l.IsInMetadata || l.IsInSource))
+                        if (namedType.Locations.Any(static l => l.IsInMetadata || l.IsInSource))
                         {
                             yield return state.CodeModelService.CreateCodeType(state, projectId, namedType);
                         }

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationViewModel.cs
@@ -189,21 +189,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
             {
                 _symbolKind = symbolKind;
                 Name = name;
-                IsChecked = specification.ApplicableSymbolKindList.Any(k => k.SymbolKind == symbolKind);
+                IsChecked = specification.ApplicableSymbolKindList.Any(static (k, symbolKind) => k.SymbolKind == symbolKind, symbolKind);
             }
 
             public SymbolKindViewModel(TypeKind typeKind, string name, SymbolSpecification specification)
             {
                 _typeKind = typeKind;
                 Name = name;
-                IsChecked = specification.ApplicableSymbolKindList.Any(k => k.TypeKind == typeKind);
+                IsChecked = specification.ApplicableSymbolKindList.Any(static (k, typeKind) => k.TypeKind == typeKind, typeKind);
             }
 
             public SymbolKindViewModel(MethodKind methodKind, string name, SymbolSpecification specification)
             {
                 _methodKind = methodKind;
                 Name = name;
-                IsChecked = specification.ApplicableSymbolKindList.Any(k => k.MethodKind == methodKind);
+                IsChecked = specification.ApplicableSymbolKindList.Any(static (k, methodKind) => k.MethodKind == methodKind, methodKind);
             }
 
             internal SymbolKindOrTypeKind CreateSymbolOrTypeOrMethodKind()
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
                 _accessibility = accessibility;
                 Name = name;
 
-                IsChecked = specification.ApplicableAccessibilityList.Any(a => a == accessibility);
+                IsChecked = specification.ApplicableAccessibilityList.Any(static (a, accessibility) => a == accessibility, accessibility);
             }
         }
 
@@ -256,7 +256,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
                 _modifier = modifier;
                 Name = name;
 
-                IsChecked = specification.RequiredModifierList.Any(m => m.Modifier == modifier);
+                IsChecked = specification.RequiredModifierList.Any(static (m, modifier) => m.Modifier == modifier, modifier);
             }
         }
     }

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersCommandHandler.cs
@@ -333,7 +333,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
         private void UpdateSeverityMenuItemsEnabled()
         {
-            var configurable = !_tracker.SelectedDiagnosticItems.Any(item => item.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.NotConfigurable));
+            var configurable = !_tracker.SelectedDiagnosticItems.Any(static item => item.Descriptor.ImmutableCustomTags().Contains(WellKnownDiagnosticTags.NotConfigurable));
 
             _setSeverityDefaultMenuItem.Enabled = configurable;
             _setSeverityErrorMenuItem.Enabled = configurable;

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersFolderItem/AnalyzersFolderItemSourceProvider.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersFolderItem/AnalyzersFolderItemSourceProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 var itemId = item.HierarchyIdentity.NestedItemID;
 
                 var projectTreeCapabilities = GetProjectTreeCapabilities(hierarchy, itemId);
-                if (projectTreeCapabilities.Any(c => c.Equals("References")))
+                if (projectTreeCapabilities.Any(static c => c.Equals("References")))
                 {
                     var hierarchyMapper = TryGetProjectMap();
                     if (hierarchyMapper != null &&

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/CpsDiagnosticItemSourceProvider.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/CpsDiagnosticItemSourceProvider.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             var itemId = item.HierarchyIdentity.NestedItemID;
 
             var projectTreeCapabilities = GetProjectTreeCapabilities(hierarchy, itemId);
-            return projectTreeCapabilities.Any(c => c.Equals(capability));
+            return projectTreeCapabilities.Any(static (c, capability) => c.Equals(capability), capability);
         }
 
         private static ImmutableArray<string> GetProjectTreeCapabilities(IVsHierarchy hierarchy, uint itemId)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/NamedTypeGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/NamedTypeGenerator.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 members = members.Remove(primaryConstructor);
 
                 // remove any fields/properties that were created by the primary constructor
-                members = members.WhereAsArray(m => m is not IPropertySymbol and not IFieldSymbol || !primaryConstructor.Parameters.Any(p => p.Name == m.Name));
+                members = members.WhereAsArray(m => m is not IPropertySymbol and not IFieldSymbol || !primaryConstructor.Parameters.Any(static (p, m) => p.Name == m.Name, m));
             }
 
             // remove any implicit overrides to generate.

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -743,7 +743,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     if (((IMethodSymbol)symbol).TypeArguments.Length != 0)
                     {
                         var typeArguments = ((IMethodSymbol)symbol).TypeArguments;
-                        if (!typeArguments.Any(t => t.ContainsAnonymousType()))
+                        if (!typeArguments.Any(static t => t.ContainsAnonymousType()))
                         {
                             var genericName = SyntaxFactory.GenericName(
                                             ((IdentifierNameSyntax)newNode).Identifier,

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/AbstractCSharpSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/AbstractCSharpSimplifier.cs
@@ -399,7 +399,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
                 !SyntaxFacts.IsInNamespaceOrTypeContext(expression))
             {
                 var symbols = semanticModel.LookupSymbols(expression.SpanStart, name: identifierName.Identifier.ValueText);
-                return symbols.Any(s => s is ILocalSymbol);
+                return symbols.Any(static s => s is ILocalSymbol);
             }
 
             return false;

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
 
         private static bool IsInGAC(string filePath)
         {
-            return GlobalAssemblyCacheLocation.RootLocations.Any(gloc => PathUtilities.IsChildPath(gloc, filePath));
+            return GlobalAssemblyCacheLocation.RootLocations.Any(static (gloc, filePath) => PathUtilities.IsChildPath(gloc, filePath), filePath);
         }
 
         private static string? s_frameworkRoot;

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 throw new ArgumentException(WorkspacesResources.At_least_one_diagnostic_must_be_supplied, nameof(diagnostics));
             }
 
-            if (diagnostics.Any(d => d == null))
+            if (diagnostics.Any(static d => d == null))
             {
                 throw new ArgumentException(WorkspaceExtensionsResources.Supplied_diagnostic_cannot_be_null, nameof(diagnostics));
             }

--- a/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public bool CanAddTo(ISymbol destination, Solution solution, CancellationToken cancellationToken)
         {
             var declarations = _symbolDeclarationService.GetDeclarations(destination);
-            return declarations.Any(r => CanAddTo(r.GetSyntax(cancellationToken), solution, cancellationToken));
+            return declarations.Any(static (r, arg) => arg.self.CanAddTo(r.GetSyntax(arg.cancellationToken), arg.solution, arg.cancellationToken), (self: this, solution, cancellationToken));
         }
 
         protected static SyntaxToken GetEndToken(SyntaxNode node)

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
@@ -108,6 +108,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private static bool IsTelemetryCollectionAllowed(DiagnosticAnalyzer analyzer, ImmutableArray<DiagnosticDescriptor> descriptors)
             => analyzer.IsCompilerAnalyzer() ||
                analyzer is IBuiltInAnalyzer ||
-               descriptors.Length > 0 && descriptors[0].ImmutableCustomTags().Any(t => t == WellKnownDiagnosticTags.Telemetry);
+               descriptors.Length > 0 && descriptors[0].ImmutableCustomTags().Any(static t => t == WellKnownDiagnosticTags.Telemetry);
     }
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalyzerInfoCache.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private DiagnosticDescriptorsInfo GetOrCreateDescriptorsInfo(DiagnosticAnalyzer analyzer)
             => _descriptorsInfo.GetValue(analyzer, CalculateDescriptorsInfo);
 
-        private DiagnosticDescriptorsInfo CalculateDescriptorsInfo(DiagnosticAnalyzer analyzer)
+        private static DiagnosticDescriptorsInfo CalculateDescriptorsInfo(DiagnosticAnalyzer analyzer)
         {
             ImmutableArray<DiagnosticDescriptor> descriptors;
             try

--- a/src/Workspaces/Core/Portable/ExtensionManager/IExtensionManagerExtensions.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IExtensionManagerExtensions.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Extensions
             {
                 var query = from e in extensions
                             let types = extensionManager.PerformFunction(e, () => nodeTypeGetter(e), ImmutableArray<Type>.Empty)
-                            where !types.Any() || types.Any(t2 => t1 == t2 || t1.GetTypeInfo().IsSubclassOf(t2))
+                            where !types.Any() || types.Any(static (t2, t1) => t1 == t2 || t1.GetTypeInfo().IsSubclassOf(t2), t1)
                             select e;
 
                 return query.ToImmutableArray();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             Solution solution, ImmutableArray<ISymbol> symbols, IImmutableSet<Project> projects, CancellationToken cancellationToken)
         {
             // namespaces are visible in all projects.
-            if (symbols.Any(s => s.Kind == SymbolKind.Namespace))
+            if (symbols.Any(static s => s.Kind == SymbolKind.Namespace))
                 return projects.ToImmutableArray();
 
             var dependentProjects = await GetDependentProjectsWorkerAsync(solution, symbols, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -39,8 +39,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     {
         // Static helpers so we can pass delegates around without allocations.
 
-        private static readonly Func<Location, bool> s_isInMetadata = loc => loc.IsInMetadata;
-        private static readonly Func<Location, bool> s_isInSource = loc => loc.IsInSource;
+        private static readonly Func<Location, bool> s_isInMetadata = static loc => loc.IsInMetadata;
+        private static readonly Func<Location, bool> s_isInSource = static loc => loc.IsInSource;
 
         private static readonly Func<INamedTypeSymbol, bool> s_isInterface = t => t?.TypeKind == TypeKind.Interface;
         private static readonly Func<INamedTypeSymbol, bool> s_isNonSealedClass = t => t?.TypeKind == TypeKind.Class && !t.IsSealed;

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                     deconstructMethods = semanticFacts.GetDeconstructionForEachMethods(semanticModel, node);
                 }
 
-                if (deconstructMethods.Any(m => Matches(m, symbol)))
+                if (deconstructMethods.Any(static (m, symbol) => Matches(m, symbol), symbol))
                 {
                     var location = syntaxFacts.GetDeconstructionReferenceLocation(node);
                     var symbolUsageInfo = GetSymbolUsageInfo(node, semanticModel, syntaxFacts, semanticFacts, cancellationToken);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/ConstructorSymbolReferenceFinder.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 ? int.MaxValue
                 : symbol.Parameters.Length;
 
-            var exactArgumentCount = symbol.Parameters.Any(p => p.IsOptional || p.IsParams)
+            var exactArgumentCount = symbol.Parameters.Any(static p => p.IsOptional || p.IsParams)
                 ? -1
                 : symbol.Parameters.Length;
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/MetadataUnifyingEquivalenceComparer.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/MetadataUnifyingEquivalenceComparer.cs
@@ -50,6 +50,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         private static bool IsInSource(ISymbol symbol)
-            => symbol.Locations.Any(l => l.IsInSource);
+            => symbol.Locations.Any(static l => l.IsInSource);
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     }
                 }
             }
-            else if (!symbol.Locations.Any(loc => loc.IsInMetadata))
+            else if (!symbol.Locations.Any(static loc => loc.IsInMetadata))
             {
                 // We have a symbol that's neither in source nor metadata
                 return null;
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         private static bool InSource(ISymbol symbol)
         {
-            return symbol.Locations.Any(loc => loc.IsInSource);
+            return symbol.Locations.Any(static loc => loc.IsInSource);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Helpers.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Helpers.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     {
         private static bool IsAccessible(ISymbol symbol)
         {
-            if (symbol.Locations.Any(l => l.IsInMetadata))
+            if (symbol.Locations.Any(static l => l.IsInMetadata))
             {
                 var accessibility = symbol.DeclaredAccessibility;
                 return accessibility is Accessibility.Public or

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Options
             editorconfig.AppendLine();
 
             foreach (var optionGrouping in options
-                                           .Where(o => o.StorageLocations.Any(l => l is IEditorConfigStorageLocation2))
+                                           .Where(o => o.StorageLocations.Any(static l => l is IEditorConfigStorageLocation2))
                                            .GroupBy(o => (o as IOptionWithGroup)?.Group ?? OptionGroup.Default)
                                            .OrderBy(g => g.Key.Priority))
             {

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Options
         private ImmutableArray<Workspace> _registeredWorkspaces;
 
         private readonly object _gate = new();
+        private readonly Func<OptionKey, object?> _getOption;
 
         #region Guarded by _gate
 
@@ -61,6 +62,8 @@ namespace Microsoft.CodeAnalysis.Options
             [ImportMany] IEnumerable<Lazy<IOptionProvider, LanguageMetadata>> optionProviders,
             [ImportMany] IEnumerable<Lazy<IOptionPersisterProvider>> optionPersisters)
         {
+            _getOption = GetOption;
+
             _workspaceThreadingService = workspaceThreadingService;
             _lazyAllOptions = new Lazy<ImmutableHashSet<IOption>>(() => optionProviders.SelectMany(p => p.Value.Options).ToImmutableHashSet());
             _optionPersisterProviders = optionPersisters.ToImmutableArray();
@@ -314,16 +317,16 @@ namespace Microsoft.CodeAnalysis.Options
         }
 
         public T GetOption<T>(Option<T> option)
-            => OptionsHelpers.GetOption(option, GetOption);
+            => OptionsHelpers.GetOption(option, _getOption);
 
         public T GetOption<T>(Option2<T> option)
-            => OptionsHelpers.GetOption(option, GetOption);
+            => OptionsHelpers.GetOption(option, _getOption);
 
         public T GetOption<T>(PerLanguageOption<T> option, string? language)
-            => OptionsHelpers.GetOption(option, language, GetOption);
+            => OptionsHelpers.GetOption(option, language, _getOption);
 
         public T GetOption<T>(PerLanguageOption2<T> option, string? language)
-            => OptionsHelpers.GetOption(option, language, GetOption);
+            => OptionsHelpers.GetOption(option, language, _getOption);
 
         public object? GetOption(OptionKey optionKey)
         {

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -116,7 +116,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext>
 
         private ImmutableArray<ITypeSymbol> SubstituteTypeParameters(ImmutableArray<ITypeSymbol> parameterTypeSymbols, SyntaxNode invocationExpression)
         {
-            if (!parameterTypeSymbols.Any(t => t.IsKind(SymbolKind.TypeParameter)))
+            if (!parameterTypeSymbols.Any(static t => t.IsKind(SymbolKind.TypeParameter)))
             {
                 return parameterTypeSymbols;
             }
@@ -288,8 +288,8 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext>
             //
             return recommendationSymbol.IsNamespace() &&
                    recommendationSymbol.Locations.Any(
-                       candidateLocation => !(declarationSyntax.SyntaxTree == candidateLocation.SourceTree &&
-                                              declarationSyntax.Span.IntersectsWith(candidateLocation.SourceSpan)));
+                       static (candidateLocation, declarationSyntax) => !(declarationSyntax.SyntaxTree == candidateLocation.SourceTree &&
+                                              declarationSyntax.Span.IntersectsWith(candidateLocation.SourceSpan)), declarationSyntax);
         }
 
         protected ImmutableArray<ISymbol> GetMemberSymbols(

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         {
             // if we rename an identifier and it now binds to a symbol from metadata this should be treated as
             // an invalid rename.
-            return conflictResolution.ReplacementTextValid && renamedSymbol != null && renamedSymbol.Locations.Any(loc => loc.IsInSource);
+            return conflictResolution.ReplacementTextValid && renamedSymbol != null && renamedSymbol.Locations.Any(static loc => loc.IsInSource);
         }
 
         private static async Task AddImplicitConflictsAsync(

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.ReferenceProcessing.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Rename
                 // Do not cascade to symbols that are defined only in metadata.
                 if (referencedSymbol.Kind == originalSymbol.Kind &&
                     string.Compare(TrimNameToAfterLastDot(referencedSymbol.Name), TrimNameToAfterLastDot(originalSymbol.Name), StringComparison.OrdinalIgnoreCase) == 0 &&
-                    referencedSymbol.Locations.Any(loc => loc.IsInSource))
+                    referencedSymbol.Locations.Any(static loc => loc.IsInSource))
                 {
                     return true;
                 }
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.Rename
                 if (referencedSymbol.ContainingSymbol != null &&
                     referencedSymbol.ContainingSymbol.Kind == SymbolKind.NamedType &&
                     ((INamedTypeSymbol)referencedSymbol.ContainingSymbol).TypeKind == TypeKind.Interface &&
-                    !originalSymbol.ExplicitInterfaceImplementations().Any(s => s.Equals(referencedSymbol)))
+                    !originalSymbol.ExplicitInterfaceImplementations().Any(static (s, referencedSymbol) => s.Equals(referencedSymbol), referencedSymbol))
                 {
                     return true;
                 }

--- a/src/Workspaces/Core/Portable/Rename/Renamer.RenameDocumentActionSet.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.RenameDocumentActionSet.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Rename
                     throw new ArgumentNullException(nameof(solution));
                 }
 
-                if (actions.Any(a => !ApplicableActions.Contains(a)))
+                if (actions.Any(static (a, self) => !self.ApplicableActions.Contains(a), this))
                 {
                     throw new ArgumentException(string.Format(WorkspacesResources.Cannot_apply_action_that_is_not_in_0, nameof(ApplicableActions)));
                 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IFindReferencesResultExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IFindReferencesResultExtensions.cs
@@ -74,13 +74,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             // Otherwise we still show the item even if there are no references to it.
             // And it's at least a source definition.
-            if (definition.Locations.Any(loc => loc.IsInSource))
+            if (definition.Locations.Any(static loc => loc.IsInSource))
             {
                 return true;
             }
 
             if (showMetadataSymbolsWithoutReferences &&
-                definition.Locations.Any(loc => loc.IsInMetadata))
+                definition.Locations.Any(static loc => loc.IsInMetadata))
             {
                 return true;
             }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -184,12 +184,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             // Many static predicates use the same state argument in this method
             var arg = (removeAttributeTypes, accessibleWithin);
 
-            var methodHasAttribute = method.GetAttributes().Any(static (attribute, arg) => shouldRemoveAttribute(attribute, arg), arg);
+            var methodHasAttribute = method.GetAttributes().Any(shouldRemoveAttribute, arg);
 
             var someParameterHasAttribute = method.Parameters
-                .Any(static (m, arg) => m.GetAttributes().Any(static (attribute, arg) => shouldRemoveAttribute(attribute, arg), arg), arg);
+                .Any(static (m, arg) => m.GetAttributes().Any(shouldRemoveAttribute, arg), arg);
 
-            var returnTypeHasAttribute = method.GetReturnTypeAttributes().Any(static (attribute, arg) => shouldRemoveAttribute(attribute, arg), arg);
+            var returnTypeHasAttribute = method.GetReturnTypeAttributes().Any(shouldRemoveAttribute, arg);
 
             if (!methodHasAttribute && !someParameterHasAttribute && !returnTypeHasAttribute)
             {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -181,12 +181,15 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             this IMethodSymbol method, ISymbol accessibleWithin,
             params INamedTypeSymbol[] removeAttributeTypes)
         {
-            var methodHasAttribute = method.GetAttributes().Any(shouldRemoveAttribute);
+            // Many static predicates use the same state argument in this method
+            var arg = (removeAttributeTypes, accessibleWithin);
+
+            var methodHasAttribute = method.GetAttributes().Any(static (attribute, arg) => shouldRemoveAttribute(attribute, arg), arg);
 
             var someParameterHasAttribute = method.Parameters
-                .Any(m => m.GetAttributes().Any(shouldRemoveAttribute));
+                .Any(static (m, arg) => m.GetAttributes().Any(static (attribute, arg) => shouldRemoveAttribute(attribute, arg), arg), arg);
 
-            var returnTypeHasAttribute = method.GetReturnTypeAttributes().Any(shouldRemoveAttribute);
+            var returnTypeHasAttribute = method.GetReturnTypeAttributes().Any(static (attribute, arg) => shouldRemoveAttribute(attribute, arg), arg);
 
             if (!methodHasAttribute && !someParameterHasAttribute && !returnTypeHasAttribute)
             {
@@ -197,17 +200,17 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 method,
                 containingType: method.ContainingType,
                 explicitInterfaceImplementations: method.ExplicitInterfaceImplementations,
-                attributes: method.GetAttributes().WhereAsArray(a => !shouldRemoveAttribute(a)),
-                parameters: method.Parameters.SelectAsArray(p =>
+                attributes: method.GetAttributes().WhereAsArray(static (a, arg) => !shouldRemoveAttribute(a, arg), arg),
+                parameters: method.Parameters.SelectAsArray(static (p, arg) =>
                     CodeGenerationSymbolFactory.CreateParameterSymbol(
-                        p.GetAttributes().WhereAsArray(a => !shouldRemoveAttribute(a)),
+                        p.GetAttributes().WhereAsArray(static (a, arg) => !shouldRemoveAttribute(a, arg), arg),
                         p.RefKind, p.IsParams, p.Type, p.Name, p.IsOptional,
-                        p.HasExplicitDefaultValue, p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null)),
-                returnTypeAttributes: method.GetReturnTypeAttributes().WhereAsArray(a => !shouldRemoveAttribute(a)));
+                        p.HasExplicitDefaultValue, p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null), arg),
+                returnTypeAttributes: method.GetReturnTypeAttributes().WhereAsArray(static (a, arg) => !shouldRemoveAttribute(a, arg), arg));
 
-            bool shouldRemoveAttribute(AttributeData a) =>
-                removeAttributeTypes.Any(attr => attr.Equals(a.AttributeClass)) ||
-                a.AttributeClass?.IsAccessibleWithin(accessibleWithin) == false;
+            static bool shouldRemoveAttribute(AttributeData a, (INamedTypeSymbol[] removeAttributeTypes, ISymbol accessibleWithin) arg) =>
+                arg.removeAttributeTypes.Any(attr => attr.Equals(a.AttributeClass)) ||
+                a.AttributeClass?.IsAccessibleWithin(arg.accessibleWithin) == false;
         }
 
         public static bool? IsMoreSpecificThan(this IMethodSymbol method1, IMethodSymbol method2)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IParameterSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IParameterSymbolExtensions.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 // ok, we have a record constructor.  This might be the primary constructor or not.
                 var parameterSyntax = parameter.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
                 var constructorSyntax = constructor.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
-                if (containingType.DeclaringSyntaxReferences.Any(r => r.GetSyntax(cancellationToken) == constructorSyntax))
+                if (containingType.DeclaringSyntaxReferences.Any(static (r, arg) => r.GetSyntax(arg.cancellationToken) == arg.constructorSyntax, (constructorSyntax, cancellationToken)))
                 {
                     // this was a primary constructor. see if we can map this parameter to a corresponding synthesized property 
                     foreach (var member in containingType.GetMembers(parameter.Name))

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var arg = (attributesToRemove, accessibleWithin);
 
             var someParameterHasAttribute = property.Parameters
-                .Any(static (p, arg) => p.GetAttributes().Any(static (attribute, arg) => shouldRemoveAttribute(attribute, arg), arg), arg);
+                .Any(static (p, arg) => p.GetAttributes().Any(shouldRemoveAttribute, arg), arg);
             if (!someParameterHasAttribute)
             {
                 return property;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
@@ -40,8 +40,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static IPropertySymbol RemoveInaccessibleAttributesAndAttributesOfTypes(
             this IPropertySymbol property, ISymbol accessibleWithin, params INamedTypeSymbol[] attributesToRemove)
         {
+            // Many static predicates use the same state argument in this method
+            var arg = (attributesToRemove, accessibleWithin);
+
             var someParameterHasAttribute = property.Parameters
-                .Any(p => p.GetAttributes().Any(shouldRemoveAttribute));
+                .Any(static (p, arg) => p.GetAttributes().Any(static (attribute, arg) => shouldRemoveAttribute(attribute, arg), arg), arg);
             if (!someParameterHasAttribute)
             {
                 return property;
@@ -56,18 +59,18 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 property.RefKind,
                 property.ExplicitInterfaceImplementations,
                 property.Name,
-                property.Parameters.SelectAsArray(p =>
+                property.Parameters.SelectAsArray(static (p, arg) =>
                     CodeGenerationSymbolFactory.CreateParameterSymbol(
-                        p.GetAttributes().WhereAsArray(a => !shouldRemoveAttribute(a)),
+                        p.GetAttributes().WhereAsArray(static (a, arg) => !shouldRemoveAttribute(a, arg), arg),
                         p.RefKind, p.IsParams, p.Type, p.Name, p.IsOptional,
-                        p.HasExplicitDefaultValue, p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null)),
+                        p.HasExplicitDefaultValue, p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null), arg),
                 property.GetMethod,
                 property.SetMethod,
                 property.IsIndexer);
 
-            bool shouldRemoveAttribute(AttributeData a) =>
-                attributesToRemove.Any(attr => attr.Equals(a.AttributeClass)) ||
-                a.AttributeClass?.IsAccessibleWithin(accessibleWithin) == false;
+            static bool shouldRemoveAttribute(AttributeData a, (INamedTypeSymbol[] attributesToRemove, ISymbol accessibleWithin) arg) =>
+                arg.attributesToRemove.Any(attr => attr.Equals(a.AttributeClass)) ||
+                a.AttributeClass?.IsAccessibleWithin(arg.accessibleWithin) == false;
         }
 
         public static bool IsWritableInConstructor(this IPropertySymbol property)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             // the XmlReader.Dispose() method will not be an explicit implementation of
             // IDisposable.Dispose()
             if ((!semanticFacts.SupportsImplicitInterfaceImplementation &&
-                typeSymbol.Locations.Any(location => location.IsInSource)) ||
+                typeSymbol.Locations.Any(static location => location.IsInSource)) ||
                 typeSymbol.TypeKind == TypeKind.Interface)
             {
                 return explicitMatches.FirstOrDefault();

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return false;
 
             var enumerableType = semanticModel.Compilation.IEnumerableOfTType();
-            return type.AllInterfaces.Any(i => i.OriginalDefinition.Equals(enumerableType));
+            return type.AllInterfaces.Any(static (i, enumerableType) => i.OriginalDefinition.Equals(enumerableType), enumerableType);
         }
 
         private static bool TryGeneratePluralizedNameFromTypeArgument(

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var constructor = CodeGenerationSymbolFactory.CreateConstructorSymbol(
                 attributes: default,
                 accessibility: accessibility,
-                modifiers: new DeclarationModifiers(isUnsafe: !isContainedInUnsafeType && parameters.Any(p => p.RequiresUnsafeModifier())),
+                modifiers: new DeclarationModifiers(isUnsafe: !isContainedInUnsafeType && parameters.Any(static p => p.RequiresUnsafeModifier())),
                 typeName: typeName,
                 parameters: parameters,
                 statements: statements,

--- a/src/Workspaces/Core/Portable/Shared/Extensions/TelemetryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/TelemetryExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static string GetTelemetryDiagnosticID(this Diagnostic diagnostic)
         {
             // we log diagnostic id as it is if it is from us
-            if (diagnostic.Descriptor.ImmutableCustomTags().Any(t => t == WellKnownDiagnosticTags.Telemetry))
+            if (diagnostic.Descriptor.ImmutableCustomTags().Any(static t => t == WellKnownDiagnosticTags.Telemetry))
             {
                 return diagnostic.Id;
             }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis
                     using (Logger.LogBlock(FunctionId.Workspace_Events, (s, p, d, k) => $"{s.Id} - {p} - {d} {kind.ToString()}", newSolution, projectId, documentId, kind, CancellationToken.None))
                     {
                         var args = new WorkspaceChangeEventArgs(kind, oldSolution, newSolution, projectId, documentId);
-                        ev.RaiseEvent(handler => handler(this, args));
+                        ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
                     }
                 }, WorkspaceChangeEventName);
             }
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis
             if (ev.HasHandlers)
             {
                 var args = new WorkspaceDiagnosticEventArgs(diagnostic);
-                ev.RaiseEvent(handler => handler(this, args));
+                ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
             }
         }
 
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis
                 return this.ScheduleTask(() =>
                 {
                     var args = new DocumentEventArgs(document);
-                    ev.RaiseEvent(handler => handler(this, args));
+                    ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
                 }, DocumentOpenedEventName);
             }
             else
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis
                 return this.ScheduleTask(() =>
                 {
                     var args = new DocumentEventArgs(document);
-                    ev.RaiseEvent(handler => handler(this, args));
+                    ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
                 }, DocumentClosedEventName);
             }
             else
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis
                 return this.ScheduleTask(() =>
                 {
                     var args = new DocumentActiveContextChangedEventArgs(currentSolution, sourceTextContainer, oldActiveContextDocumentId, newActiveContextDocumentId);
-                    ev.RaiseEvent(handler => handler(this, args));
+                    ev.RaiseEvent(static (handler, arg) => handler(arg.self, arg.args), (self: this, args));
                 }, "Workspace.WorkspaceChanged");
             }
             else

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ExpressionSyntaxExtensions.cs
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                         // method (or if it doesn't bind).
 
                         var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
-                        return symbolInfo.GetBestOrAllSymbols().Any() && !symbolInfo.GetBestOrAllSymbols().Any(s => s is IMethodSymbol);
+                        return symbolInfo.GetBestOrAllSymbols().Any() && !symbolInfo.GetBestOrAllSymbols().Any(static s => s is IMethodSymbol);
                     }
                     else
                     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SemanticFacts/CSharpSemanticFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SemanticFacts/CSharpSemanticFacts.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // The token may be part of a larger name (for example, `int` in `public static operator int[](Goo g);`.
                         // So check if the symbol's location encompasses the span of the token we're asking about.
-                        if (symbol.Locations.Any(loc => loc.SourceTree == location.SourceTree && loc.SourceSpan.Contains(location.SourceSpan)))
+                        if (symbol.Locations.Any(static (loc, location) => loc.SourceTree == location.SourceTree && loc.SourceSpan.Contains(location.SourceSpan), location))
                             return symbol;
                     }
                     else
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool IsPartial(ITypeSymbol typeSymbol, CancellationToken cancellationToken)
         {
             var syntaxRefs = typeSymbol.DeclaringSyntaxReferences;
-            return syntaxRefs.Any(n => ((BaseTypeDeclarationSyntax)n.GetSyntax(cancellationToken)).Modifiers.Any(SyntaxKind.PartialKeyword));
+            return syntaxRefs.Any(static (n, cancellationToken) => ((BaseTypeDeclarationSyntax)n.GetSyntax(cancellationToken)).Modifiers.Any(SyntaxKind.PartialKeyword), cancellationToken);
         }
 
         public IEnumerable<ISymbol> GetDeclaredSymbols(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticDescriptorExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/DiagnosticDescriptorExtensions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             //  2. Compiler diagnostics
             //  3. Non-configurable diagnostics
             if (!descriptor.IsEnabledByDefault ||
-                descriptor.ImmutableCustomTags().Any(tag => tag is WellKnownDiagnosticTags.Compiler or WellKnownDiagnosticTags.NotConfigurable))
+                descriptor.ImmutableCustomTags().Any(static tag => tag is WellKnownDiagnosticTags.Compiler or WellKnownDiagnosticTags.NotConfigurable))
             {
                 return false;
             }
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             //  2. Compiler diagnostics
             //  3. Non-configurable diagnostics
             if (!descriptor.IsEnabledByDefault ||
-                descriptor.ImmutableCustomTags().Any(tag => tag is WellKnownDiagnosticTags.Compiler or WellKnownDiagnosticTags.NotConfigurable))
+                descriptor.ImmutableCustomTags().Any(static tag => tag is WellKnownDiagnosticTags.Compiler or WellKnownDiagnosticTags.NotConfigurable))
             {
                 return ReportDiagnostic.Default;
             }
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             //  2. Compiler diagnostics
             //  3. Non-configurable diagnostics
             if (!descriptor.IsEnabledByDefault ||
-                descriptor.ImmutableCustomTags().Any(tag => tag is WellKnownDiagnosticTags.Compiler or WellKnownDiagnosticTags.NotConfigurable))
+                descriptor.ImmutableCustomTags().Any(static tag => tag is WellKnownDiagnosticTags.Compiler or WellKnownDiagnosticTags.NotConfigurable))
             {
                 severity = default;
                 return false;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/INamedTypeSymbolExtensions.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     // interface I<T> where T : I<T> { static abstract int operator -(T x); }
 
                     // See https://github.com/dotnet/csharplang/blob/main/spec/classes.md#unary-operators.
-                    return method.Parameters.Any(p => p.Type.Equals(within, SymbolEqualityComparer.Default));
+                    return method.Parameters.Any(static (p, within) => p.Type.Equals(within, SymbolEqualityComparer.Default), within);
                 }
 
                 return true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.RequiresUnsafeModifierVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.RequiresUnsafeModifierVisitor.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
                 return
                     symbol.Type.Accept(this) ||
-                    symbol.Parameters.Any(p => p.Accept(this));
+                    symbol.Parameters.Any(static (p, self) => p.Accept(self), this);
             }
 
             public override bool VisitTypeParameter(ITypeParameterSymbol symbol)
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return false;
                 }
 
-                return symbol.ConstraintTypes.Any(ts => ts.Accept(this));
+                return symbol.ConstraintTypes.Any(static (ts, self) => ts.Accept(self), this);
             }
 
             public override bool VisitMethod(IMethodSymbol symbol)
@@ -112,8 +112,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
                 return
                     symbol.ReturnType.Accept(this) ||
-                    symbol.Parameters.Any(p => p.Accept(this)) ||
-                    symbol.TypeParameters.Any(tp => tp.Accept(this));
+                    symbol.Parameters.Any(static (p, self) => p.Accept(self), this) ||
+                    symbol.TypeParameters.Any(static (tp, self) => tp.Accept(self), this);
             }
 
             public override bool VisitParameter(IParameterSymbol symbol)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
@@ -761,7 +761,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         /// <param name="symbol"></param>
         /// <returns><see langword="true"/> if the symbol is marked with the <see cref="System.ObsoleteAttribute"/>.</returns>
         public static bool IsObsolete(this ISymbol symbol)
-            => symbol.GetAttributes().Any(x => x.AttributeClass is
+            => symbol.GetAttributes().Any(static x => x.AttributeClass is
             {
                 MetadataName: nameof(ObsoleteAttribute),
                 ContainingNamespace.Name: nameof(System),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             this ITypeSymbol type, ITypeSymbol interfaceType)
         {
             var originalInterfaceType = interfaceType.OriginalDefinition;
-            return type.AllInterfaces.Any(t => SymbolEquivalenceComparer.Instance.Equals(t.OriginalDefinition, originalInterfaceType));
+            return type.AllInterfaces.Any(static (t, originalInterfaceType) => SymbolEquivalenceComparer.Instance.Equals(t.OriginalDefinition, originalInterfaceType), originalInterfaceType);
         }
 
         public static bool Implements(
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static bool CanSupportCollectionInitializer(this ITypeSymbol typeSymbol, ISymbol within)
         {
             return
-                typeSymbol.AllInterfaces.Any(i => i.SpecialType == SpecialType.System_Collections_IEnumerable) &&
+                typeSymbol.AllInterfaces.Any(static i => i.SpecialType == SpecialType.System_Collections_IEnumerable) &&
                 typeSymbol.GetBaseTypesAndThis()
                     .Union(typeSymbol.GetOriginalInterfacesAndTheirBaseInterfaces())
                     .SelectAccessibleMembers<IMethodSymbol>(WellKnownMemberNames.CollectionInitializerAddMethodName, within ?? typeSymbol)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                     if (modifier.ModifierKindWrapper is SymbolSpecification.ModifierKindEnum.IsStatic
                         or SymbolSpecification.ModifierKindEnum.IsReadOnly)
                     {
-                        if (x.SymbolSpecification.RequiredModifierList.Any(x => x.ModifierKindWrapper == SymbolSpecification.ModifierKindEnum.IsConst))
+                        if (x.SymbolSpecification.RequiredModifierList.Any(static x => x.ModifierKindWrapper == SymbolSpecification.ModifierKindEnum.IsConst))
                         {
                             // 'const' implies both 'readonly' and 'static'
                             continue;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/Serialization/SymbolSpecification.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
         public bool AppliesTo(SymbolKindOrTypeKind kind, DeclarationModifiers modifiers, Accessibility? accessibility)
         {
-            if (!ApplicableSymbolKindList.Any(k => k.Equals(kind)))
+            if (!ApplicableSymbolKindList.Any(static (k, kind) => k.Equals(kind), kind))
             {
                 return false;
             }
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                 return false;
             }
 
-            if (accessibility.HasValue && !ApplicableAccessibilityList.Any(k => k == accessibility))
+            if (accessibility.HasValue && !ApplicableAccessibilityList.Any(static (k, accessibility) => k == accessibility, accessibility))
             {
                 return false;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/HeaderFacts/AbstractHeaderFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/HeaderFacts/AbstractHeaderFacts.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             // Holes are exclusive: 
             // To be consistent with other 'being on the edge' of Tokens/Nodes a position is 
             // in a hole (not in a header) only if it's inside _inside_ a hole, not only on the edge.
-            if (holes.Any(h => h.Span.Contains(position) && position > h.Span.Start))
+            if (holes.Any(static (h, position) => h.Span.Contains(position) && position > h.Span.Start, position))
             {
                 return false;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/EventMap.cs
@@ -105,12 +105,12 @@ namespace Roslyn.Utilities
             public void Unregister()
                 => _handler = null;
 
-            public void Invoke(Action<TEventHandler> invoker)
+            public void Invoke<TArg>(Action<TEventHandler, TArg> invoker, TArg arg)
             {
                 var handler = _handler;
                 if (handler != null)
                 {
-                    invoker(handler);
+                    invoker(handler, arg);
                 }
             }
 
@@ -157,7 +157,7 @@ namespace Roslyn.Utilities
                 get { return _registries != null && _registries.Length > 0; }
             }
 
-            public void RaiseEvent(Action<TEventHandler> invoker)
+            public void RaiseEvent<TArg>(Action<TEventHandler, TArg> invoker, TArg arg)
             {
                 // The try/catch here is to find additional telemetry for https://devdiv.visualstudio.com/DevDiv/_queries/query/71ee8553-7220-4b2a-98cf-20edab701fd1/.
                 // We've realized there's a problem with our eventing, where if an exception is encountered while calling into subscribers to Workspace events,
@@ -171,7 +171,7 @@ namespace Roslyn.Utilities
                     {
                         foreach (var registry in _registries)
                         {
-                            registry.Invoke(invoker);
+                            registry.Invoke(invoker, arg);
                         }
                     }
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/TaskExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/TaskExtensions.cs
@@ -153,10 +153,11 @@ namespace Roslyn.Utilities
 
             Contract.ThrowIfNull(continuationFunction, nameof(continuationFunction));
 
-            TResult outerFunction(Task t)
+            static TResult outerFunction(Task t, object? state)
             {
                 try
                 {
+                    var continuationFunction = (Func<Task, TResult>)state!;
                     return continuationFunction(t);
                 }
                 catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e))
@@ -166,7 +167,7 @@ namespace Roslyn.Utilities
             }
 
             // This is the only place in the code where we're allowed to call ContinueWith.
-            return task.ContinueWith(outerFunction, cancellationToken, continuationOptions | TaskContinuationOptions.LazyCancellation, scheduler);
+            return task.ContinueWith(outerFunction, continuationFunction, cancellationToken, continuationOptions | TaskContinuationOptions.LazyCancellation, scheduler);
         }
 
         [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "This is a Task wrapper, not an asynchronous method.")]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1012,7 +1012,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             var symbols = semanticModelOpt.LookupName(nameToken, cancellationToken);
-            return symbols.Any(s =>
+            return symbols.Any(static s =>
             {
                 return s switch
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -630,7 +630,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // If the method has already been constructed poorly (i.e. with error types for type 
                 // arguments), then unconstruct it.
-                if (method.TypeArguments.Any(t => t.Kind == SymbolKind.ErrorType))
+                if (method.TypeArguments.Any(static t => t.Kind == SymbolKind.ErrorType))
                 {
                     method = method.ConstructedFrom;
                 }
@@ -1011,7 +1011,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // is the case where the other side was also unknown.  So we walk one higher and if
                     // we get a delegate or a string type, then use that type here.
                     var parentTypes = InferTypes(binop);
-                    if (parentTypes.Any(parentType => parentType.InferredType.SpecialType == SpecialType.System_String || parentType.InferredType.TypeKind == TypeKind.Delegate))
+                    if (parentTypes.Any(static parentType => parentType.InferredType.SpecialType == SpecialType.System_String || parentType.InferredType.TypeKind == TypeKind.Delegate))
                     {
                         return parentTypes.Where(parentType => parentType.InferredType.SpecialType == SpecialType.System_String || parentType.InferredType.TypeKind == TypeKind.Delegate);
                     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/NullableHelpers/NullableHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Utilities/NullableHelpers/NullableHelpers.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis
                 ILocalReferenceOperation localReference => localReference.Local.Equals(symbol),
                 IParameterReferenceOperation parameterReference => parameterReference.Parameter.Equals(symbol),
                 IAssignmentOperation assignment => IsSymbolReferencedByOperation(assignment.Target, symbol),
-                ITupleOperation tupleOperation => tupleOperation.Elements.Any(element => IsSymbolReferencedByOperation(element, symbol)),
+                ITupleOperation tupleOperation => tupleOperation.Elements.Any(static (element, symbol) => IsSymbolReferencedByOperation(element, symbol), symbol),
                 IForEachLoopOperation { LoopControlVariable: IVariableDeclaratorOperation variableDeclarator } => variableDeclarator.Symbol.Equals(symbol),
 
                 // A variable initializer is required for this to be a meaningful operation for determining possible null assignment


### PR DESCRIPTION
This pull request is the result of walking down a local performance trace running code analysis on Roslyn.sln, and looking for delegate and capture allocations that were easily eliminated. For some cases where a simple pattern emerged (such as the trivial elimination of allocations for `ImmutableArray<T>.Any`), the correction was applied throughout production code as a preventative  measure.

⚠️ Review commit-by-commit ***highly*** recommended, as the changes are broken out by concept.