### PR TITLE
Insert braces for field and event in SmartBreakLine

### DIFF
--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -336,8 +336,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
                 if (selectedNode is BaseTypeDeclarationSyntax
                     or BaseMethodDeclarationSyntax
                     or LocalFunctionStatementSyntax
-                    or FieldDeclarationSyntax
-                    or EventFieldDeclarationSyntax
                     or AccessorDeclarationSyntax
                     or ObjectCreationExpressionSyntax
                     or WhileStatementSyntax
@@ -406,8 +404,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
             if (selectedNode is BaseTypeDeclarationSyntax
                 or BaseMethodDeclarationSyntax
                 or LocalFunctionStatementSyntax
-                or FieldDeclarationSyntax
-                or EventFieldDeclarationSyntax
                 or AccessorDeclarationSyntax)
             {
                 var newRoot = ReplaceNodeAndFormat(
@@ -624,6 +620,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
                 CatchClauseSyntax catchClauseNode => catchClauseNode.Block.SpanStart,
                 FinallyClauseSyntax finallyClauseNode => finallyClauseNode.Block.SpanStart,
                 CheckedStatementSyntax checkedStatementNode => checkedStatementNode.Keyword.Span.End,
+                FieldDeclarationSyntax fieldDeclarationNode => fieldDeclarationNode.Declaration.Variables[0].Identifier.Span.End,
+                EventFieldDeclarationSyntax eventFieldDeclarationNode => eventFieldDeclarationNode.Declaration.Variables[0].Identifier.Span.End,
                 _ => throw ExceptionUtilities.Unreachable,
             };
         }

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler.cs
@@ -367,7 +367,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
                     // }
                     // In this case, the last close brace of 'void Main()' would be thought as a part of the try statement,
                     // and the last close brace of 'Bar' would be thought as a part of Main()
-                    // So for these case, just find the missing open brace position and directly insert '()' to the document
+                    // For field and event declarations node because
+                    // class A
+                    // {
+                    //     int Hel$$lo
+                    //
+                    //     [SomeAttribute]
+                    //     void Bar() { }
+                    // }
+                    // Parser would think '[SomeAttribute]' (BrackedArgumentList) is a part of the 'Hello' (VariableDeclarator).
+                    // So for these cases, just find the missing open brace position and directly insert '()' to the document
 
                     // 1. Find the position to insert braces.
                     var insertionPosition = GetBraceInsertionPosition(selectedNode);

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
@@ -871,9 +871,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
             {
                 BaseTypeDeclarationSyntax baseTypeDeclarationNode => WithBracesForBaseTypeDeclaration(baseTypeDeclarationNode, formattingOptions),
                 BaseObjectCreationExpressionSyntax objectCreationExpressionNode => GetObjectCreationExpressionWithInitializer(objectCreationExpressionNode, formattingOptions),
-                FieldDeclarationSyntax fieldDeclarationNode when fieldDeclarationNode.Declaration.Variables.IsSingle()
-                    => ConvertFieldDeclarationToPropertyDeclaration(fieldDeclarationNode, formattingOptions),
-                EventFieldDeclarationSyntax eventFieldDeclarationNode => ConvertEventFieldDeclarationToEventDeclaration(eventFieldDeclarationNode, formattingOptions),
                 BaseMethodDeclarationSyntax baseMethodDeclarationNode => AddBlockToBaseMethodDeclaration(baseMethodDeclarationNode, formattingOptions),
                 LocalFunctionStatementSyntax localFunctionStatementNode => AddBlockToLocalFunctionDeclaration(localFunctionStatementNode, formattingOptions),
                 AccessorDeclarationSyntax accessorDeclarationNode => AddBlockToAccessorDeclaration(accessorDeclarationNode, formattingOptions),

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/AutomaticLineEnderCommandHandler_Helpers.cs
@@ -896,39 +896,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
             => objectCreationExpressionNode.WithInitializer(GetInitializerExpressionNode(formattingOptions));
 
         /// <summary>
-        /// Convert <param name="fieldDeclarationNode"/> to a property declarations.
-        /// </summary>
-        private static PropertyDeclarationSyntax ConvertFieldDeclarationToPropertyDeclaration(
-            FieldDeclarationSyntax fieldDeclarationNode,
-            SyntaxFormattingOptions formattingOptions)
-            => SyntaxFactory.PropertyDeclaration(
-                fieldDeclarationNode.AttributeLists,
-                fieldDeclarationNode.Modifiers,
-                fieldDeclarationNode.Declaration.Type,
-                explicitInterfaceSpecifier: null,
-                identifier: fieldDeclarationNode.Declaration.Variables[0].Identifier,
-                accessorList: GetAccessorListNode(formattingOptions),
-                expressionBody: null,
-                initializer: null,
-                semicolonToken: SyntaxFactory.Token(SyntaxKind.None)).WithTriviaFrom(fieldDeclarationNode);
-
-        /// <summary>
-        /// Convert <param name="eventFieldDeclarationNode"/> to an eventDeclaration node.
-        /// </summary>
-        private static EventDeclarationSyntax ConvertEventFieldDeclarationToEventDeclaration(
-            EventFieldDeclarationSyntax eventFieldDeclarationNode,
-            SyntaxFormattingOptions formattingOptions)
-            => SyntaxFactory.EventDeclaration(
-                eventFieldDeclarationNode.AttributeLists,
-                eventFieldDeclarationNode.Modifiers,
-                eventFieldDeclarationNode.EventKeyword,
-                eventFieldDeclarationNode.Declaration.Type,
-                explicitInterfaceSpecifier: null,
-                identifier: eventFieldDeclarationNode.Declaration.Variables[0].Identifier,
-                accessorList: GetAccessorListNode(formattingOptions),
-                semicolonToken: SyntaxFactory.Token(SyntaxKind.None)).WithTriviaFrom(eventFieldDeclarationNode);
-
-        /// <summary>
         /// Add an empty block to <param name="baseMethodDeclarationNode"/>.
         /// </summary>
         private static BaseMethodDeclarationSyntax AddBlockToBaseMethodDeclaration(

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticLineEnderTests.cs
@@ -3182,6 +3182,62 @@ public class Bar
 }}");
         }
 
