### PR TITLE
Disallow an interface containing or inheriting static abstract/virtual members without implementation as a type argument

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6887,7 +6887,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Target runtime doesn't support static abstract members in interfaces.</value>
   </data>
   <data name="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers" xml:space="preserve">
-    <value>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</value>
+    <value>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</value>
   </data>
   <data name="ERR_BadAbstractUnaryOperatorSignature" xml:space="preserve">
     <value>The parameter of a unary operator must be the containing type, or its type parameter constrained to it.</value>

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -985,6 +985,13 @@ hasRelatedInterfaces:
                                                                            ignoreTypeConstraintsDependentOnTypeParametersOpt);
             bool hasError = false;
 
+            if (typeArgument.Type is NamedTypeSymbol { IsInterface: true } iFace && SelfOrBaseHasStaticAbstractMember(iFace, ref useSiteInfo, out Symbol member))
+            {
+                diagnosticsBuilder.Add(new TypeParameterDiagnosticInfo(typeParameter,
+                    new UseSiteInfo<AssemblySymbol>(new CSDiagnosticInfo(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, iFace, member))));
+                hasError = true;
+            }
+
             foreach (var constraintType in constraintTypes)
             {
                 CheckConstraintType(containingSymbol, in args, typeParameter, typeArgument, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt, ref useSiteInfo, constraintType, ref hasError);
@@ -1078,20 +1085,7 @@ hasRelatedInterfaces:
             ErrorCode errorCode;
             if (typeArgument.Type.IsReferenceType)
             {
-                // When constraint has static abstract members this needs to be further restricted so that generic argument cannot itself be an interface.
-                if (typeArgument.Type.IsInterfaceType() && constraintType.Type.IsInterfaceType() &&
-                    args.Conversions.WithNullability(false).HasIdentityOrImplicitReferenceConversion(typeArgument.Type, constraintType.Type, ref useSiteInfo))
-                {
-#if DEBUG
-                    var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
-                    Debug.Assert(SelfOrBaseHasStaticAbstractMember(constraintType, ref discardedUseSiteInfo));
-#endif
-                    errorCode = ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers;
-                }
-                else
-                {
-                    errorCode = ErrorCode.ERR_GenericConstraintNotSatisfiedRefType;
-                }
+                errorCode = ErrorCode.ERR_GenericConstraintNotSatisfiedRefType;
             }
             else if (typeArgument.IsNullableType())
             {
@@ -1261,13 +1255,6 @@ hasRelatedInterfaces:
 
             if (conversions.HasIdentityOrImplicitReferenceConversion(typeArgument.Type, constraintType.Type, ref useSiteInfo))
             {
-                // When constraint has static abstract members this needs to be further restricted so that generic argument cannot itself be an interface.
-                if (typeArgument.Type.IsInterfaceType() && constraintType.Type.IsInterfaceType() &&
-                    SelfOrBaseHasStaticAbstractMember(constraintType, ref useSiteInfo))
-                {
-                    return false;
-                }
-
                 return true;
             }
 
@@ -1305,29 +1292,34 @@ hasRelatedInterfaces:
             return false;
         }
 
-        private static bool SelfOrBaseHasStaticAbstractMember(TypeWithAnnotations constraintType, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+        private static bool SelfOrBaseHasStaticAbstractMember(NamedTypeSymbol iFace, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo, out Symbol memberWithoutImplementation)
         {
-            Debug.Assert(constraintType.Type.IsInterfaceType());
+            Debug.Assert(iFace.IsInterfaceType());
 
-            Func<Symbol, bool> predicate = static m => m.IsStatic && (m.IsAbstract || m.IsVirtual);
-            var definition = (NamedTypeSymbol)constraintType.Type.OriginalDefinition;
-
-            if (definition.GetMembersUnordered().Any(predicate))
+            foreach (Symbol m in iFace.GetMembers())
             {
-                return true;
-            }
-
-            foreach (var baseInterface in definition.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.Keys)
-            {
-                var baseDefinition = baseInterface.OriginalDefinition;
-                if (baseDefinition.GetMembersUnordered().Any(predicate))
+                if (m.IsStatic && m.IsImplementableInterfaceMember() && iFace.FindImplementationForInterfaceMember(m) is null)
                 {
+                    memberWithoutImplementation = m;
                     return true;
                 }
-
-                baseDefinition.AddUseSiteInfo(ref useSiteInfo);
             }
 
+            foreach (var baseInterface in iFace.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.Keys)
+            {
+                foreach (Symbol m in baseInterface.GetMembers())
+                {
+                    if (m.IsStatic && m.IsImplementableInterfaceMember() && iFace.FindImplementationForInterfaceMember(m) is null)
+                    {
+                        memberWithoutImplementation = m;
+                        return true;
+                    }
+                }
+
+                baseInterface.OriginalDefinition.AddUseSiteInfo(ref useSiteInfo);
+            }
+
+            memberWithoutImplementation = null;
             return false;
         }
 

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">Rozhraní {3} nelze použít jako parametr obecného typu {2} v obecném typu nebo metodě {0}. Rozhraní s omezením {1} nebo jeho základní rozhraní má statické abstraktní členy.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">Die Schnittstelle „{3}“ kann nicht als Typparameter „{2}“ im generischen Typ oder in der Methode „{0}“ verwendet werden. Die Einschränkungsschnittstelle „{1}“ oder die Basisschnittstelle weist statische abstrakte Elemente auf.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">La interfaz "{3}" no se puede usar como parámetro de tipo "{2}" en el tipo o método genérico "{0}". La interfaz de restricción "{1}" o su interfaz base tiene miembros abstractos estáticos.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">L’interface « {3} » ne peut pas être utilisée comme paramètre de type « {2} » dans le type ou la méthode générique « {0} ». L’interface de contrainte « {1} » ou son interface de base a des membres abstraits statiques.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">Non è possibile usare l'interfaccia '{3}' come parametro di tipo '{2}' nel metodo o nel tipo generico '{0}'. L'interfaccia di vincolo '{1}' o la relativa interfaccia di base contiene membri statici astratti.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">インターフェイス '{3}' をジェネリック型またはメソッド '{0}' で型パラメーター '{2}' として使用することはできません。制約インターフェイス '{1}' またはその基本インターフェイスに、静的な抽象メンバーが含まれています。</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">인터페이스 '{3}'은(는) 제네릭 유형 또는 메소드 '{0}'에서 유형 매개 변수 '{2}'(으)로 사용할 수 없습니다. 제약 조건 인터페이스 '{1}' 또는 기본 인터페이스에 정적 추상 멤버가 있습니다.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">Interfejsu "{3}" nie można użyć jako parametru typu "{2}" w typie ogólnym lub metodzie "{0}". Interfejs ograniczenia "{1}" lub jego interfejs podstawowy ma statyczne składowe abstrakcyjne.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">A interface '{3}' não pode ser usada como o parâmetro de tipo '{2}' no tipo ou método genérico '{0}'. A interface de restrição '{1}' ou sua interface base tem membros abstratos estáticos.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">Невозможно использовать интерфейс "{3}" в качестве параметра типа "{2}" в универсальном типе или методе "{0}". Интерфейс ограничения "{1}" или его базовый интерфейс содержит статические абстрактные элементы.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">'{3}' arabirimi '{2}' tür parametresi olarak '{0}' genel türünde veya yönteminde kullanılamaz. '{1}' kısıtlama arabirimi veya onun temel arabirimi, statik soyut üyelere sahip.</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">接口“{3}”不能用作泛型类型或方法“{2}”中的类型参数“{0}”。约束接口“{1}”或其基接口具有静态抽象成员。</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -593,8 +593,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers">
-        <source>The interface '{3}' cannot be used as type parameter '{2}' in the generic type or method '{0}'. The constraint interface '{1}' or its base interface has static abstract or virtual members.</source>
-        <target state="needs-review-translation">無法使用介面 '{3}' 作為泛型型別或方法 '{0}' 中的型別參數 '{2}'。限制式介面 '{1}' 或其基底介面具有靜態抽象成員。</target>
+        <source>The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</source>
+        <target state="new">The interface '{0}' cannot be used as type argument. Member '{1}' does not have a most specific implementation in the interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_GlobalUsingInNamespace">

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests.cs
@@ -10521,12 +10521,19 @@ class C2 { }
                 // (8,26): error CS8919: Target runtime doesn't support static abstract members in interfaces.
                 //     static abstract void M();
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "M").WithLocation(8, 26),
-                // (19,8): error CS8920: The interface 'I1' cannot be used as type parameter 'T' in the generic type or method 'Attr2<T>'. The constraint interface 'I1' or its base interface has static abstract or virtual members.
+                // (18,8): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.M()' does not have a most specific implementation in the interface.
+                // [Attr1<I1>]
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "I1").WithArguments("I1", "I1.M()").WithLocation(18, 8),
+                // (19,8): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.M()' does not have a most specific implementation in the interface.
                 // [Attr2<I1>]
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "I1").WithArguments("Attr2<T>", "I1", "T", "I1").WithLocation(19, 8),
-                // (23,8): error CS8920: The interface 'I2' cannot be used as type parameter 'T' in the generic type or method 'Attr2<T>'. The constraint interface 'I1' or its base interface has static abstract or virtual members.
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "I1").WithArguments("I1", "I1.M()").WithLocation(19, 8),
+                // (22,8): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M()' does not have a most specific implementation in the interface.
+                // [Attr1<I2>]
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "I2").WithArguments("I2", "I1.M()").WithLocation(22, 8),
+                // (23,8): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M()' does not have a most specific implementation in the interface.
                 // [Attr2<I2>]
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "I2").WithArguments("Attr2<T>", "I1", "T", "I2").WithLocation(23, 8));
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "I2").WithArguments("I2", "I1.M()").WithLocation(23, 8)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/BadSymbolReference.cs
+++ b/src/Compilers/CSharp/Test/Symbol/BadSymbolReference.cs
@@ -287,6 +287,12 @@ interface I1<T>
                 // (137,15): error CS0012: The type 'CL2_I1' is defined in an assembly that is not referenced. You must add a reference to assembly 'CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //     interface I2 : CL3_I1, I1<CL3_I1>
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "I2").WithArguments("CL2_I1", "CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(137, 15),
+                // (140,11): error CS0012: The type 'CL2_I1' is defined in an assembly that is not referenced. You must add a reference to assembly 'CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //     class C5 : CL3_I1, I1<CL3_I1>
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "C5").WithArguments("CL2_I1", "CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(140, 11),
+                // (137,15): error CS0012: The type 'CL2_I1' is defined in an assembly that is not referenced. You must add a reference to assembly 'CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //     interface I2 : CL3_I1, I1<CL3_I1>
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "I2").WithArguments("CL2_I1", "CL2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(137, 15),
                 // (9,16): warning CS0219: The variable 'x1' is assigned but its value is never used
                 //         CL3_C1 x1;
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x1").WithArguments("x1").WithLocation(9, 16),
@@ -474,6 +480,12 @@ public interface CL3_I1 : CL2_I1
                 // (133,16): error CS0509: 'Module1.C4': cannot derive from sealed type 'CL3_S1'
                 //     class C4 : CL3_S1
                 Diagnostic(ErrorCode.ERR_CantDeriveFromSealedType, "CL3_S1").WithArguments("Module1.C4", "CL3_S1").WithLocation(133, 16),
+                // (137,15): error CS0246: The type or namespace name 'CL2_I1' could not be found (are you missing a using directive or an assembly reference?)
+                //     interface I2 : CL3_I1, I1<CL3_I1>
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("CL2_I1").WithLocation(137, 15),
+                // (140,11): error CS0246: The type or namespace name 'CL2_I1' could not be found (are you missing a using directive or an assembly reference?)
+                //     class C5 : CL3_I1, I1<CL3_I1>
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "C5").WithArguments("CL2_I1").WithLocation(140, 11),
                 // (137,15): error CS0246: The type or namespace name 'CL2_I1' could not be found (are you missing a using directive or an assembly reference?)
                 //     interface I2 : CL3_I1, I1<CL3_I1>
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("CL2_I1").WithLocation(137, 15),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
@@ -6351,38 +6351,47 @@ class C8
                                                  targetFramework: _supportingFramework,
                                                  references: new[] { compilation1.ToMetadataReference() });
 
