### PR TITLE
Include IndentBlockFormattingRule in AddMissingImportsService

### DIFF
--- a/src/Features/CSharp/Portable/AddImport/CSharpAddMissingImportsFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddMissingImportsFeatureService.cs
@@ -9,7 +9,10 @@ using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.AddMissingImports;
 using Microsoft.CodeAnalysis.CSharp.AddImport;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.AddMissingImports
 {
@@ -23,5 +26,8 @@ namespace Microsoft.CodeAnalysis.CSharp.AddMissingImports
         }
 
         protected sealed override ImmutableArray<string> FixableDiagnosticIds => AddImportDiagnosticIds.FixableDiagnosticIds;
+
+        protected override ImmutableArray<AbstractFormattingRule> GetFormatRules(SourceText text)
+            => ImmutableArray.Create<AbstractFormattingRule>(new CleanUpNewLinesFormatter(text), new IndentBlockFormattingRule());
     }
 }

--- a/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddMissingImportsFeatureService.vb
+++ b/src/Features/VisualBasic/Portable/AddImport/VisualBasicAddMissingImportsFeatureService.vb
@@ -5,7 +5,9 @@
 Imports System.Collections.Immutable
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.AddMissingImports
+Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.AddImport
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.AddMissingImports
@@ -19,5 +21,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.AddMissingImports
         End Sub
 
         Protected Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String) = AddImportDiagnosticIds.FixableDiagnosticIds
+
+        Protected Overrides Function GetFormatRules(text As SourceText) As ImmutableArray(Of AbstractFormattingRule)
+            Return ImmutableArray.Create(Of AbstractFormattingRule)(New CleanUpNewLinesFormatter(text))
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/61605
For code
```
namespace MyNS
{
    using System;
    
     class MyClass
     {
         // Copy 'Task GetSomething() => Task.CompletedTask;'
          $$
     }
}
```
Add import service will add `using System.Threading.Tasks` after `System`, and use this [rule ](https://sourceroslyn.io/#Microsoft.CodeAnalysis.Features/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs,235), to format the extra lines between 'usings'. However, it doesn't include the correct indentation.

This PR adds `IndentBlockFormattingRule` to the format rules to give the right indentation to the using statements.