### PR TITLE
Fix FindReference crash in metadata/source inheritance and multi-targetting.

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LinkedFiles.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LinkedFiles.vb
@@ -267,5 +267,91 @@ namespace {|Definition:System|}
                 Assert.Equal(2, documents.Count)
             End Using
         End Function
+
+        <WorkItem(57235, "https://github.com/dotnet/roslyn/issues/57235")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestLinkedFiles_OverrideMethods_MultiTargetting1() As Task
+            Dim definition =
+<Workspace>
+    <Project Language="C#" CommonReferencesNetCoreApp="true" AssemblyName="CSProj1">
+        <Document FilePath="C.cs"><![CDATA[
+class C
+{
+    public override int $$GetHashCode() => 0;
+}
+
+class D
+{
+    void M()
+    {
+        new C().[|GetHashCode|]();
+    }
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language="C#" CommonReferencesNetStandard20="true" AssemblyName="CSProj2">
+        <Document IsLinkFile="true" LinkAssemblyName="CSProj1" LinkFilePath="C.cs"/>
+    </Project>
+</Workspace>
+            Using workspace = TestWorkspace.Create(definition)
+                Dim invocationDocument = workspace.Documents.Single(Function(d) Not d.IsLinkFile)
+                Dim invocationPosition = invocationDocument.CursorPosition.Value
+
+                Dim document = workspace.CurrentSolution.GetDocument(invocationDocument.Id)
+                Assert.NotNull(document)
+
+                Dim symbol = Await SymbolFinder.FindSymbolAtPositionAsync(document, invocationPosition)
+                Dim references = Await SymbolFinder.FindReferencesAsync(symbol, document.Project.Solution, progress:=Nothing, documents:=Nothing)
+                Dim sourceReferences = references.Where(Function(r) r.Definition.Locations(0).IsInSource).ToArray()
+                Assert.Equal(2, sourceReferences.Count())
+                Assert.Equal("C.GetHashCode()", sourceReferences.ElementAt(0).Definition.ToString())
+                Assert.Equal("C.GetHashCode()", sourceReferences.ElementAt(1).Definition.ToString())
+                AssertEx.SetEqual(sourceReferences.Select(Function(r) r.Definition.ContainingAssembly.Name), {"CSProj1", "CSProj2"})
+            End Using
+        End Function
+
+        <WorkItem(57235, "https://github.com/dotnet/roslyn/issues/57235")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestLinkedFiles_OverrideMethods_MultiTargetting2() As Task
+            Dim definition =
+<Workspace>
+    <Project Language="C#" CommonReferencesNetStandard20="true" AssemblyName="CSProj1">
+        <Document FilePath="C.cs"><![CDATA[
+class C
+{
+    public override int $$GetHashCode() => 0;
+}
+
+class D
+{
+    void M()
+    {
+        new C().[|GetHashCode|]();
+    }
+}
+]]>
+        </Document>
+    </Project>
+    <Project Language="C#" CommonReferencesNetCoreApp="true" AssemblyName="CSProj2">
+        <Document IsLinkFile="true" LinkAssemblyName="CSProj1" LinkFilePath="C.cs"/>
+    </Project>
+</Workspace>
+            Using workspace = TestWorkspace.Create(definition)
+                Dim invocationDocument = workspace.Documents.Single(Function(d) Not d.IsLinkFile)
+                Dim invocationPosition = invocationDocument.CursorPosition.Value
+
+                Dim document = workspace.CurrentSolution.GetDocument(invocationDocument.Id)
+                Assert.NotNull(document)
+
+                Dim symbol = Await SymbolFinder.FindSymbolAtPositionAsync(document, invocationPosition)
+                Dim references = Await SymbolFinder.FindReferencesAsync(symbol, document.Project.Solution, progress:=Nothing, documents:=Nothing)
+                Dim sourceReferences = references.Where(Function(r) r.Definition.Locations(0).IsInSource).ToArray()
+                Assert.Equal(2, sourceReferences.Count())
+                Assert.Equal("C.GetHashCode()", sourceReferences.ElementAt(0).Definition.ToString())
+                Assert.Equal("C.GetHashCode()", sourceReferences.ElementAt(1).Definition.ToString())
+                AssertEx.SetEqual(sourceReferences.Select(Function(r) r.Definition.ContainingAssembly.Name), {"CSProj1", "CSProj2"})
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.BidirectionalSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.BidirectionalSymbolSet.cs
@@ -28,7 +28,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// </summary>
             private readonly MetadataUnifyingSymbolHashSet _allSymbols = new();
 
-            public BidirectionalSymbolSet(FindReferencesSearchEngine engine, HashSet<ISymbol> initialSymbols, HashSet<ISymbol> upSymbols)
+            public BidirectionalSymbolSet(
+                FindReferencesSearchEngine engine,
+                MetadataUnifyingSymbolHashSet initialSymbols,
+                MetadataUnifyingSymbolHashSet upSymbols)
                 : base(engine)
             {
                 _allSymbols.AddRange(initialSymbols);

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.SymbolSet.cs
@@ -154,8 +154,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return result;
             }
 
-            private static async Task<HashSet<ISymbol>> DetermineInitialUpSymbolsAsync(
-                FindReferencesSearchEngine engine, HashSet<ISymbol> initialSymbols, CancellationToken cancellationToken)
+            private static async Task<MetadataUnifyingSymbolHashSet> DetermineInitialUpSymbolsAsync(
+                FindReferencesSearchEngine engine,
+                MetadataUnifyingSymbolHashSet initialSymbols,
+                CancellationToken cancellationToken)
             {
                 var upSymbols = new MetadataUnifyingSymbolHashSet();
                 var workQueue = new Stack<ISymbol>();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.UnidirectionalSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.UnidirectionalSymbolSet.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
@@ -36,16 +37,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 : base(engine)
             {
                 _initialAndDownSymbols = initialSymbols;
-                _upSymbols = upSymbols.ToImmutableHashSet();
+                _upSymbols = upSymbols.ToImmutableHashSet(MetadataUnifyingEquivalenceComparer.Instance);
             }
 
             public override ImmutableArray<ISymbol> GetAllSymbols()
             {
-                using var _ = ArrayBuilder<ISymbol>.GetInstance(_upSymbols.Count + _initialAndDownSymbols.Count, out var result);
+                var result = new MetadataUnifyingSymbolHashSet();
                 result.AddRange(_upSymbols);
                 result.AddRange(_initialAndDownSymbols);
-                result.RemoveDuplicates();
-                return result.ToImmutable();
+                return result.ToImmutableArray();
             }
 
             public override async Task InheritanceCascadeAsync(Project project, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.UnidirectionalSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.UnidirectionalSymbolSet.cs
@@ -33,7 +33,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// </summary>
             private readonly ImmutableHashSet<ISymbol> _upSymbols;
 
-            public UnidirectionalSymbolSet(FindReferencesSearchEngine engine, MetadataUnifyingSymbolHashSet initialSymbols, HashSet<ISymbol> upSymbols)
+            public UnidirectionalSymbolSet(
+                FindReferencesSearchEngine engine,
+                MetadataUnifyingSymbolHashSet initialSymbols,
+                MetadataUnifyingSymbolHashSet upSymbols)
                 : base(engine)
             {
                 _initialAndDownSymbols = initialSymbols;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -16,6 +16,7 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -690,7 +691,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         private static ImmutableArray<T> RemoveOverriddenSymbolsWithinSet<T>(this ImmutableArray<T> symbols) where T : ISymbol
         {
-            var overriddenSymbols = new HashSet<ISymbol>();
+            var overriddenSymbols = new MetadataUnifyingSymbolHashSet();
 
             foreach (var symbol in symbols)
             {


### PR DESCRIPTION
More complete fix for: https://github.com/dotnet/roslyn/issues/57235