-            var expected = new[] {
-                // (4,22): error CS8920: The interface 'I2' cannot be used as type parameter 'T1' in the generic type or method 'C1<T1>'. The constraint interface 'I1' or its base interface has static abstract or virtual members.
-                //     void Test(C1<I2> x)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("C1<T1>", "I1", "T1", "I2").WithLocation(4, 22),
-                // (15,11): error CS8920: The interface 'I2' cannot be used as type parameter 'T2' in the generic type or method 'C2.M<T2>()'. The constraint interface 'I1' or its base interface has static abstract or virtual members.
-                //         x.M<I2>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I2>").WithArguments("C2.M<T2>()", "I1", "T2", "I2").WithLocation(15, 11),
-                // (21,22): error CS8920: The interface 'I2' cannot be used as type parameter 'T3' in the generic type or method 'C3<T3>'. The constraint interface 'I2' or its base interface has static abstract or virtual members.
-                //     void Test(C3<I2> x, C3<I3> y)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("C3<T3>", "I2", "T3", "I2").WithLocation(21, 22),
-                // (21,32): error CS8920: The interface 'I3' cannot be used as type parameter 'T3' in the generic type or method 'C3<T3>'. The constraint interface 'I2' or its base interface has static abstract or virtual members.
-                //     void Test(C3<I2> x, C3<I3> y)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("C3<T3>", "I2", "T3", "I3").WithLocation(21, 32),
-                // (32,11): error CS8920: The interface 'I2' cannot be used as type parameter 'T4' in the generic type or method 'C4.M<T4>()'. The constraint interface 'I2' or its base interface has static abstract or virtual members.
-                //         x.M<I2>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I2>").WithArguments("C4.M<T4>()", "I2", "T4", "I2").WithLocation(32, 11),
-                // (33,11): error CS8920: The interface 'I3' cannot be used as type parameter 'T4' in the generic type or method 'C4.M<T4>()'. The constraint interface 'I2' or its base interface has static abstract or virtual members.
-                //         x.M<I3>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("C4.M<T4>()", "I2", "T4", "I3").WithLocation(33, 11),
-                // (39,22): error CS8920: The interface 'I3' cannot be used as type parameter 'T5' in the generic type or method 'C5<T5>'. The constraint interface 'I3' or its base interface has static abstract or virtual members.
-                //     void Test(C5<I3> y)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("C5<T5>", "I3", "T5", "I3").WithLocation(39, 22),
-                // (50,11): error CS8920: The interface 'I3' cannot be used as type parameter 'T6' in the generic type or method 'C6.M<T6>()'. The constraint interface 'I3' or its base interface has static abstract or virtual members.
-                //         x.M<I3>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("C6.M<T6>()", "I3", "T6", "I3").WithLocation(50, 11),
-                // (56,22): error CS8920: The interface 'I1' cannot be used as type parameter 'T7' in the generic type or method 'C7<T7>'. The constraint interface 'I1' or its base interface has static abstract or virtual members.
-                //     void Test(C7<I1> y)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("C7<T7>", "I1", "T7", "I1").WithLocation(56, 22),
-                // (67,11): error CS8920: The interface 'I1' cannot be used as type parameter 'T8' in the generic type or method 'C8.M<T8>()'. The constraint interface 'I1' or its base interface has static abstract or virtual members.
-                //         x.M<I1>();
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I1>").WithArguments("C8.M<T8>()", "I1", "T8", "I1").WithLocation(67, 11)
-            };
+            DiagnosticDescription[] expected;
+
+            if (!isVirtual)
+            {
+                expected = new[] {
+                    // (4,22): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //     void Test(C1<I2> x)
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I2", "I1.M01()").WithLocation(4, 22),
+                    // (15,11): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //         x.M<I2>();
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I2>").WithArguments("I2", "I1.M01()").WithLocation(15, 11),
+                    // (21,22): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //     void Test(C3<I2> x, C3<I3> y)
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I2", "I1.M01()").WithLocation(21, 22),
+                    // (21,32): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //     void Test(C3<I2> x, C3<I3> y)
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I3", "I1.M01()").WithLocation(21, 32),
+                    // (32,11): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //         x.M<I2>();
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I2>").WithArguments("I2", "I1.M01()").WithLocation(32, 11),
+                    // (33,11): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //         x.M<I3>();
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("I3", "I1.M01()").WithLocation(33, 11),
+                    // (39,22): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //     void Test(C5<I3> y)
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I3", "I1.M01()").WithLocation(39, 22),
+                    // (50,11): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //         x.M<I3>();
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("I3", "I1.M01()").WithLocation(50, 11),
+                    // (56,22): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //     void Test(C7<I1> y)
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1", "I1.M01()").WithLocation(56, 22),
+                    // (67,11): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    //         x.M<I1>();
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I1>").WithArguments("I1", "I1.M01()").WithLocation(67, 11)
+                };
+            }
+            else
+            {
+                expected = Array.Empty<DiagnosticDescription>();
+            }
 
             compilation2.VerifyDiagnostics(expected);
 
