### PR TITLE
Simplify nested lambda

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // If no switch sections are subsumed, just return
-            if (!switchSections.Any(static (s, reachableLabels) => s.SwitchLabels.Any(static (l, reachableLabels) => isSubsumed(l, reachableLabels), reachableLabels), reachableLabels))
+            if (!switchSections.Any(static (s, reachableLabels) => s.SwitchLabels.Any(isSubsumed, reachableLabels), reachableLabels))
             {
                 return;
             }


### PR DESCRIPTION
The `isSubsumed` local function is marked `static`, so the compiler will cache the delegate.

This was not flagged by our analyzer due to the following condition. I don't have a good answer here; the `static` modifier is great for clarity but bad for readability.

https://github.com/dotnet/roslyn/blob/5ada1d50295dbdff8c8b34f124354b6fad31427d/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs#L77-L81