### PR TITLE
React to DartLab.Templates changes

### DIFF
--- a/azure-pipelines-integration-dartlab.yml
+++ b/azure-pipelines-integration-dartlab.yml
@@ -29,7 +29,7 @@ variables:
   value: $(Build.SourcesDirectory)\artifacts\log\$(_configuration)
 
 stages:
-- template: \stages\visual-studio\base.yml@DartLabTemplates
+- template: \stages\visual-studio\agent.yml@DartLabTemplates
   parameters:
     displayName: VS Integration
     testLabPoolName: VS-Platform


### PR DESCRIPTION
This is the Roslyn version of https://github.com/dotnet/razor-tooling/pull/6494, which fixes breaks such as [this one](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6252460&view=results) due to a change in their templates.

This will be proven correct once [this build passes](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6256815&view=results) in Razor.