@@ -6474,14 +6483,583 @@ class C6 : C5<I1>
                                                  targetFramework: _supportingFramework,
                                                  references: new[] { compilation1.ToMetadataReference() });
 
-            compilation2.VerifyEmitDiagnostics();
+            if (isVirtual)
+            {
+                compilation2.VerifyEmitDiagnostics();
+            }
+            else
+            {
+                compilation2.VerifyEmitDiagnostics(
+                    // (43,7): error CS8920: The interface 'I1' cannot be used as type argumen. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    // class C6 : C5<I1>
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "C6").WithArguments("I1", "I1.M01()").WithLocation(43, 7)
+                    );
+            }
 
             compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework,
                                                  references: new[] { compilation1.EmitToImageReference() });
 
-            compilation2.VerifyEmitDiagnostics();
+            if (isVirtual)
+            {
+                compilation2.VerifyEmitDiagnostics();
+            }
+            else
+            {
+                compilation2.VerifyEmitDiagnostics(
+                    // (43,7): error CS8920: The interface 'I1' cannot be used as type argumen. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                    // class C6 : C5<I1>
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "C6").WithArguments("I1", "I1.M01()").WithLocation(43, 7)
+                    );
+            }
+        }
+
+        [Fact]
+        public void ConstraintChecks_03()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    abstract static void M01();
+}
+
+public interface I2 : I1
+{
+    static void I1.M01() {}
+}
+
+public interface I3 : I2
+{
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            var source2 =
+@"
+class C1<T1> where T1 : I1
+{
+    void Test(C1<I2> x)
+    {
+    }
+}
+
+class C2
+{
+    void M<T2>() where T2 : I1 {}
+
+    void Test(C2 x)
+    {
+        x.M<I2>();
+    }
+}
+
+class C3<T3> where T3 : I2
+{
+    void Test(C3<I2> x, C3<I3> y)
+    {
+    }
+}
+
+class C4
+{
+    void M<T4>() where T4 : I2 {}
+
+    void Test(C4 x)
+    {
+        x.M<I2>();
+        x.M<I3>();
+    }
+}
+
+class C5<T5> where T5 : I3
+{
+    void Test(C5<I3> y)
+    {
+    }
+}
+
+class C6
+{
+    void M<T6>() where T6 : I3 {}
+
+    void Test(C6 x)
+    {
+        x.M<I3>();
+    }
+}
+
+class C7<T7> where T7 : I1
+{
+    void Test(C7<I1> y)
+    {
+    }
+}
+
+class C8
+{
+    void M<T8>() where T8 : I1 {}
+
+    void Test(C8 x)
+    {
+        x.M<I1>();
+    }
+}
+";
+            var compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework,
+                                                 references: new[] { compilation1.ToMetadataReference() });
+
+            var expected = new[] {
+                // (56,22): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //     void Test(C7<I1> y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1", "I1.M01()").WithLocation(56, 22),
+                // (67,11): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //         x.M<I1>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I1>").WithArguments("I1", "I1.M01()").WithLocation(67, 11)
+                };
+
+            compilation2.VerifyDiagnostics(expected);
+
+            compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework,
+                                                 references: new[] { compilation1.EmitToImageReference() });
+
+            compilation2.VerifyDiagnostics(expected);
+        }
+
+        [Fact]
+        public void ConstraintChecks_04()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    virtual static void M01(){}
+}
+
+public interface I2 : I1
+{
+    abstract static void I1.M01();
+}
+
+public interface I3 : I2
+{
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            var source2 =
+@"
+class C1<T1> where T1 : I1
+{
+    void Test(C1<I2> x)
+    {
+    }
+}
+
+class C2
+{
+    void M<T2>() where T2 : I1 {}
+
+    void Test(C2 x)
+    {
+        x.M<I2>();
+    }
+}
+
+class C3<T3> where T3 : I2
+{
+    void Test(C3<I2> x, C3<I3> y)
+    {
+    }
+}
+
+class C4
+{
+    void M<T4>() where T4 : I2 {}
+
+    void Test(C4 x)
+    {
+        x.M<I2>();
+        x.M<I3>();
+    }
+}
+
+class C5<T5> where T5 : I3
+{
+    void Test(C5<I3> y)
+    {
+    }
+}
+
+class C6
+{
+    void M<T6>() where T6 : I3 {}
+
+    void Test(C6 x)
+    {
+        x.M<I3>();
+    }
+}
+
+class C7<T7> where T7 : I1
+{
+    void Test(C7<I1> y)
+    {
+    }
+}
+
+class C8
+{
+    void M<T8>() where T8 : I1 {}
+
+    void Test(C8 x)
+    {
+        x.M<I1>();
+    }
+}
+";
+            var compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework,
+                                                 references: new[] { compilation1.ToMetadataReference() });
+
+            var expected = new[] {
+                // (4,22): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //     void Test(C1<I2> x)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I2", "I1.M01()").WithLocation(4, 22),
+                // (15,11): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //         x.M<I2>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I2>").WithArguments("I2", "I1.M01()").WithLocation(15, 11),
+                // (21,22): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //     void Test(C3<I2> x, C3<I3> y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I2", "I1.M01()").WithLocation(21, 22),
+                // (21,32): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //     void Test(C3<I2> x, C3<I3> y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I3", "I1.M01()").WithLocation(21, 32),
+                // (32,11): error CS8920: The interface 'I2' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //         x.M<I2>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I2>").WithArguments("I2", "I1.M01()").WithLocation(32, 11),
+                // (33,11): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //         x.M<I3>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("I3", "I1.M01()").WithLocation(33, 11),
+                // (39,22): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //     void Test(C5<I3> y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I3", "I1.M01()").WithLocation(39, 22),
+                // (50,11): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //         x.M<I3>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("I3", "I1.M01()").WithLocation(50, 11)
+                };
+
+            compilation2.VerifyDiagnostics(expected);
+
+            compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework,
+                                                 references: new[] { compilation1.EmitToImageReference() });
+
+            compilation2.VerifyDiagnostics(expected);
+        }
+
+        [Fact]
+        public void ConstraintChecks_05()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    virtual static void M01(){}
+}
+
+public interface I2 : I1
+{
+    static void I1.M01(){}
+}
+
+public interface I4 : I1
+{
+    abstract static void I1.M01();
+}
+
+public interface I3 : I2, I4
+{
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            var source2 =
+@"
+class C1<T1> where T1 : I1
+{
+    void Test(C1<I2> x)
+    {
+    }
+}
+
+class C2
+{
+    void M<T2>() where T2 : I1 {}
+
+    void Test(C2 x)
+    {
+        x.M<I2>();
+    }
+}
+
+class C3<T3> where T3 : I2
+{
+    void Test(C3<I2> x, C3<I3> y)
+    {
+    }
+}
+
+class C4
+{
+    void M<T4>() where T4 : I2 {}
+
+    void Test(C4 x)
+    {
+        x.M<I2>();
+        x.M<I3>();
+    }
+}
+
+class C5<T5> where T5 : I3
+{
+    void Test(C5<I3> y)
+    {
+    }
+}
+
+class C6
+{
+    void M<T6>() where T6 : I3 {}
+
+    void Test(C6 x)
+    {
+        x.M<I3>();
+    }
+}
+
+class C7<T7> where T7 : I1
+{
+    void Test(C7<I1> y)
+    {
+    }
+}
+
+class C8
+{
+    void M<T8>() where T8 : I1 {}
+
+    void Test(C8 x)
+    {
+        x.M<I1>();
+    }
+}
+";
+            var compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework,
+                                                 references: new[] { compilation1.ToMetadataReference() });
+
+            var expected = new[] {
+                // (21,32): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //     void Test(C3<I2> x, C3<I3> y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I3", "I1.M01()").WithLocation(21, 32),
+                // (33,11): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //         x.M<I3>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("I3", "I1.M01()").WithLocation(33, 11),
+                // (39,22): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //     void Test(C5<I3> y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I3", "I1.M01()").WithLocation(39, 22),
+                // (50,11): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //         x.M<I3>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("I3", "I1.M01()").WithLocation(50, 11)
+                };
+
+            compilation2.VerifyDiagnostics(expected);
+
+            compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework,
+                                                 references: new[] { compilation1.EmitToImageReference() });
+
+            compilation2.VerifyDiagnostics(expected);
+        }
+
+        [Fact]
+        public void ConstraintChecks_06()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    virtual static void M01(){}
+}
+
+public interface I2 : I1
+{
+    static void I1.M01(){}
+}
+
+public interface I4 : I1
+{
+    static void I1.M01(){}
+}
+
+public interface I3 : I2, I4
+{
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            var source2 =
+@"
+class C1<T1> where T1 : I1
+{
+    void Test(C1<I2> x)
+    {
+    }
+}
+
+class C2
+{
+    void M<T2>() where T2 : I1 {}
+
+    void Test(C2 x)
+    {
+        x.M<I2>();
+    }
+}
+
+class C3<T3> where T3 : I2
+{
+    void Test(C3<I2> x, C3<I3> y)
+    {
+    }
+}
+
+class C4
+{
+    void M<T4>() where T4 : I2 {}
+
+    void Test(C4 x)
+    {
+        x.M<I2>();
+        x.M<I3>();
+    }
+}
+
+class C5<T5> where T5 : I3
+{
+    void Test(C5<I3> y)
+    {
+    }
+}
+
+class C6
+{
+    void M<T6>() where T6 : I3 {}
+
+    void Test(C6 x)
+    {
+        x.M<I3>();
+    }
+}
+
+class C7<T7> where T7 : I1
+{
+    void Test(C7<I1> y)
+    {
+    }
+}
+
+class C8
+{
+    void M<T8>() where T8 : I1 {}
+
+    void Test(C8 x)
+    {
+        x.M<I1>();
+    }
+}
+";
+            var compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework,
+                                                 references: new[] { compilation1.ToMetadataReference() });
+
+            var expected = new[] {
+                // (21,32): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //     void Test(C3<I2> x, C3<I3> y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I3", "I1.M01()").WithLocation(21, 32),
+                // (33,11): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //         x.M<I3>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("I3", "I1.M01()").WithLocation(33, 11),
+                // (39,22): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //     void Test(C5<I3> y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I3", "I1.M01()").WithLocation(39, 22),
+                // (50,11): error CS8920: The interface 'I3' cannot be used as type argument. Member 'I1.M01()' does not have a most specific implementation in the interface.
+                //         x.M<I3>();
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "M<I3>").WithArguments("I3", "I1.M01()").WithLocation(50, 11)
+                };
+
+            compilation2.VerifyDiagnostics(expected);
+
+            compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework,
+                                                 references: new[] { compilation1.EmitToImageReference() });
+
+            compilation2.VerifyDiagnostics(expected);
+        }
+
+        [Fact]
+        public void ConstraintChecks_07()
+        {
+            var source1 =
+@"
+abstract class C<T>
+{
+    public abstract void M<U>() where U : T;
+    public void M0() { M<T>(); }
+}
+interface I
+{
+    static abstract string P { get; }
+}
+class D : C<I>
+{
+    public override void M<U>() => System.Console.WriteLine(U.P);
+    
+    static void Main()
+    {
+        new D().M0();
+    }
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.VerifyDiagnostics(
+                // (11,7): error CS8920: The interface 'I' cannot be used as type argument. Member 'I.P' does not have a most specific implementation in the interface.
+                // class D : C<I>
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "D").WithArguments("I", "I.P").WithLocation(11, 7)
+                );
         }
 
         [Theory]
