### PR TITLE
Don't bubble up linked token cancellation to the batching work queue

### DIFF
--- a/src/EditorFeatures/Core/Remote/SolutionChecksumUpdater.cs
+++ b/src/EditorFeatures/Core/Remote/SolutionChecksumUpdater.cs
@@ -175,10 +175,10 @@ namespace Microsoft.CodeAnalysis.Remote
                         cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (!disposalToken.IsCancellationRequested)
             {
-                // Don't bubble up cancellation to the queue.  Just because we decided to cancel this batch isn't
-                // something the queue should be aware of.
+                // Don't bubble up cancellation to the queue for our own internal cancellation.  Just because we decided
+                // to cancel this batch isn't something the queue should be aware of.
             }
         }
 

--- a/src/EditorFeatures/Core/Remote/SolutionChecksumUpdater.cs
+++ b/src/EditorFeatures/Core/Remote/SolutionChecksumUpdater.cs
@@ -156,22 +156,29 @@ namespace Microsoft.CodeAnalysis.Remote
 
             // Create a token that will fire if we are disposed or if we get paused.
             using var source = CancellationTokenSource.CreateLinkedTokenSource(uncancelledToken.Value, disposalToken);
-
-            // Now actually synchronize the workspace.
-            var cancellationToken = source.Token;
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var client = await RemoteHostClient.TryGetClientAsync(_workspace, cancellationToken).ConfigureAwait(false);
-            if (client == null)
-                return;
-
-            using (Logger.LogBlock(FunctionId.SolutionChecksumUpdater_SynchronizePrimaryWorkspace, cancellationToken))
+            try
             {
-                var workspaceVersion = solution.WorkspaceVersion;
-                await client.TryInvokeAsync<IRemoteAssetSynchronizationService>(
-                    solution,
-                    (service, solution, cancellationToken) => service.SynchronizePrimaryWorkspaceAsync(solution, workspaceVersion, cancellationToken),
-                    cancellationToken).ConfigureAwait(false);
+                // Now actually synchronize the workspace.
+                var cancellationToken = source.Token;
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var client = await RemoteHostClient.TryGetClientAsync(_workspace, cancellationToken).ConfigureAwait(false);
+                if (client == null)
+                    return;
+
+                using (Logger.LogBlock(FunctionId.SolutionChecksumUpdater_SynchronizePrimaryWorkspace, cancellationToken))
+                {
+                    var workspaceVersion = solution.WorkspaceVersion;
+                    await client.TryInvokeAsync<IRemoteAssetSynchronizationService>(
+                        solution,
+                        (service, solution, cancellationToken) => service.SynchronizePrimaryWorkspaceAsync(solution, workspaceVersion, cancellationToken),
+                        cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Don't bubble up cancellation to the queue.  Just because we decided to cancel this batch isn't
+                // something the queue should be aware of.
             }
         }
 

--- a/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
@@ -118,10 +118,10 @@ namespace Microsoft.CodeAnalysis.Host
                 await AddCompilationsForVisibleDocumentsAsync(
                     workspace.CurrentSolution, compilations, source.Token).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (!disposalToken.IsCancellationRequested)
             {
-                // Don't bubble up cancellation to the queue.  Just because we decided to cancel this batch isn't
-                // something the queue should be aware of.
+                // Don't bubble up cancellation to the queue for our own internal cancellation.  Just because we decided
+                // to cancel this batch isn't something the queue should be aware of.
             }
         }
 

--- a/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
+++ b/src/Features/Core/Portable/Workspace/BackgroundCompiler.cs
@@ -113,8 +113,16 @@ namespace Microsoft.CodeAnalysis.Host
                 return;
 
             using var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken.Value, disposalToken);
-            await AddCompilationsForVisibleDocumentsAsync(
-                workspace.CurrentSolution, compilations, source.Token).ConfigureAwait(false);
+            try
+            {
+                await AddCompilationsForVisibleDocumentsAsync(
+                    workspace.CurrentSolution, compilations, source.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Don't bubble up cancellation to the queue.  Just because we decided to cancel this batch isn't
+                // something the queue should be aware of.
+            }
         }
 
         private static async ValueTask AddCompilationsForVisibleDocumentsAsync(

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
@@ -147,7 +147,7 @@ namespace Roslyn.Utilities
                 }
                 // Make sure the task being performed doesn't propagate out a cancellation exception that isn't
                 // associated with the token we pass into it.