+        [WpfFact]
+        public void TestConvertFieldToPropertyWithAttributeAndComment()
+        {
+            Test(@"
+public class Bar
+{
+    public int Property
+    {
+        $$
+    }
+
+    /// <summary>
+    /// </summary>
+    [SomeAttri]
+    public void Method() { }
+}",
+@"
+public class Bar
+{
+    public int Property$$
+
+    /// <summary>
+    /// </summary>
+    [SomeAttri]
+    public void Method() { }
+}");
+        }
+
+        [WpfFact]
+        public void TestConvertEventFieldToPropertyWithAttributeAndComment()
+        {
+            Test(@"
+public class Bar
+{
+    public event EventHandler MyEvent
+    {
+        $$
+    }
+
+    /// <summary>
+    /// </summary>
+    [SomeAttri]
+    public void Method() { }
+}",
+@"
+public class Bar
+{
+    public event EventHandler MyEvent$$
+
+    /// <summary>
+    /// </summary>
+    [SomeAttri]
+    public void Method() { }
+}");
+        }
+
         protected override string Language => LanguageNames.CSharp;
 
         protected override Action CreateNextHandler(TestWorkspace workspace)


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/61291

Back when SmartBreakLine is implemented, there are two ways to add braces to a syntax node,
1. Using the syntax node information (how field/event is modified now) And this is the reason for the bug
The syntax tree is in a bad state if a field/event is followed by an attribute.
![image](https://user-images.githubusercontent.com/24360909/172230702-3a9f5d83-e3c1-4540-99c5-75ea72f3c870.png)
If we try to rewrite the node by using the syntax node information the comment and the attribute would be dropped.

2. When the syntax node information is not reliable (because in many cases the code is incomplete), just simply add "()" to the document. (how field/event is modified after)