@@ -8793,20 +9371,49 @@ class C<T>
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.VerifyDiagnostics(
-                // (9,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
-                //         _ = x == x;
-                Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "x " + op + " x").WithLocation(9, 13),
-                // (14,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
-                //         _ = y == y;
-                Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "y " + op + " y").WithLocation(14, 13),
-                // (22,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
-                //         _ = a == a;
-                Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "a " + op + " a").WithLocation(22, 13),
-                // (27,98): error CS8382: An expression tree may not contain a tuple == or != operator
-                //         _ = (System.Linq.Expressions.Expression<System.Action<(int, C<T>)>>)(((int, C<T>) b) => (b == b).ToString());
-                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsTupleBinOp, "b " + op + " b").WithLocation(27, 98)
-                );
+            if (isVirtual)
+            {
+                compilation1.VerifyDiagnostics(
+                    // (9,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
+                    //         _ = x == x;
+                    Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "x " + op + " x").WithLocation(9, 13),
+                    // (14,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
+                    //         _ = y == y;
+                    Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "y " + op + " y").WithLocation(14, 13),
+                    // (22,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
+                    //         _ = a == a;
+                    Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "a " + op + " a").WithLocation(22, 13),
+                    // (27,98): error CS8382: An expression tree may not contain a tuple == or != operator
+                    //         _ = (System.Linq.Expressions.Expression<System.Action<(int, C<T>)>>)(((int, C<T>) b) => (b == b).ToString());
+                    Diagnostic(ErrorCode.ERR_ExpressionTreeContainsTupleBinOp, "b " + op + " b").WithLocation(27, 98)
+                    );
+            }
+            else
+            {
+                compilation1.VerifyDiagnostics(
+                    // (7,34): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.operator true(I1)' does not have a most specific implementation in the interface.
+                    //     static void M02((int, C<I1>) x)
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I1", "I1.operator true(I1)").WithLocation(7, 34),
+                    // (12,27): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.operator true(I1)' does not have a most specific implementation in the interface.
+                    //     void M03((int, C<I1>) y)
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1", "I1.operator true(I1)").WithLocation(12, 27),
+                    // (20,34): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.operator true(I1)' does not have a most specific implementation in the interface.
+                    //     static void MT1((int, C<I1>) a)
+                    Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "a").WithArguments("I1", "I1.operator true(I1)").WithLocation(20, 34),
+                    // (9,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
+                    //         _ = x == x;
+                    Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "x " + op + " x").WithLocation(9, 13),
+                    // (14,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
+                    //         _ = y == y;
+                    Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "y " + op + " y").WithLocation(14, 13),
+                    // (22,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
+                    //         _ = a == a;
+                    Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "a " + op + " a").WithLocation(22, 13),
+                    // (27,98): error CS8382: An expression tree may not contain a tuple == or != operator
+                    //         _ = (System.Linq.Expressions.Expression<System.Action<(int, C<T>)>>)(((int, C<T>) b) => (b == b).ToString());
+                    Diagnostic(ErrorCode.ERR_ExpressionTreeContainsTupleBinOp, "b " + op + " b").WithLocation(27, 98)
+                    );
+            }
         }
 
         [Theory]