-                catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, _cancellationToken))
+                catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, _cancellationToken, ErrorSeverity.Critical))
                 {
                 }
 

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
@@ -179,6 +179,10 @@ namespace Roslyn.Utilities
                 // Make sure the task being performed doesn't propagate out a cancellation exception that isn't
                 // associated with the token we pass into it.  We don't want an errant cancellation token for some
                 // other reason to cancel this queue from performing work.
+                //
+                // Note: we report-and-catch, so that further batches of work can still process.  The sentiment being
+                // that generally failures are recoverable here, and we will have reported the error so we can see in
+                // telemetry if we have a problem that needs addressing.
                 return default;
             }
         }

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
@@ -145,10 +145,11 @@ namespace Roslyn.Utilities
                 {
                     await lastTask.ConfigureAwait(false);
                 }
-                // Make sure the task being performed doesn't propagate out a cancellation exception that isn't
-                // associated with the token we pass into it.
                 catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, _cancellationToken, ErrorSeverity.Critical))
                 {
+                    // Make sure the task being performed doesn't propagate out a cancellation exception that isn't
+                    // associated with the token we pass into it.  We don't want an errant cancellation token for some
+                    // other reason to cancel this queue from performing work.
                 }
 
                 // If we were asked to shutdown, immediately transition to the canceled state without doing any more work.

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
@@ -14,10 +14,15 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 namespace Roslyn.Utilities
 {
     /// <summary>
-    /// A queue where items can be added to to be processed in batches after some delay has passed.
-    /// When processing happens, all the items added since the last processing point will be passed
-    /// along to be worked on.  Rounds of processing happen serially, only starting up after a
-    /// previous round has completed.
+    /// A queue where items can be added to to be processed in batches after some delay has passed. When processing
+    /// happens, all the items added since the last processing point will be passed along to be worked on.  Rounds of
+    /// processing happen serially, only starting up after a previous round has completed.
+    /// <para>
+    /// Failure to complete a particular batch (either due to cancellation or some faulting error) will not prevent
+    /// further batches from executing. The only thing that will permenantly stop this queue from processing items is if
+    /// the <see cref="CancellationToken"/> passed to the constructor switches to <see
+    /// cref="CancellationToken.IsCancellationRequested"/>.
+    /// </para>
     /// </summary>
     internal class AsyncBatchingWorkQueue<TItem, TResult>
     {
@@ -161,8 +166,8 @@ namespace Roslyn.Utilities
 
         /// <summary>
         /// Waits until the current batch of work completes and returns the last value successfully computed from <see
-        /// cref="_processBatchAsync"/>.  If the last <see cref="_processBatchAsync"/> canceled or failed, then a Task
-        /// with <see cref="Task{TResult}.Result"/> or <see langword="default"/> will be returned.
+        /// cref="_processBatchAsync"/>.  If the last <see cref="_processBatchAsync"/> canceled or failed, then a
+        /// corresponding canceled or faulted task will be returned that propagates that outwards.
         /// </summary>
         public Task<TResult?> WaitUntilCurrentBatchCompletesAsync()
         {

--- a/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/AsyncBatchingWorkQueue`2.cs
@@ -151,6 +151,9 @@ namespace Roslyn.Utilities
                 {
                 }
 
+                // If we were asked to shutdown, immediately transition to the canceled state without doing any more work.
+                _cancellationToken.ThrowIfCancellationRequested();
+
                 // Ensure that we always yield the current thread this is necessary for correctness as we are called
                 // inside a lock that _taskInFlight to true.  We must ensure that the work to process the next batch
                 // must be on another thread that runs afterwards, can only grab the thread once we release it and will


### PR DESCRIPTION
We were bubbling out an interior cancellation operation to our async batching queue, causing it to cancel all further work.  This violates the contract about how cancellation is supposed to operate (Where callers should only get cancellation on the tokens they pass into methods).  This was leading to us having a race where we might cancel nested work, but end up in a canceled state forever.