@@ -9655,17 +10262,44 @@ class Test
                                                  targetFramework: _supportingFramework);
 
             compilation1.VerifyDiagnostics(
+                // (10,34): error CS8920: The interface 'I1<T>' cannot be used as type argument. Member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
+                //     static void M02((int, I1<T>) x)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(10, 34),
                 // (12,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
-                //         _ = x == x;
+                //         _ = x != x;
                 Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "x " + op + " x").WithLocation(12, 13),
+                // (12,13): error CS8920: The interface 'I1<T>' cannot be used as type argument. Member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
+                //         _ = x != x;
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(12, 13),
+                // (12,18): error CS8920: The interface 'I1<T>' cannot be used as type argument. Member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
+                //         _ = x != x;
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(12, 18),
+                // (15,27): error CS8920: The interface 'I1<T>' cannot be used as type argument. Member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
+                //     void M03((int, I1<T>) y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(15, 27),
                 // (17,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
-                //         _ = y == y;
+                //         _ = y != y;
                 Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "y " + op + " y").WithLocation(17, 13),
+                // (17,13): error CS8920: The interface 'I1<T>' cannot be used as type argument. Member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
+                //         _ = y != y;
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(17, 13),
+                // (17,18): error CS8920: The interface 'I1<T>' cannot be used as type argument. Member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
+                //         _ = y != y;
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(17, 18),
+                // (23,37): error CS8920: The interface 'I1<T>' cannot be used as type argument. Member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
+                //     static void MT1<T>((int, I1<T>) a) where T : I1<T>
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "a").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(23, 37),
                 // (25,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
-                //         _ = a == a;
+                //         _ = a != a;
                 Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "a " + op + " a").WithLocation(25, 13),
+                // (25,13): error CS8920: The interface 'I1<T>' cannot be used as type argument. Member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
+                //         _ = a != a;
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "a").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(25, 13),
+                // (25,18): error CS8920: The interface 'I1<T>' cannot be used as type argument. Member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
+                //         _ = a != a;
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "a").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(25, 18),
                 // (30,92): error CS8382: An expression tree may not contain a tuple == or != operator
-                //         _ = (System.Linq.Expressions.Expression<System.Action<(int, T)>>)(((int, T) b) => (b == b).ToString());
+                //         _ = (System.Linq.Expressions.Expression<System.Action<(int, T)>>)(((int, T) b) => (b != b).ToString());
                 Diagnostic(ErrorCode.ERR_ExpressionTreeContainsTupleBinOp, "b " + op + " b").WithLocation(30, 92)
                 );
         }
@@ -28914,12 +29548,21 @@ class C<T>
                 // (4,39): error CS0552: 'I1.implicit operator bool(I1)': user-defined conversions to or from an interface are not allowed
                 //     abstract static implicit operator bool(I1 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "bool").WithArguments("I1.implicit operator bool(I1)").WithLocation(4, 39),
+                // (7,34): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.implicit operator bool(I1)' does not have a most specific implementation in the interface.
+                //     static void M02((int, C<I1>) x)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I1", "I1.implicit operator bool(I1)").WithLocation(7, 34),
                 // (9,13): error CS0029: Cannot implicitly convert type 'I1' to 'bool'
                 //         _ = x == x;
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "x " + op + " x").WithArguments("I1", "bool").WithLocation(9, 13),
+                // (12,27): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.implicit operator bool(I1)' does not have a most specific implementation in the interface.
+                //     void M03((int, C<I1>) y)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1", "I1.implicit operator bool(I1)").WithLocation(12, 27),
                 // (14,13): error CS0029: Cannot implicitly convert type 'I1' to 'bool'
                 //         _ = y == y;
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "y " + op + " y").WithArguments("I1", "bool").WithLocation(14, 13),
+                // (20,34): error CS8920: The interface 'I1' cannot be used as type argument. Member 'I1.implicit operator bool(I1)' does not have a most specific implementation in the interface.
+                //     static void MT1((int, C<I1>) a)
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "a").WithArguments("I1", "I1.implicit operator bool(I1)").WithLocation(20, 34),
                 // (22,13): error CS0029: Cannot implicitly convert type 'I1' to 'bool'
                 //         _ = a == a;
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "a " + op + " a").WithArguments("I1", "bool").WithLocation(22, 13),


### PR DESCRIPTION
Closes #61461.